### PR TITLE
Harden Workbench redirects and release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Workbench demo screenshots:
 ![Workbench finding detail with ATT&CK TTP context](docs/examples/media/workbench-finding-detail-ttp.png)
 ![Workbench reports and evidence](docs/examples/media/workbench-reports-evidence.png)
 
-README media refresh checklist for release candidates:
+README media maintenance checklist for future releases:
 
 - Capture screenshots from the locked offline demo path in [docs/workbench-offline-demo.md](docs/workbench-offline-demo.md), not from customer data or live provider-only runs.
 - Keep screenshot paths repository-relative, and keep or update README links in the same change.
 - Crop to the Workbench or report UI only; do not include shell history, API keys, cookies, private home-directory paths, browser profiles, or environment variable values.
 - Show secret-bearing settings only in their redacted `<set>` or `<not set>` state.
-- Commit generated screenshot replacements only as part of a release evidence change.
+- Commit generated screenshot replacements only as part of a release evidence or docs refresh change.
 
 ## Why Use It
 
@@ -437,7 +437,7 @@ Reference material:
 
 The repository includes a composite GitHub Action for `analyze`, static report rendering, Workbench-style report artifacts, evidence bundles, and SARIF validation.
 
-Use it after `actions/checkout`, because the scanned input files live in the consumer repository, not in the action repository.
+Use it after `actions/checkout`, because scanner exports, SBOMs, or other analysis input files live in the consumer repository, not in the action repository.
 In `mode: analyze`, `input` and `input-format` accept newline-delimited values so one action step can merge multiple sources. The action also passes through the CLI's waiver, filter, sort, cache, provider replay, and fail-gate flags for deterministic CI runs.
 
 ```yaml

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -14,7 +14,7 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - Added `analyze --summary-output` plus composite GitHub Action support for Markdown summary sidecars and GitHub step summaries.
 - Extended the composite GitHub Action with additive `analyze` inputs for waivers, waiver fail gates, provider/cache controls, CVE limits, KEV-only analysis, and post-enrichment sorting/filtering.
 - Added read-only temp-copy maintainer targets for demo artifact sync checks and package checks.
-- Started the default pytest coverage gate with `--cov-fail-under=85`.
+- Started the default pytest coverage gate with `--cov-fail-under=90`.
 - Published JSON schemas for the new `doctor`, `snapshot`, `snapshot diff`, and `rollup` contracts.
 - Refreshed README, docs navigation, and committed preview media for public-facing use cases, including clearer command-specific output support.
 - Added the Workbench local app surface for projects, imports, dashboard, findings, vulnerability intelligence, reports, evidence bundles, assets, waivers, and settings.
@@ -46,7 +46,7 @@ The release tag and the subsequent post-release documentation update both comple
 
 ### Reproducible Demo Evidence
 
-The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00` from the checked-in demo provider snapshot and fixture input. The published release evidence artifacts are:
+The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00` from the checked-in demo provider snapshot and fixture input. The reproducible demo evidence artifacts produced during release validation are:
 
 | Artifact | SHA-256 | Size |
 | --- | --- | ---: |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ The product remains a CLI and local Workbench for prioritizing known CVEs and im
 - Default prioritization stays grounded in `CVSS + EPSS + KEV`.
 - ATT&CK, asset context, and VEX remain explicit contextual layers.
 - The composite GitHub Action mirrors `analyze` policy, waiver, provider/cache, filter, sort, and fail-gate flags as additive inputs.
-- Local quality gates now start enforcing coverage with `--cov-fail-under=85`, and temp-copy package/demo checks are available for read-only validation.
+- Local quality gates now start enforcing coverage with `--cov-fail-under=90`, and temp-copy package/demo checks are available for read-only validation.
 - Docker and Compose provide a local runtime bootstrap for the Workbench MVP while keeping the CLI core available in the same image.
 
 ## Workbench Add-On Direction
@@ -110,7 +110,7 @@ Status: implemented; release workflow is wired for tagged GitHub Releases and ga
 
 ### `v1.1.0` Operability and Public Polish
 
-Status: implemented on `main`; `v1.1.0` is the valid package tag target for the current tree
+Status: published as `v1.1.0`; current `main` contains post-release documentation and security hygiene updates
 
 - First-class runtime config discovery via `vuln-prioritizer.yml`, plus `--config` and `--no-config`.
 - New `doctor`, `snapshot create`, `snapshot diff`, and `rollup` commands.

--- a/src/vuln_prioritizer/web/routes.py
+++ b/src/vuln_prioritizer/web/routes.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import secrets
 from pathlib import Path
 from typing import Annotated, cast
-from urllib.parse import quote
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
@@ -56,6 +55,20 @@ from vuln_prioritizer.workbench_config import WorkbenchSettings
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 web_router = APIRouter()
+
+_PROJECT_CHILD_ROUTES = frozenset(
+    {
+        "assets",
+        "coverage",
+        "dashboard",
+        "findings",
+        "governance",
+        "imports/new",
+        "settings",
+        "vulnerabilities",
+        "waivers",
+    }
+)
 
 
 @web_router.get("/", response_class=HTMLResponse)
@@ -354,7 +367,7 @@ def update_asset_form(
         criticality=criticality.strip() or None,
     )
     session.commit()
-    return RedirectResponse(f"/projects/{asset.project_id}/assets", status_code=303)
+    return RedirectResponse(_project_path(asset.project_id, "assets"), status_code=303)
 
 
 @web_router.get("/projects/{project_id}/waivers", response_class=HTMLResponse)
@@ -808,7 +821,16 @@ def _check_csrf(submitted: str, settings: WorkbenchSettings) -> None:
 
 
 def _project_path(project_id: str, child: str) -> str:
-    return f"/projects/{quote(project_id, safe='')}/{child}"
+    if child not in _PROJECT_CHILD_ROUTES:
+        raise HTTPException(status_code=404, detail="Project route not found.")
+    return f"/projects/{_safe_project_path_value(project_id)}/{child}"
+
+
+def _safe_project_path_value(value: str) -> str:
+    try:
+        return UUID(value).hex
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
 
 
 def _optional_bool_filter(value: str | None) -> bool | None:

--- a/tests/web/test_workbench_pages.py
+++ b/tests/web/test_workbench_pages.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import pytest
 from bs4 import BeautifulSoup
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from vuln_prioritizer.api.app import create_app, get_engine
 from vuln_prioritizer.db import WorkbenchRepository, create_session_factory
-from vuln_prioritizer.web.routes import _redacted_database_url
+from vuln_prioritizer.web.routes import _project_path, _redacted_database_url
 from vuln_prioritizer.workbench_config import WorkbenchSettings
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -179,6 +181,18 @@ def test_web_route_error_paths_and_local_redirects(tmp_path: Path) -> None:
         ).status_code
         == 404
     )
+
+
+def test_project_redirect_paths_are_local_and_validated() -> None:
+    project_id = "1" * 32
+
+    assert _project_path(project_id, "waivers") == f"/projects/{project_id}/waivers"
+    assert _project_path(project_id, "coverage") == f"/projects/{project_id}/coverage"
+
+    with pytest.raises(HTTPException):
+        _project_path("//example.invalid", "waivers")
+    with pytest.raises(HTTPException):
+        _project_path(project_id, "//example.invalid")
 
 
 def test_web_settings_redacts_database_password() -> None:


### PR DESCRIPTION
## Summary
- validate Workbench project redirect paths through UUID-normalized project IDs and an allowlisted child route set
- reuse the hardened helper for asset, waiver, coverage, and settings form redirects
- refresh release/roadmap/README wording for the v1.1.0 coverage gate and post-release artifact phrasing

## Validation
- python3 -m pytest -q --no-cov tests/web/test_workbench_pages.py
- make docs-check
- make check
- make dependency-audit
- git diff --check

This targets the open CodeQL py/url-redirection findings for the Workbench form redirects and the docs consistency items from the final audit.