### PR TITLE
VPW-008: Add core Workbench SQLModel tables

### DIFF
--- a/backend/app/alembic/versions/20260428_0002_core_workbench_tables.py
+++ b/backend/app/alembic/versions/20260428_0002_core_workbench_tables.py
@@ -1,0 +1,162 @@
+"""add core workbench domain tables
+
+Revision ID: 20260428_0002
+Revises: 20260428_0001
+Create Date: 2026-04-28 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+
+revision = "20260428_0002"
+down_revision = "20260428_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "asset",
+        sa.Column("asset_key", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=300), nullable=False),
+        sa.Column("target_ref", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
+        sa.Column("owner", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=True),
+        sa.Column("business_service", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=True),
+        sa.Column("environment", sa.String(length=80), nullable=False),
+        sa.Column("exposure", sa.String(length=80), nullable=False),
+        sa.Column("criticality", sa.String(length=80), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("project_id", "asset_key", name="uq_asset_project_asset_key"),
+    )
+    op.create_index(
+        "ix_asset_project_criticality", "asset", ["project_id", "criticality"], unique=False
+    )
+    op.create_index(
+        "ix_asset_project_environment", "asset", ["project_id", "environment"], unique=False
+    )
+    op.create_index("ix_asset_project_exposure", "asset", ["project_id", "exposure"], unique=False)
+    op.create_index(op.f("ix_asset_project_id"), "asset", ["project_id"], unique=False)
+    op.create_table(
+        "component",
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=300), nullable=False),
+        sa.Column("version", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=True),
+        sa.Column("purl", sqlmodel.sql.sqltypes.AutoString(length=1000), nullable=True),
+        sa.Column("ecosystem", sqlmodel.sql.sqltypes.AutoString(length=120), nullable=True),
+        sa.Column("package_type", sqlmodel.sql.sqltypes.AutoString(length=120), nullable=True),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", "version", "ecosystem", name="uq_component_identity"),
+        sa.UniqueConstraint("purl", name="uq_component_purl"),
+    )
+    op.create_table(
+        "vulnerability",
+        sa.Column("source_id", sqlmodel.sql.sqltypes.AutoString(length=120), nullable=True),
+        sa.Column("title", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("cvss_score", sa.Float(), nullable=True),
+        sa.Column("cvss_vector", sqlmodel.sql.sqltypes.AutoString(length=300), nullable=True),
+        sa.Column("severity", sqlmodel.sql.sqltypes.AutoString(length=40), nullable=True),
+        sa.Column("cwe", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=True),
+        sa.Column("published_at", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=True),
+        sa.Column("modified_at", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=True),
+        sa.Column("provider_json", sa.JSON(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("cve_id", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_vulnerability_cve_id"), "vulnerability", ["cve_id"], unique=True)
+    op.create_table(
+        "finding",
+        sa.Column("cve_id", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("dedup_key", sqlmodel.sql.sqltypes.AutoString(length=512), nullable=False),
+        sa.Column("status", sa.String(length=40), nullable=False),
+        sa.Column("priority", sa.String(length=40), nullable=False),
+        sa.Column("priority_rank", sa.Integer(), nullable=False),
+        sa.Column("risk_score", sa.Float(), nullable=True),
+        sa.Column("operational_rank", sa.Integer(), nullable=False),
+        sa.Column("in_kev", sa.Boolean(), nullable=False),
+        sa.Column("epss", sa.Float(), nullable=True),
+        sa.Column("cvss_base_score", sa.Float(), nullable=True),
+        sa.Column("attack_mapped", sa.Boolean(), nullable=False),
+        sa.Column("suppressed_by_vex", sa.Boolean(), nullable=False),
+        sa.Column("under_investigation", sa.Boolean(), nullable=False),
+        sa.Column("waived", sa.Boolean(), nullable=False),
+        sa.Column("recommended_action", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("rationale", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("explanation_json", sa.JSON(), nullable=False),
+        sa.Column("data_quality_json", sa.JSON(), nullable=False),
+        sa.Column("evidence_json", sa.JSON(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("vulnerability_id", sa.Uuid(), nullable=False),
+        sa.Column("component_id", sa.Uuid(), nullable=True),
+        sa.Column("asset_id", sa.Uuid(), nullable=True),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["asset_id"], ["asset.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["component_id"], ["component.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["vulnerability_id"], ["vulnerability.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("project_id", "dedup_key", name="uq_finding_project_dedup_key"),
+        sa.UniqueConstraint(
+            "project_id",
+            "vulnerability_id",
+            "component_id",
+            "asset_id",
+            name="uq_finding_project_vulnerability_component_asset",
+        ),
+    )
+    op.create_index(op.f("ix_finding_asset_id"), "finding", ["asset_id"], unique=False)
+    op.create_index("ix_finding_cve_id", "finding", ["cve_id"], unique=False)
+    op.create_index(op.f("ix_finding_component_id"), "finding", ["component_id"], unique=False)
+    op.create_index("ix_finding_project_asset", "finding", ["project_id", "asset_id"], unique=False)
+    op.create_index(op.f("ix_finding_project_id"), "finding", ["project_id"], unique=False)
+    op.create_index(
+        "ix_finding_project_priority", "finding", ["project_id", "priority_rank"], unique=False
+    )
+    op.create_index("ix_finding_project_status", "finding", ["project_id", "status"], unique=False)
+    op.create_index(
+        "ix_finding_project_vulnerability",
+        "finding",
+        ["project_id", "vulnerability_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_finding_vulnerability_id"), "finding", ["vulnerability_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_finding_vulnerability_id"), table_name="finding")
+    op.drop_index("ix_finding_project_vulnerability", table_name="finding")
+    op.drop_index("ix_finding_project_status", table_name="finding")
+    op.drop_index("ix_finding_project_priority", table_name="finding")
+    op.drop_index(op.f("ix_finding_project_id"), table_name="finding")
+    op.drop_index("ix_finding_project_asset", table_name="finding")
+    op.drop_index(op.f("ix_finding_component_id"), table_name="finding")
+    op.drop_index("ix_finding_cve_id", table_name="finding")
+    op.drop_index(op.f("ix_finding_asset_id"), table_name="finding")
+    op.drop_table("finding")
+    op.drop_index(op.f("ix_vulnerability_cve_id"), table_name="vulnerability")
+    op.drop_table("vulnerability")
+    op.drop_table("component")
+    op.drop_index(op.f("ix_asset_project_id"), table_name="asset")
+    op.drop_index("ix_asset_project_exposure", table_name="asset")
+    op.drop_index("ix_asset_project_environment", table_name="asset")
+    op.drop_index("ix_asset_project_criticality", table_name="asset")
+    op.drop_table("asset")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,7 +5,16 @@ use ``from app.models import User, ProjectPublic`` while table definitions live
 in focused modules.
 """
 
