### PR TITLE
VPW-010: Add template Workbench repository layer

### DIFF
--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, HTTPException
-from sqlmodel import col, func, select
 
 from app.api.deps import CurrentUser, SessionDep
 from app.models import Project, ProjectCreate, ProjectPublic, ProjectsPublic
+from app.repositories import ProjectRepository
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -16,14 +16,7 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 @router.get("/", response_model=ProjectsPublic)
 def read_projects(session: SessionDep, current_user: CurrentUser) -> ProjectsPublic:
     """List projects visible to the current user."""
-    count_statement = select(func.count()).select_from(Project)
-    statement = select(Project).order_by(col(Project.created_at).desc())
-    if not current_user.is_superuser:
-        count_statement = count_statement.where(Project.owner_id == current_user.id)
-        statement = statement.where(Project.owner_id == current_user.id)
-
-    count = session.exec(count_statement).one()
-    projects = session.exec(statement).all()
+    projects, count = ProjectRepository(session).list_visible_projects(current_user)
     return ProjectsPublic(
         data=[ProjectPublic.model_validate(project) for project in projects],
         count=count,
@@ -38,8 +31,7 @@ def create_project(
     project_in: ProjectCreate,
 ) -> Project:
     """Create a Project owned by the current user."""
-    project = Project.model_validate(project_in, update={"owner_id": current_user.id})
-    session.add(project)
+    project = ProjectRepository(session).create_project(project_in, owner_id=current_user.id)
     session.commit()
     session.refresh(project)
     return project
@@ -48,7 +40,8 @@ def create_project(
 @router.get("/{project_id}", response_model=ProjectPublic)
 def read_project(project_id: uuid.UUID, session: SessionDep, current_user: CurrentUser) -> Project:
     """Read a single project if it belongs to the user or the user is superuser."""
-    project = session.get(Project, project_id)
+    repository = ProjectRepository(session)
+    project = repository.get_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
     if not current_user.is_superuser and project.owner_id != current_user.id:

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,13 @@
+"""Template Workbench repository exports."""
+
+from app.repositories.assets import AssetRepository
+from app.repositories.findings import FindingRepository
+from app.repositories.projects import ProjectRepository
+from app.repositories.runs import RunRepository
+
+__all__ = [
+    "AssetRepository",
+    "FindingRepository",
+    "ProjectRepository",
+    "RunRepository",
+]

--- a/backend/app/repositories/assets.py
+++ b/backend/app/repositories/assets.py
@@ -1,0 +1,59 @@
+"""Asset repository for template Workbench persistence."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlmodel import Session, select
+
+from app.models import Asset, AssetCriticality, AssetEnvironment, AssetExposure
+
+
+class AssetRepository:
+    """Asset persistence helpers."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def upsert_asset(
+        self,
+        *,
+        project_id: uuid.UUID,
+        asset_key: str,
+        name: str | None = None,
+        target_ref: str | None = None,
+        owner: str | None = None,
+        business_service: str | None = None,
+        environment: AssetEnvironment | str = AssetEnvironment.UNKNOWN,
+        exposure: AssetExposure | str = AssetExposure.UNKNOWN,
+        criticality: AssetCriticality | str = AssetCriticality.UNKNOWN,
+    ) -> Asset:
+        """Create or update a project-scoped asset by business dedup key."""
+        statement = select(Asset).where(
+            Asset.project_id == project_id,
+            Asset.asset_key == asset_key,
+        )
+        asset = self.session.exec(statement).first()
+        if asset is None:
+            asset = Asset(project_id=project_id, asset_key=asset_key, name=name or asset_key)
+            self.session.add(asset)
+        elif name is not None:
+            asset.name = name
+
+        asset.target_ref = target_ref
+        asset.owner = owner
+        asset.business_service = business_service
+        asset.environment = AssetEnvironment(environment)
+        asset.exposure = AssetExposure(exposure)
+        asset.criticality = AssetCriticality(criticality)
+        self.session.flush()
+        return asset
+
+    def get_asset(self, asset_id: uuid.UUID) -> Asset | None:
+        """Return an asset by primary key."""
+        return self.session.get(Asset, asset_id)
+
+    def list_project_assets(self, project_id: uuid.UUID) -> list[Asset]:
+        """Return project assets ordered for stable API output."""
+        statement = select(Asset).where(Asset.project_id == project_id).order_by(Asset.asset_key)
+        return list(self.session.exec(statement).all())

--- a/backend/app/repositories/findings.py
+++ b/backend/app/repositories/findings.py
@@ -1,0 +1,167 @@
+"""Finding repository for template Workbench persistence."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlmodel import Session, col, select
+
+from app.models import (
+    Component,
+    Finding,
+    FindingPriority,
+    FindingStatus,
+    Vulnerability,
+)
+from app.models.base import get_datetime_utc
+
+
+class FindingRepository:
+    """Finding, component, and vulnerability persistence helpers."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def upsert_component(
+        self,
+        *,
+        name: str,
+        version: str | None = None,
+        purl: str | None = None,
+        ecosystem: str | None = None,
+        package_type: str | None = None,
+    ) -> Component:
+        """Create or update a shared component identity."""
+        if purl:
+            statement = select(Component).where(Component.purl == purl)
+        else:
+            statement = select(Component).where(
+                Component.name == name,
+                Component.version == version,
+                Component.ecosystem == ecosystem,
+            )
+        component = self.session.exec(statement).first()
+        if component is None:
+            component = Component(name=name, version=version, purl=purl, ecosystem=ecosystem)
+            self.session.add(component)
+        else:
+            component.name = name
+            component.version = version
+            component.purl = purl
+            component.ecosystem = ecosystem
+
+        component.package_type = package_type
+        self.session.flush()
+        return component
+
+    def upsert_vulnerability(
+        self,
+        *,
+        cve_id: str,
+        source_id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        cvss_score: float | None = None,
+        cvss_vector: str | None = None,
+        severity: str | None = None,
+        cwe: str | None = None,
+        published_at: str | None = None,
+        modified_at: str | None = None,
+        provider_json: dict[str, Any] | None = None,
+    ) -> Vulnerability:
+        """Create or update a CVE/provider record by CVE id."""
+        statement = select(Vulnerability).where(Vulnerability.cve_id == cve_id)
+        vulnerability = self.session.exec(statement).first()
+        if vulnerability is None:
+            vulnerability = Vulnerability(cve_id=cve_id)
+            self.session.add(vulnerability)
+
+        vulnerability.source_id = source_id
+        vulnerability.title = title
+        vulnerability.description = description
+        vulnerability.cvss_score = cvss_score
+        vulnerability.cvss_vector = cvss_vector
+        vulnerability.severity = severity
+        vulnerability.cwe = cwe
+        vulnerability.published_at = published_at
+        vulnerability.modified_at = modified_at
+        vulnerability.provider_json = provider_json or {}
+        self.session.flush()
+        return vulnerability
+
+    def create_or_update_finding(
+        self,
+        *,
+        project_id: uuid.UUID,
+        vulnerability_id: uuid.UUID,
+        cve_id: str,
+        priority: FindingPriority | str,
+        component_id: uuid.UUID | None = None,
+        asset_id: uuid.UUID | None = None,
+        status: FindingStatus | str = FindingStatus.OPEN,
+        priority_rank: int = 99,
+        risk_score: float | None = None,
+        operational_rank: int = 0,
+        in_kev: bool = False,
+        epss: float | None = None,
+        cvss_base_score: float | None = None,
+        explanation_json: dict[str, Any] | None = None,
+        data_quality_json: dict[str, Any] | None = None,
+        evidence_json: dict[str, Any] | None = None,
+    ) -> Finding:
+        """Create or update a finding by project/vulnerability/component/asset identity."""
+        filters: list[Any] = [
+            Finding.project_id == project_id,
+            Finding.vulnerability_id == vulnerability_id,
+        ]
+        filters.append(
+            col(Finding.component_id).is_(None)
+            if component_id is None
+            else Finding.component_id == component_id
+        )
+        filters.append(
+            col(Finding.asset_id).is_(None) if asset_id is None else Finding.asset_id == asset_id
+        )
+        finding = self.session.exec(select(Finding).where(*filters)).first()
+        if finding is None:
+            finding = Finding(
+                project_id=project_id,
+                vulnerability_id=vulnerability_id,
+                component_id=component_id,
+                asset_id=asset_id,
+                cve_id=cve_id,
+                status=FindingStatus(status),
+                priority=FindingPriority(priority),
+                priority_rank=priority_rank,
+            )
+            self.session.add(finding)
+
+        finding.cve_id = cve_id
+        finding.priority = FindingPriority(priority)
+        finding.priority_rank = priority_rank
+        finding.status = FindingStatus(status)
+        finding.risk_score = risk_score
+        finding.operational_rank = operational_rank
+        finding.in_kev = in_kev
+        finding.epss = epss
+        finding.cvss_base_score = cvss_base_score
+        finding.explanation_json = explanation_json or {}
+        finding.data_quality_json = data_quality_json or {}
+        finding.evidence_json = evidence_json or {}
+        finding.last_seen_at = get_datetime_utc()
+        self.session.flush()
+        return finding
+
+    def get_finding(self, finding_id: uuid.UUID) -> Finding | None:
+        """Return a finding by primary key."""
+        return self.session.get(Finding, finding_id)
+
+    def list_project_findings(self, project_id: uuid.UUID) -> list[Finding]:
+        """Return project findings ordered by operational priority."""
+        statement = (
+            select(Finding)
+            .where(Finding.project_id == project_id)
+            .order_by(col(Finding.operational_rank), col(Finding.priority_rank), Finding.cve_id)
+        )
+        return list(self.session.exec(statement).all())

