### PR TITLE
docs: harden post-release repository hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Status: v1.1.0](https://img.shields.io/badge/status-v1.1.0-brightgreen)](./CHANGELOG.md)
 [![Quality: local-first](https://img.shields.io/badge/quality-local--first-informational)](#development)
 
-`vuln-prioritizer` is a Python CLI and self-hosted Workbench for prioritizing known CVEs. It accepts plain CVE lists plus scanner and SBOM exports, enriches them with `NVD + EPSS + CISA KEV`, and adds optional ATT&CK, asset-context, VEX, waiver, and evidence layers without turning the priority model into a black box.
+`vuln-prioritizer` is a Python CLI and self-hosted Workbench for prioritizing known CVEs. It accepts plain CVE lists plus existing scanner and SBOM exports, enriches them with `NVD + EPSS + CISA KEV`, and adds optional ATT&CK, asset-context, VEX, waiver, and evidence layers without turning the priority model into a black box.
 
 ![HTML report preview](docs/examples/media/html-report-preview.png)
 
@@ -32,20 +32,20 @@ README media maintenance checklist for future releases:
 - CI-friendly outputs including Markdown summaries, SARIF, GitHub Action support, and policy gates.
 - Explicit support for VEX, asset context, waivers, and reproducible review artifacts.
 - Waiver lifecycle visibility with active, review-due, and expired states instead of silent long-lived exceptions.
-- A Docker/Compose path that makes the current CLI core easy to run and establishes the local Workbench bootstrap contract.
+- A Docker/Compose path that runs the current local Workbench app while keeping the CLI core available in the same image.
 
 ## What It Can Do
 
 Core commands:
 
-- `analyze`: prioritize findings from CVE lists, scanners, or SBOM exports
+- `analyze`: prioritize findings from CVE lists, scanner exports, or SBOM exports
 - `compare`: show how enriched prioritization differs from CVSS-only
 - `explain`: explain a single CVE decision in detail
 - `doctor`: validate local setup, config, cache, files, and optional live source reachability
 - `snapshot create|diff`: capture a run and compare before/after states
 - `state init|import-snapshot|history|waivers|top-services|trends|service-history`: persist snapshots in an optional local SQLite store and inspect history, waiver debt, repeated services, or service trends
 - `rollup`: aggregate saved analysis or snapshots by asset or service
-- `input validate`: locally validate CVE lists, scanner/SBOM exports, asset context, and VEX before enrichment
+- `input validate`: locally validate CVE lists, scanner/SBOM export files, asset context, and VEX before enrichment
 - `attack validate|coverage|navigator-layer`: validate and use local ATT&CK mappings
 - `report html|evidence-bundle|verify-evidence-bundle`: render HTML, build reproducible ZIP evidence packages, or verify bundle integrity
 - `data status|update|verify|export-provider-snapshot`: inspect cache state, maintain local provider data, and export replayable provider snapshots
@@ -132,7 +132,7 @@ Then set `NVD_API_KEY` in `.env` if you want authenticated NVD access.
 
 ### Docker / Compose Workbench
 
-Run the current self-hosted Workbench MVP API and web UI locally:
+Run the current self-hosted Workbench API and web UI locally:
 
 ```bash
 docker compose up --build
@@ -216,14 +216,14 @@ recorded without replacing the previous provider snapshot. GitHub issue export s
 `POST /api/projects/{project_id}/github/issues/export` when `dry_run` is false, a repository is
 provided, and the selected token environment variable is configured.
 
-Current Workbench MVP limitations:
+Current local Workbench limitations:
 
 - The Compose path is local-first and single-node. It is not hardened for internet exposure.
 - The Workbench UI/API currently focuses on CVE lists, `generic-occurrence-csv`, Trivy JSON, and Grype JSON imports. The CLI still supports the broader input matrix documented below.
-- SQLite remains the default Workbench runtime; the Compose Postgres profile is an optional migration smoke path. Background workers, SSO, ticket sync, and multi-workspace tenancy remain out of MVP scope.
+- SQLite remains the default Workbench runtime; the Compose Postgres profile is an optional migration smoke path. Background workers, SSO, ticket sync, and multi-workspace tenancy remain outside the current local-first scope.
 - The project still does not scan systems, patch software, or generate heuristic/AI CVE-to-ATT&CK mappings.
 
-Workbench readiness is tracked in [docs/workbench-threat-model.md](docs/workbench-threat-model.md), and planning lives in [docs/workbench-masterplan.md](docs/workbench-masterplan.md). The roadmap tracks how the current CLI release line is being repositioned as the reusable core for that add-on.
+Current Workbench readiness is tracked in [docs/workbench-threat-model.md](docs/workbench-threat-model.md). The historical implementation plan remains available in [docs/workbench-masterplan.md](docs/workbench-masterplan.md), and [docs/roadmap.md](docs/roadmap.md) tracks the shipped CLI plus local Workbench release line.
 
 ## Quickstart
 
@@ -234,7 +234,7 @@ printf 'CVE-2021-44228\nCVE-2024-3094\n' > cves.txt
 vuln-prioritizer analyze --input cves.txt --format markdown --output report.md
 ```
 
-### 2. Public-Install Analyze from Your Own Scanner Export
+### 2. Public-Install Analyze from Your Own Existing Scan Export
 
 ```bash
 vuln-prioritizer analyze \
@@ -361,7 +361,7 @@ shasum -a 256 \
   build/v1.0-demo-evidence-bundle-verification.json
 ```
 
-Do not record machine-specific absolute paths, `.env` contents, API keys, tokens, cookies, or private scanner exports in public release evidence.
+Do not record machine-specific absolute paths, `.env` contents, API keys, tokens, cookies, or private scan exports in public release evidence.
 
 ## Runtime Config
 
@@ -401,7 +401,7 @@ vuln-prioritizer --no-config analyze --input cves.txt
 
 ## Public Docs
 
-Start here for public CLI usage and the Workbench add-on path:
+Start here for public CLI usage and the local Workbench app path:
 
 - [docs/use_cases.md](docs/use_cases.md)
 - [docs/playbooks.md](docs/playbooks.md)
@@ -413,7 +413,7 @@ Start here for public CLI usage and the Workbench add-on path:
 - [docs/integrations/reporting_and_ci.md](docs/integrations/reporting_and_ci.md)
 - [docs/releases/v1.1.0.md](docs/releases/v1.1.0.md)
 - [docs/roadmap.md](docs/roadmap.md)
-- [docs/workbench-masterplan.md](docs/workbench-masterplan.md)
+- Historical Workbench masterplan: [docs/workbench-masterplan.md](docs/workbench-masterplan.md)
 
 Maintainer / repo-checkout workflows:
 
@@ -423,7 +423,7 @@ Maintainer / repo-checkout workflows:
 
 - Usage questions and workflow help: GitHub Discussions
 - Reproducible bugs and scoped feature requests: GitHub Issues
-- Security reports: private vulnerability reporting when enabled, otherwise [SECURITY.md](SECURITY.md)
+- Security reports: GitHub private vulnerability reporting, with [SECURITY.md](SECURITY.md) as the fallback route
 - Contribution rules and local validation: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Support routing: [SUPPORT.md](SUPPORT.md)
 
@@ -431,13 +431,12 @@ Reference material:
 
 - [docs/roadmap.md](docs/roadmap.md)
 - [docs/reference_cve_prioritizer_gap_analysis.md](docs/reference_cve_prioritizer_gap_analysis.md)
-- [docs/examples/media/workflow-demo.gif](docs/examples/media/workflow-demo.gif)
 
 ## GitHub Action
 
 The repository includes a composite GitHub Action for `analyze`, static report rendering, Workbench-style report artifacts, evidence bundles, and SARIF validation.
 
-Use it after `actions/checkout`, because scanner exports, SBOMs, or other analysis input files live in the consumer repository, not in the action repository.
+Use it after `actions/checkout`, because scan exports, SBOMs, or other analysis input files live in the consumer repository, not in the action repository.
 In `mode: analyze`, `input` and `input-format` accept newline-delimited values so one action step can merge multiple sources. The action also passes through the CLI's waiver, filter, sort, cache, provider replay, and fail-gate flags for deterministic CI runs.
 
 ```yaml
@@ -494,7 +493,7 @@ Pull request readiness:
 
 - State whether the change affects CLI, Workbench, Docker, docs, release, or packaging behavior.
 - Include the local checks you ran. For docs-only changes, `make docs-check` plus targeted CLI help checks is usually enough; broader behavior changes should use `make check` or `make release-check`.
-- Keep public examples aligned with the supported install path, the Workbench MVP limitations above, and the no-scanner/no-heuristic-ATT&CK scope boundary.
+- Keep public examples aligned with the supported install path, the local Workbench limitations above, and the no-scanner/no-heuristic-ATT&CK scope boundary.
 
 ## Project Status
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ If you discover a security issue in this repository, do not open a public bug re
 
 Preferred disclosure path:
 
-1. Use GitHub private vulnerability reporting or a GitHub security advisory draft if that repository feature is enabled.
-2. If private reporting is not available, contact the repository owner privately through the GitHub profile or repository security contact path before any public disclosure.
+1. Use GitHub private vulnerability reporting for this public repository.
+2. If that GitHub flow is temporarily unavailable, contact the repository owner privately through the GitHub profile or repository security contact path before any public disclosure.
 
 Avoid posting proof-of-concept exploit details, weaponized payloads, or sensitive reproduction steps in public issues.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -32,7 +32,7 @@ Before opening an issue, include the exact command, input format, observed outpu
 
 Do not open public issues for security vulnerabilities in the CLI, release workflow, or repository configuration.
 
-Use the private vulnerability reporting flow if it is enabled for the public repository. Otherwise, follow [SECURITY.md](SECURITY.md).
+Use GitHub private vulnerability reporting for this public repository. If that flow is temporarily unavailable, follow [SECURITY.md](SECURITY.md).
 
 ## Scope Reminder
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ The Workbench app is an additive FastAPI/Jinja2 layer over the existing core. `d
 
 Workbench runtime state is controlled by environment variables for database URL, upload directory, report directory, trusted provider snapshot directory, provider cache directory, upload size, NVD API-key environment name, and the local CSRF token. The Docker Compose path uses named volumes for writable runtime state, keeps provider snapshots writable for refresh jobs, and mounts checked-in demo data read-only so startup can seed locked demo snapshots without making fixture data mutable.
 
-The MVP web/API import path is intentionally narrower than the CLI input matrix: CVE lists, `generic-occurrence-csv`, Trivy JSON, and Grype JSON. The CLI remains the broader automation surface for SBOM, XML scanner exports, state snapshots, CI outputs, and advanced report generation.
+The current web/API import path is intentionally narrower than the CLI input matrix: CVE lists, `generic-occurrence-csv`, Trivy JSON, and Grype JSON. The CLI remains the broader automation surface for SBOM, XML scanner exports, state snapshots, CI outputs, and advanced report generation.
 
 The Workbench threat model and readiness checklist are maintained in [workbench-threat-model.md](workbench-threat-model.md). The current architecture assumes a trusted local operator, SQLite default storage, and no public-internet exposure until authentication and shared-deployment hardening are added.
 

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -16,20 +16,19 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - Added read-only temp-copy maintainer targets for demo artifact sync checks and package checks.
 - Started the default pytest coverage gate with `--cov-fail-under=90`.
 - Published JSON schemas for the new `doctor`, `snapshot`, `snapshot diff`, and `rollup` contracts.
-- Refreshed README, docs navigation, and committed screenshots/demo media for public-facing use cases, including clearer command-specific output support.
+- Refreshed README, docs navigation, and committed screenshots/static preview media for public-facing use cases, including clearer command-specific output support.
 - Added the Workbench local app surface for projects, imports, dashboard, findings, vulnerability intelligence, reports, evidence bundles, assets, waivers, and settings.
 - Added advanced ATT&CK Workbench surfaces for detection controls, coverage gaps, defensive Navigator exports, and technique detail pages.
 - Added local automation and integration surfaces: API-token gating, optional PostgreSQL profile, scheduled provider snapshot refresh, GitHub Action report/SARIF workflows, GitHub issue export, and config-as-code settings.
 
 ## Release Assets And Documentation
 
-The GitHub Release assets are the attached `vuln_prioritizer-1.1.0-py3-none-any.whl` and `vuln_prioritizer-1.1.0.tar.gz` distributions. The links below are tag-pinned source and documentation references for the `v1.1.0` package tree as released:
+The GitHub Release assets are the attached `vuln_prioritizer-1.1.0-py3-none-any.whl` and `vuln_prioritizer-1.1.0.tar.gz` distributions plus the `SHA256SUMS` checksum manifest. The links below are tag-pinned source and documentation references for the `v1.1.0` package tree as released:
 
 - [docs/use_cases.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/use_cases.md)
 - [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md)
 - [docs/workbench-v1-release-checklist.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/workbench-v1-release-checklist.md)
 - [docs/examples/media/html-report-preview.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/html-report-preview.png)
-- [docs/examples/media/workflow-demo.gif](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workflow-demo.gif)
 - [docs/examples/media/workbench-dashboard.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-dashboard.png)
 - [docs/examples/media/workbench-findings.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-findings.png)
 - [docs/examples/media/workbench-finding-detail-ttp.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-finding-detail-ttp.png)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ The product remains a CLI and local Workbench for prioritizing known CVEs and im
 ## Current Release Surface
 
 - `v1.1.0` provides `analyze`, `compare`, `explain`, `doctor`, `snapshot create`, `snapshot diff`, `rollup`, `input validate`, `state`, `data`, `db init`, `web serve`, `report html`, `report evidence-bundle`, `report verify-evidence-bundle`, and ATT&CK utility commands.
-- `analyze` and `compare` support scanner/SBOM JSON input formats. Output support is command-specific; `analyze` provides Markdown, JSON, SARIF, table output, direct HTML sidecars, and Markdown summary sidecars for CI-friendly workflows.
+- `analyze` and `compare` support existing scanner/SBOM JSON export formats. Output support is command-specific; `analyze` provides Markdown, JSON, SARIF, table output, direct HTML sidecars, and Markdown summary sidecars for CI-friendly workflows.
 - Waiver files, evidence bundles, and fixture-benchmark regressions extend the operational governance surface without changing the transparent base score.
 - Runtime config discovery via `vuln-prioritizer.yml` is available for the main operational commands.
 - The base JSON export contract remains versioned with `metadata.schema_version = 1.0.0`; new helper surfaces ship as additive `1.1.0` contracts.
@@ -15,15 +15,15 @@ The product remains a CLI and local Workbench for prioritizing known CVEs and im
 - ATT&CK, asset context, and VEX remain explicit contextual layers.
 - The composite GitHub Action mirrors `analyze` policy, waiver, provider/cache, filter, sort, and fail-gate flags as additive inputs.
 - Local quality gates now start enforcing coverage with `--cov-fail-under=90`, and temp-copy package/demo checks are available for read-only validation.
-- Docker and Compose provide a local runtime bootstrap for the Workbench MVP while keeping the CLI core available in the same image.
+- Docker and Compose provide a local runtime bootstrap for the Workbench while keeping the CLI core available in the same image.
 
-## Workbench Add-On Direction
+## Current Workbench App Direction
 
-Status: roadmap slices through Workbench v1.2 are implemented on `main`; the original implementation plan remains documented by [docs/workbench-masterplan.md](./workbench-masterplan.md).
+Status: roadmap slices through Workbench v1.2 are implemented on `main`; the original implementation plan is preserved as a historical planning artifact in [docs/workbench-masterplan.md](./workbench-masterplan.md).
 
-The Workbench turns the existing CLI/core behavior into a local-first, self-hosted vulnerability prioritization application. The CLI remains supported for automation and CI; the Workbench adds API, database-backed imports, a browser UI, team-oriented worklists, and report workflows around the same transparent prioritization model.
+The current Workbench exposes the existing CLI/core behavior as a local-first, self-hosted vulnerability prioritization application. The CLI remains supported for automation and CI; the Workbench adds API, database-backed imports, a browser UI, team-oriented worklists, and report workflows around the same transparent prioritization model.
 
-Workbench scope:
+Current Workbench scope:
 
 - Docker Compose quickstart as the local web/API runtime entry point.
 - SQLite-first deployment with provider cache, upload, and report directories mounted locally.
@@ -35,10 +35,10 @@ Workbench scope:
 
 The current `docker compose up --build` service runs the Workbench web application on `127.0.0.1:8000`; the CLI remains available through the installed `vuln-prioritizer` command.
 
-Current MVP limits:
+Current local Workbench limits:
 
 - Local-first single-node runtime, not a hardened public internet deployment.
-- SQLite remains the default. The optional PostgreSQL profile is a migration smoke path, and local API tokens are an automation control rather than a full public-internet auth model. Background workers, queues, SSO, ticket sync, and multi-workspace support remain out of MVP scope.
+- SQLite remains the default. The optional PostgreSQL profile is a migration smoke path, and local API tokens are an automation control rather than a full public-internet auth model. Background workers, queues, SSO, ticket sync, and multi-workspace support remain outside the current local-first scope.
 - Web/API import path currently targets CVE lists, `generic-occurrence-csv`, Trivy JSON, and Grype JSON. The CLI remains the broader automation surface.
 - No vulnerability scanning, AI autopatching, or heuristic/AI CVE-to-ATT&CK mapping.
 
@@ -105,7 +105,7 @@ Status: implemented; release workflow is wired for tagged GitHub Releases and ga
 
 - Stable CLI and JSON contracts.
 - Documented and tested `pipx` installation.
-- Stable scanner/SBOM inputs, Asset Context, VEX, and GitHub integration.
+- Stable scanner/SBOM export inputs, Asset Context, VEX, and GitHub integration.
 - Local MkDocs-based documentation site for a browsable public doc surface.
 
 ### `v1.1.0` Operability and Public Polish
@@ -120,12 +120,12 @@ Status: published as `v1.1.0`; current `main` contains post-release documentatio
 
 ## CLI Release-Line Non-Goals Through `v1.1.0`
 
-- Database-backed service in the CLI-only release line; the Workbench branch adds this as an explicit app-layer surface.
+- Database-backed service in the historical CLI-only release line; the current Workbench app exposes this as an explicit app-layer surface.
 - ServiceNow or Jira integration
 - Mandatory live TAXII integration
 - Heuristic or ML-based CVE-to-ATT&CK mapping
 
-## Deliberate Non-Goals For The Workbench MVP
+## Deliberate Non-Goals For The Current Local Workbench
 
 - Vulnerability scanning
 - SIEM replacement

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -4,13 +4,13 @@ This page focuses on concrete operational workflows that the current CLI surface
 
 If you want the shortest operator-facing runbooks instead of the product-story view, start with [Operator Playbooks](playbooks.md).
 
-All CLI examples below are repo-checkout examples that intentionally use the checked-in fixtures under `data/`. The commands themselves are part of the public CLI surface, but after `pipx install` alone you must replace those fixture paths with your own scanner exports, SBOMs, VEX files, asset-context CSVs, and ATT&CK mapping files.
+All CLI examples below are repo-checkout examples that intentionally use the checked-in fixtures under `data/`. The commands themselves are part of the public CLI surface, but after `pipx install` alone you must replace those fixture paths with your own existing scan exports, SBOMs, VEX files, asset-context CSVs, and ATT&CK mapping files.
 
 ## 1. Trivy + VEX + GitHub Summary
 
 Goal:
 
-- turn a container-security scan into a CI-friendly prioritized summary
+- turn an existing container-security scan export into a CI-friendly prioritized summary
 - suppress matching `not_affected` VEX cases
 - keep a JSON artifact plus a short Markdown summary for the GitHub run
 
@@ -59,7 +59,7 @@ Why it matters:
 
 Goal:
 
-- move from a flat infrastructure scan to service-aware prioritization
+- move from an existing infrastructure scan export to service-aware prioritization
 - attach mapped assets and business services
 - add optional ATT&CK context and later aggregate by asset or service
 
@@ -129,7 +129,6 @@ Why it matters:
 
 ## Media
 
-Committed preview assets live here:
+Current static preview assets live here:
 
 - [HTML report preview](examples/media/html-report-preview.png)
-- [Workflow demo GIF](examples/media/workflow-demo.gif)

--- a/docs/workbench-attack-methodology.md
+++ b/docs/workbench-attack-methodology.md
@@ -1,21 +1,21 @@
 # Workbench ATT&CK Methodology
 
-This page defines the methodology contract for the Workbench ATT&CK milestones. It complements the CLI ATT&CK methodology by describing how the Workbench should expose ATT&CK context through API, UI, reports, and evidence artifacts.
+Current state: this page describes the local Workbench ATT&CK contract reviewed on 2026-04-25. It is not an unshipped milestone plan. It complements the CLI ATT&CK methodology by documenting the implemented API, UI/report, and evidence behavior.
 
 ## Source Contract
 
 Workbench ATT&CK context uses CTID Mappings Explorer JSON as the canonical source for CVE-to-ATT&CK mappings.
 
 - CTID JSON is the only canonical source for Workbench CVE-to-ATT&CK mapping decisions.
-- Local CSV mapping remains legacy CLI compatibility and is not the Workbench v0.6 source of record.
-- Imported technique metadata may enrich names, tactics, URLs, STIX spec/version metadata, and deprecation state, but it must not create new CVE mappings.
-- Pinned ATT&CK STIX bundles are supported as technique metadata snapshots only; they are not CVE-to-technique mapping sources.
-- Each Workbench run should record ATT&CK source provenance: source kind, source path or identifier, checksum, import timestamp, and mapping counts.
-- Missing CTID data should leave findings unmapped or ATT&CK-unavailable. It must not block base CVE prioritization.
+- Local CSV mapping remains legacy CLI compatibility and is not the Workbench source of record.
+- Imported technique metadata enriches names, tactics, URLs, STIX spec/version metadata, and deprecation state; it does not create new CVE mappings.
+- Pinned ATT&CK STIX bundles are technique metadata snapshots only. They are not CVE-to-technique mapping sources.
+- CTID-enabled imports record source provenance in run and finding context: source kind, source path, source checksum, ATT&CK version/domain metadata when available, and mapped-CVE counts.
+- CVEs absent from the selected CTID source are stored as unmapped. Enabling `ctid-json` without the required mapping file fails import validation instead of falling back to inferred mappings.
 
 ## No Generated Mapping
 
-Workbench ATT&CK enrichment must be evidence-based and deterministic.
+Workbench ATT&CK enrichment is evidence-based and deterministic.
 
 - Do not infer CVE-to-technique links from CVE descriptions, CWE IDs, vendor names, product names, KEV titles, exploit text, or EPSS rank.
 - Do not use LLM-generated mappings.
@@ -23,62 +23,61 @@ Workbench ATT&CK enrichment must be evidence-based and deterministic.
 - Do not silently promote analyst notes into canonical ATT&CK mappings.
 - If a CVE is absent from the CTID JSON source, report it as unmapped.
 
-Analyst annotations may be supported later, but they must be stored and displayed separately from CTID mappings.
+Analyst annotations are outside the current Workbench contract. If added later, they need separate storage and display from CTID mappings.
 
 ## Priority Boundary
 
 ATT&CK is a contextual threat-rank and reporting layer. It is not part of the base priority model.
 
-The base priority remains transparent and rule-based from CVSS, EPSS, and CISA KEV. ATT&CK context can help explain exposure paths, likely attacker objectives, dashboard grouping, and management reporting, but it must not silently change `priority`, `priority_rank`, or the published base priority rationale.
+The base priority remains transparent and rule-based from CVSS, EPSS, and CISA KEV. ATT&CK context can explain exposure paths, likely attacker objectives, dashboard grouping, and management reporting, but it does not silently change `priority`, `priority_rank`, or the published base priority rationale.
 
-Workbench may expose a separate deterministic ATT&CK label such as `attack_threat_rank` or `attack_relevance`. That label should be derived only from imported CTID mapping type, tactic, technique metadata, and documented local rules. Reports and UI must make clear that this is context for triage discussions, not the base remediation priority.
+The Workbench exposes ATT&CK context separately through fields such as `attack_mapped`, `attack_relevance`, and `threat_context_rank`, plus full finding TTP context. These values are derived from imported CTID mapping type, tactic, technique metadata, and documented local rules. Reports and UI present them as triage context, not as the base remediation priority.
 
-## Expected API Surface
+## Current API Surface
 
-The v0.6 Workbench API should preserve existing project, import, finding, report, and evidence endpoints while adding ATT&CK context in stable response fields.
+The current Workbench API preserves project, import, finding, report, and evidence endpoints while adding ATT&CK context through stable response fields and dedicated ATT&CK endpoints.
 
-Expected API behavior:
+- `POST /api/projects/{project_id}/imports` accepts `attack_source=ctid-json`, `attack_mapping_file`, and `attack_technique_metadata_file` values rooted in the configured ATT&CK artifact directory.
+- `GET /api/analysis-runs/{run_id}` and `GET /api/runs/{run_id}/summary` include ATT&CK summary fields such as `attack_enabled`, `attack_mapped_cves`, `attack_source`, `attack_version`, `attack_domain`, `attack_mapping_file_sha256`, `attack_technique_metadata_file_sha256`, `attack_metadata_format`, and `attack_stix_spec_version`.
+- `GET /api/projects/{project_id}/findings` includes per-finding `attack_mapped` and `threat_context_rank` while keeping base priority fields separate.
+- `GET /api/findings/{finding_id}` returns the base finding detail and the same high-level ATT&CK flags. Full CTID-backed TTP context lives at `GET /api/findings/{finding_id}/ttps`.
+- `GET /api/findings/{finding_id}/ttps` returns source provenance, source and metadata hashes, ATT&CK version/domain, `attack_relevance`, `threat_context_rank`, review status, tactics, techniques, and mapping payloads for the finding.
+- `GET /api/projects/{project_id}/attack/top-techniques` returns project-level technique rollups from persisted finding ATT&CK context.
+- `GET /api/analysis-runs/{run_id}/attack/navigator-layer` returns a Navigator layer from CTID-backed mapped techniques for the run.
+- `POST /api/projects/{project_id}/detection-controls/import` and `GET /api/projects/{project_id}/detection-controls` manage defensive detection-control coverage records.
+- `GET /api/projects/{project_id}/attack/coverage-gaps`, `GET /api/projects/{project_id}/attack/coverage-gap-navigator-layer`, and `GET /api/projects/{project_id}/attack/techniques/{technique_id}` expose coverage gaps and technique detail without describing offensive procedures.
+- Report and evidence endpoints preserve ATT&CK context in generated artifacts without weakening download path and checksum validation.
 
-- `POST /api/projects/{project_id}/imports` records the ATT&CK source used for the run when CTID JSON is configured or supplied.
-- `GET /api/analysis-runs/{run_id}` and `GET /api/runs/{run_id}/summary` include `attack_summary` with mapped and unmapped counts, top tactics, top techniques, source provenance, and warnings.
-- `GET /api/projects/{project_id}/findings` includes ATT&CK summary fields per finding, such as `attack_mapped`, `attack_threat_rank`, tactic count, technique count, and source kind.
-- Finding list filters may include `attack_mapped`, `attack_tactic`, `attack_technique`, and `attack_threat_rank`.
-- `GET /api/findings/{finding_id}` includes full CTID-backed mappings, mapping types, tactics, techniques, URLs, source checksum, and unmapped state.
-- `GET /api/findings/{finding_id}/explain` explains ATT&CK context separately from the base priority rationale.
-- `GET /api/providers/status` or an equivalent status endpoint shows CTID availability, checksum, source age, and warnings without treating ATT&CK as a live provider requirement.
-- Report and evidence endpoints preserve ATT&CK context in generated artifacts without changing download integrity checks.
+## Current UI and Report Surface
 
-If a dedicated Navigator export endpoint is added, it should generate an ATT&CK Navigator layer from CTID-backed mapped techniques only.
+The Workbench UI makes ATT&CK useful for triage without presenting it as a hidden score.
 
-## Expected UI Surface
+- Import flows accept local CTID mapping and technique metadata artifacts when ATT&CK context is enabled.
+- Dashboard and findings views surface mapped ATT&CK context separately from the base priority column.
+- Finding detail and TTP views show CTID mapping evidence, tactics, techniques, mapping type, source checksum, metadata checksum, and explicit unmapped states.
+- "Why this priority?" remains separate from ATT&CK context so users can see that CVSS, EPSS, and KEV still drive the base priority.
+- Detection-control and coverage-gap views describe defensive coverage status and recommended defensive follow-up.
+- Reports and generated artifacts include ATT&CK context only as optional, provenance-backed context.
 
-Workbench UI should make ATT&CK useful for triage without making it look like a hidden score.
+## Current Evidence Artifacts
 
-- Dashboard: show mapped and unmapped counts, top tactics, top techniques, and KEV findings with ATT&CK context.
-- Findings table: show concise ATT&CK badges and filters, but keep the base priority column visually distinct.
-- Finding detail: show CTID mapping evidence, tactics, techniques, mapping type, technique URL, source checksum, and an explicit unmapped state.
-- Explain view: separate "Why this priority?" from "ATT&CK context" so users can see that CVSS, EPSS, and KEV still drive the base priority.
-- Provider or settings view: show configured CTID JSON source, last loaded timestamp, checksum, and validation warnings.
-- Reports page: offer ATT&CK-aware JSON, Markdown, HTML, evidence bundle, and optional Navigator layer artifacts.
+Evidence artifacts make ATT&CK provenance auditable.
 
-## Expected Evidence Artifacts
+- `analysis.json`: per-finding ATT&CK fields, CTID-backed mappings, source provenance, ATT&CK metadata, and unmapped state.
+- Generated Markdown/HTML/JSON/CSV/SARIF reports: ATT&CK context remains separate from base priority and uses defensive wording.
+- `attack-navigator-layer.json`: optional Navigator layer containing CTID-backed mapped techniques for the run.
+- Coverage-gap Navigator output: optional defensive layer for techniques with partial, missing, or unknown detection coverage.
+- `evidence-bundle.zip`: analysis JSON, generated reports, manifest with SHA256 hashes, ATT&CK source provenance, and any Navigator layer generated for the run.
+- Manifest entries checksum every generated artifact, including optional ATT&CK Navigator output.
 
-Evidence artifacts should make ATT&CK provenance auditable.
+The bundle does not claim ATT&CK coverage for unmapped CVEs. Unmapped findings remain useful evidence because they document that no CTID mapping was available for the selected source.
 
-- `analysis.json`: per-finding ATT&CK fields, full CTID-backed mappings, source provenance, `attack_summary`, and unmapped state.
-- `summary.md` and `executive-report.html`: mapped and unmapped counts, top tactics and techniques, source provenance, warnings, and clear wording that ATT&CK is contextual.
-- `attack-navigator-layer.json`: optional Navigator layer containing only CTID-backed mapped techniques.
-- `evidence-bundle.zip`: analysis JSON, generated reports, manifest with SHA256 hashes, ATT&CK source provenance, warnings, and any Navigator layer generated for the run.
-- Manifest entries: checksum every generated artifact and identify the CTID source checksum used for ATT&CK context.
+## Current Acceptance Checks
 
-The bundle must not claim ATT&CK coverage for unmapped CVEs. Unmapped findings remain useful evidence because they document that no CTID mapping was available for the selected source.
-
-## Acceptance Checks
-
-For the v0.6 milestone, documentation and implementation should be reviewed against these checks:
+The current Workbench ATT&CK contract is aligned when:
 
 - CTID JSON is documented as the Workbench canonical source.
 - Heuristic, fuzzy, and LLM-generated mappings are explicitly out of scope.
-- ATT&CK fields are separate from base priority fields.
+- ATT&CK fields stay separate from base priority fields.
 - API, UI, and artifact wording does not imply that ATT&CK changes the base score.
 - Evidence artifacts include enough source provenance to reproduce the ATT&CK context for a run.

--- a/docs/workbench-engineering-roadmap-attack-ttp-v3.md
+++ b/docs/workbench-engineering-roadmap-attack-ttp-v3.md
@@ -6,7 +6,7 @@
 
 > Hinweis: Die V2-Inhalte bleiben enthalten. Die neue V3-Erweiterung beginnt ab Abschnitt 57 und ergänzt Versionen, Epics, konkrete GitHub Issues, Tests, Release-Gates, Definition of Done, Risiko-Register und die ATT&CK/TTP-Umsetzung als Software-Engineering-Plan.
 
-> Historischer Planungsstand: Dieses Dokument bleibt als Entwurfs- und Planungsartefakt erhalten. Verbindlich für den aktuellen Release-Stand sind `docs/roadmap.md`, `docs/workbench-v1-release-checklist.md` und `docs/releases/v1.1.0.md`; der aktuelle Coverage-Gate liegt bei 90%.
+> Historischer Planungsstand: Dieses Dokument bleibt als Entwurfs- und Planungsartefakt erhalten. Es ist kein aktueller Backlog, keine aktuelle Release-Checkliste und keine Quelle für heutige Coverage-Gates. Verbindlich für den aktuellen Release-Stand sind `docs/roadmap.md`, `docs/workbench-threat-model.md`, `docs/workbench-v1-release-checklist.md` und `docs/releases/v1.1.0.md`; der aktuelle lokale Coverage-Gate liegt bei `--cov-fail-under=90`. Alle darunterliegenden alten Ziele unter 90% und alle nicht abgehakten Backlog-Punkte sind historischer Kontext.
 
 ---
 
@@ -3071,6 +3071,8 @@ Supported outputs:
 
 ## 51. GitHub-Backlog als konkrete Issues
 
+> Archivhinweis: Die folgenden Issue-Entwürfe sind ein historischer Planungsbacklog. Sie sind nicht der aktuelle öffentliche Projektbacklog; aktuelle shipped/local-first Workbench-Scope-Informationen stehen in `docs/roadmap.md` und `docs/releases/v1.1.0.md`.
+
 ### Epic 1 — ATT&CK-Lite
 
 ```text
@@ -4132,8 +4134,8 @@ Das Projekt wird releasefähig.
 - [ ] Parser Robustness Tests.
 - [ ] Performance Import 10.000 Findings.
 - [ ] E2E Demo Test.
-- [ ] Coverage Core >= 85%.
-- [ ] Coverage Services >= 75%.
+- [ ] Coverage Core >= 85% (historisches Teilziel; aktueller Gate ist 90% repo-weit).
+- [ ] Coverage Services >= 75% (historisches Teilziel; aktueller Gate ist 90% repo-weit).
 - [ ] Dependency Audit ohne kritische Findings oder mit dokumentierter Ausnahme.
 - [ ] CodeQL ohne kritische Findings.
 
@@ -4198,6 +4200,8 @@ Erster stabiler Open-Source-Release.
 ---
 
 ## 61. Epic-Backlog
+
+> Archivhinweis: Dieser Epic-Backlog ist eine historische Umsetzungsplanung. Nicht abgehakte Punkte in diesem Abschnitt sind nicht automatisch offene Arbeit auf `main`.
 
 ## 61.1 Epic E01 — Repo Governance und Open-Source-Reife
 
@@ -4871,7 +4875,7 @@ Diese Liste kann direkt in GitHub Issues übertragen werden.
 73. `[E13] Harden file upload handling`
 74. `[E13] Add safe report rendering tests`
 75. `[E14] Add performance test with 10k findings`
-76. `[E14] Raise core coverage gate to 85 percent`
+76. `[E14] Raise core coverage gate to 85 percent` (historical target; superseded by the current 90% repo-wide gate)
 77. `[E15] Complete Quickstart and Demo docs`
 78. `[E15] Complete scoring and ATT&CK methodology docs`
 79. `[E13] Run dependency audit and document exceptions`
@@ -4936,7 +4940,9 @@ Static Checks: Ruff, Mypy, Security, Schema, Docs
 | Performance Tests | Nutzbarkeit prüfen | 10.000 Findings Import |
 | Docs Tests | Beispiele und Links prüfen | MkDocs Build, Link Check |
 
-### 63.3 Coverage-Ziele
+### 63.3 Historische Coverage-Ziele
+
+> Aktueller Gate: Der heutige lokale Qualitätsgate liegt repo-weit bei `--cov-fail-under=90`. Die niedrigeren bereichsbezogenen Ziele in der Tabelle sind als historischer Planungsstand erhalten und dürfen nicht als aktuelle Ausnahme vom 90%-Gate gelesen werden.
 
 | Bereich | Mindestziel |
 |---|---:|

--- a/docs/workbench-threat-model.md
+++ b/docs/workbench-threat-model.md
@@ -1,15 +1,15 @@
-# Workbench Threat Model and Readiness Draft
+# Workbench Threat Model and Readiness
 
-Status: docs-only draft for the v1.2 Workbench readiness milestone.
+Status: current local-first Workbench threat model. Last reviewed: 2026-04-25.
 
 This page defines the defensive threat model and operational readiness assumptions for the local Workbench. It keeps the same product boundaries as the rest of the project: `vuln-prioritizer` prioritizes known CVEs and existing findings. It is not a scanner, exploit tool, proof-of-concept generator, or general-purpose vulnerability-management platform.
 
 ## Scope
 
-The v1.2 Workbench threat model covers:
+The current local-first Workbench threat model covers:
 
 - local CLI use and the self-hosted FastAPI/Jinja2 Workbench
-- import of existing CVE lists and selected scanner exports
+- import of existing CVE lists and selected scanner export files
 - provider enrichment from NVD, FIRST EPSS, CISA KEV, local caches, and locked provider snapshots
 - optional ATT&CK context from local CTID Mappings Explorer JSON and local technique metadata
 - SQLite-backed single-node Workbench state by default
@@ -17,7 +17,7 @@ The v1.2 Workbench threat model covers:
 - local-first API token bootstrap for mutating `/api/*` routes
 - generated JSON, Markdown, HTML, CSV, SARIF, and evidence bundle artifacts
 
-The v1.2 Workbench threat model does not cover:
+The current local-first Workbench threat model does not cover:
 
 - active network, host, container, cloud, or source-code scanning
 - exploitation, payload generation, exploit verification, or PoC handling
@@ -30,7 +30,7 @@ The v1.2 Workbench threat model does not cover:
 | Asset | Security objective | Notes |
 | --- | --- | --- |
 | Imported finding files | Confidentiality, integrity, provenance | Inputs may contain hostnames, package paths, image names, service names, owners, or environment labels. |
-| Normalized findings and run records | Integrity, reproducibility | The Workbench should preserve source provenance and not silently rewrite evidence. |
+| Normalized findings and run records | Integrity, reproducibility | The Workbench preserves source provenance and does not silently rewrite evidence. |
 | Provider enrichment data | Integrity, freshness transparency | NVD, EPSS, KEV, local cache, and locked snapshot data must remain distinguishable in outputs. |
 | ATT&CK mapping data | Integrity, source provenance | `ctid-json` is canonical for Workbench ATT&CK mappings. Technique metadata may enrich labels but must not create mappings. |
 | Asset context, VEX, and waivers | Integrity, auditability | These records influence explanation, applicability, or suppression and need explicit rationale. |
@@ -90,7 +90,7 @@ Primary boundaries:
 ## Operational Assumptions
 
 - The operator runs the Workbench on a trusted workstation, local VM, CI runner, or private single-node host.
-- The default database is SQLite. The optional Postgres Compose profile is for private single-node smoke testing or operator-managed deployments; clustered deployments, background workers, and multi-tenant state separation are not part of this draft.
+- The default database is SQLite. The optional Postgres Compose profile is for private single-node smoke testing or operator-managed deployments; clustered deployments, background workers, and multi-tenant state separation are not part of the current local-first scope.
 - The Workbench is not exposed directly to the public internet.
 - The operator controls local filesystem permissions for the SQLite database, uploads, reports, provider cache, and evidence bundles. For Postgres, the operator controls credentials, database network reachability, volumes, backups, and retention.
 - Imported files are treated as sensitive security data and are not committed unless they are sanitized fixtures.
@@ -102,7 +102,7 @@ Primary boundaries:
 
 ## Readiness Checklist
 
-The v1.2 Workbench is readiness-aligned when:
+The current local-first Workbench is readiness-aligned when:
 
 - scope text in README, architecture docs, and Workbench docs consistently says known-CVE prioritizer, not scanner
 - Workbench runtime docs identify SQLite as the default single-node persistence model and the Postgres profile as optional/private

--- a/tests/db/test_workbench_db.py
+++ b/tests/db/test_workbench_db.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
-pytest.importorskip("sqlalchemy")
-
 from sqlalchemy import inspect, select
 
 from vuln_prioritizer.db import (

--- a/tests/services/test_workbench_governance.py
+++ b/tests/services/test_workbench_governance.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
-pytest.importorskip("sqlalchemy")
-
 from vuln_prioritizer.db.models import Asset, Finding
 from vuln_prioritizer.services.workbench_governance import (
     build_governance_summary,


### PR DESCRIPTION
## Summary
- align active Workbench docs with the shipped local-first app wording and mark historical roadmap artifacts more clearly
- document current private vulnerability reporting, release checksum asset, and ATT&CK methodology/threat-model contracts
- make SQLAlchemy-backed tests fail fast if the required runtime dependency is missing

## Validation
- make docs-check
- python3 -m pytest -q tests/db/test_workbench_db.py tests/services/test_workbench_governance.py --no-cov
- make release-check

## Repo settings updated outside this PR
- enabled GitHub private vulnerability reporting
- enabled Discussions and disabled Wiki
- narrowed selected third-party action refs
- uploaded v1.1.0 SHA256SUMS release asset