### PR TITLE
VPW-009: Add analysis run provider provenance models

### DIFF
--- a/backend/app/alembic/versions/20260428_0003_analysis_run_provider_models.py
+++ b/backend/app/alembic/versions/20260428_0003_analysis_run_provider_models.py
@@ -1,0 +1,123 @@
+"""add analysis run provider snapshot models
+
+Revision ID: 20260428_0003
+Revises: 20260428_0002
+Create Date: 2026-04-28 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+
+revision = "20260428_0003"
+down_revision = "20260428_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_snapshot",
+        sa.Column("nvd_last_sync", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=True),
+        sa.Column("epss_date", sqlmodel.sql.sqltypes.AutoString(length=32), nullable=True),
+        sa.Column(
+            "kev_catalog_version",
+            sqlmodel.sql.sqltypes.AutoString(length=128),
+            nullable=True,
+        ),
+        sa.Column("content_hash", sqlmodel.sql.sqltypes.AutoString(length=128), nullable=True),
+        sa.Column("source_hashes_json", sa.JSON(), nullable=False),
+        sa.Column("source_metadata_json", sa.JSON(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_provider_snapshot_content_hash"),
+        "provider_snapshot",
+        ["content_hash"],
+        unique=True,
+    )
+    op.create_table(
+        "analysis_run",
+        sa.Column("input_type", sqlmodel.sql.sqltypes.AutoString(length=80), nullable=False),
+        sa.Column("filename", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=True),
+        sa.Column("status", sa.String(length=40), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("error_json", sa.JSON(), nullable=False),
+        sa.Column("summary_json", sa.JSON(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("provider_snapshot_id", sa.Uuid(), nullable=True),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["provider_snapshot_id"],
+            ["provider_snapshot.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_analysis_run_project_started_at",
+        "analysis_run",
+        ["project_id", "started_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_analysis_run_project_status",
+        "analysis_run",
+        ["project_id", "status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_analysis_run_project_id"), "analysis_run", ["project_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_analysis_run_provider_snapshot_id"),
+        "analysis_run",
+        ["provider_snapshot_id"],
+        unique=False,
+    )
+    op.create_table(
+        "finding_occurrence",
+        sa.Column("source", sqlmodel.sql.sqltypes.AutoString(length=120), nullable=True),
+        sa.Column("scanner", sqlmodel.sql.sqltypes.AutoString(length=120), nullable=True),
+        sa.Column("raw_reference", sqlmodel.sql.sqltypes.AutoString(length=1000), nullable=True),
+        sa.Column("fix_version", sqlmodel.sql.sqltypes.AutoString(length=300), nullable=True),
+        sa.Column("evidence_json", sa.JSON(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("finding_id", sa.Uuid(), nullable=False),
+        sa.Column("analysis_run_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(["analysis_run_id"], ["analysis_run.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["finding_id"], ["finding.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_finding_occurrence_analysis_run_id"),
+        "finding_occurrence",
+        ["analysis_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_finding_occurrence_finding_id"),
+        "finding_occurrence",
+        ["finding_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_finding_occurrence_finding_id"), table_name="finding_occurrence")
+    op.drop_index(op.f("ix_finding_occurrence_analysis_run_id"), table_name="finding_occurrence")
+    op.drop_table("finding_occurrence")
+    op.drop_index(op.f("ix_analysis_run_provider_snapshot_id"), table_name="analysis_run")
+    op.drop_index(op.f("ix_analysis_run_project_id"), table_name="analysis_run")
+    op.drop_index("ix_analysis_run_project_status", table_name="analysis_run")
+    op.drop_index("ix_analysis_run_project_started_at", table_name="analysis_run")
+    op.drop_table("analysis_run")
+    op.drop_index(op.f("ix_provider_snapshot_content_hash"), table_name="provider_snapshot")
+    op.drop_table("provider_snapshot")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ in focused modules.
 from app.models.assets import Asset, AssetBase, Component, ComponentBase
 from app.models.auth import Token, TokenPayload
 from app.models.enums import (
+    AnalysisRunStatus,
     AssetCriticality,
     AssetEnvironment,
     AssetExposure,
@@ -24,11 +25,22 @@ from app.models.projects import (
     ProjectUpdate,
 )
 from app.models.registry import import_table_models
+from app.models.runs import (
+    AnalysisRun,
+    AnalysisRunBase,
+    FindingOccurrence,
+    FindingOccurrenceBase,
+    ProviderSnapshot,
+    ProviderSnapshotBase,
+)
 from app.models.users import User, UserBase, UserPublic, UsersPublic
 from app.models.vulnerabilities import Vulnerability, VulnerabilityBase
 from app.models.workbench import MigrationStatus, WorkbenchStatus
 
 __all__ = [
+    "AnalysisRun",
+    "AnalysisRunBase",
+    "AnalysisRunStatus",
     "Asset",
     "AssetBase",
     "AssetCriticality",
@@ -38,6 +50,8 @@ __all__ = [
     "ComponentBase",
     "Finding",
     "FindingBase",
+    "FindingOccurrence",
+    "FindingOccurrenceBase",
     "FindingPriority",
     "FindingStatus",
     "MigrationStatus",
@@ -47,6 +61,8 @@ __all__ = [
     "ProjectPublic",
     "ProjectsPublic",
     "ProjectUpdate",
+    "ProviderSnapshot",
+    "ProviderSnapshotBase",
     "Token",
     "TokenPayload",
     "User",

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -50,3 +50,14 @@ class FindingStatus(StrEnum):
     FIXED = "fixed"
     ACCEPTED = "accepted"
     SUPPRESSED = "suppressed"
+
+
+class AnalysisRunStatus(StrEnum):
+    """Import or analysis run lifecycle state."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    COMPLETED_WITH_ERRORS = "completed_with_errors"
+    FAILED = "failed"
+    CANCELLED = "cancelled"