--- a/backend/app/repositories/projects.py
+++ b/backend/app/repositories/projects.py
@@ -1,0 +1,48 @@
+"""Project repository for template Workbench persistence."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlmodel import Session, col, func, select
+
+from app.models import Project, ProjectCreate, User
+
+
+class ProjectRepository:
+    """Project persistence helpers for API routes and future services."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def list_visible_projects(self, user: User) -> tuple[list[Project], int]:
+        """Return projects visible to a user plus the matching total count."""
+        count_statement = select(func.count()).select_from(Project)
+        statement = select(Project).order_by(col(Project.created_at).desc())
+        if not user.is_superuser:
+            count_statement = count_statement.where(Project.owner_id == user.id)
+            statement = statement.where(Project.owner_id == user.id)
+
+        count = self.session.exec(count_statement).one()
+        projects = self.session.exec(statement).all()
+        return list(projects), count
+
+    def create_project(self, project_in: ProjectCreate, *, owner_id: uuid.UUID) -> Project:
+        """Create a project shell without committing the transaction."""
+        project = Project.model_validate(project_in, update={"owner_id": owner_id})
+        self.session.add(project)
+        self.session.flush()
+        return project
+
+    def get_project(self, project_id: uuid.UUID) -> Project | None:
+        """Return a project by primary key."""
+        return self.session.get(Project, project_id)
+
+    def get_visible_project(self, project_id: uuid.UUID, user: User) -> Project | None:
+        """Return a project only when it is visible to the user."""
+        project = self.get_project(project_id)
+        if project is None:
+            return None
+        if user.is_superuser or project.owner_id == user.id:
+            return project
+        return None

