### PR TITLE
Clarify historical planning docs and release notes

### DIFF
--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -21,7 +21,9 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - Added advanced ATT&CK Workbench surfaces for detection controls, coverage gaps, defensive Navigator exports, and technique detail pages.
 - Added local automation and integration surfaces: API-token gating, optional PostgreSQL profile, scheduled provider snapshot refresh, GitHub Action report/SARIF workflows, GitHub issue export, and config-as-code settings.
 
-## Included Artifacts
+## Release Assets And Documentation
+
+The GitHub Release assets are the attached `vuln_prioritizer-1.1.0-py3-none-any.whl` and `vuln_prioritizer-1.1.0.tar.gz` distributions. The links below are tag-pinned source and documentation references for the `v1.1.0` package tree as released:
 
 - [docs/use_cases.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/use_cases.md)
 - [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md)
@@ -33,6 +35,11 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - [docs/examples/media/workbench-finding-detail-ttp.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-finding-detail-ttp.png)
 - [docs/examples/media/workbench-reports-evidence.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-reports-evidence.png)
 - [docs/examples/example_report.html](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/example_report.html)
+
+Current post-release documentation and security-hygiene status is tracked on `main`:
+
+- [docs/workbench-v1-release-checklist.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/workbench-v1-release-checklist.md)
+- [docs/roadmap.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/roadmap.md)
 
 ## Validation
 
@@ -58,6 +65,7 @@ The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIX
 
 - The existing `analyze`, `compare`, and `explain` JSON contracts remain on `metadata.schema_version = 1.0.0`.
 - The new helper contracts introduced in this release use `1.1.0`.
+- The wheel and sdist include the tag-time README from `v1.1.0`; current `main` contains post-publication README wording updates. A patch release should be cut if package metadata wording itself needs to be republished.
 - Use [docs/releases/v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/v1.0.0.md) for the first stable baseline release notes.
 - Use [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md) for Workbench milestone scope and evidence details. The package tag for this tree must be `v1.1.0` because `pyproject.toml` is versioned `1.1.0`.
 - Public PyPI/TestPyPI publication remains gated until trusted-publisher setup is explicitly enabled in the repository.

--- a/docs/workbench-engineering-roadmap-attack-ttp-v3.md
+++ b/docs/workbench-engineering-roadmap-attack-ttp-v3.md
@@ -6,6 +6,8 @@
 
 > Hinweis: Die V2-Inhalte bleiben enthalten. Die neue V3-Erweiterung beginnt ab Abschnitt 57 und ergänzt Versionen, Epics, konkrete GitHub Issues, Tests, Release-Gates, Definition of Done, Risiko-Register und die ATT&CK/TTP-Umsetzung als Software-Engineering-Plan.
 
+> Historischer Planungsstand: Dieses Dokument bleibt als Entwurfs- und Planungsartefakt erhalten. Verbindlich für den aktuellen Release-Stand sind `docs/roadmap.md`, `docs/workbench-v1-release-checklist.md` und `docs/releases/v1.1.0.md`; der aktuelle Coverage-Gate liegt bei 90%.
+
 ---
 
 # Vuln Prioritizer Workbench — vollständiger Open-Source-App-Masterplan mit MITRE ATT&CK/TTP-Vertiefung
@@ -1239,7 +1241,7 @@ vuln-prioritizer analyze examples/cve-list.txt \
 ### 21.2 Mindestkriterien
 
 - `pytest` grün.
-- Coverage >= 85%.
+- Coverage >= 90%.
 - `ruff check` grün.
 - `ruff format --check` grün.
 - `mypy` grün für Core/API.
@@ -1564,7 +1566,7 @@ Definition of Done:
 ### 24.2 Qualität
 
 - [ ] Tests grün.
-- [ ] Coverage >= 85%.
+- [ ] Coverage >= 90%.
 - [ ] Ruff grün.
 - [ ] Mypy für Core/API grün.
 - [ ] Keine Secrets in Repo.

--- a/docs/workbench-masterplan-attack-ttp-v2.md
+++ b/docs/workbench-masterplan-attack-ttp-v2.md
@@ -5,6 +5,8 @@
 **Ausgangsprojekt:** `vuln-prioritizer` `1.1.0`
 **Ziel:** Aus der bestehenden Python-CLI wird eine vollständige, selbst hostbare Open-Source-Anwendung mit Weboberfläche, API, Datenbank, Import-Wizard, priorisierten Arbeitslisten, MITRE-ATT&CK-/TTP-Kontext, Detection-/Mitigation-Gaps, Evidence-Bundles und managementfähigen Reports.
 
