### PR TITLE
VPW-006: Add template Project domain shell

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -1,0 +1,67 @@
+"""Alembic environment for the template-aligned backend app."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+from app import models  # noqa: F401
+from app.core.config import settings
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+
+def get_url() -> str:
+    """Return an Alembic URL override or the active template settings URL."""
+    configured_url = config.get_main_option("sqlalchemy.url")
+    if configured_url:
+        return configured_url
+    return settings.SQLALCHEMY_DATABASE_URI
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+    context.configure(
+        url=get_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = get_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/app/alembic/script.py.mako
+++ b/backend/app/alembic/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/app/alembic/versions/20260428_0001_initialize_user_project_models.py
+++ b/backend/app/alembic/versions/20260428_0001_initialize_user_project_models.py
@@ -1,0 +1,51 @@
+"""initialize user and project models
+
+Revision ID: 20260428_0001
+Revises:
+Create Date: 2026-04-28 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+
+revision = "20260428_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user",
+        sa.Column("email", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("is_superuser", sa.Boolean(), nullable=False),
+        sa.Column("full_name", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("hashed_password", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_user_email"), "user", ["email"], unique=True)
+    op.create_table(
+        "project",
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(length=4096), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["owner_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_project_owner_id"), "project", ["owner_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_project_owner_id"), table_name="project")
+    op.drop_table("project")
+    op.drop_index(op.f("ix_user_email"), table_name="user")
+    op.drop_table("user")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -2,32 +2,34 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import ValidationError
+from sqlmodel import Session
 
 from app.core import security
 from app.core.config import settings
-from app.models import TokenPayload, UserPublic
+from app.core.db import engine, ensure_configured_superuser
+from app.models import TokenPayload, User
 
 reusable_oauth2 = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/login/access-token")
 
 TokenDep = Annotated[str, Depends(reusable_oauth2)]
 
 
-def configured_superuser() -> UserPublic:
-    """Return the configured local-first superuser until DB-backed users land."""
-    return UserPublic(
-        id=settings.FIRST_SUPERUSER,
-        email=settings.FIRST_SUPERUSER,
-        is_active=True,
-        is_superuser=True,
-    )
+def get_db() -> Generator[Session, None, None]:
+    """Yield a SQLModel session for template-backed API routes."""
+    with Session(engine) as session:
+        yield session
 
 
-def get_current_user(token: TokenDep) -> UserPublic:
+SessionDep = Annotated[Session, Depends(get_db)]
+
+
+def get_current_user(session: SessionDep, token: TokenDep) -> User:
     """Validate the bearer token and resolve the configured template-shell user."""
     try:
         payload = security.decode_access_token(token)
@@ -40,7 +42,17 @@ def get_current_user(token: TokenDep) -> UserPublic:
 
     if token_data.sub != settings.FIRST_SUPERUSER:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-    return configured_superuser()
+    user = ensure_configured_superuser(session)
+    if not user.is_active:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Inactive user")
+    return user
 
 
-CurrentUser = Annotated[UserPublic, Depends(get_current_user)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+def get_current_active_superuser(current_user: CurrentUser) -> User:
+    """Require the configured user to be active and superuser."""
+    if not current_user.is_superuser:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough privileges")
+    return current_user

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app.api.routes import login, users, utils, workbench
+from app.api.routes import login, projects, users, utils, workbench
 
 api_router = APIRouter()
 api_router.include_router(login.router)
+api_router.include_router(projects.router)
 api_router.include_router(users.router)
 api_router.include_router(utils.router)
 api_router.include_router(workbench.router)

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -11,7 +11,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from app.api.deps import CurrentUser
 from app.core import security
 from app.core.config import settings
-from app.models import Token, UserPublic
+from app.models import Token, User, UserPublic
 
 router = APIRouter(tags=["login"])
 
@@ -37,6 +37,6 @@ def login_access_token(
 
 
 @router.post("/login/test-token", response_model=UserPublic)
-def test_token(current_user: CurrentUser) -> UserPublic:
+def test_token(current_user: CurrentUser) -> User:
     """Test access token."""
     return current_user

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -1,0 +1,56 @@
+"""Project routes for the template-aligned Workbench domain shell."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, HTTPException
+from sqlmodel import col, func, select
+
+from app.api.deps import CurrentUser, SessionDep
+from app.models import Project, ProjectCreate, ProjectPublic, ProjectsPublic
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.get("/", response_model=ProjectsPublic)
+def read_projects(session: SessionDep, current_user: CurrentUser) -> ProjectsPublic:
+    """List projects visible to the current user."""
+    count_statement = select(func.count()).select_from(Project)
+    statement = select(Project).order_by(col(Project.created_at).desc())
+    if not current_user.is_superuser:
+        count_statement = count_statement.where(Project.owner_id == current_user.id)
+        statement = statement.where(Project.owner_id == current_user.id)
+
+    count = session.exec(count_statement).one()
+    projects = session.exec(statement).all()
+    return ProjectsPublic(
+        data=[ProjectPublic.model_validate(project) for project in projects],
+        count=count,
+    )
+
+
+@router.post("/", response_model=ProjectPublic)
+def create_project(
+    *,
+    session: SessionDep,
+    current_user: CurrentUser,
+    project_in: ProjectCreate,
+) -> Project:
+    """Create a Project owned by the current user."""
+    project = Project.model_validate(project_in, update={"owner_id": current_user.id})
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return project
+
+
+@router.get("/{project_id}", response_model=ProjectPublic)
+def read_project(project_id: uuid.UUID, session: SessionDep, current_user: CurrentUser) -> Project:
+    """Read a single project if it belongs to the user or the user is superuser."""
+    project = session.get(Project, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if not current_user.is_superuser and project.owner_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not enough permissions")
+    return project

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.api.deps import CurrentUser
-from app.models import UserPublic
+from app.models import User, UserPublic
 
 router = APIRouter(prefix="/users", tags=["users"])
 
 
 @router.get("/me", response_model=UserPublic)
-def read_user_me(current_user: CurrentUser) -> UserPublic:
+def read_user_me(current_user: CurrentUser) -> User:
     """Get current user."""
     return current_user

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from os import environ
 from typing import Literal, cast
+from urllib.parse import quote_plus
 
 EnvironmentName = Literal["local", "staging", "production"]
 VALID_ENVIRONMENTS: set[str] = {"local", "staging", "production"}
@@ -24,6 +25,7 @@ class Settings:
     FIRST_SUPERUSER_PASSWORD: str = "changethis"
     FRONTEND_HOST: str = "http://localhost:5173"
     BACKEND_CORS_ORIGINS: tuple[str, ...] = field(default_factory=tuple)
+    SQLALCHEMY_DATABASE_URI: str = "sqlite:///./template.db"
 
     @property
     def all_cors_origins(self) -> tuple[str, ...]:
@@ -38,6 +40,23 @@ class Settings:
 def parse_cors_origins(raw_origins: str) -> tuple[str, ...]:
     """Parse comma-separated CORS origins using the template env var name."""
     return tuple(origin.strip().rstrip("/") for origin in raw_origins.split(",") if origin.strip())
+
+
+def build_database_uri() -> str:
+    """Build the template-style database URL from explicit or Postgres env vars."""
+    explicit_uri = environ.get("SQLALCHEMY_DATABASE_URI") or environ.get("DATABASE_URL")
+    if explicit_uri:
+        return explicit_uri
+
+    postgres_server = environ.get("POSTGRES_SERVER")
+    if postgres_server:
+        user = quote_plus(environ.get("POSTGRES_USER", "postgres"))
+        password = quote_plus(environ.get("POSTGRES_PASSWORD", "postgres"))
+        port = environ.get("POSTGRES_PORT", "5432")
+        db = quote_plus(environ.get("POSTGRES_DB", "app"))
+        return f"postgresql+psycopg://{user}:{password}@{postgres_server}:{port}/{db}"
+
+    return "sqlite:///./template.db"
 
 
 def load_settings() -> Settings:
@@ -60,6 +79,7 @@ def load_settings() -> Settings:
         FIRST_SUPERUSER_PASSWORD=environ.get("FIRST_SUPERUSER_PASSWORD", "changethis"),
         FRONTEND_HOST=environ.get("FRONTEND_HOST", "http://localhost:5173"),
         BACKEND_CORS_ORIGINS=parse_cors_origins(environ.get("BACKEND_CORS_ORIGINS", "")),
+        SQLALCHEMY_DATABASE_URI=build_database_uri(),
     )
 
 

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,0 +1,56 @@
+"""Database helpers for the template-aligned backend shell."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.core.config import settings
+from app.models import User
+
+CONFIGURED_SUPERUSER_NAMESPACE = uuid.UUID("82a5f27c-a7db-4b44-a860-143b0137e419")
+
+
+def _connect_args(database_uri: str) -> dict[str, bool]:
+    if database_uri.startswith("sqlite"):
+        return {"check_same_thread": False}
+    return {}
+
+
+engine = create_engine(
+    settings.SQLALCHEMY_DATABASE_URI,
+    connect_args=_connect_args(settings.SQLALCHEMY_DATABASE_URI),
+    pool_pre_ping=True,
+)
+
+
+def configured_superuser_id(email: str) -> uuid.UUID:
+    """Return a stable local-first UUID for the configured bootstrap user."""
+    return uuid.uuid5(CONFIGURED_SUPERUSER_NAMESPACE, email.lower())
+
+
+def init_db(session: Session) -> None:
+    """Create metadata in local/dev contexts and ensure the configured user exists."""
+    SQLModel.metadata.create_all(session.get_bind())
+    ensure_configured_superuser(session)
+
+
+def ensure_configured_superuser(session: Session) -> User:
+    """Create or return the configured superuser used by the migration shell."""
+    statement = select(User).where(User.email == settings.FIRST_SUPERUSER)
+    user = session.exec(statement).first()
+    if user:
+        return user
+
+    user = User(
+        id=configured_superuser_id(settings.FIRST_SUPERUSER),
+        email=settings.FIRST_SUPERUSER,
+        is_active=True,
+        is_superuser=True,
+        hashed_password="configured-superuser-password-placeholder",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,41 +1,128 @@
-"""Minimal template auth models for the first FastAPI-template login slice."""
+"""Template-aligned API and persistence models for the migration backend shell."""
 
-from __future__ import annotations
+import uuid
+from datetime import UTC, datetime
 
-from pydantic import BaseModel
+from sqlalchemy import Column, DateTime
+from sqlmodel import Field, Relationship, SQLModel
 
 
-class Token(BaseModel):
+def get_datetime_utc() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(UTC)
+
+
+class Token(SQLModel):
     """OAuth2 bearer token response."""
 
     access_token: str
     token_type: str = "bearer"
 
 
-class TokenPayload(BaseModel):
+class TokenPayload(SQLModel):
     """JWT payload accepted by the template shell."""
 
     sub: str | None = None
 
 
-class UserPublic(BaseModel):
-    """Public user shape exposed by the template shell auth smoke."""
+class UserBase(SQLModel):
+    """Shared user fields from the official template's account model."""
 
-    id: str
-    email: str
+    email: str = Field(index=True, max_length=255)
     is_active: bool = True
     is_superuser: bool = True
     full_name: str | None = None
 
 
-class MigrationStatus(BaseModel):
+class User(UserBase, table=True):
+    """DB-backed local-first user shell used for project ownership."""
+
+    __tablename__ = "user"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    email: str = Field(index=True, unique=True, max_length=255)
+    hashed_password: str = Field(default="configured-superuser", max_length=255)
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    projects: list["Project"] = Relationship(back_populates="owner", cascade_delete=True)
+
+
+class UserPublic(UserBase):
+    """Public user shape exposed by template auth routes."""
+
+    id: uuid.UUID
+    created_at: datetime
+
+
+class UsersPublic(SQLModel):
+    """Paginated user collection shape reserved for template parity."""
+
+    data: list[UserPublic]
+    count: int
+
+
+class ProjectBase(SQLModel):
+    """Shared Project fields for Workbench project ownership."""
+
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=4096)
+
+
+class ProjectCreate(ProjectBase):
+    """Project creation payload."""
+
+
+class ProjectUpdate(SQLModel):
+    """Project update payload reserved for the next domain slice."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=4096)
+
+
+class Project(ProjectBase, table=True):
+    """Workbench project domain shell owned by a user."""
+
+    __tablename__ = "project"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_id: uuid.UUID = Field(foreign_key="user.id", nullable=False, ondelete="CASCADE")
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    owner: User | None = Relationship(back_populates="projects")
+
+
+class ProjectPublic(ProjectBase):
+    """Public Project shape returned by the API."""
+
+    id: uuid.UUID
+    owner_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectsPublic(SQLModel):
+    """Paginated Project collection shape."""
+
+    data: list[ProjectPublic]
+    count: int
+
+
+class MigrationStatus(SQLModel):
     """Template migration state for the Workbench adapter."""
 
     phase: str
     legacy_workbench_mounted: bool
 
 
-class WorkbenchStatus(BaseModel):
+class WorkbenchStatus(SQLModel):
     """Status response returned by the template Workbench adapter."""
 
     status: str

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "requests>=2.31,<3.0",
   "rich>=13.7,<16.0",
   "sqlalchemy>=2.0,<3.0",
+  "sqlmodel>=0.0.21,<1.0",
   "typer>=0.12,<1.0",
   "uvicorn[standard]>=0.30,<1.0",
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,7 @@ respx>=0.21,<1.0
 rich>=13.7,<16.0
 ruff>=0.5,<1.0
 sqlalchemy>=2.0,<3.0
+sqlmodel>=0.0.21,<1.0
 twine>=6.0,<7.0
 types-PyYAML>=6.0,<7.0
 types-requests>=2.32,<3.0

--- a/backend/tests/api/test_template_auth_smoke.py
+++ b/backend/tests/api/test_template_auth_smoke.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import uuid
+from collections.abc import Generator
+from typing import Any
+
 from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
 
 from app.core import security
 from app.core.config import settings
@@ -8,6 +14,21 @@ from app.main import app
 
 
 def _client() -> TestClient:
+    from app.api.deps import get_db
+
+    app.dependency_overrides.clear()
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def override_get_db() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
     return TestClient(app)
 
 
@@ -54,8 +75,7 @@ def test_template_token_routes_return_current_configured_user() -> None:
     test_token = client.post("/api/v1/login/test-token", headers=headers)
     user_me = client.get("/api/v1/users/me", headers=headers)
 
-    expected_user = {
-        "id": settings.FIRST_SUPERUSER,
+    expected_user_without_generated_fields = {
         "email": settings.FIRST_SUPERUSER,
         "is_active": True,
         "is_superuser": True,
@@ -63,8 +83,12 @@ def test_template_token_routes_return_current_configured_user() -> None:
     }
     assert test_token.status_code == 200
     assert user_me.status_code == 200
-    assert test_token.json() == expected_user
-    assert user_me.json() == expected_user
+    assert _without_generated_fields(test_token.json()) == expected_user_without_generated_fields
+    assert _without_generated_fields(user_me.json()) == expected_user_without_generated_fields
+    assert uuid.UUID(test_token.json()["id"])
+    assert test_token.json()["created_at"]
+    assert user_me.json()["id"] == test_token.json()["id"]
+    assert user_me.json()["created_at"] == test_token.json()["created_at"]
 
 
 def test_template_token_routes_reject_missing_or_invalid_token() -> None:
@@ -87,3 +111,7 @@ def test_template_auth_smoke_keeps_workbench_status_available() -> None:
 
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
+
+
+def _without_generated_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if key not in {"id", "created_at"}}

--- a/backend/tests/api/test_template_projects.py
+++ b/backend/tests/api/test_template_projects.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect
+from sqlalchemy.pool import StaticPool
+
+from app.core.config import settings
+from app.main import app
+
+_SUPERUSER_ID = uuid.UUID("00000000-0000-4000-8000-000000000001")
+
+
+def test_template_project_migration_creates_user_project_tables_without_item(
+    tmp_path: Path,
+) -> None:
+    script_location = Path(__file__).resolve().parents[2] / "app" / "alembic"
+    assert script_location.exists(), "Template app Alembic migrations must live under app/alembic"
+    assert (script_location / "env.py").exists()
+
+    config = Config()
+    config.set_main_option("script_location", str(script_location))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{tmp_path / 'template.db'}")
+
+    command.upgrade(config, "head")
+
+    from sqlalchemy import create_engine
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'template.db'}")
+    inspector = inspect(engine)
+    tables = set(inspector.get_table_names())
+
+    assert {"user", "project"}.issubset(tables)
+    assert "item" not in tables
+
+    project_columns = {column["name"] for column in inspector.get_columns("project")}
+    assert {"id", "name", "owner_id"}.issubset(project_columns)
+
+    project_foreign_keys = inspector.get_foreign_keys("project")
+    assert any(
+        foreign_key["referred_table"] == "user"
+        and foreign_key["constrained_columns"] == ["owner_id"]
+        and foreign_key["referred_columns"] == ["id"]
+        for foreign_key in project_foreign_keys
+    )
+
+
+def test_authenticated_superuser_can_create_list_and_read_projects() -> None:
+    client, cleanup = _client_with_temp_database()
+    try:
+        token = _login(client)
+        headers = {"Authorization": f"Bearer {token}"}
+        current_user = client.get("/api/v1/users/me", headers=headers).json()
+
+        create_response = client.post(
+            "/api/v1/projects/",
+            headers=headers,
+            json={
+                "name": "External Attack Surface",
+                "description": "Internet-facing CVE prioritization workspace.",
+            },
+        )
+
+        assert create_response.status_code == 200
+        created = create_response.json()
+        assert created["name"] == "External Attack Surface"
+        assert created["description"] == "Internet-facing CVE prioritization workspace."
+        assert created["owner_id"] == current_user["id"]
+        assert created["id"]
+
+        list_response = client.get("/api/v1/projects/", headers=headers)
+        read_response = client.get(f"/api/v1/projects/{created['id']}", headers=headers)
+
+        assert list_response.status_code == 200
+        assert list_response.json() == {"data": [created], "count": 1}
+        assert read_response.status_code == 200
+        assert read_response.json() == created
+    finally:
+        cleanup()
+
+
+def test_template_project_openapi_exposes_projects_without_items() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/v1/openapi.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    paths = payload["paths"]
+    schemas = payload["components"]["schemas"]
+
+    assert any(path.startswith("/api/v1/projects") for path in paths)
+    assert all("/items" not in path for path in paths)
+    assert {"ProjectCreate", "ProjectPublic", "ProjectsPublic"}.issubset(schemas)
+    assert all("Item" not in schema_name for schema_name in schemas)
+
+
+def _client_with_temp_database() -> tuple[TestClient, Any]:
+    try:
+        import sqlmodel
+    except ImportError as exc:
+        pytest.fail(f"Project shell tests require SQLModel: {exc}")
+    from sqlalchemy import create_engine
+
+    try:
+        from app import models as app_models
+        from app.api import deps
+        from app.core import security
+    except ImportError as exc:
+        pytest.fail(f"Project shell must expose app models and DB dependencies: {exc}")
+
+    get_db = getattr(deps, "get_db", None)
+    if get_db is None:
+        pytest.fail("Project routes must depend on app.api.deps.get_db")
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    sqlmodel.SQLModel.metadata.create_all(engine)
+    _seed_superuser(sqlmodel.Session(engine), app_models, security)
+
+    def override_get_db() -> Generator[Any, None, None]:
+        with sqlmodel.Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    def cleanup() -> None:
+        app.dependency_overrides.pop(get_db, None)
+        engine.dispose()
+
+    return TestClient(app), cleanup
+
+
+def _seed_superuser(session: Any, app_models: Any, security: Any) -> None:
+    password_hash = getattr(security, "get_password_hash", lambda password: password)(
+        settings.FIRST_SUPERUSER_PASSWORD
+    )
+    try:
+        user = app_models.User(
+            id=_SUPERUSER_ID,
+            email=settings.FIRST_SUPERUSER,
+            hashed_password=password_hash,
+            is_active=True,
+            is_superuser=True,
+        )
+        session.add(user)
+        session.commit()
+    finally:
+        session.close()
+
+
+def _login(client: TestClient) -> str:
+    response = client.post(
+        "/api/v1/login/access-token",
+        data={
+            "username": settings.FIRST_SUPERUSER,
+            "password": settings.FIRST_SUPERUSER_PASSWORD,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["token_type"] == "bearer"
+    return str(payload["access_token"])

--- a/docs/architecture/template-replacement.md
+++ b/docs/architecture/template-replacement.md
@@ -12,11 +12,12 @@ layout, `/api/v1` routing, JWT/user flow, generated OpenAPI client, React,
 TanStack Router/Query, Docker Compose, SQLModel, and Alembic. It does not keep
 the demo Item ownership model as the Workbench authorization model.
 
-Current state after `codex/fsft-04-template-login-smoke`: the active
-template-shaped app already omits `/items` and `ItemsService`. That is only
-baseline evidence that the demo surface was not copied into the shell. It is
-not completion evidence for `Project`, `Finding`, SQLModel persistence, or
-React Workbench feature parity.
+Current state after `codex/fsft-08-project-domain-shell`: the active
+template-shaped app omits `/items` and `ItemsService`, adds template-native
+SQLModel `User` and `Project` tables, and exposes `/api/v1/projects` through the
+generated client. That is completion evidence for the first `Project` domain
+shell only. It is not completion evidence for `Finding`, imports, memberships,
+RBAC, or React Workbench feature parity.
 
 ## VPW-003 Scope
 

--- a/docs/evidence/full_stack_fastapi_template_baseline.md
+++ b/docs/evidence/full_stack_fastapi_template_baseline.md
@@ -490,3 +490,82 @@ Residual risks:
   required labels and milestones already exist.
 - Issue templates are Markdown templates. GitHub issue forms can be introduced
   later if maintainers want structured form validation.
+
+## FSFT-08 Project Domain Shell
+
+Branch:
+
+- `codex/fsft-08-project-domain-shell`
+
+Scope:
+
+- Added `sqlmodel` to the backend dependency set.
+- Added template-native DB helpers in `backend/app/core/db.py`, including a
+  stable configured-superuser UUID and SQLModel session dependency.
+- Replaced the auth-only Pydantic `UserPublic` shell with SQLModel-compatible
+  `User`, `UserPublic`, `Project`, `ProjectCreate`, `ProjectUpdate`,
+  `ProjectPublic`, and `ProjectsPublic` models.
+- Added `/api/v1/projects/` create/list/read routes with current-user ownership
+  and superuser visibility.
+- Added a separate template Alembic path under `backend/app/alembic` with the
+  initial `user` and `project` tables and no `item` table.
+- Updated auth smoke expectations for UUID-backed users and regenerated the
+  tracked TypeScript OpenAPI client files so `ProjectsService` is available.
+
+Commands run:
+
+```bash
+python3 -m pip install -e "backend[dev]"
+python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py \
+  backend/tests/api/test_template_auth_smoke.py \
+  backend/tests/api/test_template_projects.py --no-cov
+bash scripts/generate-client.sh
+python3 -m ruff format --check backend/app \
+  backend/tests/api/test_template_auth_smoke.py \
+  backend/tests/api/test_template_projects.py
+python3 -m ruff check backend/app \
+  backend/tests/api/test_template_auth_smoke.py \
+  backend/tests/api/test_template_projects.py
+cd backend && python3 -m mypy app src
+make frontend-check
+make docs-check
+make check
+make docker-demo-smoke
+rg -n "vuln_prioritizer\.(db|web|api)|\bItem\b|ItemsService|/items|items\.router" \
+  backend/app frontend/src/client
+git diff --check
+# Temporary Postgres smoke:
+# docker run postgres:16-alpine, alembic upgrade backend/app/alembic to head,
+# then login and POST/GET /api/v1/projects/ through TestClient.
+```
+
+Results:
+
+- Local backend dependency install succeeded and installed `sqlmodel-0.0.38`.
+- Targeted backend tests passed: 18 passed.
+- OpenAPI client generation passed and updated
+  `frontend/src/client/{schemas.gen.ts,sdk.gen.ts,types.gen.ts}` with Project
+  schemas and `ProjectsService`.
+- Ruff format/check and backend mypy over `app src` passed.
+- `make frontend-check` passed: frontend lint, production build, and generated
+  client generation completed.
+- `make docs-check` passed and built the MkDocs site successfully.
+- `make check` passed: 547 passed, 2 skipped, total coverage 90.27%.
+- `make docker-demo-smoke` built backend/frontend images, installed
+  `sqlmodel-0.0.38` in the backend image, and verified template backend status,
+  utility health, frontend root, and login route smoke checks.
+- Temporary Postgres migration/API smoke passed: Alembic upgraded
+  `backend/app/alembic` to head, created `user`, `project`, and
+  `alembic_version`, confirmed no `item` table, and created/listed a Project via
+  `/api/v1/projects/`.
+- Template backend app and generated client contain no `Item`, `ItemsService`,
+  `/items`, `items.router`, or legacy `vuln_prioritizer.db/web/api` imports.
+- `git diff --check` passed.
+
+Residual risks:
+
+- This slice intentionally does not implement Findings, import pipelines,
+  project memberships, RBAC, project update/delete, or React project pages.
+- The configured superuser remains a migration-shell bootstrap user. Full
+  template user CRUD, password hashing/recovery, email flows, and production
+  auth hardening remain later roadmap work.

--- a/docs/full_stack_fastapi_template_migration.md
+++ b/docs/full_stack_fastapi_template_migration.md
@@ -164,6 +164,13 @@ not something to fake by pointing at the old SQLAlchemy/Jinja implementation.
   [Template Replacement Strategy](architecture/template-replacement.md):
   remove demo Items and introduce Workbench `Project`/`Finding` domain work in
   follow-up implementation PRs.
+- `codex/fsft-08-project-domain-shell` adds the first template-native SQLModel
+  domain shell: DB-backed `User` ownership, `Project` models and public schemas,
+  `/api/v1/projects` create/list/read routes, generated TypeScript client
+  updates, and a separate template Alembic migration path under
+  `backend/app/alembic`. This replaces the official template's demo `Item`
+  pattern with Workbench `Project` ownership instead of reusing the legacy
+  SQLAlchemy/Jinja Workbench stack.
 
 Frontend issues `VPW-037` to `VPW-047` must wait until the backend OpenAPI client
 is generated and the template login flow remains green.

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -88,6 +88,100 @@ export const MigrationStatusSchema = {
     type: 'object'
 } as const;
 
+export const ProjectCreateSchema = {
+    description: 'Project creation payload.',
+    properties: {
+        description: {
+            anyOf: [
+                {
+                    maxLength: 4096,
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Description'
+        },
+        name: {
+            maxLength: 255,
+            minLength: 1,
+            title: 'Name',
+            type: 'string'
+        }
+    },
+    required: ['name'],
+    title: 'ProjectCreate',
+    type: 'object'
+} as const;
+
+export const ProjectPublicSchema = {
+    description: 'Public Project shape returned by the API.',
+    properties: {
+        created_at: {
+            format: 'date-time',
+            title: 'Created At',
+            type: 'string'
+        },
+        description: {
+            anyOf: [
+                {
+                    maxLength: 4096,
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Description'
+        },
+        id: {
+            format: 'uuid',
+            title: 'Id',
+            type: 'string'
+        },
+        name: {
+            maxLength: 255,
+            minLength: 1,
+            title: 'Name',
+            type: 'string'
+        },
+        owner_id: {
+            format: 'uuid',
+            title: 'Owner Id',
+            type: 'string'
+        },
+        updated_at: {
+            format: 'date-time',
+            title: 'Updated At',
+            type: 'string'
+        }
+    },
+    required: ['name', 'id', 'owner_id', 'created_at', 'updated_at'],
+    title: 'ProjectPublic',
+    type: 'object'
+} as const;
+
+export const ProjectsPublicSchema = {
+    description: 'Paginated Project collection shape.',
+    properties: {
+        count: {
+            title: 'Count',
+            type: 'integer'
+        },
+        data: {
+            items: {
+                '$ref': '#/components/schemas/ProjectPublic'
+            },
+            title: 'Data',
+            type: 'array'
+        }
+    },
+    required: ['data', 'count'],
+    title: 'ProjectsPublic',
+    type: 'object'
+} as const;
+
 export const TokenSchema = {
     description: 'OAuth2 bearer token response.',
     properties: {
@@ -107,9 +201,15 @@ export const TokenSchema = {
 } as const;
 
 export const UserPublicSchema = {
-    description: 'Public user shape exposed by the template shell auth smoke.',
+    description: 'Public user shape exposed by template auth routes.',
     properties: {
+        created_at: {
+            format: 'date-time',
+            title: 'Created At',
+            type: 'string'
+        },
         email: {
+            maxLength: 255,
             title: 'Email',
             type: 'string'
         },
@@ -125,6 +225,7 @@ export const UserPublicSchema = {
             title: 'Full Name'
         },
         id: {
+            format: 'uuid',
             title: 'Id',
             type: 'string'
         },
@@ -139,7 +240,7 @@ export const UserPublicSchema = {
             type: 'boolean'
         }
     },
-    required: ['id', 'email'],
+    required: ['email', 'id', 'created_at'],
     title: 'UserPublic',
     type: 'object'
 } as const;

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, UsersReadUserMeResponse, UtilsHealthCheckResponse, WorkbenchTemplateWorkbenchStatusResponse } from './types.gen';
+import type { LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, ProjectsReadProjectsResponse, ProjectsCreateProjectData, ProjectsCreateProjectResponse, ProjectsReadProjectData, ProjectsReadProjectResponse, UsersReadUserMeResponse, UtilsHealthCheckResponse, WorkbenchTemplateWorkbenchStatusResponse } from './types.gen';
 
 export class LoginService {
     /**
@@ -36,6 +36,62 @@ export class LoginService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/login/test-token'
+        });
+    }
+}
+
+export class ProjectsService {
+    /**
+     * Read Projects
+     * List projects visible to the current user.
+     * @returns ProjectsPublic Successful Response
+     * @throws ApiError
+     */
+    public static readProjects(): CancelablePromise<ProjectsReadProjectsResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/projects/'
+        });
+    }
+
+    /**
+     * Create Project
+     * Create a Project owned by the current user.
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns ProjectPublic Successful Response
+     * @throws ApiError
+     */
+    public static createProject(data: ProjectsCreateProjectData): CancelablePromise<ProjectsCreateProjectResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/projects/',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+
+    /**
+     * Read Project
+     * Read a single project if it belongs to the user or the user is superuser.
+     * @param data The data for the request.
+     * @param data.projectId
+     * @returns ProjectPublic Successful Response
+     * @throws ApiError
+     */
+    public static readProject(data: ProjectsReadProjectData): CancelablePromise<ProjectsReadProjectResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/projects/{project_id}',
+            path: {
+                project_id: data.projectId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
         });
     }
 }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -22,6 +22,34 @@ export type MigrationStatus = {
 };
 
 /**
+ * Project creation payload.
+ */
+export type ProjectCreate = {
+    description?: (string | null);
+    name: string;
+};
+
+/**
+ * Public Project shape returned by the API.
+ */
+export type ProjectPublic = {
+    created_at: string;
+    description?: (string | null);
+    id: string;
+    name: string;
+    owner_id: string;
+    updated_at: string;
+};
+
+/**
+ * Paginated Project collection shape.
+ */
+export type ProjectsPublic = {
+    count: number;
+    data: Array<ProjectPublic>;
+};
+
+/**
  * OAuth2 bearer token response.
  */
 export type Token = {
@@ -30,9 +58,10 @@ export type Token = {
 };
 
 /**
- * Public user shape exposed by the template shell auth smoke.
+ * Public user shape exposed by template auth routes.
  */
 export type UserPublic = {
+    created_at: string;
     email: string;
     full_name?: (string | null);
     id: string;
@@ -69,6 +98,20 @@ export type LoginLoginAccessTokenData = {
 export type LoginLoginAccessTokenResponse = (Token);
 
 export type LoginTestTokenResponse = (UserPublic);
+
+export type ProjectsReadProjectsResponse = (ProjectsPublic);
+
+export type ProjectsCreateProjectData = {
+    requestBody: ProjectCreate;
+};
+
+export type ProjectsCreateProjectResponse = (ProjectPublic);
+
+export type ProjectsReadProjectData = {
+    projectId: string;
+};
+
+export type ProjectsReadProjectResponse = (ProjectPublic);
 
 export type UsersReadUserMeResponse = (UserPublic);
 


### PR DESCRIPTION
## Summary

Implements VPW-006 / issue #112 as the first template-native Workbench domain shell.

- Adds SQLModel-backed `User` and `Project` models with user ownership and UUID IDs.
- Adds `/api/v1/projects/` create/list/read routes and DB session dependencies.
- Adds a separate template Alembic path under `backend/app/alembic` with `user` and `project` tables, and no `item` table.
- Regenerates the tracked frontend OpenAPI client so `ProjectsService` and Project schemas are available.
- Updates evidence and migration docs to mark this as Project-shell completion only, not Findings/import/RBAC/UI completion.

Closes #112 when merged.

## Validation

- `python3 -m pip install -e "backend[dev]"`
- `python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py backend/tests/api/test_template_auth_smoke.py backend/tests/api/test_template_projects.py --no-cov` -> 18 passed
- `bash scripts/generate-client.sh`
- `python3 -m ruff format --check backend/app backend/tests/api/test_template_auth_smoke.py backend/tests/api/test_template_projects.py`
- `python3 -m ruff check backend/app backend/tests/api/test_template_auth_smoke.py backend/tests/api/test_template_projects.py`
- `cd backend && python3 -m mypy app src`
- `make frontend-check`
- `make docs-check`
- `make check` -> 547 passed, 2 skipped, total coverage 90.27%
- `make docker-demo-smoke`
- Temporary Postgres migration/API smoke: `backend/app/alembic` upgraded to head, verified `user`, `project`, `alembic_version`, no `item`, then login and create/list Project via `/api/v1/projects/`
- `rg -n "vuln_prioritizer\.(db|web|api)|\bItem\b|ItemsService|/items|items\.router" backend/app frontend/src/client` -> no matches
- `git diff --check`

## Residual Risk

- This intentionally does not implement Findings, import pipelines, project memberships, RBAC, project update/delete, or React project pages.
- The configured superuser remains a migration-shell bootstrap user. Full template auth hardening remains later roadmap work.