--- a/backend/app/repositories/runs.py
+++ b/backend/app/repositories/runs.py
@@ -1,0 +1,159 @@
+"""Run repository for template Workbench persistence."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlmodel import Session, col, select
+
+from app.models import (
+    AnalysisRun,
+    AnalysisRunStatus,
+    FindingOccurrence,
+    ProviderSnapshot,
+)
+from app.models.base import get_datetime_utc
+
+
+class RunRepository:
+    """Analysis run, occurrence, and provider snapshot persistence helpers."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create_provider_snapshot(
+        self,
+        *,
+        nvd_last_sync: str | None = None,
+        epss_date: str | None = None,
+        kev_catalog_version: str | None = None,
+        content_hash: str | None = None,
+        source_hashes_json: dict[str, Any] | None = None,
+        source_metadata_json: dict[str, Any] | None = None,
+    ) -> ProviderSnapshot:
+        """Create a provider snapshot without committing the transaction."""
+        snapshot = ProviderSnapshot(
+            nvd_last_sync=nvd_last_sync,
+            epss_date=epss_date,
+            kev_catalog_version=kev_catalog_version,
+            content_hash=content_hash,
+            source_hashes_json=source_hashes_json or {},
+            source_metadata_json=source_metadata_json or {},
+        )
+        self.session.add(snapshot)
+        self.session.flush()
+        return snapshot
+
+    def get_provider_snapshot_by_hash(self, content_hash: str) -> ProviderSnapshot | None:
+        """Return a provider snapshot by content hash."""
+        statement = select(ProviderSnapshot).where(ProviderSnapshot.content_hash == content_hash)
+        return self.session.exec(statement).first()
+
+    def get_or_create_provider_snapshot(
+        self,
+        *,
+        content_hash: str,
+        nvd_last_sync: str | None = None,
+        epss_date: str | None = None,
+        kev_catalog_version: str | None = None,
+        source_hashes_json: dict[str, Any] | None = None,
+        source_metadata_json: dict[str, Any] | None = None,
+    ) -> ProviderSnapshot:
+        """Return an existing snapshot for a hash, or create one."""
+        snapshot = self.get_provider_snapshot_by_hash(content_hash)
+        if snapshot is not None:
+            return snapshot
+        return self.create_provider_snapshot(
+            content_hash=content_hash,
+            nvd_last_sync=nvd_last_sync,
+            epss_date=epss_date,
+            kev_catalog_version=kev_catalog_version,
+            source_hashes_json=source_hashes_json,
+            source_metadata_json=source_metadata_json,
+        )
+
+    def create_analysis_run(
+        self,
+        *,
+        project_id: uuid.UUID,
+        input_type: str,
+        filename: str | None = None,
+        status: AnalysisRunStatus | str = AnalysisRunStatus.PENDING,
+        provider_snapshot_id: uuid.UUID | None = None,
+        summary_json: dict[str, Any] | None = None,
+        error_json: dict[str, Any] | None = None,
+    ) -> AnalysisRun:
+        """Create an analysis run without committing the transaction."""
+        run = AnalysisRun(
+            project_id=project_id,
+            input_type=input_type,
+            filename=filename,
+            status=AnalysisRunStatus(status),
+            provider_snapshot_id=provider_snapshot_id,
+            summary_json=summary_json or {},
+            error_json=error_json or {},
+        )
+        self.session.add(run)
+        self.session.flush()
+        return run
+
+    def finish_analysis_run(
+        self,
+        run_id: uuid.UUID,
+        *,
+        status: AnalysisRunStatus | str = AnalysisRunStatus.COMPLETED,
+        finished_at: datetime | None = None,
+        error_message: str | None = None,
+        error_json: dict[str, Any] | None = None,
+        summary_json: dict[str, Any] | None = None,
+    ) -> AnalysisRun:
+        """Mark a run terminal and flush the transaction."""
+        run = self.session.get(AnalysisRun, run_id)
+        if run is None:
+            raise LookupError(f"AnalysisRun not found: {run_id}")
+
+        run.status = AnalysisRunStatus(status)
+        run.finished_at = finished_at or get_datetime_utc()
+        run.error_message = error_message
+        if error_json is not None:
+            run.error_json = error_json
+        if summary_json is not None:
+            run.summary_json = summary_json
+        self.session.flush()
+        return run
+
+    def add_finding_occurrence(
+        self,
+        *,
+        finding_id: uuid.UUID,
+        analysis_run_id: uuid.UUID,
+        source: str | None = None,
+        scanner: str | None = None,
+        raw_reference: str | None = None,
+        fix_version: str | None = None,
+        evidence_json: dict[str, Any] | None = None,
+    ) -> FindingOccurrence:
+        """Attach source evidence for a finding produced by a run."""
+        occurrence = FindingOccurrence(
+            finding_id=finding_id,
+            analysis_run_id=analysis_run_id,
+            source=source,
+            scanner=scanner,
+            raw_reference=raw_reference,
+            fix_version=fix_version,
+            evidence_json=evidence_json or {},
+        )
+        self.session.add(occurrence)
+        self.session.flush()
+        return occurrence
+
+    def list_analysis_runs(self, project_id: uuid.UUID) -> list[AnalysisRun]:
+        """Return runs for a project newest first."""
+        statement = (
+            select(AnalysisRun)
+            .where(AnalysisRun.project_id == project_id)
+            .order_by(col(AnalysisRun.started_at).desc())
+        )
+        return list(self.session.exec(statement).all())

