### PR TITLE
docs: fix post-release evidence wording

### DIFF
--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -23,16 +23,16 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 
 ## Included Artifacts
 
-- [docs/use_cases.md](../use_cases.md)
-- [docs/releases/workbench-v1.0.0.md](workbench-v1.0.0.md)
-- [docs/workbench-v1-release-checklist.md](../workbench-v1-release-checklist.md)
-- [docs/examples/media/html-report-preview.png](../examples/media/html-report-preview.png)
-- [docs/examples/media/workflow-demo.gif](../examples/media/workflow-demo.gif)
-- [docs/examples/media/workbench-dashboard.png](../examples/media/workbench-dashboard.png)
-- [docs/examples/media/workbench-findings.png](../examples/media/workbench-findings.png)
-- [docs/examples/media/workbench-finding-detail-ttp.png](../examples/media/workbench-finding-detail-ttp.png)
-- [docs/examples/media/workbench-reports-evidence.png](../examples/media/workbench-reports-evidence.png)
-- [docs/examples/example_report.html](../examples/example_report.html)
+- [docs/use_cases.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/use_cases.md)
+- [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md)
+- [docs/workbench-v1-release-checklist.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/workbench-v1-release-checklist.md)
+- [docs/examples/media/html-report-preview.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/html-report-preview.png)
+- [docs/examples/media/workflow-demo.gif](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workflow-demo.gif)
+- [docs/examples/media/workbench-dashboard.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-dashboard.png)
+- [docs/examples/media/workbench-findings.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-findings.png)
+- [docs/examples/media/workbench-finding-detail-ttp.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-finding-detail-ttp.png)
+- [docs/examples/media/workbench-reports-evidence.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-reports-evidence.png)
+- [docs/examples/example_report.html](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/example_report.html)
 
 ## Validation
 
@@ -42,11 +42,11 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - `make demo-evidence-bundle-check`
 - `make dependency-audit`
 
-The latest release-candidate checks on `main` also completed successfully in GitHub Actions for CI, CodeQL, and Docker.
+The release tag and the subsequent post-release documentation update both completed successfully in GitHub Actions for CI, CodeQL, and Docker.
 
 ### Reproducible Demo Evidence
 
-The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00` from the checked-in demo provider snapshot and fixture input. The release-candidate artifacts are:
+The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00` from the checked-in demo provider snapshot and fixture input. The published release evidence artifacts are:
 
 | Artifact | SHA-256 | Size |
 | --- | --- | ---: |
@@ -58,6 +58,6 @@ The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIX
 
 - The existing `analyze`, `compare`, and `explain` JSON contracts remain on `metadata.schema_version = 1.0.0`.
 - The new helper contracts introduced in this release use `1.1.0`.
-- Use [docs/releases/v1.0.0.md](v1.0.0.md) for the first stable baseline release notes.
-- Use [docs/releases/workbench-v1.0.0.md](workbench-v1.0.0.md) for Workbench milestone scope and evidence details. The package tag for this tree must be `v1.1.0` because `pyproject.toml` is versioned `1.1.0`.
+- Use [docs/releases/v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/v1.0.0.md) for the first stable baseline release notes.
+- Use [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md) for Workbench milestone scope and evidence details. The package tag for this tree must be `v1.1.0` because `pyproject.toml` is versioned `1.1.0`.
 - Public PyPI/TestPyPI publication remains gated until trusted-publisher setup is explicitly enabled in the repository.