+> Historischer Planungsstand: Dieses Dokument bleibt als Entwurfs- und Planungsartefakt erhalten. Verbindlich für den aktuellen Release-Stand sind `docs/roadmap.md`, `docs/workbench-v1-release-checklist.md` und `docs/releases/v1.1.0.md`; der aktuelle Coverage-Gate liegt bei 90%.
+
 ---
 
 ## 1. Entscheidung in einem Satz
@@ -1229,7 +1231,7 @@ vuln-prioritizer analyze examples/cve-list.txt \
 ### 21.2 Mindestkriterien
 
 - `pytest` grün.
-- Coverage >= 85%.
+- Coverage >= 90%.
 - `ruff check` grün.
 - `ruff format --check` grün.
 - `mypy` grün für Core/API.
@@ -1554,7 +1556,7 @@ Definition of Done:
 ### 24.2 Qualität
 
 - [ ] Tests grün.
-- [ ] Coverage >= 85%.
+- [ ] Coverage >= 90%.
 - [ ] Ruff grün.
 - [ ] Mypy für Core/API grün.
 - [ ] Keine Secrets in Repo.

--- a/docs/workbench-masterplan.md
+++ b/docs/workbench-masterplan.md
@@ -4,6 +4,8 @@
 **Ausgangsprojekt:** `vuln-prioritizer` `1.1.0`
 **Ziel:** Aus der bestehenden Python-CLI wird eine vollständige, selbst hostbare Open-Source-Anwendung mit Weboberfläche, API, Datenbank, Import-Wizard, priorisierten Arbeitslisten, Evidence-Bundles und managementfähigen Reports.
 
+> Historischer Planungsstand: Dieses Dokument bleibt als Entwurfs- und Planungsartefakt erhalten. Verbindlich für den aktuellen Release-Stand sind `docs/roadmap.md`, `docs/workbench-v1-release-checklist.md` und `docs/releases/v1.1.0.md`; der aktuelle Coverage-Gate liegt bei 90%.
+
 ---
 
 ## 1. Entscheidung in einem Satz
@@ -1213,7 +1215,7 @@ vuln-prioritizer analyze examples/cve-list.txt \
 ### 21.2 Mindestkriterien
 
 - `pytest` grün.
-- Coverage >= 85%.
+- Coverage >= 90%.
 - `ruff check` grün.
 - `ruff format --check` grün.
 - `mypy` grün für Core/API.
@@ -1538,7 +1540,7 @@ Definition of Done:
 ### 24.2 Qualität
 
 - [ ] Tests grün.
-- [ ] Coverage >= 85%.
+- [ ] Coverage >= 90%.
 - [ ] Ruff grün.
 - [ ] Mypy für Core/API grün.
 - [ ] Keine Secrets in Repo.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,14 +24,14 @@ nav:
   - Community Setup: community_repository_setup.md
   - Release Operations: release_operations.md
   - Roadmap: roadmap.md
-  - Workbench Planning:
+  - Historical Workbench Planning:
       - v1.0 Release Checklist: workbench-v1-release-checklist.md
       - Offline Demo Runbook: workbench-offline-demo.md
       - ATT&CK Methodology: workbench-attack-methodology.md
       - Threat Model and Readiness: workbench-threat-model.md
-      - MVP Masterplan: workbench-masterplan.md
-      - ATT&CK/TTP Masterplan V2: workbench-masterplan-attack-ttp-v2.md
-      - Engineering Roadmap V3: workbench-engineering-roadmap-attack-ttp-v3.md
+      - Historical MVP Masterplan: workbench-masterplan.md
+      - Historical ATT&CK/TTP Masterplan V2: workbench-masterplan-attack-ttp-v2.md
+      - Historical Engineering Roadmap V3: workbench-engineering-roadmap-attack-ttp-v3.md
   - Examples:
       - Base Report: example_report.md
       - Base Compare: example_compare.md


### PR DESCRIPTION
## Summary
- label old Workbench masterplans as historical in MkDocs and inside each document
- align historical planning coverage thresholds with the current 90% gate
- clarify v1.1.0 release notes so attached package assets, tag-pinned docs, current post-release docs, and tag-time README metadata are not conflated

## Validation
- make docs-check
- make check
- make package-check-temp
- make demo-evidence-bundle-check
- make dependency-audit
- git diff --check

Subagent audits drove this cleanup: planning docs still referenced 85% coverage, and the v1.1.0 release body mixed tag-time links with post-release hygiene wording.