--- a/backend/tests/api/test_template_service_layer.py
+++ b/backend/tests/api/test_template_service_layer.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel
+
+
+@pytest.fixture()
+def app_models() -> Any:
+    models = importlib.import_module("app.models")
+    models.import_table_models()
+    return models
+
+
+@pytest.fixture()
+def repository_classes() -> Any:
+    return importlib.import_module("app.repositories")
+
+
+@pytest.fixture()
+def session(app_models: Any) -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def test_project_routes_delegate_domain_persistence_to_repository() -> None:
+    route_module = importlib.import_module("app.api.routes.projects")
+    source = inspect.getsource(route_module)
+
+    assert "ProjectRepository" in source
+    assert "select(" not in source
+    assert "func.count" not in source
+    assert "session.add" not in source
+
+
+def test_project_repository_scopes_visibility_and_leaves_commit_to_caller(
+    app_models: Any,
+    repository_classes: Any,
+    session: Session,
+) -> None:
+    owner = _user(app_models, email="owner@example.test", is_superuser=False)
+    other = _user(app_models, email="other@example.test", is_superuser=False)
+    admin = _user(app_models, email="admin@example.test", is_superuser=True)
+    session.add_all([owner, other, admin])
+
+    repository = repository_classes.ProjectRepository(session)
+    owned = repository.create_project(
+        app_models.ProjectCreate(name="Owned", description="Visible to owner."),
+        owner_id=owner.id,
+    )
+    session.add(
+        app_models.Project(
+            owner_id=other.id,
+            name="Other",
+            description="Hidden from owner.",
+        )
+    )
+    session.commit()
+
+    owner_projects, owner_count = repository.list_visible_projects(owner)
+    admin_projects, admin_count = repository.list_visible_projects(admin)
+
+    assert {project.id for project in owner_projects} == {owned.id}
+    assert owner_count == 1
+    assert {project.name for project in admin_projects} == {"Owned", "Other"}
+    assert admin_count == 2
+    assert repository.get_visible_project(owned.id, owner) is not None
+    assert repository.get_visible_project(owned.id, other) is None
+
+    rolled_back = repository.create_project(
+        app_models.ProjectCreate(name="Rollback", description=None),
+        owner_id=owner.id,
+    )
+    rolled_back_id = rolled_back.id
+    session.rollback()
+
+    assert session.get(app_models.Project, rolled_back_id) is None
+
+
+def test_asset_finding_and_run_repositories_persist_domain_graph(
+    app_models: Any,
+    repository_classes: Any,
+    session: Session,
+) -> None:
+    user = _user(app_models)
+    session.add(user)
+
+    project = repository_classes.ProjectRepository(session).create_project(
+        app_models.ProjectCreate(name="Repository Contract", description=None),
+        owner_id=user.id,
+    )
+    asset_repository = repository_classes.AssetRepository(session)
+    finding_repository = repository_classes.FindingRepository(session)
+    run_repository = repository_classes.RunRepository(session)
+
+    asset = asset_repository.upsert_asset(
+        project_id=project.id,
+        asset_key="payments-api",
+        name="Payments API",
+        target_ref="registry.example.test/payments-api:2026.04.28",
+        owner="platform",
+        business_service="payments",
+        environment=app_models.AssetEnvironment.PRODUCTION,
+        exposure=app_models.AssetExposure.INTERNET_FACING,
+        criticality=app_models.AssetCriticality.CRITICAL,
+    )
+    component = finding_repository.upsert_component(
+        name="log4j-core",
+        version="2.14.1",
+        purl="pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+        ecosystem="maven",
+    )
+    vulnerability = finding_repository.upsert_vulnerability(
+        cve_id="CVE-2021-44228",
+        source_id="CVE-2021-44228",
+        cvss_score=10.0,
+        severity="CRITICAL",
+        provider_json={"nvd": {"lastModified": "2026-04-28T10:15:00Z"}},
+    )
+    finding = finding_repository.create_or_update_finding(
+        project_id=project.id,
+        vulnerability_id=vulnerability.id,
+        component_id=component.id,
+        asset_id=asset.id,
+        cve_id="CVE-2021-44228",
+        priority=app_models.FindingPriority.CRITICAL,
+        priority_rank=1,
+        in_kev=True,
+        explanation_json={"reason": "KEV and internet-facing production asset"},
+    )
+    snapshot = run_repository.get_or_create_provider_snapshot(
+        content_hash="sha256:repo-contract",
+        nvd_last_sync="2026-04-28T10:15:00Z",
+        epss_date="2026-04-28",
+        kev_catalog_version="2026-04-28",
+        source_hashes_json={"nvd": "sha256:nvd"},
+    )
+    same_snapshot = run_repository.get_or_create_provider_snapshot(
+        content_hash="sha256:repo-contract",
+    )
+    run = run_repository.create_analysis_run(
+        project_id=project.id,
+        provider_snapshot_id=snapshot.id,
+        input_type="trivy-json",
+        filename="trivy.json",
+        status=app_models.AnalysisRunStatus.RUNNING,
+    )
+    occurrence = run_repository.add_finding_occurrence(
+        finding_id=finding.id,
+        analysis_run_id=run.id,
+        source="dependency-scan",
+        scanner="trivy",
+        raw_reference="pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+        fix_version="2.17.1",
+        evidence_json={"input_line": 42},
+    )
+    finished = run_repository.finish_analysis_run(
+        run.id,
+        status=app_models.AnalysisRunStatus.COMPLETED_WITH_ERRORS,
+        summary_json={"findings": 1, "degraded_providers": ["nvd"]},
+        error_json={"nvd": "cache replay used"},
+    )
+    session.commit()
+
+    assert same_snapshot.id == snapshot.id
+    assert occurrence.finding_id == finding.id
+    assert finished.finished_at is not None
+    assert finished.summary_json["findings"] == 1
+    assert [item.id for item in asset_repository.list_project_assets(project.id)] == [asset.id]
+    assert [item.id for item in finding_repository.list_project_findings(project.id)] == [
+        finding.id
+    ]
+    assert [item.id for item in run_repository.list_analysis_runs(project.id)] == [run.id]
+
+
+def test_user_auth_crud_surface_stays_outside_workbench_repositories() -> None:
+    repositories = importlib.import_module("app.repositories")
+    repository_exports = set(getattr(repositories, "__all__", ()))
+
+    assert {
+        "ProjectRepository",
+        "AssetRepository",
+        "FindingRepository",
+        "RunRepository",
+    }.issubset(repository_exports)
+    assert "UserRepository" not in repository_exports
+    assert "AuthRepository" not in repository_exports
+
+
+def _user(
+    app_models: Any,
+    *,
+    email: str = "owner@example.test",
+    is_superuser: bool = True,
+) -> Any:
+    return app_models.User(
+        id=uuid.uuid4(),
+        email=email,
+        hashed_password="not-used",
+        is_active=True,
+        is_superuser=is_superuser,
+    )