+from app.models.assets import Asset, AssetBase, Component, ComponentBase
 from app.models.auth import Token, TokenPayload
+from app.models.enums import (
+    AssetCriticality,
+    AssetEnvironment,
+    AssetExposure,
+    FindingPriority,
+    FindingStatus,
+)
+from app.models.findings import Finding, FindingBase
 from app.models.projects import (
     Project,
     ProjectBase,
@@ -16,9 +25,21 @@ from app.models.projects import (
 )
 from app.models.registry import import_table_models
 from app.models.users import User, UserBase, UserPublic, UsersPublic
+from app.models.vulnerabilities import Vulnerability, VulnerabilityBase
 from app.models.workbench import MigrationStatus, WorkbenchStatus
 
 __all__ = [
+    "Asset",
+    "AssetBase",
+    "AssetCriticality",
+    "AssetEnvironment",
+    "AssetExposure",
+    "Component",
+    "ComponentBase",
+    "Finding",
+    "FindingBase",
+    "FindingPriority",
+    "FindingStatus",
     "MigrationStatus",
     "Project",
     "ProjectBase",
@@ -32,6 +53,8 @@ __all__ = [
     "UserBase",
     "UserPublic",
     "UsersPublic",
+    "Vulnerability",
+    "VulnerabilityBase",
     "WorkbenchStatus",
     "import_table_models",
 ]

--- a/backend/app/models/assets.py
+++ b/backend/app/models/assets.py
@@ -1,0 +1,98 @@
+"""Asset and component domain models."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Column, DateTime, Index, String, UniqueConstraint
+from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.base import get_datetime_utc
+from app.models.enums import AssetCriticality, AssetEnvironment, AssetExposure
+from app.models.projects import Project
+
+if TYPE_CHECKING:
+    from app.models.findings import Finding
+
+
+class AssetBase(SQLModel):
+    """Shared asset fields."""
+
+    asset_key: str = Field(min_length=1, max_length=200)
+    name: str = Field(min_length=1, max_length=300)
+    target_ref: str | None = Field(default=None, max_length=500)
+    owner: str | None = Field(default=None, max_length=200)
+    business_service: str | None = Field(default=None, max_length=200)
+    environment: AssetEnvironment = Field(
+        default=AssetEnvironment.UNKNOWN,
+        sa_column=Column(String(80), nullable=False),
+    )
+    exposure: AssetExposure = Field(
+        default=AssetExposure.UNKNOWN,
+        sa_column=Column(String(80), nullable=False),
+    )
+    criticality: AssetCriticality = Field(
+        default=AssetCriticality.UNKNOWN,
+        sa_column=Column(String(80), nullable=False),
+    )
+
+
+class Asset(AssetBase, table=True):
+    """Project-scoped asset affected by one or more findings."""
+
+    __tablename__ = "asset"
+    __table_args__ = (
+        UniqueConstraint("project_id", "asset_key", name="uq_asset_project_asset_key"),
+        Index("ix_asset_project_environment", "project_id", "environment"),
+        Index("ix_asset_project_exposure", "project_id", "exposure"),
+        Index("ix_asset_project_criticality", "project_id", "criticality"),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    project_id: uuid.UUID = Field(
+        foreign_key="project.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    project: Project | None = Relationship(back_populates="assets")
+    findings: list["Finding"] = Relationship(back_populates="asset")
+
+
+class ComponentBase(SQLModel):
+    """Shared component fields."""
+
+    name: str = Field(min_length=1, max_length=300)
+    version: str | None = Field(default=None, max_length=200)
+    purl: str | None = Field(default=None, max_length=1000)
+    ecosystem: str | None = Field(default=None, max_length=120)
+    package_type: str | None = Field(default=None, max_length=120)
+
+
+class Component(ComponentBase, table=True):
+    """Software component associated with findings."""
+
+    __tablename__ = "component"
+    __table_args__ = (
+        UniqueConstraint("purl", name="uq_component_purl"),
+        UniqueConstraint("name", "version", "ecosystem", name="uq_component_identity"),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    findings: list["Finding"] = Relationship(back_populates="component")

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -1,0 +1,52 @@
+"""Stable string enums for Workbench domain models."""
+
+from enum import StrEnum
+
+
+class AssetEnvironment(StrEnum):
+    """Deployment environment for an affected asset."""
+
+    PRODUCTION = "production"
+    STAGING = "staging"
+    DEVELOPMENT = "development"
+    TEST = "test"
+    UNKNOWN = "unknown"
+
+
+class AssetExposure(StrEnum):
+    """Exposure level for an affected asset."""
+
+    INTERNET_FACING = "internet-facing"
+    INTERNAL = "internal"
+    PRIVATE = "private"
+    UNKNOWN = "unknown"
+
+
+class AssetCriticality(StrEnum):
+    """Business criticality for an affected asset."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    UNKNOWN = "unknown"
+
+
+class FindingPriority(StrEnum):
+    """Rule-based finding priority label."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class FindingStatus(StrEnum):
+    """Finding lifecycle state."""
+
+    OPEN = "open"
+    IN_REVIEW = "in_review"
+    REMEDIATING = "remediating"
+    FIXED = "fixed"
+    ACCEPTED = "accepted"
+    SUPPRESSED = "suppressed"

--- a/backend/app/models/findings.py
+++ b/backend/app/models/findings.py
@@ -1,0 +1,120 @@
+"""Finding domain models."""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Column, DateTime, Float, Index, Integer, String, UniqueConstraint
+from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.assets import Asset, Component
+from app.models.base import get_datetime_utc
+from app.models.enums import FindingPriority, FindingStatus
+from app.models.projects import Project
+from app.models.vulnerabilities import Vulnerability
+
+
+class FindingBase(SQLModel):
+    """Shared finding fields."""
+
+    cve_id: str = Field(min_length=1, max_length=64)
+    dedup_key: str = Field(default_factory=lambda: str(uuid.uuid4()), max_length=512)
+    status: FindingStatus = Field(
+        default=FindingStatus.OPEN,
+        sa_column=Column(String(40), nullable=False),
+    )
+    priority: FindingPriority = Field(
+        default=FindingPriority.MEDIUM,
+        sa_column=Column(String(40), nullable=False),
+    )
+    priority_rank: int = Field(default=99, sa_column=Column(Integer, nullable=False))
+    risk_score: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
+    operational_rank: int = Field(default=0, sa_column=Column(Integer, nullable=False))
+    in_kev: bool = False
+    epss: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
+    cvss_base_score: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
+    attack_mapped: bool = False
+    suppressed_by_vex: bool = False
+    under_investigation: bool = False
+    waived: bool = False
+    recommended_action: str | None = None
+    rationale: str | None = None
+    explanation_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    data_quality_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    evidence_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class Finding(FindingBase, table=True):
+    """Prioritized vulnerability finding within a project."""
+
+    __tablename__ = "finding"
+    __table_args__ = (
+        UniqueConstraint("project_id", "dedup_key", name="uq_finding_project_dedup_key"),
+        UniqueConstraint(
+            "project_id",
+            "vulnerability_id",
+            "component_id",
+            "asset_id",
+            name="uq_finding_project_vulnerability_component_asset",
+        ),
+        Index("ix_finding_cve_id", "cve_id"),
+        Index("ix_finding_project_priority", "project_id", "priority_rank"),
+        Index("ix_finding_project_status", "project_id", "status"),
+        Index("ix_finding_project_asset", "project_id", "asset_id"),
+        Index("ix_finding_project_vulnerability", "project_id", "vulnerability_id"),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    project_id: uuid.UUID = Field(
+        foreign_key="project.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    vulnerability_id: uuid.UUID = Field(
+        foreign_key="vulnerability.id",
+        index=True,
+        nullable=False,
+        ondelete="RESTRICT",
+    )
+    component_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="component.id",
+        index=True,
+        ondelete="SET NULL",
+    )
+    asset_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="asset.id",
+        index=True,
+        ondelete="SET NULL",
+    )
+    first_seen_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    last_seen_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    project: Project | None = Relationship(back_populates="findings")
+    vulnerability: Vulnerability | None = Relationship(back_populates="findings")
+    component: Component | None = Relationship(back_populates="findings")
+    asset: Asset | None = Relationship(back_populates="findings")

--- a/backend/app/models/projects.py
+++ b/backend/app/models/projects.py
@@ -2,12 +2,17 @@
 
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import Column, DateTime
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.models.base import get_datetime_utc
 from app.models.users import User
+
+if TYPE_CHECKING:
+    from app.models.assets import Asset
+    from app.models.findings import Finding
 
 
 class ProjectBase(SQLModel):
@@ -49,6 +54,8 @@ class Project(ProjectBase, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     owner: User | None = Relationship(back_populates="projects")
+    assets: list["Asset"] = Relationship(back_populates="project", cascade_delete=True)
+    findings: list["Finding"] = Relationship(back_populates="project", cascade_delete=True)
 
 
 class ProjectPublic(ProjectBase):

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -5,6 +5,9 @@ from importlib import import_module
 TABLE_MODEL_MODULES = (
     "app.models.users",
     "app.models.projects",
+    "app.models.assets",
+    "app.models.vulnerabilities",
+    "app.models.findings",
 )
 
 

--- a/backend/app/models/vulnerabilities.py
+++ b/backend/app/models/vulnerabilities.py
@@ -1,0 +1,50 @@
+"""Vulnerability domain models."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, Column, DateTime, Text
+from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.base import get_datetime_utc
+
+if TYPE_CHECKING:
+    from app.models.findings import Finding
+
+
+class VulnerabilityBase(SQLModel):
+    """Shared vulnerability fields."""
+
+    cve_id: str = Field(min_length=1, max_length=64)
+    source_id: str | None = Field(default=None, max_length=120)
+    title: str | None = Field(default=None, max_length=500)
+    description: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    cvss_score: float | None = None
+    cvss_vector: str | None = Field(default=None, max_length=300)
+    severity: str | None = Field(default=None, max_length=40)
+    cwe: str | None = Field(default=None, max_length=200)
+    published_at: str | None = Field(default=None, max_length=64)
+    modified_at: str | None = Field(default=None, max_length=64)
+    provider_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class Vulnerability(VulnerabilityBase, table=True):
+    """Known vulnerability normalized from provider context."""
+
+    __tablename__ = "vulnerability"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    cve_id: str = Field(min_length=1, max_length=64, unique=True, index=True)
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    findings: list["Finding"] = Relationship(back_populates="vulnerability")

--- a/backend/tests/api/test_template_core_workbench_models.py
+++ b/backend/tests/api/test_template_core_workbench_models.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, select
+
+CORE_WORKBENCH_TABLES = {"asset", "component", "vulnerability", "finding"}
+CORE_WORKBENCH_EXPORTS = ("Asset", "Component", "Vulnerability", "Finding")
+
+
+@pytest.fixture()
+def app_models() -> Any:
+    models = importlib.import_module("app.models")
+    import_table_models = getattr(models, "import_table_models", None)
+    assert import_table_models is not None, "app.models must expose import_table_models"
+    import_table_models()
+    return models
+
+
+@pytest.fixture()
+def alembic_config(tmp_path: Path) -> Config:
+    script_location = Path(__file__).resolve().parents[2] / "app" / "alembic"
+    assert script_location.exists(), "Template app Alembic migrations must live under app/alembic"
+
+    config = Config()
+    config.set_main_option("script_location", str(script_location))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{tmp_path / 'template.db'}")
+    return config
+
+
+@pytest.fixture()
+def migrated_engine(alembic_config: Config, app_models: Any) -> Iterator[Engine]:
+    command.upgrade(alembic_config, "head")
+
+    engine = create_engine(alembic_config.get_main_option("sqlalchemy.url"))
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_core_workbench_models_are_exported_and_registered(app_models: Any) -> None:
+    exported_names = set(getattr(app_models, "__all__", ()))
+    assert set(CORE_WORKBENCH_EXPORTS).issubset(exported_names)
+    assert CORE_WORKBENCH_TABLES.issubset(SQLModel.metadata.tables)
+
+    for model_name in CORE_WORKBENCH_EXPORTS:
+        model = getattr(app_models, model_name)
+        assert model.__module__.startswith("app.models.")
+        assert model.__module__ != "app.models"
+
+
+def test_core_workbench_migration_creates_tables_and_foreign_keys(
+    migrated_engine: Engine,
+) -> None:
+    inspector = inspect(migrated_engine)
+    assert CORE_WORKBENCH_TABLES.issubset(set(inspector.get_table_names()))
+
+    foreign_keys = {
+        table: {
+            (
+                tuple(foreign_key["constrained_columns"]),
+                foreign_key["referred_table"],
+                tuple(foreign_key["referred_columns"]),
+            )
+            for foreign_key in inspector.get_foreign_keys(table)
+        }
+        for table in CORE_WORKBENCH_TABLES
+    }
+
+    assert (("project_id",), "project", ("id",)) in foreign_keys["asset"]
+    assert (("project_id",), "project", ("id",)) in foreign_keys["finding"]
+    assert (("asset_id",), "asset", ("id",)) in foreign_keys["finding"]
+    assert (("component_id",), "component", ("id",)) in foreign_keys["finding"]
+    assert (("vulnerability_id",), "vulnerability", ("id",)) in foreign_keys["finding"]
+
+
+def test_project_can_persist_core_workbench_graph(app_models: Any, migrated_engine: Engine) -> None:
+    user_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+    component_id = uuid.uuid4()
+    vulnerability_id = uuid.uuid4()
+    finding_id = uuid.uuid4()
+
+    with Session(migrated_engine) as session:
+        session.add(
+            app_models.User(
+                id=user_id,
+                email="owner@example.test",
+                hashed_password="not-used",
+                is_active=True,
+                is_superuser=True,
+            )
+        )
+        session.add(
+            app_models.Project(
+                id=project_id,
+                owner_id=user_id,
+                name="Core Workbench",
+                description="Template SQLModel persistence contract.",
+            )
+        )
+        session.add(
+            app_models.Asset(
+                id=asset_id,
+                project_id=project_id,
+                asset_key="api-gateway",
+                name="API Gateway",
+                environment=_enum_or_string(app_models, "AssetEnvironment", "production"),
+                exposure=_enum_or_string(app_models, "AssetExposure", "internet-facing"),
+                criticality=_enum_or_string(app_models, "AssetCriticality", "critical"),
+            )
+        )
+        session.add(
+            app_models.Component(
+                id=component_id,
+                name="log4j-core",
+                version="2.14.1",
+                purl="pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+                ecosystem="maven",
+            )
+        )
+        session.add(
+            app_models.Vulnerability(
+                id=vulnerability_id,
+                cve_id="CVE-2021-44228",
+                source_id="CVE-2021-44228",
+                cvss_score=10.0,
+                severity="CRITICAL",
+            )
+        )
+        session.add(
+            app_models.Finding(
+                id=finding_id,
+                project_id=project_id,
+                asset_id=asset_id,
+                component_id=component_id,
+                vulnerability_id=vulnerability_id,
+                cve_id="CVE-2021-44228",
+                status=_enum_or_string(app_models, "FindingStatus", "open"),
+                priority=_enum_or_string(app_models, "FindingPriority", "critical"),
+                priority_rank=1,
+                in_kev=True,
+            )
+        )
+        session.commit()
+
+    with Session(migrated_engine) as session:
+        finding = session.exec(
+            select(app_models.Finding).where(app_models.Finding.id == finding_id)
+        ).one()
+        assert finding.project_id == project_id
+        assert finding.asset_id == asset_id
+        assert finding.component_id == component_id
+        assert finding.vulnerability_id == vulnerability_id
+        assert finding.cve_id == "CVE-2021-44228"
+        assert _value(finding.status) == "open"
+        assert _value(finding.priority) == "critical"
+
+
+def test_core_workbench_enum_values_serialize_as_stable_strings(app_models: Any) -> None:
+    asset = app_models.Asset(
+        project_id=uuid.uuid4(),
+        asset_key="payments-api",
+        name="Payments API",
+        environment=_enum_or_string(app_models, "AssetEnvironment", "production"),
+        exposure=_enum_or_string(app_models, "AssetExposure", "internet-facing"),
+        criticality=_enum_or_string(app_models, "AssetCriticality", "critical"),
+    )
+    finding = app_models.Finding(
+        project_id=uuid.uuid4(),
+        vulnerability_id=uuid.uuid4(),
+        cve_id="CVE-2024-0001",
+        status=_enum_or_string(app_models, "FindingStatus", "open"),
+        priority=_enum_or_string(app_models, "FindingPriority", "high"),
+        priority_rank=2,
+    )
+
+    asset_payload = asset.model_dump(mode="json")
+    finding_payload = finding.model_dump(mode="json")
+
+    assert asset_payload["environment"] == "production"
+    assert asset_payload["exposure"] == "internet-facing"
+    assert asset_payload["criticality"] == "critical"
+    assert finding_payload["status"] == "open"
+    assert finding_payload["priority"] == "high"
+
+
+def test_core_workbench_dedup_constraints_and_indexes_exist(migrated_engine: Engine) -> None:
+    inspector = inspect(migrated_engine)
+    assert CORE_WORKBENCH_TABLES.issubset(set(inspector.get_table_names()))
+
+    assert _has_unique_constraint_or_index(inspector, "asset", ("project_id", "asset_key"))
+    assert _has_unique_constraint_or_index(inspector, "component", ("purl",)) or (
+        _has_unique_constraint_or_index(inspector, "component", ("name", "version", "ecosystem"))
+    )
+    assert _has_unique_constraint_or_index(inspector, "vulnerability", ("cve_id",))
+    assert _has_unique_constraint_or_index(
+        inspector,
+        "finding",
+        ("project_id", "vulnerability_id", "component_id", "asset_id"),
+    )
+
+    assert _has_index(inspector, "asset", ("project_id",))
+    assert _has_index(inspector, "finding", ("project_id", "priority_rank"))
+    assert _has_index(inspector, "finding", ("project_id", "status"))
+    assert _has_index(inspector, "finding", ("cve_id",))
+
+
+def _enum_or_string(app_models: Any, enum_name: str, value: str) -> Any:
+    enum_class = getattr(app_models, enum_name, None)
+    if enum_class is None:
+        return value
+    return enum_class(value)
+
+
+def _value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _has_unique_constraint_or_index(inspector: Any, table: str, columns: tuple[str, ...]) -> bool:
+    return any(
+        tuple(constraint["column_names"]) == columns
+        for constraint in inspector.get_unique_constraints(table)
+    ) or any(
+        index.get("unique") and tuple(index["column_names"]) == columns
+        for index in inspector.get_indexes(table)
+    )
+
+
+def _has_index(inspector: Any, table: str, columns: tuple[str, ...]) -> bool:
+    return any(tuple(index["column_names"]) == columns for index in inspector.get_indexes(table))

--- a/docs/architecture/core-workbench-schema.md
+++ b/docs/architecture/core-workbench-schema.md
@@ -1,0 +1,162 @@
+# Core Workbench Schema
+
+## Scope
+
+VPW-008 adds the first template-stack Workbench domain tables after the user and
+project foundation. The schema is intentionally narrow: it persists already-known
+CVE findings and their project, asset, component, and vulnerability context. It
+does not introduce scanning, exploit execution, heuristic ATT&CK mapping, or a
+second opaque scoring model.
+
+The SQLModel tables are singular and owned by the template backend:
+
+- `asset`
+- `component`
+- `vulnerability`
+- `finding`
+
+The legacy `vuln_prioritizer.db.models` tables remain a reference for behavior,
+but VPW template code should use `app.models` exports and `app/alembic`
+migrations.
+
+## Model Exports
+
+`app.models` should remain the public aggregator for template models. It must
+export:
+
+- `Asset`
+- `Component`
+- `Vulnerability`
+- `Finding`
+
+Enum-like fields should serialize as stable lower-case strings through
+`model_dump(mode="json")`. The initial expected values are:
+
+- finding status: `open`
+- finding priority: `critical`, `high`, `medium`, `low`
+- asset environment: `production`
+- asset exposure: `internet-facing`
+- asset criticality: `critical`
+
+Additional values can be added later, but existing string values should remain
+stable because API payloads, generated clients, reports, and fixtures depend on
+them.
+
+## Tables
+
+### `asset`
+
+An asset is project-scoped routing and business context for a finding.
+
+Minimum fields:
+
+- `id`
+- `project_id`
+- `asset_key`
+- `name`
+- `target_ref`
+- `environment`
+- `exposure`
+- `criticality`
+- `owner`
+- `business_service`
+
+Constraints and indexes:
+
+- foreign key from `project_id` to `project.id`
+- unique dedup key on `(project_id, asset_key)`
+- index on `project_id`
+- indexes on `(project_id, environment)`, `(project_id, exposure)`, and
+  `(project_id, criticality)` for common Workbench filters
+
+### `component`
+
+A component is the affected package, dependency, image layer, product, or other
+normalized software identity. It is shared across projects and attached to a
+finding through `finding.component_id`.
+
+Minimum fields:
+
+- `id`
+- `name`
+- `version`
+- `purl`
+- `ecosystem`
+- `package_type`
+
+Constraints and indexes:
+
+- unique dedup key on `purl` when present
+- unique fallback identity on `(name, version, ecosystem)`
+
+### `vulnerability`
+
+A vulnerability is the canonical CVE/provider record shared across projects.
+
+Minimum fields:
+
+- `id`
+- `cve_id`
+- `source_id`
+- `cvss_score`
+- `severity`
+- `provider_json`
+- provider metadata fields as additive context
+
+Constraints and indexes:
+
+- unique dedup key on `cve_id`
+
+### `finding`
+
+A finding links one project to one vulnerability, optionally scoped to an asset
+and component. It stores the transparent priority result plus persisted status.
+
+Minimum fields:
+
+- `id`
+- `project_id`
+- `asset_id`
+- `component_id`
+- `vulnerability_id`
+- `cve_id`
+- `dedup_key`
+- `status`
+- `priority`
+- `priority_rank`
+- `in_kev`
+- `epss`
+- `cvss_base_score`
+- `explanation_json`
+- `data_quality_json`
+- `evidence_json`
+
+Constraints and indexes:
+
+- foreign key from `project_id` to `project.id`
+- foreign key from `asset_id` to `asset.id`
+- foreign key from `component_id` to `component.id`
+- foreign key from `vulnerability_id` to `vulnerability.id`
+- unique technical dedup key on `(project_id, dedup_key)`
+- unique dedup key on `(project_id, vulnerability_id, component_id, asset_id)`
+- index on `cve_id`
+- index on `(project_id, priority_rank)`
+- index on `(project_id, status)`
+- indexes on `(project_id, asset_id)` and `(project_id, vulnerability_id)`
+
+## Persistence Contract
+
+A single project must be able to persist and retrieve a connected graph:
+
+`Project -> Asset -> Finding -> Component -> Vulnerability`
+
+The finding remains the Workbench triage unit. Asset and component context route
+work; vulnerability records keep provider facts deduplicated; project ownership
+continues to use the template `User` and `Project` tables.
+
+## Migration Contract
+
+The template Alembic head under `backend/app/alembic` must create the four core
+Workbench tables and match SQLModel metadata on a fresh SQLite database. Tests
+use a temporary SQLite database and an Alembic `Config` rather than production
+settings.

--- a/docs/evidence/full_stack_fastapi_template_baseline.md
+++ b/docs/evidence/full_stack_fastapi_template_baseline.md
@@ -627,3 +627,71 @@ Residual risks:
 - Future table-bearing modules must be added to
   `app.models.registry.TABLE_MODEL_MODULES`; otherwise Alembic autogenerate can
   miss them.
+
+## FSFT-10 Core Workbench Tables
+
+Branch:
+
+- `codex/fsft-10-core-workbench-tables`
+
+Scope:
+
+- Added SQLModel tables for `Asset`, `Component`, `Vulnerability`, and
+  `Finding` under `backend/app/models/`.
+- Added stable string enums for finding priority/status and asset environment,
+  exposure, and criticality.
+- Added Project relationships to assets/findings and Finding relationships to
+  vulnerability, component, and asset.
+- Added JSON fields for finding explanation, data quality, and evidence, plus
+  provider JSON on vulnerabilities.
+- Added Alembic revision `20260428_0002_core_workbench_tables.py`.
+- Documented DB constraints and the core schema in
+  `docs/architecture/core-workbench-schema.md`.
+
+Commands run:
+
+```bash
+python3 -m pytest -q backend/tests/api/test_template_core_workbench_models.py \
+  backend/tests/api/test_template_model_metadata.py \
+  backend/tests/api/test_template_projects.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py \
+  backend/tests/api/test_template_auth_smoke.py \
+  backend/tests/api/test_template_projects.py \
+  backend/tests/api/test_template_model_metadata.py \
+  backend/tests/api/test_template_core_workbench_models.py --no-cov
+python3 -m ruff format --check backend/app \
+  backend/tests/api/test_template_core_workbench_models.py
+python3 -m ruff check backend/app \
+  backend/tests/api/test_template_core_workbench_models.py
+cd backend && python3 -m mypy app src
+make docs-check
+make check
+git diff --check
+# Temporary Alembic autogenerate dry-run:
+# copy backend/app/alembic to a temp dir, upgrade a fresh SQLite DB to head,
+# then run command.revision(..., autogenerate=True).
+```
+
+Results:
+
+- Core Workbench model, metadata, and project tests passed: 11 passed.
+- Template adapter, auth smoke, project, metadata, and core Workbench model
+  tests passed: 26 passed.
+- Ruff format/check over `backend/app` and the new model tests passed.
+- Backend mypy over `app src` passed.
+- `make docs-check` passed.
+- `make check` passed: 555 passed, 2 skipped, total coverage 90.27%.
+- `git diff --check` passed.
+- Temporary Alembic autogenerate dry-run generated an empty migration body with
+  `pass` in both `upgrade()` and `downgrade()`, proving metadata and migrations
+  are aligned.
+
+Residual risks:
+
+- This slice intentionally does not add `AnalysisRun`, `FindingOccurrence`,
+  provider snapshots, ATT&CK context, status history, waivers, API routes, or
+  frontend screens. Those remain separate VPW items.
+- The finding dedup model includes both a technical `(project_id, dedup_key)`
+  constraint and a domain `(project_id, vulnerability_id, component_id,
+  asset_id)` constraint so future import services can provide stable dedup keys
+  without weakening the initial domain contract.

--- a/docs/full_stack_fastapi_template_migration.md
+++ b/docs/full_stack_fastapi_template_migration.md
@@ -176,6 +176,11 @@ not something to fake by pointing at the old SQLAlchemy/Jinja implementation.
   stable public import surface. Alembic now calls `import_table_models()` before
   reading `SQLModel.metadata`, and the import convention is documented in
   [Model Import Registry](architecture/model-imports.md).
+- `codex/fsft-10-core-workbench-tables` adds the first core Workbench SQLModel
+  tables after Project: `asset`, `component`, `vulnerability`, and `finding`.
+  These tables include stable enum strings, JSON evidence/explanation fields,
+  explicit foreign keys, and prepared dedup constraints without adding API
+  routes, analysis runs, provider snapshots, or import services.
 
 Frontend issues `VPW-037` to `VPW-047` must wait until the backend OpenAPI client
 is generated and the template login flow remains green.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
       - Overview: architecture/index.md
       - Template Replacement Strategy: architecture/template-replacement.md
       - Model Import Registry: architecture/model-imports.md
+      - Core Workbench Schema: architecture/core-workbench-schema.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md
   - VPW Template Execution Sequence: vpw_template_execution_sequence.md
   - Use Cases: use_cases.md


### PR DESCRIPTION
Refs #114

## Scope
- Add template-stack SQLModel tables for Asset, Component, Vulnerability, and Finding.
- Add stable string enums for finding priority/status and asset environment/exposure/criticality.
- Wire Project -> assets/findings and Finding -> vulnerability/component/asset relationships.
- Add Alembic revision for the four core Workbench tables with foreign keys, indexes, and dedup constraints.
- Document the core Workbench schema and strict evidence in docs.

## Verification
- `python3 -m pytest -q backend/tests/api/test_template_core_workbench_models.py --no-cov` -> 5 passed
- `python3 -m pytest -q backend/tests/api/test_template_core_workbench_models.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_projects.py --no-cov` -> 11 passed
- `python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py backend/tests/api/test_template_auth_smoke.py backend/tests/api/test_template_projects.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_core_workbench_models.py --no-cov` -> 26 passed
- `python3 -m ruff format --check backend/app backend/tests/api/test_template_core_workbench_models.py` -> passed
- `python3 -m ruff check backend/app backend/tests/api/test_template_core_workbench_models.py` -> passed
- `cd backend && python3 -m mypy app src` -> passed
- `make docs-check` -> passed
- `make check` -> 555 passed, 2 skipped, total coverage 90.27%
- `git diff --check` -> passed
- Temporary Alembic autogenerate dry-run on fresh SQLite DB -> empty upgrade/downgrade body (`pass`/`pass`)

## Evidence
- Schema docs: `docs/architecture/core-workbench-schema.md`
- Execution evidence: `docs/evidence/full_stack_fastapi_template_baseline.md#fsft-10-core-workbench-tables`

## Residual Risk
- This slice intentionally does not add analysis runs, provider snapshots, import services, API routes, generated client changes, or frontend screens. Those remain separate VPW issues.
