### PR TITLE
[codex] Update VPW governance docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,12 @@ Thanks for contributing to `vuln-prioritizer`.
 - Prefer official/public sources only: NVD, FIRST EPSS, CISA KEV.
 - Do not add heuristic or LLM-generated CVE-to-ATT&CK mappings.
 - Keep ATT&CK optional and offline-file-based unless the project scope changes explicitly.
+- Do not add exploit execution, PoC generation, credential testing, active
+  probing, attack simulation, autopatching, offensive attack-chain
+  instructions, or hidden live data collection.
+- Keep the Workbench local-first unless a change explicitly updates the threat
+  model, deployment docs, audit/retention story, backup/restore expectations,
+  and token/role boundaries.
 
 ## Local Development
 
@@ -48,6 +54,61 @@ This adds:
 - `python3 -m mkdocs build --clean`
 - `python3 -m build backend --outdir dist`
 - `python3 -m twine check dist/*`
+
+## Branching And Pull Requests
+
+- Use focused branches, normally under `codex/` for Codex-authored work.
+- Prefer one roadmap issue per PR unless the dependency group is documented in
+  the PR body.
+- For the Full Stack FastAPI Template migration, keep stacked branches explicit
+  and state the base branch in the PR. Do not claim old Jinja2/SQLAlchemy
+  Workbench behavior as completion evidence for React/JWT/SQLModel/template
+  issues.
+- Open draft PRs while evidence is still being collected.
+- Keep direct pushes to `main` for emergencies only.
+
+Pull request checklist:
+
+- State the issue or roadmap ID, scope, and intended disposition.
+- List changed surfaces: CLI, backend API, DB/migrations, frontend, Docker,
+  docs, release, packaging, or security.
+- Paste commands run and their results.
+- Include evidence paths, screenshots, traces, API responses, migration output,
+  or generated-client drift checks when relevant.
+- Call out residual risk and follow-up issues.
+- Avoid closing strict-DoD issues until the PR has landed and the issue has
+  fresh evidence.
+
+## Codex Working Rules
+
+Codex-authored changes should follow the repository roadmap issue scope:
+
+- Read the issue body and its Definition of Done before editing.
+- Use the current codebase as evidence, not as an assumption that a duplicate
+  roadmap item is complete.
+- Do not revert unrelated user or maintainer changes.
+- Do not use secrets, customer scanner data, or live-provider-only behavior as
+  required CI evidence.
+- Keep generated files in the same PR as the source change that produces them.
+- For API changes, regenerate and check the OpenAPI client.
+- For DB changes, add or update migrations and include migration/test evidence.
+- For UI changes, include browser or Playwright evidence.
+- For security-sensitive changes, state the boundary checked and the remaining
+  deployment risk.
+
+## Security Checklist
+
+Before opening or merging a change, verify that it does not:
+
+- add scanner, exploit, PoC, active probing, credential testing, attack
+  simulation, autopatching, or heuristic ATT&CK mapping behavior
+- expose tokens, API keys, cookies, private exports, or absolute local paths in
+  logs, reports, screenshots, or documentation
+- weaken upload limits, safe XML/file parsing, rooted artifact paths, security
+  headers, CSRF-sensitive forms, token hashing, or authorization gates
+- imply public-internet readiness without updating the threat model and
+  deployment hardening docs
+- silently replace deterministic fixture tests with live-network tests
 
 ## Demo Artifacts
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ README media maintenance checklist for future releases:
 - Show secret-bearing settings only in their redacted `<set>` or `<not set>` state.
 - Commit generated screenshot replacements only as part of a release evidence or docs refresh change.
 
+## Problem And Goal
+
+Security teams often start with a long list of CVEs from scanners, SBOM tools,
+advisory exports, or issue trackers. Raw CVSS scores alone do not explain what
+should be fixed first, which systems are exposed, which findings are already
+covered by VEX/waivers, or which decisions need evidence.
+
+`vuln-prioritizer` turns existing CVE evidence into an explainable
+risk-to-decision workflow:
+
+```text
+existing findings or SBOM exports
+  -> normalized CVE occurrences
+  -> CVSS, EPSS, KEV, optional ATT&CK, asset, VEX, waiver, and provider context
+  -> transparent priority and rationale
+  -> reports, CI gates, evidence bundles, and Workbench decision queues
+```
+
+The goal is not to discover vulnerabilities. The goal is to help operators make
+defensible decisions from vulnerability evidence they already have.
+
 ## Why Use It
 
 - Transparent, rule-based prioritization instead of opaque scoring.
