### PR TITLE
docs: record v1.1.0 publication status

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ pipx install git+https://github.com/Noetheon/vuln-prioritizer-workbench.git@vX.Y
 vuln-prioritizer --help
 ```
 
-Replace `vX.Y.Z` with the GitHub release tag you intend to consume. This README tracks the current `main` branch, so a tagged public release can legitimately expose a smaller surface than the tip of `main`. The current package release target from this tree is `v1.1.0`; use a reviewed commit SHA for maintainer-only source installs until that tag exists.
+Replace `vX.Y.Z` with the GitHub release tag you intend to consume. This README tracks the current `main` branch, so a tagged public release can legitimately expose a smaller surface than the tip of `main`. The latest public release is currently `v1.1.0`.
 
-The repository is PyPI-ready, but the verified public install path is the GitHub tag install above once a matching tag is published. That is a source-at-tag install path, not a GitHub Release asset install path. Public PyPI/TestPyPI publication is wired and documented, but explicitly gated until the repository's trusted-publisher configuration is enabled. When PyPI goes live, the release workflows verify hosted-index installation automatically after publish; until then, the GitHub tag install remains the supported public path and the release workflow also verifies the same source-at-tag install contract on tag pushes.
+The repository is PyPI-ready, but the verified public install path is currently the GitHub tag install above. That is a source-at-tag install path, not a GitHub Release asset install path. Public PyPI/TestPyPI publication is wired and documented, but explicitly gated until the repository's trusted-publisher configuration is enabled. When PyPI goes live, the release workflows verify hosted-index installation automatically after publish; until then, the GitHub tag install remains the supported public path and the release workflow also verifies the same source-at-tag install contract on tag pushes.
 
 ### Example Scope
 
@@ -502,8 +502,8 @@ Current release line:
 
 - current package line `v1.1.0`
 - Workbench local app, advanced ATT&CK, governance, reporting, and integration surfaces implemented on `main`
-- GitHub tag install path is the supported public install contract once `v1.1.0` is tagged
-- GitHub Release publication is automated by the tag workflow and uses checked-in release notes
+- GitHub tag install path is available for `v1.1.0`
+- GitHub Release is published for `v1.1.0` with source and wheel distribution assets
 - PyPI and TestPyPI workflows prepared, but live publishing remains explicitly gated until trusted-publisher setup is enabled
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ The web/API Workbench is local-first, SQLite-backed, and focused on CVE lists, `
 - Use [roadmap.md](roadmap.md) for shipped scope and deliberate non-goals.
 - Use [release_operations.md](release_operations.md) for maintainer-only release, GitHub Release recovery, and PyPI/TestPyPI operations.
 - Use [community_repository_setup.md](community_repository_setup.md) for maintainer-facing public repo topics, labels, and triage defaults.
-- Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current package release target.
+- Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current package release.
 
 ## Local Docs Preview (Repo Checkout Only)
 

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -5,7 +5,7 @@ It is intentionally operational: use it when cutting a release, restoring a miss
 
 ## Current Release Model
 
-The repository is prepared to ship releases through:
+The repository ships releases through:
 
 - a version tag such as `v1.1.0`
 - the release workflow in [`release.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/workflows/release.yml)

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -2,7 +2,7 @@
 
 ## Focus
 
-`v1.1.0` is the package release target for the current Workbench-ready tree.
+`v1.1.0` is the public package release for the current Workbench-ready tree.
 It turns the stable prioritization core into a local-first CLI plus self-hosted Workbench release line. The scoring model stays transparent and rule-based, while the workflow surface grows around it.
 
 ## Highlights

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -14,7 +14,7 @@ The Workbench v1.0 milestone evidence is preserved here, but the current package
 - Local closeout gates recorded for the implementation baseline: `make check` (`407 passed, 2 skipped`, 90.07% coverage), `make release-check`, `make demo-evidence-bundle-check`, and `make dependency-audit`.
 - This docs closeout branch also passed `make docs-check`, `make demo-evidence-bundle-check`, `make dependency-audit`, `make docker-demo-smoke`, and `make release-check` on 2026-04-25.
 - `python3 -m pip check` is not used as release evidence in the shared user-site environment because unrelated globally installed packages conflict with each other outside this project.
-- Public package tag and GitHub Release object: pending until the release owner cuts `v1.1.0` from the intended release commit.
+- Public package tag and GitHub Release object: `v1.1.0` published from `23199ef85fb9ac08b9bb0e301b2aadbf3377f791`.
 
 ## GitHub Tracker Mapping
 
@@ -141,7 +141,7 @@ make docker-demo-smoke
 - [x] Run `make demo-sync-check-temp` before tagging when examples or report outputs changed.
 - [x] Confirm release workflow configuration still builds distributions, validates them, creates the GitHub Release from checked-in notes, and only publishes to PyPI when the repository gate allows it.
 - [x] Confirm the tagged release notes file exists under `docs/releases/`.
-- [ ] Confirm GitHub Release, tag, package metadata, and docs version all match.
+- [x] Confirm GitHub Release, tag, package metadata, and docs version all match.
 
 ## Changelog and Release Notes
 


### PR DESCRIPTION
## Summary
- update README and release operations from pre-tag wording to the published v1.1.0 state
- mark the checklist release/tag/package/docs consistency item complete
- record the v1.1.0 release commit and GitHub Release status in the checklist

## Validation
- make docs-check

Release workflow for v1.1.0 passed: https://github.com/Noetheon/vuln-prioritizer-workbench/actions/runs/24915712040