### PR TITLE
[codex] Add VPW GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/attack_mapping_review.md
+++ b/.github/ISSUE_TEMPLATE/attack_mapping_review.md
@@ -1,0 +1,67 @@
+---
+name: ATT&CK mapping review
+about: Review defensive ATT&CK/TTP context, mapping provenance, or coverage behavior
+title: "[ATT&CK] "
+labels: type:attack,status:needs-review
+assignees: ""
+---
+
+## Review Target
+
+Name the mapping file, technique metadata file, coverage report, Navigator layer,
+or finding explanation surface.
+
+## Target
+
+Which CVE(s), technique/tactic IDs, mapping file, UI/API/report surface, or
+coverage workflow should be reviewed?
+
+## Defensive Purpose
+
+Explain how this helps detection, mitigation, prioritization, or management
+explanation. Do not frame mappings as exploit proof.
+
+## Scope
+
+- [ ] mapping provenance review
+- [ ] technique metadata review
+- [ ] validation command/update
+- [ ] Navigator/coverage output
+- [ ] finding explanation/report wording
+- [ ] docs update
+
+## Source And Provenance
+
+- Mapping source:
+- Technique metadata source:
+- Version/date/checksum:
+- Reviewer:
+
+## Safety Checklist
+
+- [ ] No heuristic, fuzzy, or LLM-generated CVE-to-ATT&CK mapping is introduced.
+- [ ] Unmapped CVEs remain explicitly unmapped.
+- [ ] The issue does not include exploit payloads, PoC instructions, offensive
+      attack-chain guidance, or active exploitation claims.
+- [ ] ATT&CK context is presented as defensive context, not proof of active
+      exploitation.
+
+## Tests
+
+- [ ] `attack validate`
+- [ ] `attack coverage`
+- [ ] Navigator layer generation
+- [ ] snapshot/report fixture
+- [ ] docs check
+- [ ] not applicable; rationale:
+
+## Definition Of Done
+
+- [ ] Mapping/provenance evidence is linked or committed.
+- [ ] Validation command output is posted.
+- [ ] UI/API/report wording stays defensive and avoids overclaiming.
+
+## Evidence
+
+Paste validation output, fixture paths, checksums, screenshots, Navigator layer
+paths, or report snippets needed to verify closure.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a defect or behavioral regression in vuln-prioritizer
 title: "[Bug] "
-labels: bug
+labels: bug,status:needs-revalidation
 assignees: ""
 ---
 
@@ -10,7 +10,28 @@ assignees: ""
 
 Describe the defect clearly and concretely.
 