@@ -32,7 +53,8 @@ README media maintenance checklist for future releases:
 - CI-friendly outputs including Markdown summaries, SARIF, GitHub Action support, and policy gates.
 - Explicit support for local defensive context, VEX, asset context, waivers, and reproducible review artifacts.
 - Waiver lifecycle visibility with active, review-due, and expired states instead of silent long-lived exceptions.
-- A Docker/Compose path that runs the current local Workbench app while keeping the CLI core available in the same image.
+- A Docker/Compose path that runs the current template-aligned Workbench shell
+  while keeping the CLI core available in the same image.
 
 ## What It Can Do
 
@@ -89,11 +111,18 @@ This project is:
 This project is not:
 
 - a scanner
+- an exploit framework, PoC generator, or active probing tool
 - a SIEM
 - a ticketing system
+- an autopatcher or autonomous remediation agent
 - a replacement for heavier vulnerability-management platforms
 - a live TAXII harvester
 - a heuristic or LLM-based ATT&CK mapper
+
+It does not perform credential testing, network scanning, exploitation,
+payload generation, attack simulation, or heuristic CVE-to-ATT&CK mapping.
+ATT&CK support is defensive and evidence-based: use reviewed local mappings and
+technique metadata only.
 
 ## Installation
 
@@ -210,11 +239,15 @@ For locked Workbench replay, submit only the snapshot filename, for example
 `demo_provider_snapshot.json`. The app resolves it from
 `VULN_PRIORITIZER_PROVIDER_SNAPSHOT_DIR` or the provider cache and rejects arbitrary paths.
 
-Workbench API token behavior is intentionally local-first. A fresh local database has no active
+Legacy Workbench API token behavior is intentionally local-first. A fresh local database has no active
 tokens, so mutating `/api/*` requests remain open for the offline demo. Create the first token with
 `POST /api/tokens`; after any active token exists, `POST`, `PUT`, `PATCH`, and `DELETE` requests under
 `/api/` require `Authorization: Bearer <token>` or `X-API-Token: <token>`. Only SHA-256 token hashes
 are stored.
+
+The template-aligned Workbench shell currently has a configured-superuser JWT
+login smoke path. DB-backed template users, RBAC, and final project membership
+rules are separate migration work.
 
 Workbench project settings can be saved as config-as-code through
 `POST /api/projects/{project_id}/settings/config`. The payload uses the same
@@ -234,8 +267,26 @@ Current local Workbench limitations:
 - The Workbench UI/API supports the same input-format matrix as the CLI for local single-file and multi-file imports.
 - SQLite remains the default Workbench runtime; the Compose Postgres profile is an optional migration smoke path. The Workbench records durable job state for local imports, provider refreshes, reports, and evidence bundles, but a separate async worker process, SSO, organization-wide ticket sync policy, and multi-workspace tenancy remain outside the current local-first scope.
 - The project still does not scan systems, patch software, or generate heuristic/AI CVE-to-ATT&CK mappings.
+- Do not expose the local Workbench on the public internet without a separate hardening review covering TLS/proxying, backup/restore, audit retention, role design, token handling, and the threat model.
 
 Current Workbench readiness and shared-deployment prerequisites are tracked in [docs/workbench-threat-model.md](docs/workbench-threat-model.md). The historical implementation plan remains available in [docs/workbench-masterplan.md](docs/workbench-masterplan.md), and [docs/roadmap.md](docs/roadmap.md) tracks the shipped CLI plus local Workbench release line.
+
+## Demo
+
+For a local browser demo, use the checked-in offline runbook:
+[docs/workbench-offline-demo.md](docs/workbench-offline-demo.md). It uses
+repository fixtures and locked provider replay so screenshots and evidence can
+be reproduced without customer data or live-only provider behavior.
+
+For a template-migration smoke demo, run:
+
+```bash
+make docker-demo-smoke
+```
+
+That command starts the template backend and React shell, verifies
+`/api/v1/workbench/status`, checks the frontend and login route, then tears down
+the stack.
 
 ## Quickstart
 