--- a/backend/app/models/findings.py
+++ b/backend/app/models/findings.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON, Column, DateTime, Float, Index, Integer, String, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
@@ -12,6 +12,9 @@ from app.models.base import get_datetime_utc
 from app.models.enums import FindingPriority, FindingStatus
 from app.models.projects import Project
 from app.models.vulnerabilities import Vulnerability
+
+if TYPE_CHECKING:
+    from app.models.runs import FindingOccurrence
 
 
 class FindingBase(SQLModel):
@@ -118,3 +121,7 @@ class Finding(FindingBase, table=True):
     vulnerability: Vulnerability | None = Relationship(back_populates="findings")
     component: Component | None = Relationship(back_populates="findings")
     asset: Asset | None = Relationship(back_populates="findings")
+    occurrences: list["FindingOccurrence"] = Relationship(
+        back_populates="finding",
+        cascade_delete=True,
+    )

--- a/backend/app/models/projects.py
+++ b/backend/app/models/projects.py
@@ -13,6 +13,7 @@ from app.models.users import User
 if TYPE_CHECKING:
     from app.models.assets import Asset
     from app.models.findings import Finding
+    from app.models.runs import AnalysisRun
 
 
 class ProjectBase(SQLModel):
@@ -56,6 +57,10 @@ class Project(ProjectBase, table=True):
     owner: User | None = Relationship(back_populates="projects")
     assets: list["Asset"] = Relationship(back_populates="project", cascade_delete=True)
     findings: list["Finding"] = Relationship(back_populates="project", cascade_delete=True)
+    analysis_runs: list["AnalysisRun"] = Relationship(
+        back_populates="project",
+        cascade_delete=True,
+    )
 
 
 class ProjectPublic(ProjectBase):

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -8,6 +8,7 @@ TABLE_MODEL_MODULES = (
     "app.models.assets",
     "app.models.vulnerabilities",
     "app.models.findings",
+    "app.models.runs",
 )
 
 