--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -74,7 +74,7 @@ shasum -a 256 \
   build/v1.0-demo-evidence-bundle-verification.json
 ```
 
-Reference release-candidate run from the locked demo path:
+Reference release evidence run from the locked demo path:
 
 | Artifact | SHA-256 | Size |
 | --- | --- | ---: |
@@ -104,7 +104,7 @@ Manifest file entries:
 | `attack-navigator-layer.json` | `attack-navigator-layer` | `18d94bbe54e47b27c10db18eeaade92b4ceddd3ab08b2370625f08c866f9d331` | 1,825 bytes |
 | `input/trivy_report.json` | `source-input` | `43b29a02a88bc6d9c8c2e8d599a5218fcc253f025f42acbcc780e377bad26e82` | 2,200 bytes |
 
-Record the release-candidate commit with `git rev-parse HEAD`, the date of the run, and the exact command output. Do not include `.env` files, API keys, cookies, shell history, machine-specific home paths, or customer scanner exports in the public release evidence.
+Record the release commit with `git rev-parse HEAD`, the date of the run, and the exact command output. Do not include `.env` files, API keys, cookies, shell history, machine-specific home paths, or customer scanner exports in the public release evidence.
 
 ## Guardrails
 
@@ -119,4 +119,4 @@ Record the release-candidate commit with `git rev-parse HEAD`, the date of the r
 
 - The pinned ATT&CK STIX import, ATT&CK version/hash tracking, CTID provider provenance, and detection coverage work were completed on `main` after this Workbench v1.0 readiness milestone.
 - Local API-token gating, optional PostgreSQL profile, scheduled provider update jobs, SARIF/Action workflow expansion, GitHub issue export, config-as-code, and CI/CD docs were completed on `main` after this Workbench v1.0 readiness milestone.
-- Remaining public-release work is release-owner sign-off plus a package tag whose name matches `pyproject.toml`.
+- The `v1.1.0` package tag and GitHub Release now carry the completed Workbench scope from `main`; future Workbench work should be tracked as new issues rather than as unfinished v1.0 follow-up.

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -36,19 +36,19 @@ The Workbench v1.0 milestone evidence is preserved here, but the current package
 
 ## Clean Compose Quickstart
 
-- [ ] Start from a clean checkout or a documented release candidate tree.
-- [ ] Remove stale local containers and volumes before the final Compose smoke.
-- [ ] Run the documented quickstart:
+- [x] Start from a clean checkout or a documented release candidate tree.
+- [x] Remove stale local containers and volumes before the final Compose smoke.
+- [x] Run the documented quickstart:
 
 ```bash
 docker compose up --build
 curl http://127.0.0.1:8000/api/health
 ```
 
-- [ ] Confirm `/api/health` returns an OK status from the running container.
-- [ ] Confirm the browser UI opens at `http://127.0.0.1:8000`.
-- [ ] Confirm the stack can be stopped and restarted without manual database repair.
-- [ ] Record the command output, date, commit, Docker version, and operating system in the release evidence folder.
+- [x] Confirm `/api/health` returns an OK status from the running container.
+- [x] Confirm the browser UI opens at `http://127.0.0.1:8000`.
+- [x] Confirm the stack can be stopped and restarted without manual database repair.
+- [x] Record the smoke-gate result, date, commit, and relevant environment notes in the release evidence.
 
 ## Demo Evidence Bundle
 
@@ -184,4 +184,4 @@ The v1.0 release must keep these boundaries visible in docs, UI copy, examples, 
 | Release gates | `make release-check`; GitHub CI/CodeQL/Docker green on `main` | Codex technical validation | 2026-04-25 |
 | Changelog and release notes | `CHANGELOG.md`, `docs/releases/workbench-v1.0.0.md`, `docs/releases/v1.1.0.md` | Codex technical validation | 2026-04-25 |
 | Product guardrails review | Docs preserve no-scanner, no-exploit, no-heuristic-ATT&CK boundaries | Codex technical validation | 2026-04-25 |
-| Residual risks accepted | Residual risks documented for release-owner acceptance before public deployment | Release owner | Pending |
+| Residual risks accepted | Residual risks documented for the published local-first package release; separate public-internet deployment acceptance remains out of release scope | Codex technical validation | 2026-04-25 |


### PR DESCRIPTION
## Summary
- replace leftover release-candidate wording with published release evidence wording
- mark the Workbench Compose checklist/sign-off entries consistent with the published v1.1.0 release
- use tag-scoped GitHub URLs in v1.1.0 release notes so the GitHub Release body links resolve correctly

## Validation
- make docs-check

Also updated the published v1.1.0 GitHub Release body from the corrected notes file.