--- a/docs/architecture/template-service-layer.md
+++ b/docs/architecture/template-service-layer.md
@@ -1,0 +1,101 @@
+# Template Repository Layer
+
+## Scope
+
+VPW-010 creates the first repository boundary for the template-stack
+Workbench domain. The goal is structural: domain persistence for projects,
+assets, findings, runs, and provider snapshots should not accumulate inside API
+routes or a monolithic `crud.py`.
+
+This slice does not add new database tables or new feature APIs. It introduces
+small repositories around the SQLModel tables already added in VPW-006 through
+VPW-009.
+
+## Modules
+
+The template backend owns the repository layer under `backend/app/repositories/`:
+
+- `app.repositories.projects.ProjectRepository`
+- `app.repositories.assets.AssetRepository`
+- `app.repositories.findings.FindingRepository`
+- `app.repositories.runs.RunRepository`
+- `app.repositories.__init__` as the public import surface
+
+Existing User/Auth behavior remains in the template authentication path. VPW-010
+does not introduce `UserRepository`, `AuthRepository`, password-management
+services, or a replacement authentication flow.
+
+`backend/app/services/` is intentionally not introduced yet. That package should
+be added later only when a real use-case orchestration layer needs to coordinate
+multiple repositories, provider clients, parsers, or report builders.
+
+## Transaction Boundaries
+
+Repository methods accept a caller-owned `sqlmodel.Session`.
+
+Repository methods may:
+
+- build SQLModel statements
+- create or mutate domain models
+- add objects to the session
+- call `session.flush()` so generated IDs and constraints are visible
+
+Repository methods must not:
+
+- call `session.commit()`
+- open their own sessions
+- import frontend modules
+- perform HTTP response handling
+
+API routes and future orchestration services own request-level transaction
+boundaries. In the current project route, the route creates through
+`ProjectRepository`, then commits and refreshes the created project.
+
+## Repository Responsibilities
+
+### `ProjectRepository`
+
+- Create project shells for an owner.
+- List projects visible to the current user.
+- Resolve project visibility without duplicating select/count logic in routes.
+
+### `AssetRepository`
+
+- Upsert project-scoped assets by `(project_id, asset_key)`.
+- List assets for a project in stable order.
+
+### `FindingRepository`
+
+- Upsert components and vulnerabilities by stable identities.
+- Create or update findings by project, vulnerability, component, and asset.
+- List project findings in operational-priority order.
+
+### `RunRepository`
+
+- Create and finish analysis runs.
+- Create or reuse provider snapshots by content hash.
+- Attach finding occurrences to a run.
+- List project runs newest first.
+
+## API Route Contract
+
+Template API routes should call repositories or higher-level services for
+domain persistence. User/Auth compatibility is preserved; the existing auth
+dependency and configured superuser bootstrap remain separate from the Workbench
+domain repositories.
+
+The initial route conversion is limited to `app.api.routes.projects`, because it
+is the only template-stack Workbench domain route currently present. Later
+Project, Asset, Finding, Import, Provider, and Report routes should use this
+service layer instead of embedding SQLModel query logic directly.
+
+## Tests
+
+VPW-010 is covered by `backend/tests/api/test_template_service_layer.py`:
+
+- project routes delegate persistence/query construction to `ProjectRepository`
+- repositories flush but leave commit/rollback to the caller
+- project visibility is scoped by user/superuser status
+- asset, finding, provider snapshot, run, and occurrence repositories can
+  persist a connected domain graph
+- User/Auth CRUD is not moved into the Workbench repositories

