### PR TITLE
VPW-012: Add reusable Workbench test fixtures

### DIFF
--- a/backend/tests/api/test_template_workbench_api_skeleton.py
+++ b/backend/tests/api/test_template_workbench_api_skeleton.py
@@ -1,47 +1,22 @@
 from __future__ import annotations
 
-import importlib
 import uuid
-from collections.abc import Callable, Generator, Iterator
-from dataclasses import dataclass
 from typing import Any
 
-import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.engine import Engine
-from sqlalchemy.pool import StaticPool
-from sqlmodel import Session, SQLModel, create_engine
+from utils.template_workbench import (
+    DEMO_CVE_LOG4SHELL,
+    DEMO_CVE_XZ,
+    TemplateApiEnv,
+    auth_headers,
+    create_project_via_api,
+    current_user,
+    seed_analysis_run,
+    seed_finding_pair,
+    seed_foreign_project_graph,
+)
 
-from app.core.config import settings
 from app.main import app
-
-_CONFIGURED_USER_ID = uuid.UUID("00000000-0000-4000-8000-000000000011")
-
-
-@dataclass(frozen=True)
-class TemplateApiEnv:
-    client: TestClient
-    engine: Engine
-    app_models: Any
-    repositories: Any
-
-
-@pytest.fixture()
-def api_env() -> Iterator[TemplateApiEnv]:
-    env, cleanup = _client_with_temp_database(configured_is_superuser=True)
-    try:
-        yield env
-    finally:
-        cleanup()
-
-
-@pytest.fixture()
-def restricted_api_env() -> Iterator[TemplateApiEnv]:
-    env, cleanup = _client_with_temp_database(configured_is_superuser=False)
-    try:
-        yield env
-    finally:
-        cleanup()
 
 
 def test_vpw011_openapi_exposes_workbench_domain_routes_without_items() -> None:
@@ -86,7 +61,7 @@ def test_vpw011_openapi_exposes_workbench_domain_routes_without_items() -> None:
     assert all("Item" not in schema_name for schema_name in schemas)
 
 
-def test_vpw011_domain_routes_require_auth(api_env: TemplateApiEnv) -> None:
+def test_vpw011_domain_routes_require_auth(template_api_env: TemplateApiEnv) -> None:
     project_id = uuid.uuid4()
     asset_id = uuid.uuid4()
     run_id = uuid.uuid4()
@@ -121,16 +96,16 @@ def test_vpw011_domain_routes_require_auth(api_env: TemplateApiEnv) -> None:
     )
 
     for method, path, kwargs in protected_calls:
-        response = getattr(api_env.client, method)(path, **kwargs)
+        response = getattr(template_api_env.client, method)(path, **kwargs)
         assert response.status_code == 401, f"{method.upper()} {path}: {response.text}"
 
 
 def test_vpw011_project_lifecycle_create_list_get_update_delete(
-    api_env: TemplateApiEnv,
+    template_api_env: TemplateApiEnv,
 ) -> None:
-    headers = _auth_headers(api_env.client)
+    headers = auth_headers(template_api_env.client)
 