--- a/backend/app/models/runs.py
+++ b/backend/app/models/runs.py
@@ -1,0 +1,137 @@
+"""Analysis run, occurrence, and provider snapshot domain models."""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Column, DateTime, Index, String, Text
+from sqlmodel import Field, Relationship, SQLModel
+
+from app.models.base import get_datetime_utc
+from app.models.enums import AnalysisRunStatus
+from app.models.findings import Finding
+from app.models.projects import Project
+
+
+class ProviderSnapshotBase(SQLModel):
+    """Shared provider snapshot fields."""
+
+    nvd_last_sync: str | None = Field(default=None, max_length=64)
+    epss_date: str | None = Field(default=None, max_length=32)
+    kev_catalog_version: str | None = Field(default=None, max_length=128)
+    content_hash: str | None = Field(default=None, max_length=128)
+    source_hashes_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    source_metadata_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class ProviderSnapshot(ProviderSnapshotBase, table=True):
+    """Provider data snapshot used by one or more analysis runs."""
+
+    __tablename__ = "provider_snapshot"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    content_hash: str | None = Field(default=None, max_length=128, unique=True, index=True)
+    analysis_runs: list["AnalysisRun"] = Relationship(back_populates="provider_snapshot")
+
+
+class AnalysisRunBase(SQLModel):
+    """Shared analysis run fields."""
+
+    input_type: str = Field(min_length=1, max_length=80)
+    filename: str | None = Field(default=None, max_length=500)
+    status: AnalysisRunStatus = Field(
+        default=AnalysisRunStatus.PENDING,
+        sa_column=Column(String(40), nullable=False),
+    )
+    started_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    finished_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    error_message: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    error_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    summary_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class AnalysisRun(AnalysisRunBase, table=True):
+    """Workbench import or analysis run for a project."""
+
+    __tablename__ = "analysis_run"
+    __table_args__ = (
+        Index("ix_analysis_run_project_started_at", "project_id", "started_at"),
+        Index("ix_analysis_run_project_status", "project_id", "status"),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    project_id: uuid.UUID = Field(
+        foreign_key="project.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    provider_snapshot_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="provider_snapshot.id",
+        index=True,
+        ondelete="SET NULL",
+    )
+    project: Project | None = Relationship(back_populates="analysis_runs")
+    provider_snapshot: ProviderSnapshot | None = Relationship(back_populates="analysis_runs")
+    occurrences: list["FindingOccurrence"] = Relationship(
+        back_populates="analysis_run",
+        cascade_delete=True,
+    )
+
+
+class FindingOccurrenceBase(SQLModel):
+    """Shared finding occurrence fields."""
+
+    source: str | None = Field(default=None, max_length=120)
+    scanner: str | None = Field(default=None, max_length=120)
+    raw_reference: str | None = Field(default=None, max_length=1000)
+    fix_version: str | None = Field(default=None, max_length=300)
+    evidence_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class FindingOccurrence(FindingOccurrenceBase, table=True):
+    """Concrete scanner/source occurrence that produced a finding in a run."""
+
+    __tablename__ = "finding_occurrence"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    finding_id: uuid.UUID = Field(
+        foreign_key="finding.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    analysis_run_id: uuid.UUID = Field(
+        foreign_key="analysis_run.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    finding: Finding | None = Relationship(back_populates="occurrences")
+    analysis_run: AnalysisRun | None = Relationship(back_populates="occurrences")

--- a/backend/tests/api/test_template_run_provider_models.py
+++ b/backend/tests/api/test_template_run_provider_models.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, select
+
+RUN_PROVIDER_TABLES = {"analysis_run", "finding_occurrence", "provider_snapshot"}
+RUN_PROVIDER_EXPORTS = (
+    "AnalysisRun",
+    "AnalysisRunStatus",
+    "FindingOccurrence",
+    "ProviderSnapshot",
+)
+RUN_STATUS_VALUES = (
+    "pending",
+    "running",
+    "completed",
+    "completed_with_errors",
+    "failed",
+    "cancelled",
+)
+FIXED_STARTED_AT = datetime(2026, 4, 28, 12, 0, tzinfo=UTC)
+FIXED_FINISHED_AT = datetime(2026, 4, 28, 12, 4, tzinfo=UTC)
+
+
+def test_run_provider_models_are_exported_and_registered() -> None:
+    app_models = _app_models()
+
+    exported_names = set(getattr(app_models, "__all__", ()))
+    assert set(RUN_PROVIDER_EXPORTS).issubset(exported_names)
+    assert RUN_PROVIDER_TABLES.issubset(SQLModel.metadata.tables)
+
+    for model_name in RUN_PROVIDER_EXPORTS:
+        model = getattr(app_models, model_name)
+        assert model.__module__.startswith("app.models.")
+        assert model.__module__ != "app.models"
+
+
+def test_run_provider_migration_creates_tables_and_foreign_keys(
+    migrated_engine: Engine,
+) -> None:
+    inspector = inspect(migrated_engine)
+    assert RUN_PROVIDER_TABLES.issubset(set(inspector.get_table_names()))
+
+    foreign_keys = {
+        table: {
+            (
+                tuple(foreign_key["constrained_columns"]),
+                foreign_key["referred_table"],
+                tuple(foreign_key["referred_columns"]),
+            )
+            for foreign_key in inspector.get_foreign_keys(table)
+        }
+        for table in RUN_PROVIDER_TABLES
+    }
+
+    assert (("project_id",), "project", ("id",)) in foreign_keys["analysis_run"]
+    assert (
+        ("provider_snapshot_id",),
+        "provider_snapshot",
+        ("id",),
+    ) in foreign_keys["analysis_run"]
+    assert (
+        ("analysis_run_id",),
+        "analysis_run",
+        ("id",),
+    ) in foreign_keys["finding_occurrence"]
+    assert (("finding_id",), "finding", ("id",)) in foreign_keys["finding_occurrence"]
+
+
+def test_project_can_persist_analysis_run_without_findings_then_with_occurrence(
+    migrated_engine: Engine,
+) -> None:
+    app_models = _app_models()
+    ids = _ids()
+
+    with Session(migrated_engine) as session:
+        _persist_project_shell(session, app_models, ids)
+        session.add(
+            app_models.AnalysisRun(
+                id=ids["run"],
+                project_id=ids["project"],
+                input_type="trivy-json",
+                filename="trivy-results.json",
+                status=app_models.AnalysisRunStatus.RUNNING,
+                started_at=FIXED_STARTED_AT,
+                summary_json={"parsed": 0, "findings": 0},
+            )
+        )
+        session.commit()
+
+    with Session(migrated_engine) as session:
+        run = session.get(app_models.AnalysisRun, ids["run"])
+        assert run is not None
+        assert run.project_id == ids["project"]
+        assert _value(run.status) == "running"
+
+        occurrences = session.exec(
+            select(app_models.FindingOccurrence).where(
+                app_models.FindingOccurrence.analysis_run_id == ids["run"]
+            )
+        ).all()
+        assert occurrences == []
+
+    with Session(migrated_engine) as session:
+        session.add(
+            app_models.Vulnerability(
+                id=ids["vulnerability"],
+                cve_id="CVE-2021-44228",
+                source_id="CVE-2021-44228",
+                cvss_score=10.0,
+                severity="CRITICAL",
+            )
+        )
+        session.add(
+            app_models.Finding(
+                id=ids["finding"],
+                project_id=ids["project"],
+                vulnerability_id=ids["vulnerability"],
+                cve_id="CVE-2021-44228",
+                status=_enum_or_string(app_models, "FindingStatus", "open"),
+                priority=_enum_or_string(app_models, "FindingPriority", "critical"),
+                priority_rank=1,
+                in_kev=True,
+            )
+        )
+        session.add(
+            app_models.FindingOccurrence(
+                id=ids["occurrence"],
+                analysis_run_id=ids["run"],
+                finding_id=ids["finding"],
+                source="dependency-scan",
+                scanner="trivy",
+                raw_reference="pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+                fix_version="2.17.1",
+                evidence_json={
+                    "target_ref": "registry.example.test/payments-api:2026.04.28",
+                    "input_line": 42,
+                },
+            )
+        )
+
+        run = session.get(app_models.AnalysisRun, ids["run"])
+        assert run is not None
+        run.status = app_models.AnalysisRunStatus.COMPLETED
+        run.finished_at = FIXED_FINISHED_AT
+        run.summary_json = {"parsed": 1, "findings": 1}
+        session.commit()
+
+    with Session(migrated_engine) as session:
+        occurrence = session.get(app_models.FindingOccurrence, ids["occurrence"])
+        assert occurrence is not None
+        assert occurrence.analysis_run_id == ids["run"]
+        assert occurrence.finding_id == ids["finding"]
+        assert occurrence.source == "dependency-scan"
+        assert occurrence.scanner == "trivy"
+        assert occurrence.raw_reference == "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"
+        assert occurrence.fix_version == "2.17.1"
+        assert occurrence.evidence_json["input_line"] == 42
+
+        run = session.get(app_models.AnalysisRun, ids["run"])
+        assert run is not None
+        assert _value(run.status) == "completed"
+        assert run.summary_json == {"parsed": 1, "findings": 1}
+
+
+def test_provider_snapshot_can_be_linked_to_analysis_run(migrated_engine: Engine) -> None:
+    app_models = _app_models()
+    ids = _ids()
+
+    with Session(migrated_engine) as session:
+        _persist_project_shell(session, app_models, ids)
+        session.add(
+            app_models.ProviderSnapshot(
+                id=ids["provider_snapshot"],
+                nvd_last_sync="2026-04-28T10:15:00Z",
+                epss_date="2026-04-28",
+                kev_catalog_version="2026-04-28",
+                content_hash="sha256:6a98c6d1d5f0d57c7b7d3e1adce89c01",
+                source_hashes_json={
+                    "nvd": "sha256:nvd-feed",
+                    "epss": "sha256:epss-feed",
+                    "kev": "sha256:kev-feed",
+                },
+                source_metadata_json={
+                    "selected_sources": ["nvd", "epss", "kev"],
+                    "cache_only": True,
+                    "requested_cves": 1,
+                },
+            )
+        )
+        session.add(
+            app_models.AnalysisRun(
+                id=ids["run"],
+                project_id=ids["project"],
+                provider_snapshot_id=ids["provider_snapshot"],
+                input_type="cve-list",
+                filename="known-cves.txt",
+                status=app_models.AnalysisRunStatus.COMPLETED,
+                started_at=FIXED_STARTED_AT,
+                finished_at=FIXED_FINISHED_AT,
+                summary_json={"parsed": 1, "findings": 1},
+            )
+        )
+        session.commit()
+
+    with Session(migrated_engine) as session:
+        run = session.get(app_models.AnalysisRun, ids["run"])
+        assert run is not None
+        assert run.provider_snapshot_id == ids["provider_snapshot"]
+
+        snapshot = session.get(app_models.ProviderSnapshot, ids["provider_snapshot"])
+        assert snapshot is not None
+        assert snapshot.content_hash == "sha256:6a98c6d1d5f0d57c7b7d3e1adce89c01"
+        assert snapshot.source_hashes_json["kev"] == "sha256:kev-feed"
+        assert snapshot.source_metadata_json["selected_sources"] == ["nvd", "epss", "kev"]
+
+
+def test_analysis_run_status_values_serialize_as_stable_strings() -> None:
+    app_models = _app_models()
+    status_enum = app_models.AnalysisRunStatus
+
+    assert {status.value for status in status_enum}.issuperset(RUN_STATUS_VALUES)
+
+    for value in RUN_STATUS_VALUES:
+        run = app_models.AnalysisRun(
+            project_id=uuid.uuid4(),
+            input_type="cve-list",
+            filename="known-cves.txt",
+            status=status_enum(value),
+            error_message="Provider enrichment failed." if value == "failed" else None,
+            error_json={"provider": "nvd"} if value == "failed" else {},
+        )
+        payload = run.model_dump(mode="json")
+
+        assert payload["status"] == value
+        if value == "failed":
+            assert payload["error_message"] == "Provider enrichment failed."
+            assert payload["error_json"] == {"provider": "nvd"}
+
+
+def test_run_provider_constraints_and_indexes_exist(migrated_engine: Engine) -> None:
+    inspector = inspect(migrated_engine)
+    assert RUN_PROVIDER_TABLES.issubset(set(inspector.get_table_names()))
+
+    assert _has_unique_constraint_or_index(
+        inspector,
+        "provider_snapshot",
+        ("content_hash",),
+    )
+
+    assert _has_index(inspector, "analysis_run", ("project_id",))
+    assert _has_index(inspector, "analysis_run", ("provider_snapshot_id",))
+    assert _has_index(inspector, "analysis_run", ("project_id", "started_at"))
+    assert _has_index(inspector, "analysis_run", ("project_id", "status"))
+    assert _has_index(inspector, "finding_occurrence", ("analysis_run_id",))
+    assert _has_index(inspector, "finding_occurrence", ("finding_id",))
+
+
+def _app_models() -> Any:
+    models = importlib.import_module("app.models")
+    import_table_models = getattr(models, "import_table_models", None)
+    assert import_table_models is not None, "app.models must expose import_table_models"
+    import_table_models()
+    return models
+
+
+def _alembic_config(tmp_path: Path) -> Config:
+    script_location = Path(__file__).resolve().parents[2] / "app" / "alembic"
+    assert script_location.exists(), "Template app Alembic migrations must live under app/alembic"
+
+    config = Config()
+    config.set_main_option("script_location", str(script_location))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{tmp_path / 'template.db'}")
+    return config
+
+
+@pytest.fixture()
+def migrated_engine(tmp_path: Path) -> Iterator[Engine]:
+    config = _alembic_config(tmp_path)
+    _app_models()
+    command.upgrade(config, "head")
+
+    engine = create_engine(config.get_main_option("sqlalchemy.url"))
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def _ids() -> dict[str, uuid.UUID]:
+    return {
+        "user": uuid.uuid4(),
+        "project": uuid.uuid4(),
+        "run": uuid.uuid4(),
+        "provider_snapshot": uuid.uuid4(),
+        "vulnerability": uuid.uuid4(),
+        "finding": uuid.uuid4(),
+        "occurrence": uuid.uuid4(),
+    }
+
+
+def _persist_project_shell(session: Session, app_models: Any, ids: dict[str, uuid.UUID]) -> None:
+    session.add(
+        app_models.User(
+            id=ids["user"],
+            email=f"{ids['user']}@example.test",
+            hashed_password="not-used",
+            is_active=True,
+            is_superuser=True,
+        )
+    )
+    session.add(
+        app_models.Project(
+            id=ids["project"],
+            owner_id=ids["user"],
+            name="Run Provider Contract",
+            description="VPW-009 AnalysisRun and ProviderSnapshot test shell.",
+        )
+    )
+
+
+def _enum_or_string(app_models: Any, enum_name: str, value: str) -> Any:
+    enum_class = getattr(app_models, enum_name, None)
+    if enum_class is None:
+        return value
+    return enum_class(value)
+
+
+def _value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _has_unique_constraint_or_index(inspector: Any, table: str, columns: tuple[str, ...]) -> bool:
+    return any(
+        tuple(constraint["column_names"]) == columns
+        for constraint in inspector.get_unique_constraints(table)
+    ) or any(
+        index.get("unique") and tuple(index["column_names"]) == columns
+        for index in inspector.get_indexes(table)
+    )
+
+
+def _has_index(inspector: Any, table: str, columns: tuple[str, ...]) -> bool:
+    return any(tuple(index["column_names"]) == columns for index in inspector.get_indexes(table))

--- a/docs/architecture/analysis-run-provider-schema.md
+++ b/docs/architecture/analysis-run-provider-schema.md
@@ -1,0 +1,185 @@
+# Analysis Run Provider Schema
+
+## Scope
+
+VPW-009 adds the template-stack persistence contract for import and analysis run
+provenance. It extends the VPW-008 project, asset, vulnerability, and finding
+tables with the run record, concrete source occurrences, and provider data
+snapshot metadata needed to explain where a finding came from.
+
+This slice is storage-only. It does not introduce scanning, exploit execution,
+remote plugin loading, or heuristic ATT&CK mapping.
+
+The SQLModel tables are singular and owned by the template backend:
+
+- `analysis_run`
+- `finding_occurrence`
+- `provider_snapshot`
+
+The legacy `vuln_prioritizer.db.models` tables remain useful behavioral
+reference points, but template code should use `app.models` exports and
+`app/alembic` migrations.
+
+## Model Exports
+
+`app.models` remains the public aggregator for template models. VPW-009 expects
+it to export:
+
+- `AnalysisRun`
+- `AnalysisRunStatus`
+- `FindingOccurrence`
+- `ProviderSnapshot`
+
+The model registry used by Alembic must import the module that declares these
+table models before `SQLModel.metadata` is read. A fresh Alembic upgrade should
+therefore create all three tables with no manual metadata imports in tests or
+runtime code.
+
+## Status Values
+
+`AnalysisRun.status` is a stable string enum. Existing string values should not
+be renamed because generated clients, API payloads, report evidence, and
+fixture assertions may depend on them.
+
+Expected values:
+
+- `pending`: run was created but processing has not started
+- `running`: parser or enrichment work is active
+- `completed`: run finished successfully
+- `completed_with_errors`: run produced usable output but retained recoverable
+  errors or degraded provider evidence
+- `failed`: run did not produce usable output
+- `cancelled`: run was intentionally stopped before completion
+
+Error states are modeled on the run through `error_message` and `error_json`.
+`finished_at` should be populated for terminal states.
+
+## Tables
+
+### `provider_snapshot`
+
+A provider snapshot records the exact enrichment data context used by one or
+more runs.
+
+Minimum fields:
+
+- `id`
+- `created_at`
+- `nvd_last_sync`
+- `epss_date`
+- `kev_catalog_version`
+- `content_hash`
+- `source_hashes_json`
+- `source_metadata_json`
+
+Constraints and indexes:
+
+- unique index on `content_hash`
+
+`source_hashes_json` stores per-source hashes such as NVD, EPSS, and KEV feed
+hashes. `source_metadata_json` stores source selection, cache/replay mode, input
+scope, and other replay metadata.
+
+### `analysis_run`
+
+An analysis run records one import or analysis execution inside a project.
+
+Minimum fields:
+
+- `id`
+- `project_id`
+- `provider_snapshot_id`
+- `input_type`
+- `filename`
+- `status`
+- `started_at`
+- `finished_at`
+- `error_message`
+- `error_json`
+- `summary_json`
+
+Constraints and indexes:
+
+- foreign key from `project_id` to `project.id`
+- nullable foreign key from `provider_snapshot_id` to `provider_snapshot.id`
+- index on `project_id`
+- index on `provider_snapshot_id`
+- index on `(project_id, started_at)`
+- index on `(project_id, status)`
+
+The run can be saved before any findings exist. This supports creating a durable
+record as soon as an upload/import starts, then appending summary data and
+occurrences after parsing and enrichment complete.
+
+### `finding_occurrence`
+
+A finding occurrence stores one concrete source row, alert, package match, or
+scanner record that produced a persisted finding during a run.
+
+Minimum fields:
+
+- `id`
+- `analysis_run_id`
+- `finding_id`
+- `source`
+- `scanner`
+- `raw_reference`
+- `fix_version`
+- `evidence_json`
+
+Constraints and indexes:
+
+- foreign key from `analysis_run_id` to `analysis_run.id`
+- foreign key from `finding_id` to `finding.id`
+- index on `analysis_run_id`
+- index on `finding_id`
+
+`source` is the normalized source family, such as `dependency-scan` or
+`sbom`. `scanner` is the concrete tool name when available, such as `trivy` or
+`grype`. `raw_reference` preserves the scanner or input reference needed for
+auditable traceability.
+
+## Relationship Contract
+
+The expected graph is:
+
+```text
+Project -> AnalysisRun -> FindingOccurrence -> Finding
+AnalysisRun -> ProviderSnapshot
+```
+
+Deleting a project deletes its runs. Deleting a run deletes its occurrence
+records. Deleting a finding deletes its occurrence records. Deleting a provider
+snapshot should not delete historical runs; the run-side snapshot reference is
+nullable for that reason.
+
+## Example Provider Snapshot JSON
+
+```json
+{
+  "id": "5e3841b4-6f5a-41bc-92b9-19326ad7a84d",
+  "created_at": "2026-04-28T12:00:00Z",
+  "nvd_last_sync": "2026-04-28T10:15:00Z",
+  "epss_date": "2026-04-28",
+  "kev_catalog_version": "2026-04-28",
+  "content_hash": "sha256:6a98c6d1d5f0d57c7b7d3e1adce89c01",
+  "source_hashes_json": {
+    "nvd": "sha256:nvd-feed",
+    "epss": "sha256:epss-feed",
+    "kev": "sha256:kev-feed"
+  },
+  "source_metadata_json": {
+    "selected_sources": ["nvd", "epss", "kev"],
+    "cache_only": true,
+    "requested_cves": 1,
+    "input_type": "cve-list"
+  }
+}
+```
+
+## Migration Contract
+
+The template Alembic head under `backend/app/alembic` must create the three
+VPW-009 tables and their foreign keys/indexes on a fresh SQLite database. The
+focused API model tests use a temporary SQLite database and an Alembic `Config`
+rather than production settings.

--- a/docs/evidence/full_stack_fastapi_template_baseline.md
+++ b/docs/evidence/full_stack_fastapi_template_baseline.md
@@ -695,3 +695,70 @@ Residual risks:
   constraint and a domain `(project_id, vulnerability_id, component_id,
   asset_id)` constraint so future import services can provide stable dedup keys
   without weakening the initial domain contract.
+
+## VPW-009 Analysis Run Provider Models
+
+Branch:
+
+- `codex/vpw-009-run-provider-models`
+
+Scope:
+
+- Added SQLModel tables for `AnalysisRun`, `FindingOccurrence`, and
+  `ProviderSnapshot` under `backend/app/models/`.
+- Added stable `AnalysisRunStatus` string values: `pending`, `running`,
+  `completed`, `completed_with_errors`, `failed`, and `cancelled`.
+- Added Project to AnalysisRun, AnalysisRun to FindingOccurrence, Finding to
+  FindingOccurrence, and AnalysisRun to ProviderSnapshot relationships.
+- Added JSON fields for run errors/summaries, occurrence evidence, provider
+  source hashes, and provider source metadata.
+- Added Alembic revision `20260428_0003_analysis_run_provider_models.py`.
+- Documented DB constraints and provider snapshot example JSON in
+  `docs/architecture/analysis-run-provider-schema.md`.
+
+Commands run:
+
+```bash
+python3 -m pytest -q backend/tests/api/test_template_run_provider_models.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_core_workbench_models.py \
+  backend/tests/api/test_template_run_provider_models.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_model_metadata.py \
+  backend/tests/api/test_template_core_workbench_models.py \
+  backend/tests/api/test_template_run_provider_models.py --no-cov
+python3 -m ruff format --check backend/app \
+  backend/tests/api/test_template_run_provider_models.py
+python3 -m ruff check backend/app \
+  backend/tests/api/test_template_run_provider_models.py
+cd backend && python3 -m mypy app src
+make docs-check
+make check
+git diff --check
+# Temporary Alembic autogenerate dry-run:
+# copy backend/app/alembic to a temp dir, upgrade a fresh SQLite DB to head,
+# then run command.revision(..., autogenerate=True).
+```
+
+Results:
+
+- Focused run/provider model tests passed: 6 passed.
+- Core Workbench and run/provider model tests passed together: 11 passed.
+- Model metadata, core Workbench, and run/provider model tests passed: 14
+  passed.
+- Ruff format/check over `backend/app` and the new model tests passed.
+- Backend mypy over `app src` passed.
+- `make docs-check` passed.
+- `make check` passed: 561 passed, 2 skipped, total coverage 90.27%.
+- `git diff --check` passed.
+- Temporary Alembic autogenerate dry-run generated an empty migration body with
+  `pass` in both `upgrade()` and `downgrade()`, proving metadata and migrations
+  are aligned.
+
+Residual risks:
+
+- This slice intentionally does not add import execution, parser integration,
+  provider clients, provider update jobs, API routes, generated client changes,
+  reports, evidence bundles, ATT&CK context, or frontend screens. Those remain
+  separate VPW issues.
+- `FindingOccurrence` is the provenance source of truth for run-to-finding
+  linkage; this slice intentionally does not add a denormalized
+  `Finding.analysis_run_id`.

--- a/docs/full_stack_fastapi_template_migration.md
+++ b/docs/full_stack_fastapi_template_migration.md
@@ -181,6 +181,11 @@ not something to fake by pointing at the old SQLAlchemy/Jinja implementation.
   These tables include stable enum strings, JSON evidence/explanation fields,
   explicit foreign keys, and prepared dedup constraints without adding API
   routes, analysis runs, provider snapshots, or import services.
+- `codex/vpw-009-run-provider-models` adds the run provenance layer:
+  `analysis_run`, `finding_occurrence`, and `provider_snapshot`, with stable
+  run status strings, error state fields, provider source hashes/metadata, and
+  FKs back to Project/Finding without adding import APIs, provider clients, or
+  frontend screens.
 
 Frontend issues `VPW-037` to `VPW-047` must wait until the backend OpenAPI client
 is generated and the template login flow remains green.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - Template Replacement Strategy: architecture/template-replacement.md
       - Model Import Registry: architecture/model-imports.md
       - Core Workbench Schema: architecture/core-workbench-schema.md
+      - Analysis Run Provider Schema: architecture/analysis-run-provider-schema.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md
   - VPW Template Execution Sequence: vpw_template_execution_sequence.md
   - Use Cases: use_cases.md


### PR DESCRIPTION
Refs #115

## Scope
- Add template-stack SQLModel models for `AnalysisRun`, `FindingOccurrence`, and `ProviderSnapshot`.
- Add stable `AnalysisRunStatus` strings for pending/running/completed/completed_with_errors/failed/cancelled.
- Wire relationships from Project to runs, runs to occurrences, findings to occurrences, and runs to provider snapshots.
- Add Alembic revision `20260428_0003_analysis_run_provider_models.py` with FKs, indexes, JSON fields, and provider snapshot hash uniqueness.
- Document schema, status values, relationship contract, and example provider snapshot JSON.

## Verification
- `python3 -m pytest -q backend/tests/api/test_template_run_provider_models.py --no-cov` -> 6 passed
- `python3 -m pytest -q backend/tests/api/test_template_core_workbench_models.py backend/tests/api/test_template_run_provider_models.py --no-cov` -> 11 passed
- `python3 -m pytest -q backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_core_workbench_models.py backend/tests/api/test_template_run_provider_models.py --no-cov` -> 14 passed
- `python3 -m ruff format --check backend/app backend/tests/api/test_template_run_provider_models.py` -> passed
- `python3 -m ruff check backend/app backend/tests/api/test_template_run_provider_models.py` -> passed
- `cd backend && python3 -m mypy app src` -> passed
- `make docs-check` -> passed
- `make check` -> 561 passed, 2 skipped, total coverage 90.27%
- `git diff --check` -> passed
- Temporary Alembic autogenerate dry-run on fresh SQLite DB -> empty upgrade/downgrade body (`pass`/`pass`)

## Evidence
- Schema docs: `docs/architecture/analysis-run-provider-schema.md`
- Execution evidence: `docs/evidence/full_stack_fastapi_template_baseline.md#vpw-009-analysis-run-provider-models`
- Model/migration tests: `backend/tests/api/test_template_run_provider_models.py`

## Residual Risk
- This slice intentionally does not add import execution, parser integration, provider clients, provider update jobs, API routes, generated client changes, reports, evidence bundles, ATT&CK context, or frontend screens. Those remain separate VPW issues.
- `FindingOccurrence` is the provenance source of truth for run-to-finding linkage; no denormalized `Finding.analysis_run_id` is added in this issue.