--- a/docs/evidence/full_stack_fastapi_template_baseline.md
+++ b/docs/evidence/full_stack_fastapi_template_baseline.md
@@ -762,3 +762,59 @@ Residual risks:
 - `FindingOccurrence` is the provenance source of truth for run-to-finding
   linkage; this slice intentionally does not add a denormalized
   `Finding.analysis_run_id`.
+
+## VPW-010 Template Repository Layer
+
+Branch:
+
+- `codex/vpw-010-service-layer`
+
+Scope:
+
+- Added split template Workbench repositories under `backend/app/repositories/`:
+  `ProjectRepository`, `AssetRepository`, `FindingRepository`, and
+  `RunRepository`.
+- Updated template Project routes to delegate Project query/persistence logic to
+  `ProjectRepository`.
+- Kept User/Auth CRUD and authentication dependencies outside the Workbench
+  repositories.
+- Documented path ownership, transaction boundaries, route contract, and test
+  coverage in `docs/architecture/template-service-layer.md`.
+
+Commands run:
+
+```bash
+python3 -m pytest -q backend/tests/api/test_template_service_layer.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_projects.py \
+  backend/tests/api/test_template_core_workbench_models.py \
+  backend/tests/api/test_template_run_provider_models.py \
+  backend/tests/api/test_template_service_layer.py --no-cov
+python3 -m ruff format --check backend/app \
+  backend/tests/api/test_template_service_layer.py
+python3 -m ruff check backend/app \
+  backend/tests/api/test_template_service_layer.py
+cd backend && python3 -m mypy app src
+make docs-check
+make check
+git diff --check
+```
+
+Results:
+
+- Focused template service/repository tests passed: 4 passed.
+- Project, core Workbench, run/provider, and service/repository tests passed:
+  18 passed.
+- Ruff format/check over `backend/app` and the new service/repository tests
+  passed.
+- Backend mypy over `app src` passed.
+- `make docs-check` passed.
+- `make check` passed: 565 passed, 2 skipped, total coverage 90.27%.
+- `git diff --check` passed.
+
+Residual risks:
+
+- This slice intentionally does not add Asset/Finding/Run API routes; those
+  routes should use these repositories when introduced.
+- `backend/app/services/` remains intentionally absent until there is real
+  use-case orchestration across repositories, provider clients, parsers, or
+  report builders.

