### PR TITLE
Clear remaining CodeQL quality alerts

### DIFF
--- a/src/vuln_prioritizer/providers/nvd.py
+++ b/src/vuln_prioritizer/providers/nvd.py
@@ -327,6 +327,3 @@ def has_nvd_content(item: NvdData) -> bool:
             bool(item.reference_tags),
         ]
     )
-
-
-_has_nvd_content = has_nvd_content

--- a/src/vuln_prioritizer/reporting_payloads.py
+++ b/src/vuln_prioritizer/reporting_payloads.py
@@ -240,8 +240,17 @@ def generate_compact_summary_markdown(report_payload: dict[str, Any]) -> str:
         f"- Input format: `{metadata.get('input_format', 'N.A.')}`",
         f"- Policy profile: `{metadata.get('policy_profile', 'default')}`",
         "",
-        "| Findings shown | Critical | High | KEV hits | "
-        "ATT&CK mapped | Review due | Expired waivers |",
+        " | ".join(
+            [
+                "| Findings shown",
+                "Critical",
+                "High",
+                "KEV hits",
+                "ATT&CK mapped",
+                "Review due",
+                "Expired waivers |",
+            ]
+        ),
         "| --- | --- | --- | --- | --- | --- | --- |",
         "| " + " | ".join(metrics) + " |",
     ]

--- a/src/vuln_prioritizer/services/prioritization.py
+++ b/src/vuln_prioritizer/services/prioritization.py
@@ -170,7 +170,7 @@ class PrioritizationService:
         findings: list[PrioritizedFinding],
     ) -> list[PrioritizedFinding]:
         """Attach deterministic operational work-queue ranks without changing base priority."""
-        ordered = sorted(findings, key=lambda finding: _operational_sort_key(finding))
+        ordered = sorted(findings, key=_operational_sort_key)
         rank_by_cve = {finding.cve_id: index for index, finding in enumerate(ordered, start=1)}
         return [
             finding.model_copy(

--- a/tests/test_input_loader_contracts.py
+++ b/tests/test_input_loader_contracts.py
@@ -181,14 +181,61 @@ def test_generic_occurrence_csv_preserves_component_target_and_asset_context(
     input_file.write_text(
         "\n".join(
             [
-                "cve,component,version,purl,fix_version,target_kind,target,asset_id,"
-                "criticality,exposure,environment,owner,service,severity",
-                "CVE-2024-0001,Django,4.2.0,pkg:pypi/django@4.2.0,4.2.8,"
-                "repository,backend/requirements.txt,asset-api,Crit,public,production,"
-                "team-app,identity,HIGH",
+                ",".join(
+                    [
+                        "cve",
+                        "component",
+                        "version",
+                        "purl",
+                        "fix_version",
+                        "target_kind",
+                        "target",
+                        "asset_id",
+                        "criticality",
+                        "exposure",
+                        "environment",
+                        "owner",
+                        "service",
+                        "severity",
+                    ]
+                ),
+                ",".join(
+                    [
+                        "CVE-2024-0001",
+                        "Django",
+                        "4.2.0",
+                        "pkg:pypi/django@4.2.0",
+                        "4.2.8",
+                        "repository",
+                        "backend/requirements.txt",
+                        "asset-api",
+                        "Crit",
+                        "public",
+                        "production",
+                        "team-app",
+                        "identity",
+                        "HIGH",
+                    ]
+                ),
                 "not-a-cve,ignored,,,,,,,,,,,",
-                "CVE-2024-0002,openssl,3.0.0,,3.0.13,host,app-01,asset-host,"
-                "urgent,edge,live,team-platform,payments,critical",
+                ",".join(
+                    [
+                        "CVE-2024-0002",
+                        "openssl",
+                        "3.0.0",
+                        "",
+                        "3.0.13",
+                        "host",
+                        "app-01",
+                        "asset-host",
+                        "urgent",
+                        "edge",
+                        "live",
+                        "team-platform",
+                        "payments",
+                        "critical",
+                    ]
+                ),
             ]
         )
         + "\n",


### PR DESCRIPTION
## Summary
- remove the unnecessary operational-rank sort lambda flagged by CodeQL
- remove an unused NVD compatibility alias flagged by CodeQL
- rewrite flagged adjacent string literals in CSV/Markdown fixtures as explicit joins without changing output text

## Validation
- python3 -m pytest -q --no-cov tests/test_input_loader_contracts.py tests/test_v11_output_contracts.py tests/cli/test_analyze.py -k 'compact or summary or markdown or Findings or generic_occurrence'
- python3 -m ruff check src/vuln_prioritizer/services/prioritization.py src/vuln_prioritizer/providers/nvd.py src/vuln_prioritizer/reporting_payloads.py tests/test_input_loader_contracts.py
- git diff --check
- make check

This targets the six remaining non-security CodeQL alerts after PR #88 cleared the open security-severity alerts.