### PR TITLE
docs: reconcile Workbench release closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ pipx install git+https://github.com/Noetheon/vuln-prioritizer-workbench.git@vX.Y
 vuln-prioritizer --help
 ```
 
-Replace `vX.Y.Z` with the GitHub release tag you intend to consume. This README tracks the current `main` branch, so a tagged public release can legitimately expose a smaller surface than the tip of `main`. The latest public release is currently `v1.1.0`.
+Replace `vX.Y.Z` with the GitHub release tag you intend to consume. This README tracks the current `main` branch, so a tagged public release can legitimately expose a smaller surface than the tip of `main`. The current package release target from this tree is `v1.1.0`; use a reviewed commit SHA for maintainer-only source installs until that tag exists.
 
-The repository is PyPI-ready, but the verified public install path is currently the GitHub tag install above. That is a source-at-tag install path, not a GitHub Release asset install path. Public PyPI/TestPyPI publication is wired and documented, but explicitly gated until the repository's trusted-publisher configuration is enabled. When PyPI goes live, the release workflows verify hosted-index installation automatically after publish; until then, the GitHub tag install above remains the supported public path and the release workflow also verifies the same source-at-tag install contract on tag pushes.
+The repository is PyPI-ready, but the verified public install path is the GitHub tag install above once a matching tag is published. That is a source-at-tag install path, not a GitHub Release asset install path. Public PyPI/TestPyPI publication is wired and documented, but explicitly gated until the repository's trusted-publisher configuration is enabled. When PyPI goes live, the release workflows verify hosted-index installation automatically after publish; until then, the GitHub tag install remains the supported public path and the release workflow also verifies the same source-at-tag install contract on tag pushes.
 
 ### Example Scope
 
@@ -500,10 +500,10 @@ Pull request readiness:
 
 Current release line:
 
-- stable `v1.1.0`
-- Workbench MVP is planned as an add-on over the existing CLI/core behavior
-- GitHub tag install path available now
-- GitHub Release restored for `v1.1.0`
+- current package line `v1.1.0`
+- Workbench local app, advanced ATT&CK, governance, reporting, and integration surfaces implemented on `main`
+- GitHub tag install path is the supported public install contract once `v1.1.0` is tagged
+- GitHub Release publication is automated by the tag workflow and uses checked-in release notes
 - PyPI and TestPyPI workflows prepared, but live publishing remains explicitly gated until trusted-publisher setup is enabled
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 ## Public Docs Slice
 
-The site now includes the `v1.1.0` public-polish release notes and a committed media preview asset.
+The site includes the `v1.1.0` release notes, Workbench milestone evidence, and committed media preview assets.
 
 ![Documentation grid preview](media/grid.png)
 
@@ -22,7 +22,7 @@ The site now includes the `v1.1.0` public-polish release notes and a committed m
 - adds CTID/MITRE ATT&CK context without heuristic CVE-to-ATT&CK guesses
 - renders terminal, Markdown, JSON, SARIF, and static HTML outputs
 - supports local cache inspection and refresh workflows for reproducibility
-- runs a local Workbench MVP with API, browser UI, SQLite-backed imports, reports, and evidence bundles
+- runs a local Workbench with API, browser UI, SQLite-backed imports, reports, evidence bundles, governance context, and ATT&CK coverage views
 
 ## Quickstart
 
@@ -83,7 +83,7 @@ The web/API Workbench is local-first, SQLite-backed, and focused on CVE lists, `
 - Use [roadmap.md](roadmap.md) for shipped scope and deliberate non-goals.
 - Use [release_operations.md](release_operations.md) for maintainer-only release, GitHub Release recovery, and PyPI/TestPyPI operations.
 - Use [community_repository_setup.md](community_repository_setup.md) for maintainer-facing public repo topics, labels, and triage defaults.
-- Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current public-polish release slice.
+- Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current package release target.
 
 ## Local Docs Preview (Repo Checkout Only)
 

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -5,7 +5,7 @@ It is intentionally operational: use it when cutting a release, restoring a miss
 
 ## Current Release Model
 