--- a/docs/full_stack_fastapi_template_migration.md
+++ b/docs/full_stack_fastapi_template_migration.md
@@ -186,6 +186,11 @@ not something to fake by pointing at the old SQLAlchemy/Jinja implementation.
   run status strings, error state fields, provider source hashes/metadata, and
   FKs back to Project/Finding without adding import APIs, provider clients, or
   frontend screens.
+- `codex/vpw-010-service-layer` adds split template repositories under
+  `backend/app/repositories/` for Projects, Assets, Findings, and Runs. Existing
+  Project routes now delegate Workbench persistence/query construction to
+  `ProjectRepository`; User/Auth code remains outside the Workbench repository
+  layer.
 
 Frontend issues `VPW-037` to `VPW-047` must wait until the backend OpenAPI client
 is generated and the template login flow remains green.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Model Import Registry: architecture/model-imports.md
       - Core Workbench Schema: architecture/core-workbench-schema.md
       - Analysis Run Provider Schema: architecture/analysis-run-provider-schema.md
+      - Template Repository Layer: architecture/template-service-layer.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md
   - VPW Template Execution Sequence: vpw_template_execution_sequence.md
   - Use Cases: use_cases.md


### PR DESCRIPTION
Refs #116

## Scope
- Add split template Workbench repositories under `backend/app/repositories/` for Projects, Assets, Findings, and Runs.
- Move template Project route query/persistence construction behind `ProjectRepository`.
- Keep User/Auth CRUD outside the Workbench repository layer.
- Document path ownership, transaction boundaries, route contract, and repository responsibilities.