@@ -291,6 +342,11 @@ vuln-prioritizer report verify-evidence-bundle \
 ```
 
 ### 5. ATT&CK-Aware Analyze with Your Own Local Mapping Files
+
+ATT&CK/TTP context in this project is defensive context for risk explanation,
+detection coverage, mitigation discussion, and prioritization. It is not
+exploit proof, attack-chain guidance, or evidence that a CVE is actively being
+used against your environment.
 
 ```bash
 vuln-prioritizer analyze \
@@ -438,6 +494,7 @@ Start here for public CLI usage and the local Workbench app path:
 - [docs/integrations/reporting_and_ci.md](docs/integrations/reporting_and_ci.md)
 - [docs/releases/v1.1.0.md](docs/releases/v1.1.0.md)
 - [docs/roadmap.md](docs/roadmap.md)
+- [ROADMAP.md](ROADMAP.md)
 - Historical Workbench masterplan: [docs/workbench-masterplan.md](docs/workbench-masterplan.md)
 
 Maintainer / repo-checkout workflows:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,64 @@
+# Vuln Prioritizer Workbench Roadmap
+
+This top-level roadmap summarizes the current delivery direction. Detailed
+release-line history remains in [docs/roadmap.md](docs/roadmap.md). The active
+template-first execution plan is tracked in
+[docs/vpw_template_execution_sequence.md](docs/vpw_template_execution_sequence.md)
+and [docs/full_stack_fastapi_template_migration.md](docs/full_stack_fastapi_template_migration.md).
+
+## Product Direction
+
+`vuln-prioritizer` is a CLI and local Workbench for prioritizing known CVEs from
+existing findings, scanner exports, SBOM exports, and advisory data. It enriches
+those inputs with transparent CVSS, EPSS, KEV, optional defensive ATT&CK, asset,
+VEX, waiver, and provider context so teams can move from technical findings to
+defensible decisions.
+
+The project does not scan systems, exploit targets, generate PoCs, perform
+credential testing, actively probe networks, autopatch software, or infer
+CVE-to-ATT&CK mappings with heuristics or AI.
+
+## Current Execution Track
+
+The current VPW cycle rebuilds the Workbench on the official
+`fastapi/full-stack-fastapi-template` shape without discarding the existing
+CLI/core domain value.
+
+1. Baseline and governance: prove the official template baseline, product
+   identity, auth smoke, governance docs, issue templates, milestones, and
+   strict evidence flow.
+2. Backend domain foundation: replace template demo Items with Workbench
+   Projects, Findings, Assets, Components, Vulnerabilities, Analysis Runs,
+   Provider Snapshots, and SQLModel/Alembic persistence.
+3. Core package extraction: keep parser, provider, scoring, reporting, ATT&CK,
+   VEX, and governance logic framework-neutral so the template backend can call
+   it through service boundaries.
+4. Import MVP: persist imported scanner/SBOM/advisory data as findings and
+   occurrences with provenance.
+5. Enrichment and prioritization: attach provider context, risk reasons,
+   operational ranking, waivers, and explanations.
+6. React Workbench workflow: replace demo frontend pages with dashboard,
+   projects, imports, findings, detail, reports, providers, settings, and
+   browser-tested user flows.
+7. Evidence, reporting, ATT&CK, asset, VEX, governance, deployment, release, and
+   integration hardening: land each capability with tests and evidence before
+   closure.
+
+## Roadmap Guardrails
+
+- Keep one roadmap issue per PR unless a dependency group is explicitly stated.
+- Close issues only after fresh evidence is posted: changed scope, commands run,
+  artifacts, residual risk, and follow-up links.
+- Treat the old FastAPI/Jinja2/SQLAlchemy Workbench as reference material, not
+  automatic completion evidence for template React/JWT/SQLModel work.
+- Preserve the local-first posture until public/shared deployment hardening is
+  explicitly implemented and documented.
+- Keep ATT&CK defensive and evidence-based. Do not infer mappings.
+
+## Key References
+
+- [VPW Template Execution Sequence](docs/vpw_template_execution_sequence.md)
+- [Full Stack FastAPI Template Migration Plan](docs/full_stack_fastapi_template_migration.md)
+- [Template Replacement Strategy](docs/architecture/template-replacement.md)
+- [Workbench Threat Model](docs/workbench-threat-model.md)
+- [Current Release Roadmap](docs/roadmap.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,19 @@
 
 ## Supported Use
 
-`vuln-prioritizer` is a defensive prioritization CLI for known CVEs. It is not a scanning engine, exploit framework, or asset discovery platform.
+`vuln-prioritizer` is a defensive prioritization CLI and local self-hosted
+Workbench for known CVEs and imported findings. It is not a scanning engine,
+exploit framework, or asset discovery platform.
+
+The Workbench is local-first and self-hosted by default. Treat it as a trusted
+single-workspace operator tool unless a specific deployment hardening review has
+covered TLS/proxy configuration, backup and restore, audit retention, token
+handling, role boundaries, upload/download storage, and the published threat
+model.
+
+The project does not accept changes that turn the tool into an exploit runner,
+PoC generator, credential tester, active network probe, attack simulator,
+autopatcher, or heuristic/AI CVE-to-ATT&CK mapper.
 
 ## Reporting a Security Issue
 
@@ -14,6 +26,16 @@ Preferred disclosure path:
 2. If that GitHub flow is temporarily unavailable, contact the repository owner privately through the GitHub profile or repository security contact path before any public disclosure.
 
 Avoid posting proof-of-concept exploit details, weaponized payloads, or sensitive reproduction steps in public issues.
+
+Safe disclosure guidance:
+
+- Report the minimum reproduction detail needed to confirm impact.
+- Redact tokens, cookies, API keys, private scan exports, customer names,
+  internal hostnames, and absolute local paths.
+- Prefer synthetic files or sanitized exports when a parser/import issue is
+  involved.
+- Do not attach exploit payloads, live target details, public proof-of-concept
+  links, or instructions for active exploitation to public tickets.
 
 ## Supported Versions
 
@@ -30,6 +52,10 @@ Include, when possible:
 - clear impact summary
 - exact reproduction prerequisites
 - whether the issue affects the CLI itself, packaging, release workflow, or repository configuration
+- whether the issue requires local Workbench access, API-token access, a crafted
+  input file, or a specific deployment configuration
+- whether the issue touches Workbench API/auth behavior, uploads, report
+  downloads, evidence bundles, provider snapshots, or generated artifacts
 
 ## Maintainer Response Expectations
 
@@ -42,3 +68,7 @@ Include, when possible:
 - The tool consumes public vulnerability data from NVD, FIRST EPSS, and CISA KEV.
 - Network integrations should remain limited to documented, official sources.
 - Optional ATT&CK support must stay offline-mapping-based unless the project explicitly adopts a reviewed live approach.
+- XML, SBOM, scanner, and advisory inputs are treated as local exported evidence
+  files. The tool must not scan remote systems to create those files.
+- Public internet deployment is out of scope until the threat model and
+  operational hardening documents explicitly say otherwise.

--- a/docs/evidence/full_stack_fastapi_template_baseline.md
+++ b/docs/evidence/full_stack_fastapi_template_baseline.md
@@ -385,3 +385,47 @@ Residual risks:
   frontend pages. Those remain `VPW-006`, `VPW-008`, `VPW-011`, and `VPW-037`.
 - Current old SQLAlchemy/Jinja Workbench behavior remains reference material,
   not template completion evidence.
+
+## FSFT-06 Governance Docs
+
+Branch:
+
+- `codex/fsft-06-governance-docs`
+
+Scope:
+
+- Updated `README.md` with an explicit problem/goal statement,
+  risk-to-decision chain, expanded non-goals, demo path, ATT&CK/TTP safety
+  disclaimer, template-vs-legacy Workbench wording, and VPW roadmap link.
+- Updated `SECURITY.md` with local Workbench scope, responsible disclosure
+  handling, safe report guidance, and explicit non-scanner/non-exploit
+  boundaries.
+- Updated `CONTRIBUTING.md` with branch/PR rules, Codex working rules, evidence
+  expectations, and a security checklist.
+- Added root `ROADMAP.md` derived from the VPW execution plan.
+- Aligned `docs/roadmap.md`, `docs/workbench-threat-model.md`, and
+  `docs/full_stack_fastapi_template_migration.md` with the current
+  template-migration and local-first security posture.
+
+Commands run:
+
+```bash
+make docs-check
+python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py \
+  backend/tests/api/test_template_auth_smoke.py --no-cov
+git diff --check
+```
+
+Results:
+
+- `make docs-check` passed and built the MkDocs site successfully.
+- Targeted template backend/auth tests passed: 15 passed.
+- `git diff --check` passed.
+
+Residual risks:
+
+- This slice is governance/docs-only. It does not create the VPW issue
+  templates or PR template requested by `VPW-005`.
+- Public/shared Workbench deployment remains out of scope until explicit
+  hardening work updates the threat model, auth, roles, retention,
+  backup/restore, and deployment docs.

--- a/docs/full_stack_fastapi_template_migration.md
+++ b/docs/full_stack_fastapi_template_migration.md
@@ -12,8 +12,9 @@ is a template-based full-stack application that reuses the existing
 
 ## Why This Direction
 
-The current app has FastAPI, a Workbench, persistence, reports, providers, ATT&CK,
-VEX, waivers, and evidence bundles. It does not have the actual template shape:
+At the time of this migration decision, the current app had FastAPI, a
+Workbench, persistence, reports, providers, ATT&CK, VEX, waivers, and evidence
+bundles, but not the actual template shape:
 
 - no documented `upstream` remote to `fastapi/full-stack-fastapi-template`
 - no Copier answer file or template baseline record
@@ -23,9 +24,9 @@ VEX, waivers, and evidence bundles. It does not have the actual template shape:
 - no SQLModel domain model layer
 - no generated frontend client workflow on `main`
 
-Trying to mutate the existing tree directly would mix two application
-architectures. The cleaner path is to preserve the domain code and build the
-Workbench shell from the template.
+Trying to mutate that tree directly would mix two application architectures. The
+cleaner path is to preserve the domain code and build the Workbench shell from
+the template. Current implementation progress is tracked below.
 
 ## Target Architecture
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,6 +4,22 @@ This roadmap records the release line implemented from the ATT&CK-focused `v0.3.
 
 The product remains a CLI and local Workbench for prioritizing known CVEs and imported findings. It is not a scanner and does not use heuristic or AI-generated CVE-to-ATT&CK mappings.
 
+## Current VPW Template Roadmap
+
+The active duplicate VPW cycle is now tracked as a template-first execution
+track, summarized in the repository-root `ROADMAP.md`. It starts with
+FastAPI Full Stack Template baseline and governance work, then replaces demo
+Items with Workbench Projects and Findings, rebuilds import/enrichment/scoring
+APIs behind SQLModel/Alembic, and finally restores the React Workbench workflow,
+evidence, reporting, ATT&CK, asset, VEX, governance, deployment, release, and
+integration slices.
+
+Strict DoD evidence remains required for every VPW issue: scoped PR, commands
+run, artifacts or screenshots where relevant, residual risks, and follow-up
+links. Existing Jinja2/SQLAlchemy Workbench behavior is supporting reference
+material, not automatic completion evidence for template React/JWT/SQLModel
+work.
+
 ## Current Release Surface
 
 - `v1.1.0` provides `analyze`, `compare`, `explain`, `doctor`, `snapshot create`, `snapshot diff`, `rollup`, `input validate`, `input inspect`, `input normalize`, `state`, `data`, `db init`, `web serve`, `report html`, `report evidence-bundle`, `report verify-evidence-bundle`, and ATT&CK utility commands.
@@ -21,7 +37,7 @@ The product remains a CLI and local Workbench for prioritizing known CVEs and im
 
 Status: roadmap slices through Workbench v1.2 are implemented on `main`; the original implementation plan is preserved as a historical planning artifact in [docs/workbench-masterplan.md](./workbench-masterplan.md).
 
-The current Workbench exposes the existing CLI/core behavior as a local-first, self-hosted vulnerability prioritization application. The CLI remains supported for automation and CI; the Workbench adds API, database-backed imports, a browser UI, team-oriented worklists, and report workflows around the same transparent prioritization model.
+The current Workbench exposes the existing CLI/core behavior as a local-first, self-hosted vulnerability prioritization application. The CLI remains supported for automation and CI; the Workbench adds API, database-backed imports, a browser UI, local project worklists, and report workflows around the same transparent prioritization model.
 
 Current Workbench scope:
 
@@ -47,7 +63,7 @@ Current local Workbench limits:
 
 ## Implemented Release Line
 
-### `v0.3.1` Public Readiness
+### `v0.3.1` OSS Public Readiness
 
 Status: shipped
 
@@ -111,7 +127,7 @@ Status: implemented; release workflow is wired for tagged GitHub Releases and ga
 - Stable scanner/SBOM export inputs, Asset Context, VEX, and GitHub integration.
 - Local MkDocs-based documentation site for a browsable public doc surface.
 
-### `v1.1.0` Operability and Public Polish
+### `v1.1.0` Operability and OSS Public Polish
 
 Status: published as `v1.1.0`; current `main` contains post-release documentation and security hygiene updates
 
@@ -124,7 +140,7 @@ Status: published as `v1.1.0`; current `main` contains post-release documentatio
 ## CLI Release-Line Non-Goals Through `v1.1.0`
 
 - Database-backed service in the historical CLI-only release line; the current Workbench app exposes this as an explicit app-layer surface.
-- ServiceNow or Jira integration
+- ServiceNow or Jira integration in the historical CLI-only release line
 - Mandatory live TAXII integration
 - Heuristic or ML-based CVE-to-ATT&CK mapping
 

--- a/docs/workbench-threat-model.md
+++ b/docs/workbench-threat-model.md
@@ -8,7 +8,8 @@ This page defines the defensive threat model and operational readiness assumptio
 
 The current local-first Workbench threat model covers:
 
-- local CLI use and the self-hosted FastAPI/Jinja2 Workbench
+- local CLI use, the legacy self-hosted FastAPI/Jinja2 Workbench command, and
+  the template-aligned Workbench shell during migration
 - import of existing CVE lists and selected scanner export files
 - provider enrichment from NVD, FIRST EPSS, CISA KEV, local caches, and locked provider snapshots
 - optional ATT&CK context from local CTID Mappings Explorer JSON and local technique metadata
@@ -21,7 +22,8 @@ The current local-first Workbench threat model covers:
 The current local-first Workbench threat model does not cover:
 
 - active network, host, container, cloud, or source-code scanning
-- exploitation, payload generation, exploit verification, or PoC handling
+- exploitation, payload generation, exploit verification, public PoC workflows,
+  exploit-instruction handling, or offensive attack-chain guidance
 - internet-exposed multi-tenant hosting
 - SSO, organization-wide ticket sync policy, background workers, or managed database operations
 - heuristic, fuzzy, or LLM-generated CVE-to-ATT&CK mapping


### PR DESCRIPTION
## Summary

- Updates README with explicit problem/goal, risk-to-decision chain, expanded non-goals, demo path, defensive ATT&CK/TTP disclaimer, and VPW roadmap link.
- Updates SECURITY with local Workbench scope, responsible disclosure guidance, reporter evidence expectations, and non-scanner/non-exploit boundaries.
- Updates CONTRIBUTING with branch/PR rules, Codex working rules, evidence expectations, and a security checklist.
- Adds root ROADMAP.md derived from the VPW execution plan.
- Aligns docs roadmap, threat model, and template migration wording with the current template-migration/local-first posture.

## Evidence

- `make docs-check`
- `python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py backend/tests/api/test_template_auth_smoke.py --no-cov`
- `git diff --check`

## Residual Risk

- Docs-only slice. It does not create issue templates or PR template content; that remains VPW-005/#111.
- Public/shared Workbench deployment remains out of scope until explicit hardening work updates the threat model, auth, roles, retention, backup/restore, and deployment docs.

Refs #110.