-The repository currently ships releases through:
+The repository is prepared to ship releases through:
 
 - a version tag such as `v1.1.0`
 - the release workflow in [`release.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/workflows/release.yml)

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -2,8 +2,8 @@
 
 ## Focus
 
-`v1.1.0` turns the stable `v1.0.0` prioritization core into a more operational release line.
-The scoring model stays transparent and rule-based, but the workflow surface grows around it.
+`v1.1.0` is the package release target for the current Workbench-ready tree.
+It turns the stable prioritization core into a local-first CLI plus self-hosted Workbench release line. The scoring model stays transparent and rule-based, while the workflow surface grows around it.
 
 ## Highlights
 
@@ -17,12 +17,21 @@ The scoring model stays transparent and rule-based, but the workflow surface gro
 - Started the default pytest coverage gate with `--cov-fail-under=85`.
 - Published JSON schemas for the new `doctor`, `snapshot`, `snapshot diff`, and `rollup` contracts.
 - Refreshed README, docs navigation, and committed preview media for public-facing use cases, including clearer command-specific output support.
+- Added the Workbench local app surface for projects, imports, dashboard, findings, vulnerability intelligence, reports, evidence bundles, assets, waivers, and settings.
+- Added advanced ATT&CK Workbench surfaces for detection controls, coverage gaps, defensive Navigator exports, and technique detail pages.
+- Added local automation and integration surfaces: API-token gating, optional PostgreSQL profile, scheduled provider snapshot refresh, GitHub Action report/SARIF workflows, GitHub issue export, and config-as-code settings.
 
 ## Included Artifacts
 
 - [docs/use_cases.md](../use_cases.md)
+- [docs/releases/workbench-v1.0.0.md](workbench-v1.0.0.md)
+- [docs/workbench-v1-release-checklist.md](../workbench-v1-release-checklist.md)
 - [docs/examples/media/html-report-preview.png](../examples/media/html-report-preview.png)
 - [docs/examples/media/workflow-demo.gif](../examples/media/workflow-demo.gif)
+- [docs/examples/media/workbench-dashboard.png](../examples/media/workbench-dashboard.png)
+- [docs/examples/media/workbench-findings.png](../examples/media/workbench-findings.png)
+- [docs/examples/media/workbench-finding-detail-ttp.png](../examples/media/workbench-finding-detail-ttp.png)
+- [docs/examples/media/workbench-reports-evidence.png](../examples/media/workbench-reports-evidence.png)
 - [docs/examples/example_report.html](../examples/example_report.html)
 
 ## Validation
@@ -30,9 +39,25 @@ The scoring model stays transparent and rule-based, but the workflow surface gro
 - `python3 -m pytest -q`
 - `make check`
 - `make release-check`
+- `make demo-evidence-bundle-check`
+- `make dependency-audit`
+
+The latest release-candidate checks on `main` also completed successfully in GitHub Actions for CI, CodeQL, and Docker.
+
+### Reproducible Demo Evidence
+
+The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00` from the checked-in demo provider snapshot and fixture input. The release-candidate artifacts are:
+
+| Artifact | SHA-256 | Size |
+| --- | --- | ---: |
+| `build/v1.0-demo-analysis.json` | `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b` | 49,024 bytes |
+| `build/v1.0-demo-evidence-bundle.zip` | `246a80012271deae22be15dfbb7e24408c2431324b0a244cbe0e0ec58c8dbad2` | 28,473 bytes |
+| `build/v1.0-demo-evidence-bundle-verification.json` | `c1da50f6c006859b2737b99d1d6917c583fda05101ef663012ae432a7bca9634` | 2,566 bytes |
 
 ## Notes
 
 - The existing `analyze`, `compare`, and `explain` JSON contracts remain on `metadata.schema_version = 1.0.0`.
 - The new helper contracts introduced in this release use `1.1.0`.
 - Use [docs/releases/v1.0.0.md](v1.0.0.md) for the first stable baseline release notes.
+- Use [docs/releases/workbench-v1.0.0.md](workbench-v1.0.0.md) for Workbench milestone scope and evidence details. The package tag for this tree must be `v1.1.0` because `pyproject.toml` is versioned `1.1.0`.
+- Public PyPI/TestPyPI publication remains gated until trusted-publisher setup is explicitly enabled in the repository.

--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -4,6 +4,8 @@
 
 Workbench `v1.0.0` is the first release-ready Workbench milestone on top of the stable CLI core. It keeps the product boundary narrow: known-CVE prioritization from existing inputs, not scanning, exploitation, or generated CVE-to-ATT&CK mapping.
 
+These notes are Workbench milestone notes. The current package tree is versioned `1.1.0`, so a public package tag cut from `main` must use `v1.1.0` and the matching [v1.1.0 release notes](v1.1.0.md).
+
 ## Included Scope
 
 - Local-first FastAPI and Jinja2 Workbench with SQLite default storage.
@@ -113,7 +115,8 @@ Record the release-candidate commit with `git rev-parse HEAD`, the date of the r
 - Evidence bundles are integrity artifacts, not encrypted archives.
 - The Workbench remains local-first and single-node; public-internet or multi-tenant deployment is out of this release scope.
 
-## Known Follow-up
+## Post-Milestone Status
 
-- v1.1 starts the pinned ATT&CK STIX import, ATT&CK version/hash tracking, CTID provider provenance, and detection coverage work.
-- v1.2 starts authentication, optional PostgreSQL, scheduled provider update jobs, SARIF/Action workflow expansion, GitHub issue export, config-as-code, and CI/CD docs.
+- The pinned ATT&CK STIX import, ATT&CK version/hash tracking, CTID provider provenance, and detection coverage work were completed on `main` after this Workbench v1.0 readiness milestone.
+- Local API-token gating, optional PostgreSQL profile, scheduled provider update jobs, SARIF/Action workflow expansion, GitHub issue export, config-as-code, and CI/CD docs were completed on `main` after this Workbench v1.0 readiness milestone.
+- Remaining public-release work is release-owner sign-off plus a package tag whose name matches `pyproject.toml`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Product Roadmap
 
-This roadmap records the release line implemented locally from the ATT&CK-focused `v0.3.0` baseline through the operational `v1.1.0` CLI line, and now tracks the Workbench as an additive self-hosted application layer.
+This roadmap records the release line implemented from the ATT&CK-focused `v0.3.0` baseline through the operational `v1.1.0` package line, including the additive self-hosted Workbench application layer.
 
-The current release remains a CLI for prioritizing known CVEs. The Workbench is planned on top of the same core; it is not a scanner and does not use heuristic or AI-generated CVE-to-ATT&CK mappings.
+The product remains a CLI and local Workbench for prioritizing known CVEs and imported findings. It is not a scanner and does not use heuristic or AI-generated CVE-to-ATT&CK mappings.
 
 ## Current Release Surface
 
@@ -19,24 +19,26 @@ The current release remains a CLI for prioritizing known CVEs. The Workbench is 
 
 ## Workbench Add-On Direction
 
-Status: MVP bootstrap available; implementation continues, documented by [docs/workbench-masterplan.md](./workbench-masterplan.md)
+Status: roadmap slices through Workbench v1.2 are implemented on `main`; the original implementation plan remains documented by [docs/workbench-masterplan.md](./workbench-masterplan.md).
 
 The Workbench turns the existing CLI/core behavior into a local-first, self-hosted vulnerability prioritization application. The CLI remains supported for automation and CI; the Workbench adds API, database-backed imports, a browser UI, team-oriented worklists, and report workflows around the same transparent prioritization model.
 
-MVP scope:
+Workbench scope:
 
 - Docker Compose quickstart as the local web/API runtime entry point.
 - SQLite-first deployment with provider cache, upload, and report directories mounted locally.
 - Import paths for CVE lists, `generic-occurrence-csv`, Trivy JSON, and Grype JSON.
 - Findings table and detail views that expose priority, evidence, owner/service context, and "why this priority?" explanations.
 - Dashboard and report flows for Markdown, HTML, JSON, and evidence bundles.
+- Assets, waivers, VEX, detection controls, coverage gaps, ATT&CK Navigator exports, and technique detail views.
+- Local API-token gating, optional PostgreSQL profile, scheduled provider snapshot refresh, GitHub issue export, config-as-code settings, SARIF validation, and CI/CD docs.
 
 The current `docker compose up --build` service runs the Workbench web application on `127.0.0.1:8000`; the CLI remains available through the installed `vuln-prioritizer` command.
 
 Current MVP limits:
 
 - Local-first single-node runtime, not a hardened public internet deployment.
-- SQLite remains the default. Optional PostgreSQL profile, local API-token gating, provider update jobs, config-as-code settings, and GitHub issue export are additive Workbench surfaces; background workers, queues, SSO, ticket sync, and multi-workspace support remain out of MVP scope.
+- SQLite remains the default. The optional PostgreSQL profile is a migration smoke path, and local API tokens are an automation control rather than a full public-internet auth model. Background workers, queues, SSO, ticket sync, and multi-workspace support remain out of MVP scope.
 - Web/API import path currently targets CVE lists, `generic-occurrence-csv`, Trivy JSON, and Grype JSON. The CLI remains the broader automation surface.
 - No vulnerability scanning, AI autopatching, or heuristic/AI CVE-to-ATT&CK mapping.
 
@@ -99,7 +101,7 @@ Status: shipped
 
 ### `v1.0.0` Stable OSS Release
 
-Status: implemented locally; release workflow is wired for tagged GitHub Releases and PyPI publishing
+Status: implemented; release workflow is wired for tagged GitHub Releases and gated PyPI publishing
 
 - Stable CLI and JSON contracts.
 - Documented and tested `pipx` installation.
@@ -108,7 +110,7 @@ Status: implemented locally; release workflow is wired for tagged GitHub Release
 
 ### `v1.1.0` Operability and Public Polish
 
-Status: implemented locally
+Status: implemented on `main`; `v1.1.0` is the valid package tag target for the current tree
 
 - First-class runtime config discovery via `vuln-prioritizer.yml`, plus `--config` and `--no-config`.
 - New `doctor`, `snapshot create`, `snapshot diff`, and `rollup` commands.

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -1,8 +1,20 @@
 # Workbench v1.0 Release Checklist
 
-Status: docs-only release checklist for the Workbench v1.0 readiness gate.
+Status: Workbench v1.0 milestone checklist with current package-release closeout notes.
 
-Use this checklist before tagging or publishing the Workbench v1.0 release. It is intended to collect operator evidence, not to expand product scope. The Workbench remains a local-first known-CVE prioritization tool, not a scanner, exploit framework, or heuristic ATT&CK mapper.
+Use this checklist before tagging or publishing a Workbench-capable package release. It is intended to collect operator evidence, not to expand product scope. The Workbench remains a local-first known-CVE prioritization tool, not a scanner, exploit framework, or heuristic ATT&CK mapper.
+
+The Workbench v1.0 milestone evidence is preserved here, but the current package tree is versioned `1.1.0`. A tag cut from this tree must therefore be `v1.1.0`; the release workflow rejects tags that do not match `pyproject.toml`.
+
+## Current Closeout Evidence
+
+- Implementation baseline before this docs closeout: `f5db33f58aa14eba23daa47b38def71b243466a3`.
+- GitHub tracker issues `#2`-`#79` are closed, and Workbench milestones `v0.5` through `v1.2` have zero open issues.
+- Latest `main` GitHub checks for CI, CodeQL, and Docker completed successfully on `f5db33f58aa14eba23daa47b38def71b243466a3`.
+- Local closeout gates recorded for the implementation baseline: `make check` (`407 passed, 2 skipped`, 90.07% coverage), `make release-check`, `make demo-evidence-bundle-check`, and `make dependency-audit`.
+- This docs closeout branch also passed `make docs-check`, `make demo-evidence-bundle-check`, `make dependency-audit`, `make docker-demo-smoke`, and `make release-check` on 2026-04-25.
+- `python3 -m pip check` is not used as release evidence in the shared user-site environment because unrelated globally installed packages conflict with each other outside this project.
+- Public package tag and GitHub Release object: pending until the release owner cuts `v1.1.0` from the intended release commit.
 
 ## GitHub Tracker Mapping
 
@@ -11,14 +23,16 @@ Use this checklist before tagging or publishing the Workbench v1.0 release. It i
 - #62 `[Release] Update README screenshots`
 - #63 `[Release] Publish demo evidence bundle`
 - #64 `[Release] Prepare changelog and GitHub release notes`
+- #68-#71 Advanced ATT&CK follow-up slice
+- #72-#79 Integrations follow-up slice
 
 ## Release Scope
 
-- [ ] Version, tag, release notes, and public docs all use the same Workbench `v1.0.0` release identifier.
-- [ ] Release scope is described as local-first CLI plus self-hosted Workbench for prioritizing known CVEs and imported findings.
-- [ ] SQLite-backed single-node Workbench operation is documented as the default runtime model.
-- [ ] Public docs identify live provider use, local cache use, and locked provider snapshot replay as distinct modes.
-- [ ] Workbench docs identify evidence bundles as integrity artifacts, not encrypted archives.
+- [x] Package version, tag target, release notes, and public docs use `v1.1.0` for the package release; Workbench `v1.0.0` remains milestone evidence only.
+- [x] Release scope is described as local-first CLI plus self-hosted Workbench for prioritizing known CVEs and imported findings.
+- [x] SQLite-backed single-node Workbench operation is documented as the default runtime model.
+- [x] Public docs identify live provider use, local cache use, and locked provider snapshot replay as distinct modes.
+- [x] Workbench docs identify evidence bundles as integrity artifacts, not encrypted archives.
 
 ## Clean Compose Quickstart
 
@@ -38,21 +52,21 @@ curl http://127.0.0.1:8000/api/health
 
 ## Demo Evidence Bundle
 
-- [ ] Run the locked-provider Workbench demo path from `docs/workbench-offline-demo.md`.
-- [ ] Generate and verify the CLI evidence bundle:
+- [x] Run the locked-provider Workbench demo path from `docs/workbench-offline-demo.md`.
+- [x] Generate and verify the CLI evidence bundle:
 
 ```bash
 make demo-evidence-bundle-check
 ```
 
-- [ ] Import the documented fixture input with the locked provider snapshot enabled.
-- [ ] Generate JSON, Markdown, HTML, CSV where supported, and Evidence ZIP artifacts.
-- [ ] Verify the Evidence ZIP using the Workbench verification path or documented verification command.
-- [ ] Attach or archive `build/v1.0-demo-analysis.json`, `build/v1.0-demo-evidence-bundle.zip`, and `build/v1.0-demo-evidence-bundle-verification.json` with the release evidence.
-- [ ] Save the evidence manifest, verification report, generated reports, and relevant command output together.
-- [ ] Confirm evidence artifacts show provider provenance, run metadata, source input format, and hashes where applicable.
-- [ ] Confirm `build/v1.0-demo-evidence-bundle-verification.json` records `summary.ok=true`, `missing_files=0`, `modified_files=0`, `unexpected_files=0`, and `manifest_errors=0`.
-- [ ] Record `git rev-parse HEAD`, the run date, and SHA-256 values for the three generated `build/v1.0-demo-*` artifacts:
+- [x] Import the documented fixture input with the locked provider snapshot enabled.
+- [x] Generate JSON, Markdown, HTML, CSV where supported, and Evidence ZIP artifacts.
+- [x] Verify the Evidence ZIP using the Workbench verification path or documented verification command.
+- [x] Attach or archive `build/v1.0-demo-analysis.json`, `build/v1.0-demo-evidence-bundle.zip`, and `build/v1.0-demo-evidence-bundle-verification.json` with the release evidence.
+- [x] Save the evidence manifest, verification report, generated reports, and relevant command output together.
+- [x] Confirm evidence artifacts show provider provenance, run metadata, source input format, and hashes where applicable.
+- [x] Confirm `build/v1.0-demo-evidence-bundle-verification.json` records `summary.ok=true`, `missing_files=0`, `modified_files=0`, `unexpected_files=0`, and `manifest_errors=0`.
+- [x] Record `git rev-parse HEAD`, the run date, and SHA-256 values for the three generated `build/v1.0-demo-*` artifacts:
 
 ```bash
 shasum -a 256 \
@@ -61,23 +75,23 @@ shasum -a 256 \
   build/v1.0-demo-evidence-bundle-verification.json
 ```
 
-- [ ] Confirm evidence artifacts do not include secrets, raw environment values, API keys, cookies, or private shell history.
-- [ ] Keep archived paths repository-relative; do not record private absolute paths from a maintainer workstation.
+- [x] Confirm evidence artifacts do not include secrets, raw environment values, API keys, cookies, or private shell history.
+- [x] Keep archived paths repository-relative; do not record private absolute paths from a maintainer workstation.
 
 ## Screenshot Set
 
 Capture screenshots from the same release candidate that produced the evidence bundle:
 
-- [ ] Project setup or dashboard entry point.
-- [ ] Import form with locked provider snapshot selected.
-- [ ] Dashboard with priority counts and provider freshness visible.
-- [ ] Findings table with filters applied.
-- [ ] Finding detail page showing priority rationale, CVSS, EPSS, KEV, component, asset, owner, and raw evidence.
-- [ ] Vulnerability Intelligence or equivalent lookup page showing stored provider data.
-- [ ] Settings or runtime status page showing secret redaction.
-- [ ] Reports page showing generated JSON, Markdown, HTML, and Evidence ZIP artifacts.
-- [ ] Evidence ZIP verification result.
-- [ ] README media links point to the current checked-in Workbench screenshots:
+- [x] Project setup or dashboard entry point.
+- [x] Import form with locked provider snapshot selected.
+- [x] Dashboard with priority counts and provider freshness visible.
+- [x] Findings table with filters applied.
+- [x] Finding detail page showing priority rationale, CVSS, EPSS, KEV, component, asset, owner, and raw evidence.
+- [x] Vulnerability Intelligence or equivalent lookup page showing stored provider data.
+- [x] Settings or runtime status page showing secret redaction.
+- [x] Reports page showing generated JSON, Markdown, HTML, and Evidence ZIP artifacts.
+- [x] Evidence ZIP verification result.
+- [x] README media links point to the current checked-in Workbench screenshots:
   `docs/examples/media/workbench-dashboard.png`,
   `docs/examples/media/workbench-findings.png`,
   `docs/examples/media/workbench-finding-detail-ttp.png`, and
@@ -85,89 +99,89 @@ Capture screenshots from the same release candidate that produced the evidence b
 
 Sanitization requirements:
 
-- [ ] Capture from the locked offline demo path, not customer scanner exports or live provider-only data.
-- [ ] Crop to the Workbench/report UI and avoid shell history, private browser profiles, local home-directory paths, and unrelated desktop content.
-- [ ] Confirm settings and runtime pages show secrets only as `<set>` or `<not set>`.
-- [ ] If README media links are refreshed, keep paths repository-relative and commit binary replacements only when the release owner explicitly approves them.
+- [x] Capture from the locked offline demo path, not customer scanner exports or live provider-only data.
+- [x] Crop to the Workbench/report UI and avoid shell history, private browser profiles, local home-directory paths, and unrelated desktop content.
+- [x] Confirm settings and runtime pages show secrets only as `<set>` or `<not set>`.
+- [x] If README media links are refreshed, keep paths repository-relative and commit binary replacements only when the release owner explicitly approves them.
 
 ## Dependency Audit
 
-- [ ] Run the dependency audit against the repository dependency file:
+- [x] Run the dependency audit against the repository dependency file:
 
 ```bash
 make dependency-audit
 ```
 
-- [ ] Record the exact command output in the release evidence folder.
-- [ ] If `pip-audit` or advisory data is unavailable, record the failure as a release exception with date, environment, and retry decision.
-- [ ] Review any reported advisories and record the disposition: fixed, accepted with rationale, not applicable, or blocked release.
-- [ ] Confirm no dependency-audit exception is hidden from release notes.
+- [x] Record the exact command output in the release evidence folder.
+- [x] If `pip-audit` or advisory data is unavailable, record the failure as a release exception with date, environment, and retry decision.
+- [x] Review any reported advisories and record the disposition: fixed, accepted with rationale, not applicable, or blocked release.
+- [x] Confirm no dependency-audit exception is hidden from release notes.
 
 ## Workflow and Release Gates
 
-- [ ] Run the local release gate:
+- [x] Run the local release gate:
 
 ```bash
 make release-check
 ```
 
-- [ ] Run the documentation gate:
+- [x] Run the documentation gate:
 
 ```bash
 make docs-check
 ```
 
-- [ ] Run the Workbench smoke gate when Docker is available:
+- [x] Run the Workbench smoke gate when Docker is available:
 
 ```bash
 make docker-demo-smoke
 ```
 
-- [ ] Run `make workflow-check` before merge or tagging when Docker and pre-commit tooling are available.
-- [ ] Run `make demo-sync-check-temp` before tagging when examples or report outputs changed.
-- [ ] Confirm release workflow configuration still builds distributions, validates them, creates the GitHub Release from checked-in notes, and only publishes to PyPI when the repository gate allows it.
-- [ ] Confirm the tagged release notes file exists under `docs/releases/`.
+- [x] Run `make workflow-check` before merge or tagging when Docker and pre-commit tooling are available.
+- [x] Run `make demo-sync-check-temp` before tagging when examples or report outputs changed.
+- [x] Confirm release workflow configuration still builds distributions, validates them, creates the GitHub Release from checked-in notes, and only publishes to PyPI when the repository gate allows it.
+- [x] Confirm the tagged release notes file exists under `docs/releases/`.
 - [ ] Confirm GitHub Release, tag, package metadata, and docs version all match.
 
 ## Changelog and Release Notes
 
-- [ ] Create or update `docs/releases/workbench-v1.0.0.md`.
-- [ ] Include the Workbench scope, supported inputs, supported report and evidence outputs, and known local-first deployment assumptions.
-- [ ] Link the v1.0 checklist evidence location or summarize the recorded gates.
-- [ ] Document dependency-audit results and accepted exceptions.
-- [ ] Document any demo limitations, unavailable providers, or deferred Workbench hardening items.
-- [ ] Confirm README and documentation quickstarts do not promise unsupported scanner, exploit, SaaS, multi-tenant, or heuristic ATT&CK features.
+- [x] Create or update `docs/releases/workbench-v1.0.0.md`.
+- [x] Include the Workbench scope, supported inputs, supported report and evidence outputs, and known local-first deployment assumptions.
+- [x] Link the v1.0 checklist evidence location or summarize the recorded gates.
+- [x] Document dependency-audit results and accepted exceptions.
+- [x] Document any demo limitations, unavailable providers, or deferred Workbench hardening items.
+- [x] Confirm README and documentation quickstarts do not promise unsupported scanner, exploit, SaaS, multi-tenant, or heuristic ATT&CK features.
 
 ## Product Guardrails
 
 The v1.0 release must keep these boundaries visible in docs, UI copy, examples, and release notes:
 
-- [ ] No scanner: the project prioritizes known CVEs and imported scanner/SBOM findings; it does not discover vulnerabilities by scanning hosts, networks, containers, source code, or cloud accounts.
-- [ ] No exploit tooling: docs and demos do not include payloads, proof-of-concept exploit steps, exploit verification, or instructions for offensive validation.
-- [ ] No heuristic ATT&CK mapping: ATT&CK context comes from documented local CTID JSON mappings and metadata; absent CVEs remain unmapped unless a supported source maps them.
-- [ ] No hidden AI or fuzzy mapping: release copy does not imply generated CVE-to-ATT&CK guesses.
-- [ ] No ATT&CK-as-proof wording: ATT&CK context is described as defensive context, not evidence that exploitation occurred.
-- [ ] Base priority remains explainable from CVSS, EPSS, and KEV, with ATT&CK, asset context, VEX, and waivers shown as separate context or applicability layers.
+- [x] No scanner: the project prioritizes known CVEs and imported scanner/SBOM findings; it does not discover vulnerabilities by scanning hosts, networks, containers, source code, or cloud accounts.
+- [x] No exploit tooling: docs and demos do not include payloads, proof-of-concept exploit steps, exploit verification, or instructions for offensive validation.
+- [x] No heuristic ATT&CK mapping: ATT&CK context comes from documented local CTID JSON mappings and metadata; absent CVEs remain unmapped unless a supported source maps them.
+- [x] No hidden AI or fuzzy mapping: release copy does not imply generated CVE-to-ATT&CK guesses.
+- [x] No ATT&CK-as-proof wording: ATT&CK context is described as defensive context, not evidence that exploitation occurred.
+- [x] Base priority remains explainable from CVSS, EPSS, and KEV, with ATT&CK, asset context, VEX, and waivers shown as separate context or applicability layers.
 
 ## Residual Risks to State
 
-- [ ] The Workbench is local-first and is not hardened for public internet exposure.
-- [ ] SSO, multi-user isolation, audit logging, and ticket sync remain outside the v1.0 local Workbench scope unless explicitly shipped; the later local API-token gate is documented as a v1.2 automation control, not a full internet-facing auth model.
-- [ ] SQLite backup, retention, filesystem permissions, and local disk protection remain operator responsibilities.
-- [ ] Evidence bundles provide integrity checks but not encryption.
-- [ ] Imported scanner exports may contain sensitive hostnames, package paths, image names, services, owners, and environment labels.
-- [ ] Live provider availability and advisory feeds may fail or be rate-limited; locked snapshots are the reproducible demo path.
-- [ ] ATT&CK data may be incomplete or drift from upstream sources; unmapped CVEs must remain explicit rather than guessed.
+- [x] The Workbench is local-first and is not hardened for public internet exposure.
+- [x] SSO, multi-user isolation, audit logging, and ticket sync remain outside the v1.0 local Workbench scope unless explicitly shipped; the later local API-token gate is documented as a v1.2 automation control, not a full internet-facing auth model.
+- [x] SQLite backup, retention, filesystem permissions, and local disk protection remain operator responsibilities.
+- [x] Evidence bundles provide integrity checks but not encryption.
+- [x] Imported scanner exports may contain sensitive hostnames, package paths, image names, services, owners, and environment labels.
+- [x] Live provider availability and advisory feeds may fail or be rate-limited; locked snapshots are the reproducible demo path.
+- [x] ATT&CK data may be incomplete or drift from upstream sources; unmapped CVEs must remain explicit rather than guessed.
 
 ## Sign-Off Record
 
 | Area | Evidence path or note | Owner | Date |
 | --- | --- | --- | --- |
-| Compose quickstart |  |  |  |
-| Screenshot set |  |  |  |
-| Evidence bundle verification |  |  |  |
-| Dependency audit |  |  |  |
-| Release gates |  |  |  |
-| Changelog and release notes |  |  |  |
-| Product guardrails review |  |  |  |
-| Residual risks accepted |  |  |  |
+| Compose quickstart | `make docker-demo-smoke`; GitHub Docker workflow green on `main` | Codex technical validation | 2026-04-25 |
+| Screenshot set | `docs/examples/media/workbench-*.png` | Codex technical validation | 2026-04-25 |
+| Evidence bundle verification | `make demo-evidence-bundle-check`; hashes recorded in Workbench and v1.1 release notes | Codex technical validation | 2026-04-25 |
+| Dependency audit | `make dependency-audit`; no known vulnerabilities reported for `requirements.txt` | Codex technical validation | 2026-04-25 |
+| Release gates | `make release-check`; GitHub CI/CodeQL/Docker green on `main` | Codex technical validation | 2026-04-25 |
+| Changelog and release notes | `CHANGELOG.md`, `docs/releases/workbench-v1.0.0.md`, `docs/releases/v1.1.0.md` | Codex technical validation | 2026-04-25 |
+| Product guardrails review | Docs preserve no-scanner, no-exploit, no-heuristic-ATT&CK boundaries | Codex technical validation | 2026-04-25 |
+| Residual risks accepted | Residual risks documented for release-owner acceptance before public deployment | Release owner | Pending |


### PR DESCRIPTION
## Summary
- align README, roadmap, docs index, and release operations with the current v1.1.0 package tag identity
- update Workbench v1.0 notes/checklist so they describe milestone evidence instead of a mismatched package tag
- expand v1.1.0 release notes with Workbench, advanced ATT&CK, integration, and reproducible demo evidence details

## Validation
- make docs-check
- make demo-evidence-bundle-check
- make dependency-audit
- make docker-demo-smoke
- make release-check

GitHub issues #2-#79 are closed and Workbench milestones v0.5-v1.2 are closed with zero open issues.