### PR TITLE
docs: clean Workbench v1 release references

### DIFF
--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -4,7 +4,7 @@
 
 Workbench `v1.0.0` is the first release-ready Workbench milestone on top of the stable CLI core. It keeps the product boundary narrow: known-CVE prioritization from existing inputs, not scanning, exploitation, or generated CVE-to-ATT&CK mapping.
 
-These notes are Workbench milestone notes. The current package tree is versioned `1.1.0`, so a public package tag cut from `main` must use `v1.1.0` and the matching [v1.1.0 release notes](v1.1.0.md).
+These notes are Workbench milestone notes. The current package tree is versioned `1.1.0`, so a public package tag cut from `main` must use `v1.1.0` and the matching [v1.1.0 release notes](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/v1.1.0.md).
 
 ## Included Scope
 
@@ -20,7 +20,7 @@ These notes are Workbench milestone notes. The current package tree is versioned
 
 ## Release Evidence
 
-The v1.0 release gate should attach or record:
+The v1.0 release gate recorded these historical acceptance criteria:
 
 - #60-#64 tracker closure evidence
 - `make workflow-check`
@@ -33,7 +33,7 @@ The v1.0 release gate should attach or record:
   `docs/examples/media/workbench-findings.png`,
   `docs/examples/media/workbench-finding-detail-ttp.png`, and
   `docs/examples/media/workbench-reports-evidence.png`
-- the completed checklist in [workbench-v1-release-checklist.md](../workbench-v1-release-checklist.md)
+- the completed checklist in [workbench-v1-release-checklist.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/workbench-v1-release-checklist.md)
 
 Dependency audit disposition for the 2026-04-24 release pass: `make dependency-audit` completed successfully and `pip-audit` reported no known vulnerabilities for `requirements.txt`; there are no accepted dependency-audit exceptions for this release.
 

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -12,7 +12,7 @@ The Workbench v1.0 milestone evidence is preserved here, but the current package
 - GitHub tracker issues `#2`-`#79` are closed, and Workbench milestones `v0.5` through `v1.2` have zero open issues.
 - Latest `main` GitHub checks for CI, CodeQL, and Docker completed successfully on `f5db33f58aa14eba23daa47b38def71b243466a3`.
 - Local closeout gates recorded for the implementation baseline: `make check` (`407 passed, 2 skipped`, 90.07% coverage), `make release-check`, `make demo-evidence-bundle-check`, and `make dependency-audit`.
-- This docs closeout branch also passed `make docs-check`, `make demo-evidence-bundle-check`, `make dependency-audit`, `make docker-demo-smoke`, and `make release-check` on 2026-04-25.
+- The post-release docs closeout pass also passed `make docs-check`, `make demo-evidence-bundle-check`, `make dependency-audit`, `make docker-demo-smoke`, and `make release-check` on 2026-04-25.
 - `python3 -m pip check` is not used as release evidence in the shared user-site environment because unrelated globally installed packages conflict with each other outside this project.
 - Public package tag and GitHub Release object: `v1.1.0` published from `23199ef85fb9ac08b9bb0e301b2aadbf3377f791`.
 


### PR DESCRIPTION
## Summary
- make Workbench v1.0 release-note links safe for GitHub-rendered release contexts
- change remaining v1.0 release-gate copy to historical evidence wording
- remove branch-specific wording from the Workbench v1 checklist

## Validation
- make docs-check

Repository hygiene also completed outside this PR: Dependabot alerts/security fixes are enabled, and merged stale codex branches were deleted from origin/local.