-## Command
+## Target
+
+What user workflow, command, API route, page, package, or release path is
+affected?
+
+## Affected Surface
+
+- [ ] CLI
+- [ ] Template backend API
+- [ ] Legacy Workbench API/UI
+- [ ] React frontend
+- [ ] Docker/Compose
+- [ ] Docs/release/packaging
+- [ ] Security/deployment
+
+## Scope / Impact
+
+What is broken, how severe is it, and what should stay unchanged?
+
+## Reproduction
+
+Command or steps:
 
 ```bash
 # paste the exact command
@@ -29,6 +50,26 @@ What should have happened instead?
 - Python version:
 - OS:
 - `vuln-prioritizer` version/tag:
+
+## Tests
+
+- [ ] regression test
+- [ ] parser fixture
+- [ ] API test
+- [ ] migration test
+- [ ] browser/Playwright smoke
+- [ ] docs check
+- [ ] not applicable; rationale:
+
+## Definition Of Done
+
+- [ ] Root cause is identified or the issue is linked to a narrower follow-up.
+- [ ] Regression test, parser fixture, API test, Playwright smoke, or docs proof
+      is added where relevant.
+- [ ] Fixed behavior is described in observable terms.
+- [ ] Commands run and results are posted before closure.
+- [ ] No secrets, customer scanner exports, tokens, cookies, or private paths are
+      included in public evidence.
 
 ## Evidence
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a scoped improvement for vuln-prioritizer
 title: "[Feature] "
-labels: enhancement
+labels: type:feature,status:needs-review
 assignees: ""
 ---
 
@@ -10,20 +10,58 @@ assignees: ""
 
 What user or maintainer problem does this solve?
 
+## Target
+
+Who needs this, and what decision or workflow should improve?
+
 ## Proposed Change
 
 Describe the smallest useful version of the feature.
 
+## Scope
+
+Target surface:
+
+- [ ] CLI/core
+- [ ] Template backend API
+- [ ] SQLModel/Alembic persistence
+- [ ] React frontend
+- [ ] Import/parser
+- [ ] Provider/enrichment
+- [ ] Reports/evidence
+- [ ] Governance/security/deployment
+
 ## Scope Check
 
 - [ ] this keeps the project focused on prioritizing known CVEs
-- [ ] this does not require a web UI, hosted control plane, or non-optional remote database
+- [ ] this does not add scanning, exploit execution, PoC generation, active
+      probing, credential testing, autopatching, or offensive guidance
 - [ ] this does not require heuristic or LLM-generated CVE-to-ATT&CK mapping
+- [ ] this does not claim public/shared Workbench readiness without explicit
+      threat-model and deployment-hardening work
+
+## Tests
+
+- [ ] unit tests
+- [ ] API tests
+- [ ] migration tests
+- [ ] generated-client drift check
+- [ ] browser/Playwright evidence
+- [ ] docs check
+- [ ] not applicable; rationale:
 
 ## Alternatives Considered
 
 What simpler approaches were considered?
 
-## Evidence Or Usage Example
+## Definition Of Done
 
-Provide an example command, report need, or workflow.
+- [ ] Acceptance criteria are written in observable terms.
+- [ ] Tests or evidence artifacts are named before implementation.
+- [ ] API, DB, generated-client, UI, docs, and security impacts are identified.
+- [ ] Residual risk and follow-up work are documented.
+
+## Evidence
+
+Provide example commands, report needs, screenshots, API responses, migration
+output, generated artifacts, or workflow evidence expected for closure.

--- a/.github/ISSUE_TEMPLATE/parser.md
+++ b/.github/ISSUE_TEMPLATE/parser.md
@@ -1,0 +1,69 @@
+---
+name: Parser or import format
+about: Add or change an input parser, normalized occurrence contract, or import workflow
+title: "[Parser] "
+labels: type:parser,status:needs-review
+assignees: ""
+---
+
+## Input Source
+
+Name the scanner, SBOM, advisory, or export format.
+
+## Target
+
+Which parser, import path, CLI command, API route, or Workbench workflow should
+change?
+
+## Goal
+
+What known-CVE evidence should be normalized and why does this matter for
+prioritization?
+
+## Scope
+
+- [ ] new parser/import format
+- [ ] existing parser behavior change
+- [ ] Workbench import path
+- [ ] CLI input validation/normalization
+- [ ] schema or contract update
+- [ ] documentation/support matrix update
+
+## Sample Shape
+
+Describe the smallest sanitized fixture shape. Do not attach customer exports,
+secrets, internal hostnames, tokens, cookies, or private paths.
+
+```json
+{}
+```
+
+## Normalization Contract
+
+- [ ] CVE extraction is deterministic.
+- [ ] Component, package, asset, path, source, fix version, and evidence fields
+      are mapped where present.
+- [ ] Unsupported or malformed records produce warnings instead of crashes.
+- [ ] XML or archive parsing remains safe/local and does not execute content.
+- [ ] No live scanner execution or active probing is introduced.
+
+## Tests
+
+- [ ] sanitized valid fixture
+- [ ] malformed fixture
+- [ ] empty/no-CVE fixture
+- [ ] CLI normalization or validation test
+- [ ] Workbench import test, if applicable
+- [ ] docs/support matrix check
+
+## Definition Of Done
+
+- [ ] Sanitized fixtures are committed.
+- [ ] Parser/import tests cover valid, malformed, and empty inputs.
+- [ ] CLI and Workbench import behavior stays consistent where applicable.
+- [ ] Commands run and results are posted before closure.
+
+## Evidence
+
+Paste command results, fixture paths, normalized output samples, warnings, or API
+responses needed to verify closure.

--- a/.github/ISSUE_TEMPLATE/provider.md
+++ b/.github/ISSUE_TEMPLATE/provider.md
@@ -1,0 +1,68 @@
+---
+name: Provider or enrichment source
+about: Add or change an enrichment provider, cache, snapshot, or freshness workflow
+title: "[Provider] "
+labels: type:provider,status:needs-review
+assignees: ""
+---
+
+## Provider Source
+
+Name the provider, endpoint, file format, cache, or snapshot source.
+
+## Target
+
+Which provider, cache, snapshot, CLI command, API route, or report/evidence
+surface should change?
+
+## Decision Need
+
+What prioritization, explanation, freshness, or evidence decision should this
+provider support?
+
+## Scope
+
+- [ ] new provider/source
+- [ ] provider contract change
+- [ ] cache or snapshot behavior
+- [ ] freshness/status behavior
+- [ ] report/API/evidence output
+- [ ] docs/support matrix update
+
+## Data Contract
+
+- [ ] Source is official/public or explicitly local.
+- [ ] CVE keys and timestamps are clearly defined.
+- [ ] Cache and locked-snapshot behavior are documented.
+- [ ] Rate limits, authentication, and offline behavior are described.
+- [ ] Provider data is context/evidence unless the scoring rule explicitly says
+      otherwise.
+
+## Safety Check
+
+- [ ] No remote code execution, plugin loading, exploit lookup, payload fetch, or
+      hidden live dependency is introduced.
+- [ ] Secrets are read from explicit environment variables and are never logged
+      or persisted.
+- [ ] Tests can run offline with fixtures.
+
+## Tests
+
+- [ ] fixture-based provider success
+- [ ] missing data
+- [ ] stale data
+- [ ] provider failure/degraded mode
+- [ ] cache/snapshot replay
+- [ ] docs check
+
+## Definition Of Done
+
+- [ ] Provider fixtures and tests cover success, missing data, stale data, and
+      provider failure.
+- [ ] Freshness/provenance appears in API/report/evidence output where relevant.
+- [ ] Commands run and results are posted before closure.
+
+## Evidence
+
+Paste command results, fixture paths, cache/snapshot metadata, API/report
+samples, and residual provider risks.

--- a/.github/ISSUE_TEMPLATE/security_hardening.md
+++ b/.github/ISSUE_TEMPLATE/security_hardening.md
@@ -1,0 +1,65 @@
+---
+name: Security hardening
+about: Propose auth, token, upload/download, deployment, audit, or secure-default work
+title: "[Security] "
+labels: type:security,status:needs-review
+assignees: ""
+---
+
+## Boundary
+
+What security boundary changes?
+
+## Target
+
+Which route, command, token, upload/download path, deployment setting, report,
+evidence artifact, or documentation surface is affected?
+
+## Scope
+
+- [ ] Auth/session/token behavior
+- [ ] Upload/import/download/artifact handling
+- [ ] API authorization or project access
+- [ ] Docker/Compose/deployment configuration
+- [ ] Audit/retention/backup/restore
+- [ ] Provider/ticket-system integration
+- [ ] Documentation/threat model
+
+## Risk
+
+Describe the asset, attacker capability, impact, and current mitigation gap.
+
+## Proposed Hardening
+
+Describe the smallest safe change.
+
+## Tests
+
+- [ ] Targeted tests or smoke checks
+- [ ] Threat-model or SECURITY/README update where scope changes
+- [ ] API response, migration, browser evidence, or config output where relevant
+- [ ] Residual deployment risk documented
+
+## Safety Checklist
+
+- [ ] No public internet readiness is claimed without explicit hardening docs.
+- [ ] No secrets, token values, cookies, API keys, customer exports, or private
+      paths are exposed.
+- [ ] No scanner, exploit, PoC, active probing, credential testing, or
+      autopatching behavior is introduced.
+- [ ] Upload limits, rooted paths, safe parsing, CSRF-sensitive forms, security
+      headers, and token hashing are not weakened.
+
+## Definition Of Done
+
+- [ ] Threat, asset, and boundary are explicitly documented.
+- [ ] Security regression test or documented manual evidence is attached.
+- [ ] SECURITY.md, README, deployment docs, or threat model are updated if scope
+      changed.
+- [ ] Commands run and residual risk are posted before closure.
+
+## Evidence
+
+Paste command output, screenshots/traces, API responses, migration/config output,
+or threat-model links needed to verify closure. Do not include exploit payloads,
+tokens, cookies, customer exports, or private paths.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,16 +3,72 @@
 - what changed
 - why it changed
 
+## Linked Issue / Roadmap ID
+
+- Issue:
+- VPW ID:
+- Disposition intended after merge:
+
+## Scope
+
+- [ ] CLI/core
+- [ ] Template backend API
+- [ ] DB/migrations
+- [ ] Generated OpenAPI client
+- [ ] React frontend
+- [ ] Docker/Compose
+- [ ] Docs/governance/security
+- [ ] Release/packaging
+
 ## Validation
 
-- [ ] `make check`
-- [ ] `make demo-report`
-- [ ] `make demo-compare`
-- [ ] `make demo-explain`
+- [ ] `make check` or a scoped equivalent is listed below
+- [ ] `make docs-check` for docs changes
+- [ ] generated client check for API changes
+- [ ] migration/test evidence for DB changes
+- [ ] browser/Playwright evidence for UI changes
+- [ ] Docker/Compose smoke evidence for runtime/deployment changes
 - [ ] additional local validation, if applicable
 
-## Scope Notes
+Commands and results:
+
+```text
+paste command output summary here
+```
+
+## Evidence
+
+- paths, screenshots, traces, API responses, migration output, or generated
+  artifacts:
+- residual risk:
+- follow-up issues:
+
+## Definition Of Done
+
+- [ ] linked issue scope, acceptance criteria, and evidence requirements are met
+- [ ] commands run and results are pasted above
+- [ ] evidence artifact paths or screenshots/traces are listed above
+- [ ] residual risk and follow-up issues are listed above
+- [ ] no issue is closed as `verified-shipped` or `superseded` without fresh
+      evidence and explicit rationale in the issue
+
+## Security Review
 
 - [ ] no scanner/asset-discovery scope was introduced
+- [ ] no exploit, PoC, active probing, credential testing, offensive
+      attack-chain, or autopatching scope was introduced
 - [ ] no heuristic or LLM-generated CVE-to-ATT&CK mapping was introduced
+- [ ] no secrets, tokens, cookies, customer exports, or private paths are
+      exposed in code, logs, screenshots, reports, or docs
+- [ ] upload limits, rooted artifact paths, safe parsing, CSRF-sensitive forms,
+      security headers, and token hashing are not weakened
+- [ ] public/shared Workbench readiness is not claimed without threat-model and
+      deployment-hardening updates
+
+## Docs / Release Notes
+
 - [ ] README and changelog were updated if user-visible behavior changed
+- [ ] SECURITY/threat model/deployment docs were updated if a security boundary
+      changed
+- [ ] old Jinja2/SQLAlchemy Workbench behavior is not used as automatic closure
+      evidence for template React/JWT/SQLModel work

--- a/docs/evidence/full_stack_fastapi_template_baseline.md
+++ b/docs/evidence/full_stack_fastapi_template_baseline.md
@@ -429,3 +429,64 @@ Residual risks:
 - Public/shared Workbench deployment remains out of scope until explicit
   hardening work updates the threat model, auth, roles, retention,
   backup/restore, and deployment docs.
+
+## FSFT-07 GitHub Templates
+
+Branch:
+
+- `codex/fsft-07-github-templates`
+
+Scope:
+
+- Updated `.github/ISSUE_TEMPLATE/feature_request.md` and
+  `.github/ISSUE_TEMPLATE/bug_report.md` so they ask for target, scope, tests,
+  Definition of Done, and evidence.
+- Added required VPW issue templates:
+  `.github/ISSUE_TEMPLATE/parser.md`,
+  `.github/ISSUE_TEMPLATE/provider.md`,
+  `.github/ISSUE_TEMPLATE/attack_mapping_review.md`, and
+  `.github/ISSUE_TEMPLATE/security_hardening.md`.
+- Updated `.github/pull_request_template.md` with linked issue/VPW ID, scoped
+  validation, pasted command output, evidence artifacts, residual risk,
+  Definition of Done, and security review.
+- Verified the required roadmap labels and milestones already exist in GitHub;
+  no metadata write was needed for this slice.
+
+Commands run:
+
+```bash
+find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print | sort
+for f in .github/ISSUE_TEMPLATE/*.md .github/pull_request_template.md; do
+  rg -n '^(## Target|## Scope|## Tests|## Definition Of Done|## Evidence|## Security Review|## Validation)' "$f"
+done
+gh label list --limit 200 --json name --jq '.[].name' | rg '^(type:backend|type:frontend|type:api|type:db|type:parser|type:provider|type:attack|type:governance|type:docs|type:feature|type:security|priority:p0|priority:p1|priority:p2|status:strict-dod|status:needs-revalidation|status:template-gap)$' | sort
+gh api repos/Noetheon/vuln-prioritizer-workbench/milestones --paginate --jq '.[].title' | rg '^(v0\.1-template-baseline|v0\.2-domain-api-foundation|v0\.3-import-mvp|v0\.4-provider-enrichment|v0\.5-decision-engine|v0\.6-frontend-workflow|v0\.7-reports-evidence|v0\.8-attack-lite|v0\.9-governance-context|v1\.0-release-hardening|v1\.1-advanced-attack-detection|v1\.2-integrations)$' | sort
+make docs-check
+python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py \
+  backend/tests/api/test_template_auth_smoke.py --no-cov
+git diff --check
+```
+
+Results:
+
+- Template path list contains feature, bug, parser, provider, ATT&CK mapping
+  review, security hardening, and config templates.
+- Required template sections are present across issue templates and the PR
+  template.
+- Required roadmap labels are present: `type:backend`, `type:frontend`,
+  `type:api`, `type:db`, `type:parser`, `type:provider`, `type:attack`,
+  `type:governance`, `type:docs`, `type:feature`, `type:security`,
+  `priority:p0`, `priority:p1`, `priority:p2`, `status:strict-dod`,
+  `status:needs-revalidation`, and `status:template-gap`.
+- Required roadmap milestones are present from `v0.1-template-baseline` through
+  `v1.2-integrations`.
+- `make docs-check` passed and built the MkDocs site successfully.
+- Targeted template backend/auth tests passed: 15 passed.
+- `git diff --check` passed.
+
+Residual risks:
+
+- This slice does not create or modify GitHub labels/milestones because the
+  required labels and milestones already exist.
+- Issue templates are Markdown templates. GitHub issue forms can be introduced
+  later if maintainers want structured form validation.


### PR DESCRIPTION
## Summary

- Adds required VPW issue templates for Parser, Provider, ATT&CK Mapping Review, and Security Hardening.
- Expands Feature and Bug templates so they ask for target, scope, tests, Definition of Done, and evidence.
- Expands the PR template with linked issue/VPW ID, scoped validation, command output, evidence artifacts, residual risk, DoD, and security review.
- Verifies required roadmap labels and milestones already exist; no GitHub metadata write was needed.

## Evidence

- `find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print | sort`
- `for f in .github/ISSUE_TEMPLATE/*.md .github/pull_request_template.md; do rg -n '^(## Target|## Scope|## Tests|## Definition Of Done|## Evidence|## Security Review|## Validation)' "$f"; done`
- `gh label list --limit 200 --json name --jq '.[].name' | rg '^(type:backend|type:frontend|type:api|type:db|type:parser|type:provider|type:attack|type:governance|type:docs|type:feature|type:security|priority:p0|priority:p1|priority:p2|status:strict-dod|status:needs-revalidation|status:template-gap)$' | sort`
- `gh api repos/Noetheon/vuln-prioritizer-workbench/milestones --paginate --jq '.[].title' | rg '^(v0\.1-template-baseline|v0\.2-domain-api-foundation|v0\.3-import-mvp|v0\.4-provider-enrichment|v0\.5-decision-engine|v0\.6-frontend-workflow|v0\.7-reports-evidence|v0\.8-attack-lite|v0\.9-governance-context|v1\.0-release-hardening|v1\.1-advanced-attack-detection|v1\.2-integrations)$' | sort`
- `make docs-check`
- `python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py backend/tests/api/test_template_auth_smoke.py --no-cov`
- `git diff --check`

## Residual Risk

- Markdown issue templates are intentionally used here. GitHub issue forms can be added later if maintainers want structured field validation.
- Labels and milestones were verified but not changed because the required VPW labels/milestones already exist.

Refs #111.
