### PR TITLE
Align post-release docs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- No notable changes yet.
+
+## [1.1.0] - 2026-04-25
+
 ### Added
 
 - Workbench v1.0 release notes, release checklist, and locked-provider demo evidence guidance for the local-first Workbench release line.
@@ -27,7 +31,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 - Expanded CTID mapping provenance with creation/update metadata and explicit SHA256 tracking while keeping `ctid-json` as the canonical CVE-to-ATT&CK mapping source.
 - Expanded cache transparency from timestamp-only inspection to namespace counts, namespace checksums, and ATT&CK/local-file checksum visibility.
 - Documented the local workflow-equivalent path for SARIF, HTML, and cache verification when GitHub-hosted execution is unavailable.
-- Pinned consumer GitHub Action examples to the stable `v1.0.0` tag and widened the composite action surface to cover `target-kind` and `target-ref`.
+- Pinned consumer GitHub Action examples to explicit release tags and widened the composite action surface to cover `target-kind` and `target-ref`.
 - Hardened CI/release workflows so hosted runs are aligned with the stronger local workflow gate before publishing artifacts.
 - Hardened ATT&CK validation and CLI failure handling around CTID/metadata file mismatches, missing files, and legacy `local-csv` messaging.
 - Clarified the public install story, support routing, and issue-template scope guidance for the public repository surface.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -10,9 +10,9 @@
 
 ## Included Artifacts
 
-- [example_report.md](../example_report.md)
-- [example_compare.md](../example_compare.md)
-- [example_explain.json](../example_explain.json)
+- [example_report.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.2.0/docs/example_report.md)
+- [example_compare.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.2.0/docs/example_compare.md)
+- [example_explain.json](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.2.0/docs/example_explain.json)
 
 ## Validation
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -10,11 +10,11 @@
 
 ## Included Artifacts
 
-- [example_attack_report.md](../example_attack_report.md)
-- [example_attack_compare.md](../example_attack_compare.md)
-- [example_attack_explain.json](../example_attack_explain.json)
-- [example_attack_coverage.md](../example_attack_coverage.md)
-- [example_attack_navigator_layer.json](../example_attack_navigator_layer.json)
+- [example_attack_report.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.3.0/docs/example_attack_report.md)
+- [example_attack_compare.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.3.0/docs/example_attack_compare.md)
+- [example_attack_explain.json](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.3.0/docs/example_attack_explain.json)
+- [example_attack_coverage.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.3.0/docs/example_attack_coverage.md)
+- [example_attack_navigator_layer.json](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v0.3.0/docs/example_attack_navigator_layer.json)
 
 ## Validation
 

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -32,7 +32,7 @@ The tool remains a CLI for known CVEs. It does not become a scanner and it does 
 ## Contract notes
 
 - The documented machine contract is the JSON export surface, versioned with `metadata.schema_version`.
-- Bundled schemas live under [analysis-report.schema.json](../schemas/analysis-report.schema.json), [compare-report.schema.json](../schemas/compare-report.schema.json), and [explain-report.schema.json](../schemas/explain-report.schema.json).
+- Bundled schemas live under [analysis-report.schema.json](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.0.0/docs/schemas/analysis-report.schema.json), [compare-report.schema.json](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.0.0/docs/schemas/compare-report.schema.json), and [explain-report.schema.json](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.0.0/docs/schemas/explain-report.schema.json).
 - Terminal layout, Markdown layout, and warning wording remain human-facing and are not strict parsing contracts.
 
 ## Guardrails

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -16,7 +16,7 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - Added read-only temp-copy maintainer targets for demo artifact sync checks and package checks.
 - Started the default pytest coverage gate with `--cov-fail-under=90`.
 - Published JSON schemas for the new `doctor`, `snapshot`, `snapshot diff`, and `rollup` contracts.
-- Refreshed README, docs navigation, and committed preview media for public-facing use cases, including clearer command-specific output support.
+- Refreshed README, docs navigation, and committed screenshots/demo media for public-facing use cases, including clearer command-specific output support.
 - Added the Workbench local app surface for projects, imports, dashboard, findings, vulnerability intelligence, reports, evidence bundles, assets, waivers, and settings.
 - Added advanced ATT&CK Workbench surfaces for detection controls, coverage gaps, defensive Navigator exports, and technique detail pages.
 - Added local automation and integration surfaces: API-token gating, optional PostgreSQL profile, scheduled provider snapshot refresh, GitHub Action report/SARIF workflows, GitHub issue export, and config-as-code settings.
@@ -42,7 +42,7 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - `make demo-evidence-bundle-check`
 - `make dependency-audit`
 
-The release tag and the subsequent post-release documentation update both completed successfully in GitHub Actions for CI, CodeQL, and Docker.
+The release tag and subsequent post-release documentation/security hygiene updates through April 25, 2026 completed successfully in GitHub Actions for CI, CodeQL, and Docker.
 
 ### Reproducible Demo Evidence
 

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -8,11 +8,12 @@ The Workbench v1.0 milestone evidence is preserved here, but the current package
 
 ## Current Closeout Evidence
 
-- Implementation baseline before this docs closeout: `f5db33f58aa14eba23daa47b38def71b243466a3`.
+- Historical implementation baseline before the first docs closeout: `f5db33f58aa14eba23daa47b38def71b243466a3`.
 - GitHub tracker issues `#2`-`#79` are closed, and Workbench milestones `v0.5` through `v1.2` have zero open issues.
-- Latest `main` GitHub checks for CI, CodeQL, and Docker completed successfully on `f5db33f58aa14eba23daa47b38def71b243466a3`.
+- Implementation closeout GitHub checks for CI, CodeQL, and Docker completed successfully on `f5db33f58aa14eba23daa47b38def71b243466a3`.
 - Local closeout gates recorded for the implementation baseline: `make check` (`407 passed, 2 skipped`, 90.07% coverage), `make release-check`, `make demo-evidence-bundle-check`, and `make dependency-audit`.
 - The post-release docs closeout pass also passed `make docs-check`, `make demo-evidence-bundle-check`, `make dependency-audit`, `make docker-demo-smoke`, and `make release-check` on 2026-04-25.
+- Post-release security and CodeQL hygiene through `50c3620fba76c343c8aadd3564b926937579f01b` left `main` green for CI, CodeQL, and Docker with zero open code-scanning alerts.
 - `python3 -m pip check` is not used as release evidence in the shared user-site environment because unrelated globally installed packages conflict with each other outside this project.
 - Public package tag and GitHub Release object: `v1.1.0` published from `23199ef85fb9ac08b9bb0e301b2aadbf3377f791`.
 


### PR DESCRIPTION
## Summary
- move current v1.1.0 changelog entries out of Unreleased into a dated 1.1.0 section
- convert older release-note artifact links to tag-pinned GitHub URLs for release-body safety
- refresh v1.1.0 release/checklist wording for post-release docs and security hygiene

## Validation
- make docs-check
- make check
- git diff --check

Subagent audits also confirmed no open issues/PRs/milestones, zero open code-scanning alerts, no Dependabot or secret-scanning alerts, and green main CI/CodeQL/Docker before this docs cleanup.