-    create_response = api_env.client.post(
+    create_response = template_api_env.client.post(
         "/api/v1/projects/",
         headers=headers,
         json={
@@ -142,18 +117,18 @@ def test_vpw011_project_lifecycle_create_list_get_update_delete(
     created = create_response.json()
     assert created["name"] == "External Attack Surface"
     assert created["description"] == "Internet-facing CVE prioritization workspace."
-    assert created["owner_id"] == _current_user(api_env.client, headers)["id"]
+    assert created["owner_id"] == current_user(template_api_env.client, headers)["id"]
 
-    list_response = api_env.client.get("/api/v1/projects/", headers=headers)
+    list_response = template_api_env.client.get("/api/v1/projects/", headers=headers)
     assert list_response.status_code == 200
     assert list_response.json()["data"] == [created]
     assert list_response.json()["count"] == 1
 
-    get_response = api_env.client.get(f"/api/v1/projects/{created['id']}", headers=headers)
+    get_response = template_api_env.client.get(f"/api/v1/projects/{created['id']}", headers=headers)
     assert get_response.status_code == 200
     assert get_response.json() == created
 
-    update_response = api_env.client.patch(
+    update_response = template_api_env.client.patch(
         f"/api/v1/projects/{created['id']}",
         headers=headers,
         json={
@@ -168,28 +143,28 @@ def test_vpw011_project_lifecycle_create_list_get_update_delete(
     assert updated["name"] == "External Attack Surface Updated"
     assert updated["description"] == "Updated Workbench project description."
 
-    delete_response = api_env.client.delete(
+    delete_response = template_api_env.client.delete(
         f"/api/v1/projects/{created['id']}",
         headers=headers,
     )
     assert delete_response.status_code == 204
 
-    missing_after_delete = api_env.client.get(
+    missing_after_delete = template_api_env.client.get(
         f"/api/v1/projects/{created['id']}",
         headers=headers,
     )
     assert missing_after_delete.status_code == 404
-    assert api_env.client.get("/api/v1/projects/", headers=headers).json() == {
+    assert template_api_env.client.get("/api/v1/projects/", headers=headers).json() == {
         "data": [],
         "count": 0,
     }
 
 
-def test_vpw011_asset_list_create_and_update(api_env: TemplateApiEnv) -> None:
-    headers = _auth_headers(api_env.client)
-    project = _create_project(api_env.client, headers)
+def test_vpw011_asset_list_create_and_update(template_api_env: TemplateApiEnv) -> None:
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
 
-    create_response = api_env.client.post(
+    create_response = template_api_env.client.post(
         f"/api/v1/projects/{project['id']}/assets/",
         headers=headers,
         json={
@@ -212,7 +187,7 @@ def test_vpw011_asset_list_create_and_update(api_env: TemplateApiEnv) -> None:
     assert created["exposure"] == "internet-facing"
     assert created["criticality"] == "critical"
 
-    list_response = api_env.client.get(
+    list_response = template_api_env.client.get(
         f"/api/v1/projects/{project['id']}/assets/",
         headers=headers,
     )
@@ -220,13 +195,13 @@ def test_vpw011_asset_list_create_and_update(api_env: TemplateApiEnv) -> None:
     assert list_response.json()["data"] == [created]
     assert list_response.json()["count"] == 1
 
-    update_response = api_env.client.patch(
+    update_asset_response = template_api_env.client.patch(
         f"/api/v1/assets/{created['id']}",
         headers=headers,
         json={"name": "Payments API Cluster", "criticality": "high"},
     )
-    assert update_response.status_code == 200
-    updated = update_response.json()
+    assert update_asset_response.status_code == 200
+    updated = update_asset_response.json()
     assert updated["id"] == created["id"]
     assert updated["project_id"] == project["id"]
     assert updated["name"] == "Payments API Cluster"
@@ -234,18 +209,18 @@ def test_vpw011_asset_list_create_and_update(api_env: TemplateApiEnv) -> None:
 
 
 def test_vpw011_run_list_and_get_use_repository_seeded_graph(
-    api_env: TemplateApiEnv,
+    template_api_env: TemplateApiEnv,
 ) -> None:
-    headers = _auth_headers(api_env.client)
-    project = _create_project(api_env.client, headers)
-    seeded = _seed_analysis_run(
-        api_env.engine,
-        api_env.app_models,
-        api_env.repositories,
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    seeded = seed_analysis_run(
+        template_api_env.engine,
+        template_api_env.app_models,
+        template_api_env.repositories,
         project_id=uuid.UUID(project["id"]),
     )
 
-    list_response = api_env.client.get(
+    list_response = template_api_env.client.get(
         f"/api/v1/projects/{project['id']}/runs/",
         headers=headers,
     )
@@ -256,7 +231,7 @@ def test_vpw011_run_list_and_get_use_repository_seeded_graph(
     assert list_payload["data"][0]["project_id"] == project["id"]
     assert list_payload["data"][0]["status"] == "completed"
 
-    get_response = api_env.client.get(f"/api/v1/runs/{seeded['run_id']}", headers=headers)
+    get_response = template_api_env.client.get(f"/api/v1/runs/{seeded['run_id']}", headers=headers)
     assert get_response.status_code == 200
     detail = get_response.json()
     assert detail["id"] == str(seeded["run_id"])
@@ -265,18 +240,18 @@ def test_vpw011_run_list_and_get_use_repository_seeded_graph(
 
 
 def test_vpw011_finding_list_and_get_support_pagination(
-    api_env: TemplateApiEnv,
+    template_api_env: TemplateApiEnv,
 ) -> None:
-    headers = _auth_headers(api_env.client)
-    project = _create_project(api_env.client, headers)
-    seeded = _seed_findings(
-        api_env.engine,
-        api_env.app_models,
-        api_env.repositories,
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    seeded = seed_finding_pair(
+        template_api_env.engine,
+        template_api_env.app_models,
+        template_api_env.repositories,
         project_id=uuid.UUID(project["id"]),
     )
 
-    list_response = api_env.client.get(
+    list_response = template_api_env.client.get(
         f"/api/v1/projects/{project['id']}/findings/",
         headers=headers,
         params={"limit": 1, "offset": 1},
@@ -286,9 +261,9 @@ def test_vpw011_finding_list_and_get_support_pagination(
     assert page["count"] == 2
     assert len(page["data"]) == 1
     assert page["data"][0]["id"] == str(seeded["finding_ids"][1])
-    assert page["data"][0]["cve_id"] == "CVE-2024-3094"
+    assert page["data"][0]["cve_id"] == DEMO_CVE_XZ
 
-    get_response = api_env.client.get(
+    get_response = template_api_env.client.get(
         f"/api/v1/findings/{seeded['finding_ids'][0]}",
         headers=headers,
     )
@@ -296,19 +271,19 @@ def test_vpw011_finding_list_and_get_support_pagination(
     detail = get_response.json()
     assert detail["id"] == str(seeded["finding_ids"][0])
     assert detail["project_id"] == project["id"]
-    assert detail["cve_id"] == "CVE-2021-44228"
+    assert detail["cve_id"] == DEMO_CVE_LOG4SHELL
     assert detail["priority"] == "critical"
     assert detail["in_kev"] is True
 
 
 def test_vpw011_404_and_403_are_consistent_for_project_scoped_resources(
-    restricted_api_env: TemplateApiEnv,
+    restricted_template_api_env: TemplateApiEnv,
 ) -> None:
-    headers = _auth_headers(restricted_api_env.client)
-    foreign = _seed_foreign_project_graph(
-        restricted_api_env.engine,
-        restricted_api_env.app_models,
-        restricted_api_env.repositories,
+    headers = auth_headers(restricted_template_api_env.client)
+    foreign = seed_foreign_project_graph(
+        restricted_template_api_env.engine,
+        restricted_template_api_env.app_models,
+        restricted_template_api_env.repositories,
     )
     missing_id = uuid.UUID("00000000-0000-4000-8000-000000000404")
 
@@ -332,298 +307,20 @@ def test_vpw011_404_and_403_are_consistent_for_project_scoped_resources(
     )
 
     for method, path, kwargs in not_found_calls:
-        response = getattr(restricted_api_env.client, method)(path, headers=headers, **kwargs)
+        response = getattr(restricted_template_api_env.client, method)(
+            path, headers=headers, **kwargs
+        )
         assert response.status_code == 404, f"{method.upper()} {path}: {response.text}"
 
     for method, path, kwargs in forbidden_calls:
-        response = getattr(restricted_api_env.client, method)(path, headers=headers, **kwargs)
+        response = getattr(restricted_template_api_env.client, method)(
+            path, headers=headers, **kwargs
+        )
         assert response.status_code == 403, f"{method.upper()} {path}: {response.text}"
 
-    invalid_sort = restricted_api_env.client.get(
+    invalid_sort = restricted_template_api_env.client.get(
         f"/api/v1/projects/{missing_id}/findings/",
         headers=headers,
         params={"sort": "unknown"},
     )
     assert invalid_sort.status_code == 422
-
-
-def _client_with_temp_database(
-    *,
-    configured_is_superuser: bool,
-) -> tuple[TemplateApiEnv, Callable[[], None]]:
-    from app.api import deps
-    from app.core import security
-
-    app.dependency_overrides.clear()
-    app_models = importlib.import_module("app.models")
-    app_models.import_table_models()
-    repositories = importlib.import_module("app.repositories")
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SQLModel.metadata.create_all(engine)
-
-    with Session(engine) as session:
-        _seed_configured_user(
-            session,
-            app_models,
-            security,
-            is_superuser=configured_is_superuser,
-        )
-
-    def override_get_db() -> Generator[Session, None, None]:
-        with Session(engine) as session:
-            yield session
-
-    app.dependency_overrides[deps.get_db] = override_get_db
-
-    def cleanup() -> None:
-        app.dependency_overrides.pop(deps.get_db, None)
-        engine.dispose()
-
-    return TemplateApiEnv(TestClient(app), engine, app_models, repositories), cleanup
-
-
-def _seed_configured_user(
-    session: Session,
-    app_models: Any,
-    security: Any,
-    *,
-    is_superuser: bool,
-) -> None:
-    password_hash = getattr(security, "get_password_hash", lambda password: password)(
-        settings.FIRST_SUPERUSER_PASSWORD
-    )
-    session.add(
-        app_models.User(
-            id=_CONFIGURED_USER_ID,
-            email=settings.FIRST_SUPERUSER,
-            hashed_password=password_hash,
-            is_active=True,
-            is_superuser=is_superuser,
-        )
-    )
-    session.commit()
-
-
-def _login(client: TestClient) -> str:
-    response = client.post(
-        "/api/v1/login/access-token",
-        data={
-            "username": settings.FIRST_SUPERUSER,
-            "password": settings.FIRST_SUPERUSER_PASSWORD,
-        },
-    )
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["token_type"] == "bearer"
-    return str(payload["access_token"])
-
-
-def _auth_headers(client: TestClient) -> dict[str, str]:
-    return {"Authorization": f"Bearer {_login(client)}"}
-
-
-def _current_user(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
-    response = client.get("/api/v1/users/me", headers=headers)
-    assert response.status_code == 200
-    return response.json()
-
-
-def _create_project(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
-    response = client.post(
-        "/api/v1/projects/",
-        headers=headers,
-        json={"name": "Workbench API Contract", "description": None},
-    )
-    assert response.status_code == 200
-    return response.json()
-
-
-def _seed_analysis_run(
-    engine: Engine,
-    app_models: Any,
-    repositories: Any,
-    *,
-    project_id: uuid.UUID,
-) -> dict[str, uuid.UUID]:
-    with Session(engine) as session:
-        run_repository = repositories.RunRepository(session)
-        snapshot = run_repository.get_or_create_provider_snapshot(
-            content_hash=f"sha256:{uuid.uuid4().hex}",
-            nvd_last_sync="2026-04-28T10:15:00Z",
-            epss_date="2026-04-28",
-            kev_catalog_version="2026-04-28",
-            source_hashes_json={"nvd": "sha256:nvd-feed"},
-        )
-        run = run_repository.create_analysis_run(
-            project_id=project_id,
-            provider_snapshot_id=snapshot.id,
-            input_type="cve-list",
-            filename="known-cves.txt",
-            status=app_models.AnalysisRunStatus.COMPLETED,
-            summary_json={"parsed": 2, "findings": 2},
-        )
-        run_id = run.id
-        snapshot_id = snapshot.id
-        session.commit()
-    return {"run_id": run_id, "provider_snapshot_id": snapshot_id}
-
-
-def _seed_findings(
-    engine: Engine,
-    app_models: Any,
-    repositories: Any,
-    *,
-    project_id: uuid.UUID,
-) -> dict[str, list[uuid.UUID]]:
-    with Session(engine) as session:
-        asset = repositories.AssetRepository(session).upsert_asset(
-            project_id=project_id,
-            asset_key="payments-api",
-            name="Payments API",
-            environment=app_models.AssetEnvironment.PRODUCTION,
-            exposure=app_models.AssetExposure.INTERNET_FACING,
-            criticality=app_models.AssetCriticality.CRITICAL,
-        )
-        finding_repository = repositories.FindingRepository(session)
-        component = finding_repository.upsert_component(
-            name="log4j-core",
-            version="2.14.1",
-            purl=f"pkg:maven/org.apache.logging.log4j/log4j-core@{uuid.uuid4().hex}",
-            ecosystem="maven",
-        )
-        first_vulnerability = finding_repository.upsert_vulnerability(
-            cve_id="CVE-2021-44228",
-            source_id="CVE-2021-44228",
-            cvss_score=10.0,
-            severity="CRITICAL",
-        )
-        second_vulnerability = finding_repository.upsert_vulnerability(
-            cve_id="CVE-2024-3094",
-            source_id="CVE-2024-3094",
-            cvss_score=10.0,
-            severity="CRITICAL",
-        )
-        first_finding = finding_repository.create_or_update_finding(
-            project_id=project_id,
-            vulnerability_id=first_vulnerability.id,
-            component_id=component.id,
-            asset_id=asset.id,
-            cve_id="CVE-2021-44228",
-            priority=app_models.FindingPriority.CRITICAL,
-            priority_rank=1,
-            operational_rank=1,
-            in_kev=True,
-        )
-        second_finding = finding_repository.create_or_update_finding(
-            project_id=project_id,
-            vulnerability_id=second_vulnerability.id,
-            component_id=component.id,
-            asset_id=asset.id,
-            cve_id="CVE-2024-3094",
-            priority=app_models.FindingPriority.HIGH,
-            priority_rank=2,
-            operational_rank=2,
-            in_kev=True,
-        )
-        finding_ids = [first_finding.id, second_finding.id]
-        session.commit()
-    return {"finding_ids": finding_ids}
-
-
-def _seed_foreign_project_graph(
-    engine: Engine,
-    app_models: Any,
-    repositories: Any,
-) -> dict[str, uuid.UUID]:
-    foreign_user_id = uuid.uuid4()
-    with Session(engine) as session:
-        session.add(
-            app_models.User(
-                id=foreign_user_id,
-                email=f"{foreign_user_id}@example.test",
-                hashed_password="not-used",
-                is_active=True,
-                is_superuser=False,
-            )
-        )
-        project = repositories.ProjectRepository(session).create_project(
-            app_models.ProjectCreate(name="Foreign Project", description=None),
-            owner_id=foreign_user_id,
-        )
-        asset = repositories.AssetRepository(session).upsert_asset(
-            project_id=project.id,
-            asset_key="foreign-api",
-            name="Foreign API",
-        )
-        run_ids = _seed_analysis_run_in_session(
-            session,
-            app_models,
-            repositories,
-            project_id=project.id,
-        )
-        finding = _seed_finding_in_session(
-            session,
-            app_models,
-            repositories,
-            project_id=project.id,
-            asset_id=asset.id,
-        )
-        ids = {
-            "project_id": project.id,
-            "asset_id": asset.id,
-            "run_id": run_ids["run_id"],
-            "finding_id": finding.id,
-        }
-        session.commit()
-    return ids
-
-
-def _seed_analysis_run_in_session(
-    session: Session,
-    app_models: Any,
-    repositories: Any,
-    *,
-    project_id: uuid.UUID,
-) -> dict[str, uuid.UUID]:
-    run_repository = repositories.RunRepository(session)
-    snapshot = run_repository.get_or_create_provider_snapshot(
-        content_hash=f"sha256:{uuid.uuid4().hex}",
-        source_hashes_json={"nvd": "sha256:nvd-feed"},
-    )
-    run = run_repository.create_analysis_run(
-        project_id=project_id,
-        provider_snapshot_id=snapshot.id,
-        input_type="cve-list",
-        filename="foreign-cves.txt",
-        status=app_models.AnalysisRunStatus.COMPLETED,
-    )
-    return {"run_id": run.id, "provider_snapshot_id": snapshot.id}
-
-
-def _seed_finding_in_session(
-    session: Session,
-    app_models: Any,
-    repositories: Any,
-    *,
-    project_id: uuid.UUID,
-    asset_id: uuid.UUID,
-) -> Any:
-    finding_repository = repositories.FindingRepository(session)
-    vulnerability = finding_repository.upsert_vulnerability(
-        cve_id=f"CVE-2026-{uuid.uuid4().int % 10000:04d}",
-        source_id="foreign-cve",
-        cvss_score=7.5,
-        severity="HIGH",
-    )
-    return finding_repository.create_or_update_finding(
-        project_id=project_id,
-        vulnerability_id=vulnerability.id,
-        asset_id=asset_id,
-        cve_id=vulnerability.cve_id,
-        priority=app_models.FindingPriority.HIGH,
-        priority_rank=2,
-    )

--- a/backend/tests/api/test_template_workbench_fixture_utils.py
+++ b/backend/tests/api/test_template_workbench_fixture_utils.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+from utils.template_workbench import (
+    CONFIGURED_USER_ID,
+    DEMO_CVE_LOG4SHELL,
+    TemplateApiEnv,
+    create_analysis_run,
+    create_asset,
+    create_component,
+    create_finding,
+    create_project,
+    create_provider_snapshot,
+    create_user,
+    create_vulnerability,
+    seed_domain_graph,
+)
+
+from app.api import deps
+from app.main import app
+
+
+def test_vpw012_api_test_uses_each_core_model_fixture(
+    template_user_model: object,
+    template_project_model: object,
+    template_asset_model: object,
+    template_component_model: object,
+    template_vulnerability_model: object,
+    template_finding_model: object,
+    template_provider_snapshot_model: object,
+    template_analysis_run_model: object,
+) -> None:
+    assert template_project_model.owner_id == template_user_model.id
+    assert template_asset_model.project_id == template_project_model.id
+    assert template_component_model.name == "log4j-core"
+    assert template_vulnerability_model.cve_id == DEMO_CVE_LOG4SHELL
+    assert template_finding_model.project_id == template_project_model.id
+    assert template_finding_model.asset_id == template_asset_model.id
+    assert template_finding_model.component_id == template_component_model.id
+    assert template_finding_model.vulnerability_id == template_vulnerability_model.id
+    assert template_analysis_run_model.project_id == template_project_model.id
+    assert template_analysis_run_model.provider_snapshot_id == template_provider_snapshot_model.id
+
+
+def test_vpw012_factories_create_minimal_valid_workbench_domain_objects(
+    template_api_env: TemplateApiEnv,
+) -> None:
+    app_models = template_api_env.app_models
+    repositories = template_api_env.repositories
+
+    with Session(template_api_env.engine) as session:
+        user = create_user(
+            session,
+            app_models,
+            email="factory-owner@example.test",
+            is_superuser=False,
+        )
+        project = create_project(
+            session,
+            app_models,
+            repositories,
+            owner_id=user.id,
+            name="Factory Project",
+        )
+        asset = create_asset(session, app_models, repositories, project_id=project.id)
+        component = create_component(session, repositories)
+        vulnerability = create_vulnerability(session, repositories)
+        finding = create_finding(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+            vulnerability_id=vulnerability.id,
+            component_id=component.id,
+            asset_id=asset.id,
+            cve_id=vulnerability.cve_id,
+            priority=app_models.FindingPriority.CRITICAL,
+            priority_rank=1,
+            operational_rank=1,
+        )
+        snapshot = create_provider_snapshot(session, repositories)
+        run = create_analysis_run(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+            provider_snapshot_id=snapshot.id,
+        )
+        ids = {
+            "user": user.id,
+            "project_owner": project.owner_id,
+            "project": project.id,
+            "asset_project": asset.project_id,
+            "asset": asset.id,
+            "component_name": component.name,
+            "vulnerability_cve": vulnerability.cve_id,
+            "finding_project": finding.project_id,
+            "run_project": run.project_id,
+            "run_snapshot": run.provider_snapshot_id,
+            "snapshot": snapshot.id,
+        }
+        session.commit()
+
+    assert ids["user"]
+    assert ids["project_owner"] == ids["user"]
+    assert ids["asset_project"] == ids["project"]
+    assert ids["asset"]
+    assert ids["component_name"] == "log4j-core"
+    assert ids["vulnerability_cve"] == "CVE-2021-44228"
+    assert ids["finding_project"] == ids["project"]
+    assert ids["run_project"] == ids["project"]
+    assert ids["run_snapshot"] == ids["snapshot"]
+
+
+def test_vpw012_seed_domain_graph_uses_all_core_factories(
+    template_api_env: TemplateApiEnv,
+) -> None:
+    graph = seed_domain_graph(
+        template_api_env.engine,
+        template_api_env.app_models,
+        template_api_env.repositories,
+    )
+
+    with Session(template_api_env.engine) as session:
+        assert session.get(template_api_env.app_models.User, graph.user_id) is not None
+        assert session.get(template_api_env.app_models.Project, graph.project_id) is not None
+        assert session.get(template_api_env.app_models.Asset, graph.asset_id) is not None
+        assert session.get(template_api_env.app_models.Component, graph.component_id) is not None
+        assert (
+            session.get(template_api_env.app_models.Vulnerability, graph.vulnerability_id)
+            is not None
+        )
+        assert session.get(template_api_env.app_models.Finding, graph.finding_id) is not None
+        assert (
+            session.get(template_api_env.app_models.ProviderSnapshot, graph.provider_snapshot_id)
+            is not None
+        )
+        assert session.get(template_api_env.app_models.AnalysisRun, graph.run_id) is not None
+
+
+def test_vpw012_template_api_env_cleanup_removes_db_override() -> None:
+    from utils.template_workbench import create_template_api_env
+
+    env, cleanup = create_template_api_env()
+    assert deps.get_db in app.dependency_overrides
+
+    with Session(env.engine) as session:
+        user = session.get(env.app_models.User, CONFIGURED_USER_ID)
+        assert user is not None
+        assert user.hashed_password == "configured-superuser-password-placeholder"
+
+    cleanup()
+
+    assert deps.get_db not in app.dependency_overrides

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,6 +17,8 @@ if str(SRC_PATH) not in sys.path:
 if str(TESTS_PATH) not in sys.path:
     sys.path.insert(0, str(TESTS_PATH))
 
+pytest_plugins = ("utils.template_workbench",)
+
 
 @pytest.fixture(autouse=True)
 def _block_live_network(

--- a/backend/tests/utils/README.md
+++ b/backend/tests/utils/README.md
@@ -1,0 +1,36 @@
+# Template Workbench Test Utilities
+
+`template_workbench.py` contains reusable pytest fixtures and domain factories
+for the FastAPI-template Workbench tests.
+
+Core fixtures:
+
+- `template_api_env`: isolated in-memory SQLModel database with the configured
+  user as superuser.
+- `restricted_template_api_env`: same setup, but the configured user is not a
+  superuser for project-isolation checks.
+- `template_user_model`, `template_project_model`, `template_asset_model`,
+  `template_component_model`, `template_vulnerability_model`,
+  `template_finding_model`, `template_provider_snapshot_model`, and
+  `template_analysis_run_model`: minimal unsaved SQLModel domain objects for
+  lightweight contract tests.
+
+Persistent factories:
+
+- `create_user`
+- `create_project`
+- `create_asset`
+- `create_component`
+- `create_vulnerability`
+- `create_finding`
+- `create_provider_snapshot`
+- `create_analysis_run`
+
+Seed helpers such as `seed_domain_graph`, `seed_finding_pair`, and
+`seed_foreign_project_graph` prepare deterministic demo-CVE data for API tests.
+They use placeholder password hashes only; no real secrets are stored in test
+records.
+
+Pure factories in `workbench_factories.py` return unsaved objects with stable
+UUIDs and fixed timestamps. Use them when a test does not need database
+persistence or FastAPI dependency overrides.

--- a/backend/tests/utils/__init__.py
+++ b/backend/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable test utilities for backend test suites."""

--- a/backend/tests/utils/template_workbench.py
+++ b/backend/tests/utils/template_workbench.py
@@ -1,0 +1,640 @@
+"""Reusable fixtures and factories for the template Workbench domain tests."""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from collections.abc import Callable, Generator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.engine import Engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.core.config import settings
+from app.main import app
+from utils.workbench_factories import (
+    template_analysis_run as build_analysis_run_model,
+)
+from utils.workbench_factories import (
+    template_asset as build_asset_model,
+)
+from utils.workbench_factories import (
+    template_component as build_component_model,
+)
+from utils.workbench_factories import (
+    template_finding as build_finding_model,
+)
+from utils.workbench_factories import (
+    template_project as build_project_model,
+)
+from utils.workbench_factories import (
+    template_provider_snapshot as build_provider_snapshot_model,
+)
+from utils.workbench_factories import (
+    template_user as build_user_model,
+)
+from utils.workbench_factories import (
+    template_vulnerability as build_vulnerability_model,
+)
+
+CONFIGURED_USER_ID = uuid.UUID("00000000-0000-4000-8000-000000000011")
+DEMO_CVE_LOG4SHELL = "CVE-2021-44228"
+DEMO_CVE_XZ = "CVE-2024-3094"
+
+
+@dataclass(frozen=True)
+class TemplateApiEnv:
+    """FastAPI client plus its isolated in-memory template database."""
+
+    client: TestClient
+    engine: Engine
+    app_models: Any
+    repositories: Any
+
+
+@dataclass(frozen=True)
+class WorkbenchDomainGraph:
+    """IDs for a minimal valid Workbench domain graph."""
+
+    user_id: uuid.UUID
+    project_id: uuid.UUID
+    asset_id: uuid.UUID
+    component_id: uuid.UUID
+    vulnerability_id: uuid.UUID
+    finding_id: uuid.UUID
+    provider_snapshot_id: uuid.UUID
+    run_id: uuid.UUID
+
+
+@pytest.fixture()
+def template_api_env() -> Iterator[TemplateApiEnv]:
+    """Yield an authenticated-template-capable app with isolated SQLModel metadata."""
+    env, cleanup = create_template_api_env(configured_is_superuser=True)
+    try:
+        yield env
+    finally:
+        cleanup()
+
+
+@pytest.fixture()
+def restricted_template_api_env() -> Iterator[TemplateApiEnv]:
+    """Yield an app where the configured user is not a superuser."""
+    env, cleanup = create_template_api_env(configured_is_superuser=False)
+    try:
+        yield env
+    finally:
+        cleanup()
+
+
+@pytest.fixture()
+def template_user_model() -> Any:
+    """Return a minimal unsaved User object."""
+    return build_user_model()
+
+
+@pytest.fixture()
+def template_project_model(template_user_model: Any) -> Any:
+    """Return a minimal unsaved Project object."""
+    return build_project_model(owner=template_user_model)
+
+
+@pytest.fixture()
+def template_asset_model(template_project_model: Any) -> Any:
+    """Return a minimal unsaved Asset object."""
+    return build_asset_model(project=template_project_model)
+
+
+@pytest.fixture()
+def template_component_model() -> Any:
+    """Return a minimal unsaved Component object."""
+    return build_component_model()
+
+
+@pytest.fixture()
+def template_vulnerability_model() -> Any:
+    """Return a minimal unsaved Vulnerability object."""
+    return build_vulnerability_model(cve_id=DEMO_CVE_LOG4SHELL)
+
+
+@pytest.fixture()
+def template_finding_model(
+    template_project_model: Any,
+    template_asset_model: Any,
+    template_component_model: Any,
+    template_vulnerability_model: Any,
+) -> Any:
+    """Return a minimal unsaved Finding object."""
+    return build_finding_model(
+        project=template_project_model,
+        asset=template_asset_model,
+        component=template_component_model,
+        vulnerability=template_vulnerability_model,
+    )
+
+
+@pytest.fixture()
+def template_provider_snapshot_model() -> Any:
+    """Return a minimal unsaved ProviderSnapshot object."""
+    return build_provider_snapshot_model()
+
+
+@pytest.fixture()
+def template_analysis_run_model(
+    template_project_model: Any,
+    template_provider_snapshot_model: Any,
+) -> Any:
+    """Return a minimal unsaved AnalysisRun object."""
+    return build_analysis_run_model(
+        project=template_project_model,
+        provider_snapshot=template_provider_snapshot_model,
+    )
+
+
+def create_template_api_env(
+    *,
+    configured_is_superuser: bool = True,
+) -> tuple[TemplateApiEnv, Callable[[], None]]:
+    """Create a TestClient wired to a disposable in-memory SQLModel database."""
+    from app.api import deps
+
+    app.dependency_overrides.clear()
+    app_models = importlib.import_module("app.models")
+    app_models.import_table_models()
+    repositories = importlib.import_module("app.repositories")
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        seed_configured_user(
+            session,
+            app_models,
+            is_superuser=configured_is_superuser,
+        )
+
+    def override_get_db() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[deps.get_db] = override_get_db
+
+    def cleanup() -> None:
+        app.dependency_overrides.clear()
+        engine.dispose()
+
+    return TemplateApiEnv(TestClient(app), engine, app_models, repositories), cleanup
+
+
+def seed_configured_user(session: Session, app_models: Any, *, is_superuser: bool = True) -> Any:
+    """Persist the configured template user without storing a real password secret."""
+    user = make_user(
+        app_models,
+        user_id=CONFIGURED_USER_ID,
+        email=settings.FIRST_SUPERUSER,
+        is_superuser=is_superuser,
+        hashed_password="configured-superuser-password-placeholder",
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def make_user(
+    app_models: Any,
+    *,
+    user_id: uuid.UUID | None = None,
+    email: str = "owner@example.test",
+    is_superuser: bool = True,
+    hashed_password: str = "not-used",
+) -> Any:
+    """Build a minimal valid User model."""
+    return app_models.User(
+        id=user_id or uuid.uuid4(),
+        email=email,
+        hashed_password=hashed_password,
+        is_active=True,
+        is_superuser=is_superuser,
+    )
+
+
+def create_user(
+    session: Session,
+    app_models: Any,
+    *,
+    email: str = "owner@example.test",
+    is_superuser: bool = True,
+) -> Any:
+    """Persist a minimal valid User and flush it for downstream FK use."""
+    user = make_user(app_models, email=email, is_superuser=is_superuser)
+    session.add(user)
+    session.flush()
+    return user
+
+
+def create_project(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    owner_id: uuid.UUID,
+    name: str = "Workbench Fixture Project",
+    description: str | None = None,
+) -> Any:
+    """Persist a minimal valid Project."""
+    return repositories.ProjectRepository(session).create_project(
+        app_models.ProjectCreate(name=name, description=description),
+        owner_id=owner_id,
+    )
+
+
+def create_asset(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+    asset_key: str = "payments-api",
+    name: str = "Payments API",
+) -> Any:
+    """Persist a minimal valid Asset."""
+    return repositories.AssetRepository(session).upsert_asset(
+        project_id=project_id,
+        asset_key=asset_key,
+        name=name,
+        environment=app_models.AssetEnvironment.PRODUCTION,
+        exposure=app_models.AssetExposure.INTERNET_FACING,
+        criticality=app_models.AssetCriticality.CRITICAL,
+    )
+
+
+def create_component(
+    session: Session,
+    repositories: Any,
+    *,
+    name: str = "log4j-core",
+    version: str = "2.14.1",
+    purl: str | None = None,
+    ecosystem: str = "maven",
+) -> Any:
+    """Persist a minimal valid Component."""
+    return repositories.FindingRepository(session).upsert_component(
+        name=name,
+        version=version,
+        purl=purl or f"pkg:maven/org.apache.logging.log4j/log4j-core@{uuid.uuid4().hex}",
+        ecosystem=ecosystem,
+    )
+
+
+def create_vulnerability(
+    session: Session,
+    repositories: Any,
+    *,
+    cve_id: str = DEMO_CVE_LOG4SHELL,
+    cvss_score: float = 10.0,
+    severity: str = "CRITICAL",
+) -> Any:
+    """Persist a minimal valid Vulnerability."""
+    return repositories.FindingRepository(session).upsert_vulnerability(
+        cve_id=cve_id,
+        source_id=cve_id,
+        cvss_score=cvss_score,
+        severity=severity,
+    )
+
+
+def create_finding(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+    vulnerability_id: uuid.UUID,
+    cve_id: str,
+    component_id: uuid.UUID | None = None,
+    asset_id: uuid.UUID | None = None,
+    priority: Any | None = None,
+    priority_rank: int = 1,
+    operational_rank: int = 1,
+) -> Any:
+    """Persist a minimal valid Finding."""
+    return repositories.FindingRepository(session).create_or_update_finding(
+        project_id=project_id,
+        vulnerability_id=vulnerability_id,
+        component_id=component_id,
+        asset_id=asset_id,
+        cve_id=cve_id,
+        priority=priority or app_models.FindingPriority.CRITICAL,
+        priority_rank=priority_rank,
+        operational_rank=operational_rank,
+        in_kev=True,
+    )
+
+
+def create_provider_snapshot(
+    session: Session,
+    repositories: Any,
+    *,
+    content_hash: str | None = None,
+) -> Any:
+    """Persist a minimal valid ProviderSnapshot."""
+    return repositories.RunRepository(session).get_or_create_provider_snapshot(
+        content_hash=content_hash or f"sha256:{uuid.uuid4().hex}",
+        nvd_last_sync="2026-04-28T10:15:00Z",
+        epss_date="2026-04-28",
+        kev_catalog_version="2026-04-28",
+        source_hashes_json={"nvd": "sha256:nvd-feed"},
+    )
+
+
+def create_analysis_run(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+    provider_snapshot_id: uuid.UUID | None = None,
+    input_type: str = "cve-list",
+    filename: str = "known-cves.txt",
+    status: Any | None = None,
+) -> Any:
+    """Persist a minimal valid AnalysisRun."""
+    return repositories.RunRepository(session).create_analysis_run(
+        project_id=project_id,
+        provider_snapshot_id=provider_snapshot_id,
+        input_type=input_type,
+        filename=filename,
+        status=status or app_models.AnalysisRunStatus.COMPLETED,
+        summary_json={"parsed": 2, "findings": 2},
+    )
+
+
+def seed_domain_graph(
+    engine: Engine,
+    app_models: Any,
+    repositories: Any,
+    *,
+    user_email: str = "fixture-owner@example.test",
+) -> WorkbenchDomainGraph:
+    """Seed one valid User -> Project -> Asset/Component/Vulnerability/Finding/Run graph."""
+    with Session(engine) as session:
+        user = create_user(session, app_models, email=user_email, is_superuser=False)
+        project = create_project(
+            session,
+            app_models,
+            repositories,
+            owner_id=user.id,
+            name="Fixture Graph Project",
+        )
+        asset = create_asset(session, app_models, repositories, project_id=project.id)
+        component = create_component(session, repositories)
+        vulnerability = create_vulnerability(session, repositories)
+        finding = create_finding(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+            vulnerability_id=vulnerability.id,
+            component_id=component.id,
+            asset_id=asset.id,
+            cve_id=vulnerability.cve_id,
+        )
+        snapshot = create_provider_snapshot(session, repositories)
+        run = create_analysis_run(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+            provider_snapshot_id=snapshot.id,
+        )
+        graph = WorkbenchDomainGraph(
+            user_id=user.id,
+            project_id=project.id,
+            asset_id=asset.id,
+            component_id=component.id,
+            vulnerability_id=vulnerability.id,
+            finding_id=finding.id,
+            provider_snapshot_id=snapshot.id,
+            run_id=run.id,
+        )
+        session.commit()
+        return graph
+
+
+def seed_analysis_run(
+    engine: Engine,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+) -> dict[str, uuid.UUID]:
+    """Seed an AnalysisRun and ProviderSnapshot for API read tests."""
+    with Session(engine) as session:
+        snapshot = create_provider_snapshot(session, repositories)
+        run = create_analysis_run(
+            session,
+            app_models,
+            repositories,
+            project_id=project_id,
+            provider_snapshot_id=snapshot.id,
+        )
+        ids = {"run_id": run.id, "provider_snapshot_id": snapshot.id}
+        session.commit()
+        return ids
+
+
+def seed_finding_pair(
+    engine: Engine,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+) -> dict[str, list[uuid.UUID]]:
+    """Seed two deterministic demo-CVE findings for pagination tests."""
+    with Session(engine) as session:
+        asset = create_asset(session, app_models, repositories, project_id=project_id)
+        component = create_component(session, repositories)
+        first_vulnerability = create_vulnerability(
+            session,
+            repositories,
+            cve_id=DEMO_CVE_LOG4SHELL,
+        )
+        second_vulnerability = create_vulnerability(
+            session,
+            repositories,
+            cve_id=DEMO_CVE_XZ,
+        )
+        first_finding = create_finding(
+            session,
+            app_models,
+            repositories,
+            project_id=project_id,
+            vulnerability_id=first_vulnerability.id,
+            component_id=component.id,
+            asset_id=asset.id,
+            cve_id=DEMO_CVE_LOG4SHELL,
+            priority=app_models.FindingPriority.CRITICAL,
+            priority_rank=1,
+            operational_rank=1,
+        )
+        second_finding = create_finding(
+            session,
+            app_models,
+            repositories,
+            project_id=project_id,
+            vulnerability_id=second_vulnerability.id,
+            component_id=component.id,
+            asset_id=asset.id,
+            cve_id=DEMO_CVE_XZ,
+            priority=app_models.FindingPriority.HIGH,
+            priority_rank=2,
+            operational_rank=2,
+        )
+        finding_ids = [first_finding.id, second_finding.id]
+        session.commit()
+        return {"finding_ids": finding_ids}
+
+
+def seed_foreign_project_graph(
+    engine: Engine,
+    app_models: Any,
+    repositories: Any,
+) -> dict[str, uuid.UUID]:
+    """Seed a graph owned by a different non-superuser for 403 tests."""
+    with Session(engine) as session:
+        user = create_user(
+            session,
+            app_models,
+            email=f"{uuid.uuid4()}@example.test",
+            is_superuser=False,
+        )
+        project = create_project(
+            session,
+            app_models,
+            repositories,
+            owner_id=user.id,
+            name="Foreign Project",
+        )
+        asset = create_asset(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+            asset_key="foreign-api",
+            name="Foreign API",
+        )
+        run_ids = seed_analysis_run_in_session(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+        )
+        finding = seed_finding_in_session(
+            session,
+            app_models,
+            repositories,
+            project_id=project.id,
+            asset_id=asset.id,
+        )
+        ids = {
+            "project_id": project.id,
+            "asset_id": asset.id,
+            "run_id": run_ids["run_id"],
+            "finding_id": finding.id,
+        }
+        session.commit()
+        return ids
+
+
+def seed_analysis_run_in_session(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+) -> dict[str, uuid.UUID]:
+    """Seed a ProviderSnapshot and AnalysisRun in an existing transaction."""
+    snapshot = create_provider_snapshot(session, repositories)
+    run = create_analysis_run(
+        session,
+        app_models,
+        repositories,
+        project_id=project_id,
+        provider_snapshot_id=snapshot.id,
+        filename="foreign-cves.txt",
+    )
+    return {"run_id": run.id, "provider_snapshot_id": snapshot.id}
+
+
+def seed_finding_in_session(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> Any:
+    """Seed one Finding in an existing transaction."""
+    cve_id = f"CVE-2026-{uuid.uuid4().int % 10000:04d}"
+    vulnerability = create_vulnerability(
+        session,
+        repositories,
+        cve_id=cve_id,
+        cvss_score=7.5,
+        severity="HIGH",
+    )
+    return create_finding(
+        session,
+        app_models,
+        repositories,
+        project_id=project_id,
+        vulnerability_id=vulnerability.id,
+        asset_id=asset_id,
+        cve_id=vulnerability.cve_id,
+        priority=app_models.FindingPriority.HIGH,
+        priority_rank=2,
+    )
+
+
+def login(client: TestClient) -> str:
+    """Return a bearer token for the configured template user."""
+    response = client.post(
+        "/api/v1/login/access-token",
+        data={
+            "username": settings.FIRST_SUPERUSER,
+            "password": settings.FIRST_SUPERUSER_PASSWORD,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["token_type"] == "bearer"
+    return str(payload["access_token"])
+
+
+def auth_headers(client: TestClient) -> dict[str, str]:
+    """Return Authorization headers for the configured template user."""
+    return {"Authorization": f"Bearer {login(client)}"}
+
+
+def current_user(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
+    """Read the current user through the public template API."""
+    response = client.get("/api/v1/users/me", headers=headers)
+    assert response.status_code == 200
+    return response.json()
+
+
+def create_project_via_api(client: TestClient, headers: dict[str, str]) -> dict[str, Any]:
+    """Create a project through the API for route-level tests."""
+    response = client.post(
+        "/api/v1/projects/",
+        headers=headers,
+        json={"name": "Workbench API Contract", "description": None},
+    )
+    assert response.status_code == 200
+    return response.json()

--- a/backend/tests/utils/test_workbench_factories.py
+++ b/backend/tests/utils/test_workbench_factories.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import uuid
+
+from utils.workbench_factories import (
+    template_analysis_run,
+    template_asset,
+    template_component,
+    template_finding,
+    template_project,
+    template_provider_snapshot,
+    template_user,
+    template_vulnerability,
+    template_workbench_graph,
+)
+
+
+def test_template_workbench_graph_builds_coherent_unsaved_domain_objects() -> None:
+    graph = template_workbench_graph()
+
+    assert graph.project.owner_id == graph.user.id
+    assert graph.asset.project_id == graph.project.id
+    assert graph.finding.project_id == graph.project.id
+    assert graph.finding.asset_id == graph.asset.id
+    assert graph.finding.component_id == graph.component.id
+    assert graph.finding.vulnerability_id == graph.vulnerability.id
+    assert graph.finding.cve_id == graph.vulnerability.cve_id
+    assert graph.analysis_run.project_id == graph.project.id
+    assert graph.analysis_run.provider_snapshot_id == graph.provider_snapshot.id
+
+
+def test_template_factories_accept_overrides_without_mutating_later_instances() -> None:
+    user = template_user(email="security@example.test")
+    project = template_project(owner=user, name="Security Workbench")
+    asset = template_asset(project=project, asset_key="edge-api")
+    component = template_component(name="openssl", version="3.0.0")
+    vulnerability = template_vulnerability(cve_id="CVE-2026-9999", cvss_score=9.1)
+    finding = template_finding(
+        project=project,
+        asset=asset,
+        component=component,
+        vulnerability=vulnerability,
+        priority_rank=2,
+    )
+    snapshot = template_provider_snapshot(content_hash="sha256:custom")
+    run = template_analysis_run(project=project, provider_snapshot=snapshot, filename="scan.json")
+
+    assert user.email == "security@example.test"
+    assert project.name == "Security Workbench"
+    assert asset.asset_key == "edge-api"
+    assert component.name == "openssl"
+    assert vulnerability.cve_id == "CVE-2026-9999"
+    assert finding.priority_rank == 2
+    assert snapshot.content_hash == "sha256:custom"
+    assert run.filename == "scan.json"
+    assert template_provider_snapshot().source_hashes_json["kev"] == "sha256:kev-feed-1"
+
+
+def test_template_factories_support_explicit_foreign_key_ids() -> None:
+    owner_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+    component_id = uuid.uuid4()
+    vulnerability_id = uuid.uuid4()
+    provider_snapshot_id = uuid.uuid4()
+
+    project = template_project(owner_id=owner_id)
+    asset = template_asset(project_id=project_id)
+    finding = template_finding(
+        project_id=project_id,
+        asset_id=asset_id,
+        component_id=component_id,
+        vulnerability_id=vulnerability_id,
+    )
+    run = template_analysis_run(
+        project_id=project_id,
+        provider_snapshot_id=provider_snapshot_id,
+    )
+
+    assert project.owner_id == owner_id
+    assert asset.project_id == project_id
+    assert finding.project_id == project_id
+    assert finding.asset_id == asset_id
+    assert finding.component_id == component_id
+    assert finding.vulnerability_id == vulnerability_id
+    assert run.project_id == project_id
+    assert run.provider_snapshot_id == provider_snapshot_id

--- a/backend/tests/utils/workbench_factories.py
+++ b/backend/tests/utils/workbench_factories.py
@@ -1,0 +1,330 @@
+"""Pure factories for template Workbench domain model tests."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, TypeVar
+
+from app import models as app_models
+
+app_models.import_table_models()
+
+FIXED_STARTED_AT = datetime(2026, 4, 28, 12, 0, tzinfo=UTC)
+FIXED_FINISHED_AT = datetime(2026, 4, 28, 12, 4, tzinfo=UTC)
+
+_ID_NAMESPACE = uuid.UUID("9a371f52-26d7-45e5-9de7-7f9f14f3579d")
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class WorkbenchGraph:
+    """A coherent unsaved Workbench object graph for tests."""
+
+    user: app_models.User
+    project: app_models.Project
+    asset: app_models.Asset
+    component: app_models.Component
+    vulnerability: app_models.Vulnerability
+    finding: app_models.Finding
+    provider_snapshot: app_models.ProviderSnapshot
+    analysis_run: app_models.AnalysisRun
+
+
+def template_user(index: int = 1, **overrides: Any) -> app_models.User:
+    """Build an unsaved template user."""
+
+    values = {
+        "id": template_id("user", index),
+        "email": f"owner-{index}@example.test",
+        "hashed_password": "not-used",
+        "is_active": True,
+        "is_superuser": True,
+        "full_name": f"Workbench Owner {index}",
+        "created_at": _time(index),
+    }
+    values.update(overrides)
+    return app_models.User(**values)
+
+
+def template_project(
+    index: int = 1,
+    *,
+    owner: app_models.User | None = None,
+    owner_id: uuid.UUID | None = None,
+    **overrides: Any,
+) -> app_models.Project:
+    """Build an unsaved project owned by ``owner`` or ``owner_id``."""
+
+    resolved_owner_id = owner_id or (owner.id if owner is not None else template_id("user", index))
+    values = {
+        "id": template_id("project", index),
+        "owner_id": resolved_owner_id,
+        "name": f"Workbench Project {index}",
+        "description": "Template Workbench domain fixture.",
+        "created_at": _time(index),
+        "updated_at": _time(index),
+    }
+    values.update(overrides)
+    project = app_models.Project(**values)
+    if owner is not None:
+        project.owner = owner
+    return project
+
+
+def template_asset(
+    index: int = 1,
+    *,
+    project: app_models.Project | None = None,
+    project_id: uuid.UUID | None = None,
+    **overrides: Any,
+) -> app_models.Asset:
+    """Build an unsaved asset scoped to a project."""
+
+    resolved_project_id = project_id or (
+        project.id if project is not None else template_id("project", index)
+    )
+    values = {
+        "id": template_id("asset", index),
+        "project_id": resolved_project_id,
+        "asset_key": f"payments-api-{index}",
+        "name": f"Payments API {index}",
+        "target_ref": f"registry.example.test/payments-api:{index}",
+        "owner": "platform",
+        "business_service": "payments",
+        "environment": app_models.AssetEnvironment.PRODUCTION,
+        "exposure": app_models.AssetExposure.INTERNET_FACING,
+        "criticality": app_models.AssetCriticality.CRITICAL,
+        "created_at": _time(index),
+        "updated_at": _time(index),
+    }
+    values.update(overrides)
+    asset = app_models.Asset(**values)
+    if project is not None:
+        asset.project = project
+    return asset
+
+
+def template_component(index: int = 1, **overrides: Any) -> app_models.Component:
+    """Build an unsaved software component."""
+
+    values = {
+        "id": template_id("component", index),
+        "name": "log4j-core",
+        "version": f"2.14.{index}",
+        "purl": f"pkg:maven/org.apache.logging.log4j/log4j-core@2.14.{index}",
+        "ecosystem": "maven",
+        "package_type": "library",
+        "created_at": _time(index),
+        "updated_at": _time(index),
+    }
+    values.update(overrides)
+    return app_models.Component(**values)
+
+
+def template_vulnerability(index: int = 1, **overrides: Any) -> app_models.Vulnerability:
+    """Build an unsaved vulnerability."""
+
+    cve_id = _cve_id(index)
+    values = {
+        "id": template_id("vulnerability", index),
+        "cve_id": cve_id,
+        "source_id": cve_id,
+        "title": f"Template vulnerability {cve_id}",
+        "description": "Offline vulnerability fixture for Workbench tests.",
+        "cvss_score": 10.0,
+        "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+        "severity": "CRITICAL",
+        "cwe": "CWE-502",
+        "published_at": "2021-12-10T00:00:00Z",
+        "modified_at": "2026-04-28T00:00:00Z",
+        "provider_json": {"source": "fixture", "offline": True},
+        "created_at": _time(index),
+        "updated_at": _time(index),
+    }
+    values.update(overrides)
+    return app_models.Vulnerability(**values)
+
+
+def template_finding(
+    index: int = 1,
+    *,
+    project: app_models.Project | None = None,
+    project_id: uuid.UUID | None = None,
+    asset: app_models.Asset | None = None,
+    asset_id: uuid.UUID | None = None,
+    component: app_models.Component | None = None,
+    component_id: uuid.UUID | None = None,
+    vulnerability: app_models.Vulnerability | None = None,
+    vulnerability_id: uuid.UUID | None = None,
+    **overrides: Any,
+) -> app_models.Finding:
+    """Build an unsaved prioritized finding."""
+
+    resolved_project_id = project_id or (
+        project.id if project is not None else template_id("project", index)
+    )
+    resolved_asset_id = _optional_related_id(asset_id, asset)
+    resolved_component_id = _optional_related_id(component_id, component)
+    resolved_vulnerability_id = vulnerability_id or (
+        vulnerability.id if vulnerability is not None else template_id("vulnerability", index)
+    )
+    cve_id = vulnerability.cve_id if vulnerability is not None else _cve_id(index)
+    values = {
+        "id": template_id("finding", index),
+        "project_id": resolved_project_id,
+        "asset_id": resolved_asset_id,
+        "component_id": resolved_component_id,
+        "vulnerability_id": resolved_vulnerability_id,
+        "cve_id": cve_id,
+        "dedup_key": f"{resolved_project_id}:{cve_id}:{resolved_asset_id}:{resolved_component_id}",
+        "status": app_models.FindingStatus.OPEN,
+        "priority": app_models.FindingPriority.CRITICAL,
+        "priority_rank": 1,
+        "risk_score": 99.0,
+        "operational_rank": 1,
+        "in_kev": True,
+        "epss": 0.9442,
+        "cvss_base_score": 10.0,
+        "attack_mapped": True,
+        "recommended_action": "Patch affected component.",
+        "rationale": "Fixture combines KEV, high EPSS, and internet-facing exposure.",
+        "explanation_json": {"signals": ["kev", "epss", "internet-facing"]},
+        "data_quality_json": {"fixture": True},
+        "evidence_json": {"input": "offline-fixture"},
+        "first_seen_at": _time(index),
+        "last_seen_at": _time(index),
+        "created_at": _time(index),
+        "updated_at": _time(index),
+    }
+    values.update(overrides)
+    finding = app_models.Finding(**values)
+    _assign_if_present(finding, "project", project)
+    _assign_if_present(finding, "asset", asset)
+    _assign_if_present(finding, "component", component)
+    _assign_if_present(finding, "vulnerability", vulnerability)
+    return finding
+
+
+def template_provider_snapshot(
+    index: int = 1,
+    **overrides: Any,
+) -> app_models.ProviderSnapshot:
+    """Build an unsaved provider snapshot."""
+
+    values = {
+        "id": template_id("provider-snapshot", index),
+        "nvd_last_sync": "2026-04-28T10:15:00Z",
+        "epss_date": "2026-04-28",
+        "kev_catalog_version": "2026-04-28",
+        "content_hash": f"sha256:fixture-provider-snapshot-{index}",
+        "source_hashes_json": {
+            "nvd": f"sha256:nvd-feed-{index}",
+            "epss": f"sha256:epss-feed-{index}",
+            "kev": f"sha256:kev-feed-{index}",
+        },
+        "source_metadata_json": {
+            "selected_sources": ["nvd", "epss", "kev"],
+            "cache_only": True,
+            "requested_cves": 1,
+        },
+        "created_at": _time(index),
+    }
+    values.update(overrides)
+    return app_models.ProviderSnapshot(**values)
+
+
+def template_analysis_run(
+    index: int = 1,
+    *,
+    project: app_models.Project | None = None,
+    project_id: uuid.UUID | None = None,
+    provider_snapshot: app_models.ProviderSnapshot | None = None,
+    provider_snapshot_id: uuid.UUID | None = None,
+    **overrides: Any,
+) -> app_models.AnalysisRun:
+    """Build an unsaved analysis run."""
+
+    resolved_project_id = project_id or (
+        project.id if project is not None else template_id("project", index)
+    )
+    resolved_provider_snapshot_id = _optional_related_id(provider_snapshot_id, provider_snapshot)
+    values = {
+        "id": template_id("analysis-run", index),
+        "project_id": resolved_project_id,
+        "provider_snapshot_id": resolved_provider_snapshot_id,
+        "input_type": "cve-list",
+        "filename": f"known-cves-{index}.txt",
+        "status": app_models.AnalysisRunStatus.COMPLETED,
+        "started_at": FIXED_STARTED_AT + timedelta(minutes=index - 1),
+        "finished_at": FIXED_FINISHED_AT + timedelta(minutes=index - 1),
+        "error_message": None,
+        "error_json": {},
+        "summary_json": {"parsed": 1, "findings": 1},
+    }
+    values.update(overrides)
+    analysis_run = app_models.AnalysisRun(**values)
+    _assign_if_present(analysis_run, "project", project)
+    _assign_if_present(analysis_run, "provider_snapshot", provider_snapshot)
+    return analysis_run
+
+
+def template_workbench_graph(index: int = 1) -> WorkbenchGraph:
+    """Build a coherent, unsaved user-to-analysis-run Workbench graph."""
+
+    user = template_user(index)
+    project = template_project(index, owner=user)
+    asset = template_asset(index, project=project)
+    component = template_component(index)
+    vulnerability = template_vulnerability(index)
+    finding = template_finding(
+        index,
+        project=project,
+        asset=asset,
+        component=component,
+        vulnerability=vulnerability,
+    )
+    provider_snapshot = template_provider_snapshot(index)
+    analysis_run = template_analysis_run(
+        index,
+        project=project,
+        provider_snapshot=provider_snapshot,
+    )
+    return WorkbenchGraph(
+        user=user,
+        project=project,
+        asset=asset,
+        component=component,
+        vulnerability=vulnerability,
+        finding=finding,
+        provider_snapshot=provider_snapshot,
+        analysis_run=analysis_run,
+    )
+
+
+def template_id(name: str, index: int = 1) -> uuid.UUID:
+    """Return a stable UUID for a factory object name and index."""
+
+    return uuid.uuid5(_ID_NAMESPACE, f"{name}:{index}")
+
+
+def _cve_id(index: int) -> str:
+    return f"CVE-2026-{index:04d}"
+
+
+def _time(index: int) -> datetime:
+    return FIXED_STARTED_AT + timedelta(minutes=index - 1)
+
+
+def _optional_related_id(explicit_id: uuid.UUID | None, related: Any | None) -> uuid.UUID | None:
+    if explicit_id is not None:
+        return explicit_id
+    if related is None:
+        return None
+    return related.id
+
+
+def _assign_if_present(target: Any, field: str, value: _T | None) -> None:
+    if value is not None:
+        setattr(target, field, value)


### PR DESCRIPTION
## Summary
- adds reusable backend test utilities under backend/tests/utils for template Workbench domain objects
- adds pytest fixtures for User, Project, Asset, Component, Vulnerability, Finding, ProviderSnapshot, and AnalysisRun
- refactors the VPW-011 API skeleton tests to use shared helpers instead of local duplicate setup
- adds fixture utility tests and documentation for the helper path

Refs #118

## Verification
- python3 -m pytest -q backend/tests/utils backend/tests/api/test_template_workbench_fixture_utils.py backend/tests/api/test_template_workbench_api_skeleton.py --no-cov
- python3 -m pytest -q backend/tests/api --no-cov
- python3 -m pytest -q backend/tests/api/test_template_projects.py backend/tests/api/test_template_core_workbench_models.py backend/tests/api/test_template_run_provider_models.py backend/tests/api/test_template_service_layer.py backend/tests/api/test_template_workbench_api_skeleton.py backend/tests/api/test_template_workbench_fixture_utils.py backend/tests/utils --no-cov
- make check

## Evidence
- Fixture path list: backend/tests/utils/README.md, backend/tests/utils/template_workbench.py, backend/tests/utils/workbench_factories.py
- API fixture usage: backend/tests/api/test_template_workbench_fixture_utils.py and backend/tests/api/test_template_workbench_api_skeleton.py

## Residual Risk
- No production code, API contract, DB migration, or generated frontend client changes in this slice.
- Browser Playwright tests remain behind the existing VULN_PRIORITIZER_RUN_PLAYWRIGHT gate and were skipped by make check as expected.