### PR TITLE
Record reproducible demo evidence hashes

### DIFF
--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -72,6 +72,36 @@ shasum -a 256 \
   build/v1.0-demo-evidence-bundle-verification.json
 ```
 
+Reference release-candidate run from the locked demo path:
+
+| Artifact | SHA-256 | Size |
+| --- | --- | ---: |
+| `build/v1.0-demo-analysis.json` | `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b` | 49,024 bytes |
+| `build/v1.0-demo-evidence-bundle.zip` | `246a80012271deae22be15dfbb7e24408c2431324b0a244cbe0e0ec58c8dbad2` | 28,473 bytes |
+| `build/v1.0-demo-evidence-bundle-verification.json` | `c1da50f6c006859b2737b99d1d6917c583fda05101ef663012ae432a7bca9634` | 2,566 bytes |
+| `manifest.json` inside the ZIP | `1c828e916bd7b0e1427921acde2c77efff8c30b8790992eed010ea241fafffbb` | 2,497 bytes |
+
+Manifest details for that run:
+
+- `schema_version`: `1.1.0`
+- `bundle_kind`: `evidence-bundle`
+- `generated_at`: `2026-04-21T12:00:00+00:00`
+- `source_analysis_sha256`: `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b`
+- `provider_snapshot.path`: `data/demo_provider_snapshot.json`
+- `provider_snapshot.sha256`: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- `provider_snapshot.sources`: `nvd`, `epss`, `kev`
+- verification summary: `ok=true`, `expected_files=5`, `verified_files=5`, `missing_files=0`, `modified_files=0`, `unexpected_files=0`, `manifest_errors=0`
+
+Manifest file entries:
+
+| Bundle member | Kind | SHA-256 | Size |
+| --- | --- | --- | ---: |
+| `analysis.json` | `analysis-json` | `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b` | 49,024 bytes |
+| `report.html` | `html-report` | `9b958bf1103add7731b8068fa2fef61353f6a01a8cb47ea979b77dd6e0988f97` | 109,325 bytes |
+| `summary.md` | `markdown-summary` | `916377f25d8a84db8d338201c9e413d5df7a9518a0f2d06ece66e405fade10a3` | 3,038 bytes |
+| `attack-navigator-layer.json` | `attack-navigator-layer` | `18d94bbe54e47b27c10db18eeaade92b4ceddd3ab08b2370625f08c866f9d331` | 1,825 bytes |
+| `input/trivy_report.json` | `source-input` | `43b29a02a88bc6d9c8c2e8d599a5218fcc253f025f42acbcc780e377bad26e82` | 2,200 bytes |
+
 Record the release-candidate commit with `git rev-parse HEAD`, the date of the run, and the exact command output. Do not include `.env` files, API keys, cookies, shell history, machine-specific home paths, or customer scanner exports in the public release evidence.
 
 ## Guardrails

--- a/src/vuln_prioritizer/cli_support/report_io.py
+++ b/src/vuln_prioritizer/cli_support/report_io.py
@@ -27,6 +27,9 @@ from vuln_prioritizer.utils import iso_utc_now
 
 from .common import console, exit_input_validation
 
+DETERMINISTIC_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+DETERMINISTIC_ZIP_FILE_MODE = 0o644 << 16
+
 
 def load_analysis_report_payload(input_path: Path) -> dict[str, Any]:
     try:
@@ -312,9 +315,25 @@ def write_evidence_bundle(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for path, content, _kind in bundle_entries:
-            archive.writestr(path, content)
-        archive.writestr("manifest.json", generate_evidence_bundle_manifest_json(manifest))
+            write_deterministic_zip_member(archive, path, content)
+        write_deterministic_zip_member(
+            archive,
+            "manifest.json",
+            generate_evidence_bundle_manifest_json(manifest).encode("utf-8"),
+        )
     return manifest
+
+
+def write_deterministic_zip_member(
+    archive: zipfile.ZipFile,
+    path: str,
+    content: bytes,
+) -> None:
+    info = zipfile.ZipInfo(filename=path, date_time=DETERMINISTIC_ZIP_TIMESTAMP)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3
+    info.external_attr = DETERMINISTIC_ZIP_FILE_MODE
+    archive.writestr(info, content)
 
 
 def analysis_input_paths(metadata: object) -> list[str]:

--- a/tests/test_report_io_helpers.py
+++ b/tests/test_report_io_helpers.py
@@ -228,6 +228,42 @@ def test_write_evidence_bundle_handles_missing_input_copy_and_navigator_layer(
         assert not any(name.startswith("input/") for name in names)
 
 
+def test_write_evidence_bundle_is_byte_stable_with_fixed_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("VULN_PRIORITIZER_FIXED_NOW", "2026-04-21T12:00:00+00:00")
+    analysis_file = tmp_path / "analysis.json"
+    first_output = tmp_path / "first.zip"
+    second_output = tmp_path / "second.zip"
+    payload = {
+        "metadata": {
+            "input_path": "missing-input.txt",
+            "findings_count": 1,
+            "kev_hits": 0,
+            "waived_count": 0,
+        },
+        "attack_summary": {"mapped_cves": 0, "technique_distribution": {}},
+        "findings": [],
+    }
+    analysis_file.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+    write_evidence_bundle(
+        analysis_path=analysis_file,
+        output_path=first_output,
+        payload=payload,
+        include_input_copy=True,
+    )
+    write_evidence_bundle(
+        analysis_path=analysis_file,
+        output_path=second_output,
+        payload=payload,
+        include_input_copy=True,
+    )
+
+    assert first_output.read_bytes() == second_output.read_bytes()
+
+
 def test_manifest_validation_error_format_and_mismatch_descriptions() -> None:
     try:
         EvidenceBundleManifest.model_validate({"files": []})


### PR DESCRIPTION
## Summary

- Makes evidence bundle ZIP output byte-stable when the fixed release timestamp is set.
- Adds a regression test for deterministic evidence bundle bytes.
- Records the v1.0 demo analysis, bundle, verification, manifest, provider snapshot, and bundle-member SHA-256 values in the release notes.

## Verification

- python3 -m ruff check src/vuln_prioritizer/cli_support/report_io.py tests/test_report_io_helpers.py
- python3 -m mypy src/vuln_prioritizer/cli_support/report_io.py
- python3 -m pytest -q tests/test_report_io_helpers.py tests/test_evidence_bundle_verification.py --no-cov
- make demo-evidence-bundle-check twice; bundle SHA-256 stable at 246a80012271deae22be15dfbb7e24408c2431324b0a244cbe0e0ec58c8dbad2
- make check: 407 passed, 2 skipped, coverage 90.07%
- make docs-check
- make release-check

Fixes #63