## Verification
- `python3 -m pytest -q backend/tests/api/test_template_service_layer.py --no-cov` -> 4 passed
- `python3 -m pytest -q backend/tests/api/test_template_projects.py backend/tests/api/test_template_core_workbench_models.py backend/tests/api/test_template_run_provider_models.py backend/tests/api/test_template_service_layer.py --no-cov` -> 18 passed
- `python3 -m ruff format --check backend/app backend/tests/api/test_template_service_layer.py` -> passed
- `python3 -m ruff check backend/app backend/tests/api/test_template_service_layer.py` -> passed
- `cd backend && python3 -m mypy app src` -> passed
- `make docs-check` -> passed
- `make check` -> 565 passed, 2 skipped, total coverage 90.27%
- `git diff --check` -> passed

## Evidence
- Architecture docs: `docs/architecture/template-service-layer.md`
- Execution evidence: `docs/evidence/full_stack_fastapi_template_baseline.md#vpw-010-template-repository-layer`
- Repository tests: `backend/tests/api/test_template_service_layer.py`

## Residual Risk
- This slice intentionally does not add Asset/Finding/Run API routes; those routes should use these repositories when introduced.
- `backend/app/services/` remains intentionally absent until there is real use-case orchestration across repositories, provider clients, parsers, or report builders.
