### PR TITLE
VPW-013: Add importer registry contract

### DIFF
--- a/backend/app/importers/__init__.py
+++ b/backend/app/importers/__init__.py
@@ -1,0 +1,37 @@
+"""Importer contract and registry exports."""
+
+from app.importers.contracts import (
+    Importer,
+    ImporterError,
+    ImporterParseError,
+    ImporterValidationError,
+    InputPayload,
+    NormalizedOccurrence,
+)
+from app.importers.legacy import (
+    DEFAULT_IMPORT_INPUT_TYPES,
+    LegacyInputLoaderImporter,
+    default_importers,
+)
+from app.importers.registry import (
+    DuplicateInputTypeError,
+    ImporterRegistry,
+    UnsupportedInputTypeError,
+    build_importer_registry,
+)
+
+__all__ = [
+    "DuplicateInputTypeError",
+    "DEFAULT_IMPORT_INPUT_TYPES",
+    "Importer",
+    "ImporterError",
+    "ImporterParseError",
+    "ImporterRegistry",
+    "ImporterValidationError",
+    "InputPayload",
+    "LegacyInputLoaderImporter",
+    "NormalizedOccurrence",
+    "UnsupportedInputTypeError",
+    "build_importer_registry",
+    "default_importers",
+]

--- a/backend/app/importers/contracts.py
+++ b/backend/app/importers/contracts.py
@@ -1,0 +1,76 @@
+"""Offline importer contracts for normalizing uploaded vulnerability inputs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+CVE_PATTERN = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+InputPayload = bytes | str
+
+
+class ImporterError(Exception):
+    """Base class for importer contract failures."""
+
+
+class ImporterParseError(ImporterError):
+    """Raised when an importer cannot parse the supplied input."""
+
+
+class ImporterValidationError(ImporterError, ValueError):
+    """Raised when normalized importer output fails contract validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedOccurrence:
+    """Provider-free occurrence DTO emitted by importers before persistence."""
+
+    cve: str
+    component: str | None = None
+    version: str | None = None
+    asset_ref: str | None = None
+    source: str = "import"
+    fix_version: str | None = None
+    raw_evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cve, str):
+            raise ImporterValidationError("Occurrence cve must be a string")
+        if not isinstance(self.source, str):
+            raise ImporterValidationError("Occurrence source must be a string")
+        cve = self.cve.strip().upper()
+        if not CVE_PATTERN.fullmatch(cve):
+            raise ImporterValidationError(f"Invalid CVE identifier: {self.cve!r}")
+        source = self.source.strip()
+        if not source:
+            raise ImporterValidationError("Occurrence source must not be blank")
+        if not isinstance(self.raw_evidence, Mapping):
+            raise ImporterValidationError("Occurrence raw_evidence must be a mapping")
+        raw_evidence = dict(self.raw_evidence)
+        if not all(isinstance(key, str) for key in raw_evidence):
+            raise ImporterValidationError("Occurrence raw_evidence keys must be strings")
+
+        object.__setattr__(self, "cve", cve)
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "raw_evidence", raw_evidence)
+
+
+@runtime_checkable
+class Importer(Protocol):
+    """Pure parser that turns one input payload into normalized occurrences."""
+
+    @property
+    def input_type(self) -> str:
+        """Stable Workbench input type claimed by the importer."""
+        ...
+
+    def parse(
+        self,
+        payload: InputPayload,
+        *,
+        filename: str | None = None,
+    ) -> list[NormalizedOccurrence]:
+        """Parse payload bytes/text without provider, database, or network access."""
+        ...

--- a/backend/app/importers/legacy.py
+++ b/backend/app/importers/legacy.py
@@ -1,0 +1,122 @@
+"""Adapters from the existing local input loader into the template importer contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from app.importers.contracts import (
+    Importer,
+    ImporterParseError,
+    ImporterValidationError,
+    InputPayload,
+    NormalizedOccurrence,
+)
+from vuln_prioritizer.cli_options import InputFormat
+from vuln_prioritizer.inputs.loader import InputLoader
+from vuln_prioritizer.models_input import InputOccurrence
+
+DEFAULT_IMPORT_INPUT_TYPES = (
+    InputFormat.cve_list.value,
+    InputFormat.generic_occurrence_csv.value,
+    InputFormat.trivy_json.value,
+    InputFormat.grype_json.value,
+    InputFormat.cyclonedx_json.value,
+    InputFormat.spdx_json.value,
+    InputFormat.dependency_check_json.value,
+    InputFormat.github_alerts_json.value,
+    InputFormat.nessus_xml.value,
+    InputFormat.openvas_xml.value,
+)
+_DEFAULT_SUFFIX_BY_INPUT_TYPE = {
+    InputFormat.cve_list.value: ".txt",
+    InputFormat.generic_occurrence_csv.value: ".csv",
+    InputFormat.trivy_json.value: ".json",
+    InputFormat.grype_json.value: ".json",
+    InputFormat.cyclonedx_json.value: ".json",
+    InputFormat.spdx_json.value: ".json",
+    InputFormat.dependency_check_json.value: ".json",
+    InputFormat.github_alerts_json.value: ".json",
+    InputFormat.nessus_xml.value: ".nessus",
+    InputFormat.openvas_xml.value: ".xml",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyInputLoaderImporter:
+    """Importer backed by the existing offline input-normalization loader."""
+
+    input_type: str
+
+    def parse(
+        self,
+        payload: InputPayload,
+        *,
+        filename: str | None = None,
+    ) -> list[NormalizedOccurrence]:
+        if self.input_type not in DEFAULT_IMPORT_INPUT_TYPES:
+            raise ImporterValidationError(f"Unsupported legacy input type: {self.input_type!r}")
+        path_suffix = _payload_suffix(input_type=self.input_type, filename=filename)
+        with TemporaryDirectory(prefix="vpw-import-") as temp_dir:
+            input_path = Path(temp_dir) / f"input{path_suffix}"
+            _write_payload(input_path, payload)
+            try:
+                parsed_input = InputLoader().load(input_path, input_format=self.input_type)
+            except Exception as exc:
+                raise ImporterParseError(
+                    f"Could not parse {self.input_type!r} input payload."
+                ) from exc
+        return [_normalize_occurrence(item) for item in parsed_input.occurrences]
+
+
+def default_importers() -> tuple[Importer, ...]:
+    """Return importers for the currently supported local Workbench input types."""
+    return tuple(LegacyInputLoaderImporter(input_type) for input_type in DEFAULT_IMPORT_INPUT_TYPES)
+
+
+def _write_payload(path: Path, payload: InputPayload) -> None:
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+        return
+    if isinstance(payload, str):
+        path.write_text(payload, encoding="utf-8")
+        return
+    raise ImporterValidationError("Importer payload must be bytes or string")
+
+
+def _payload_suffix(*, input_type: str, filename: str | None) -> str:
+    if filename:
+        suffix = Path(filename).suffix.lower()
+        if suffix:
+            return suffix
+    return _DEFAULT_SUFFIX_BY_INPUT_TYPE[input_type]
+
+
+def _normalize_occurrence(occurrence: InputOccurrence) -> NormalizedOccurrence:
+    return NormalizedOccurrence(
+        cve=occurrence.cve_id,
+        component=occurrence.component_name,
+        version=occurrence.component_version,
+        asset_ref=occurrence.asset_id or occurrence.target_ref,
+        source=occurrence.source_format,
+        fix_version=occurrence.fix_versions[0] if occurrence.fix_versions else None,
+        raw_evidence=_raw_evidence(occurrence),
+    )
+
+
+def _raw_evidence(occurrence: InputOccurrence) -> dict[str, Any]:
+    return {
+        "source_format": occurrence.source_format,
+        "source_record_id": occurrence.source_record_id,
+        "purl": occurrence.purl,
+        "package_type": occurrence.package_type,
+        "file_path": occurrence.file_path,
+        "dependency_path": occurrence.dependency_path,
+        "fix_versions": list(occurrence.fix_versions),
+        "raw_severity": occurrence.raw_severity,
+        "target_kind": occurrence.target_kind,
+        "target_ref": occurrence.target_ref,
+        "asset_id": occurrence.asset_id,
+    }

--- a/backend/app/importers/registry.py
+++ b/backend/app/importers/registry.py
@@ -1,0 +1,95 @@
+"""Importer registry keyed by Workbench input type."""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import Iterable
+
+from app.importers.contracts import (
+    Importer,
+    ImporterError,
+    ImporterValidationError,
+    InputPayload,
+    NormalizedOccurrence,
+)
+from app.importers.legacy import default_importers
+
+
+class UnsupportedInputTypeError(ImporterError, LookupError):
+    """Raised when no importer is registered for an input type."""
+
+    def __init__(self, input_type: str, supported: Iterable[str]) -> None:
+        supported_types = tuple(sorted(supported))
+        message = f"Unsupported input type {input_type!r}"
+        if supported_types:
+            message = f"{message}. Supported input types: {', '.join(supported_types)}"
+        super().__init__(message)
+        self.input_type = input_type
+        self.supported = supported_types
+
+
+class DuplicateInputTypeError(ImporterValidationError):
+    """Raised when two importers claim the same input type."""
+
+    def __init__(self, input_type: str) -> None:
+        super().__init__(f"Duplicate importer input type: {input_type!r}")
+        self.input_type = input_type
+
+
+class ImporterRegistry:
+    """Small in-memory registry for offline input importers."""
+
+    def __init__(self, importers: Iterable[Importer] = ()) -> None:
+        self._importers: dict[str, Importer] = {}
+        for importer in importers:
+            self.register(importer)
+
+    def register(self, importer: Importer) -> None:
+        """Register an importer by its normalized input type."""
+        input_type = _normalize_input_type(importer.input_type)
+        if input_type in self._importers:
+            raise DuplicateInputTypeError(input_type)
+        self._importers[input_type] = importer
+
+    def list_input_types(self) -> tuple[str, ...]:
+        """Return supported input types in stable order."""
+        return tuple(sorted(self._importers))
+
+    def list(self) -> tuple[str, ...]:
+        """Return supported input types in stable order."""
+        return self.list_input_types()
+
+    def supported_input_types(self) -> tuple[str, ...]:
+        """Return supported input types in stable order."""
+        return self.list_input_types()
+
+    def get(self, input_type: str) -> Importer:
+        """Return the importer for an input type, or raise a clear lookup error."""
+        normalized = _normalize_input_type(input_type)
+        try:
+            return self._importers[normalized]
+        except KeyError as exc:
+            raise UnsupportedInputTypeError(normalized, self._importers) from exc
+
+    def parse(
+        self,
+        input_type: str,
+        payload: InputPayload,
+        *,
+        filename: str | None = None,
+    ) -> builtins.list[NormalizedOccurrence]:
+        """Parse input through the importer registered for the input type."""
+        return builtins.list(self.get(input_type).parse(payload, filename=filename))
+
+
+def build_importer_registry(importers: Iterable[Importer] | None = None) -> ImporterRegistry:
+    """Build an importer registry from the supplied offline importers."""
+    selected_importers = default_importers() if importers is None else importers
+    return ImporterRegistry(selected_importers)
+
+
+def _normalize_input_type(input_type: str) -> str:
+    normalized = input_type.strip().lower()
+    if not normalized:
+        raise ImporterValidationError("Importer input_type must not be blank")
+    return normalized

--- a/backend/tests/api/test_template_importer_registry.py
+++ b/backend/tests/api/test_template_importer_registry.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.importers import (
+    DEFAULT_IMPORT_INPUT_TYPES,
+    DuplicateInputTypeError,
+    ImporterError,
+    ImporterParseError,
+    ImporterRegistry,
+    ImporterValidationError,
+    NormalizedOccurrence,
+    UnsupportedInputTypeError,
+    build_importer_registry,
+)
+
+
+class FakeImporter:
+    input_type = "fake-json"
+
+    def parse(
+        self,
+        payload: bytes | str,
+        *,
+        filename: str | None = None,
+    ) -> list[NormalizedOccurrence]:
+        if payload == "broken":
+            raise ImporterParseError("fake payload is not parseable")
+        return [
+            NormalizedOccurrence(
+                cve="cve-2026-12345",
+                component="openssl",
+                version="3.0.0",
+                asset_ref=filename,
+                source=self.input_type,
+                fix_version="3.0.8",
+                raw_evidence={"payload_type": type(payload).__name__},
+            )
+        ]
+
+
+def test_importer_registry_lists_and_gets_importers_by_input_type() -> None:
+    importer = FakeImporter()
+    registry = build_importer_registry([importer])
+
+    assert registry.list_input_types() == ("fake-json",)
+    assert registry.list() == ("fake-json",)
+    assert registry.supported_input_types() == ("fake-json",)
+    assert registry.get("fake-json") is importer
+    assert registry.get(" FAKE-JSON ") is importer
+
+
+def test_default_importer_registry_maps_current_workbench_input_types() -> None:
+    registry = build_importer_registry()
+
+    assert registry.supported_input_types() == tuple(sorted(DEFAULT_IMPORT_INPUT_TYPES))
+
+
+def test_importer_registry_rejects_duplicate_input_types() -> None:
+    first = FakeImporter()
+    second = FakeImporter()
+
+    with pytest.raises(DuplicateInputTypeError) as exc_info:
+        ImporterRegistry([first, second])
+
+    assert exc_info.value.input_type == "fake-json"
+    assert isinstance(exc_info.value, ImporterValidationError)
+
+
+def test_importer_registry_rejects_blank_input_type() -> None:
+    with pytest.raises(ImporterValidationError, match="must not be blank"):
+        build_importer_registry([type("BlankImporter", (), {"input_type": "  "})()])
+
+
+def test_importer_registry_raises_clear_error_for_unsupported_type() -> None:
+    registry = build_importer_registry([FakeImporter()])
+
+    with pytest.raises(UnsupportedInputTypeError) as exc_info:
+        registry.get("unknown")
+
+    assert exc_info.value.input_type == "unknown"
+    assert exc_info.value.supported == ("fake-json",)
+    assert "Supported input types: fake-json" in str(exc_info.value)
+    assert isinstance(exc_info.value, ImporterError)
+
+
+def test_registry_parse_path_returns_normalized_occurrences() -> None:
+    registry = build_importer_registry([FakeImporter()])
+    occurrences = registry.parse("fake-json", b"{}", filename="scan.json")
+
+    assert occurrences == [
+        NormalizedOccurrence(
+            cve="CVE-2026-12345",
+            component="openssl",
+            version="3.0.0",
+            asset_ref="scan.json",
+            source="fake-json",
+            fix_version="3.0.8",
+            raw_evidence={"payload_type": "bytes"},
+        )
+    ]
+
+
+def test_normalized_occurrence_rejects_invalid_cve() -> None:
+    with pytest.raises(ImporterValidationError):
+        NormalizedOccurrence(cve="not-a-cve", source="fake-json")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("cve", None),
+        ("source", None),
+    ],
+)
+def test_normalized_occurrence_rejects_non_string_identifiers(
+    field_name: str,
+    value: object,
+) -> None:
+    payload = {"cve": "CVE-2026-12345", "source": "fake-json", field_name: value}
+
+    with pytest.raises(ImporterValidationError, match=field_name):
+        NormalizedOccurrence(**payload)
+
+
+def test_normalized_occurrence_rejects_non_string_raw_evidence_keys() -> None:
+    with pytest.raises(ImporterValidationError, match="keys must be strings"):
+        NormalizedOccurrence(
+            cve="CVE-2026-12345",
+            source="fake-json",
+            raw_evidence={1: "non-string-key"},
+        )
+
+
+def test_fake_importer_surfaces_parse_errors() -> None:
+    with pytest.raises(ImporterParseError, match="not parseable"):
+        FakeImporter().parse("broken")
+
+
+def test_default_registry_parses_cve_list_payload() -> None:
+    registry = build_importer_registry()
+
+    occurrences = registry.parse(
+        "cve-list",
+        "CVE-2026-12345\nCVE-2026-23456\n",
+        filename="findings.txt",
+    )
+
+    assert [item.cve for item in occurrences] == ["CVE-2026-12345", "CVE-2026-23456"]
+    assert [item.source for item in occurrences] == ["cve-list", "cve-list"]
+
+
+def test_default_registry_maps_parse_failures_to_importer_error() -> None:
+    registry = build_importer_registry()
+
+    with pytest.raises(ImporterParseError, match="trivy-json"):
+        registry.parse("trivy-json", "{not valid json", filename="trivy.json")
+
+
+def test_importer_layer_stays_framework_provider_and_db_free() -> None:
+    importer_dir = Path(__file__).resolve().parents[2] / "app" / "importers"
+    source = "\n".join(path.read_text() for path in importer_dir.glob("*.py"))
+
+    forbidden_imports = [
+        "fastapi",
+        "HTTPException",
+        "sqlmodel",
+        "app.repositories",
+        "vuln_prioritizer.db",
+        "vuln_prioritizer.providers",
+    ]
+    for forbidden in forbidden_imports:
+        assert forbidden not in source

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -77,6 +77,12 @@ The Workbench threat model and readiness checklist are maintained in [workbench-
 
 `backend/src/vuln_prioritizer/inputs/loader.py` is the canonical input entry point.
 
+The template-aligned Workbench import boundary is documented in
+[vpw-013-importer-contract.md](vpw-013-importer-contract.md). It defines the
+pure importer protocol, normalized occurrence DTO, registry lookup behavior,
+and the rule that parser adapters stay free of FastAPI, database, repository,
+and provider dependencies.
+
 Current normalized types:
 
 - `InputOccurrence`: one source occurrence of a CVE, including component, path, target, asset, and VEX fields

--- a/docs/architecture/vpw-013-importer-contract.md
+++ b/docs/architecture/vpw-013-importer-contract.md
@@ -1,0 +1,87 @@
+# VPW-013 Importer Contract
+
+## Scope
+
+VPW-013 defines the template-backend importer contract for turning an uploaded
+input payload into normalized vulnerability occurrences.
+
+Importers are pure parser adapters. They do not own project authorization,
+database writes, provider enrichment, analysis runs, or HTTP error mapping.
+Those concerns stay outside the importer layer and are handled later by the API
+or service boundary.
+
+## Importer Protocol
+
+An importer implements the `Importer` protocol:
+
+- `input_type`: stable Workbench input type string claimed by the importer
+- `parse(payload, *, filename=None)`: parses `bytes` or `str` input and returns
+  a list of `NormalizedOccurrence`
+
+`parse` must be deterministic for the supplied payload and optional filename.
+It must not call FastAPI dependencies, repositories, database sessions,
+provider clients, network APIs, background jobs, or application settings.
+
+## NormalizedOccurrence
+
+`NormalizedOccurrence` is the provider-free DTO emitted before persistence.
+
+Fields:
+
+- `cve`: required CVE identifier, normalized to uppercase
+- `component`: optional affected component or package name
+- `version`: optional affected component version
+- `asset_ref`: optional source asset reference
+- `source`: required non-blank occurrence source, defaulting to `import`
+- `fix_version`: optional fixed version
+- `raw_evidence`: mapping with source-specific evidence, copied to a plain dict
+
+Validation is local to the DTO:
+
+- CVE values must match `CVE-YYYY-NNNN...`
+- `source` must not be blank
+- `raw_evidence` must be a mapping
+- `raw_evidence` keys must be strings
+
+The DTO intentionally contains no CVSS, EPSS, KEV, ATT&CK, provider snapshot, or
+database identity fields. Enrichment and persistence attach that context later.
+
+## Registry Lookup
+
+`ImporterRegistry` is an in-memory registry keyed by normalized `input_type`.
+
+Registry behavior:
+
+- registration strips whitespace and lowercases input types
+- duplicate input types raise `DuplicateInputTypeError`
+- `list_input_types()`, `supported_input_types()`, and `list()` return supported
+  input types in stable sorted order
+- `get(input_type)` returns the matching importer or raises
+  `UnsupportedInputTypeError`
+- `parse(input_type, payload, *, filename=None)` resolves the importer and runs
+  the selected parse path
+
+`build_importer_registry()` builds the default mapping for the current local
+Workbench input types. Passing an explicit iterable builds a scoped registry for
+tests or future plugin-free extension points.
+
+## Domain Exceptions
+
+Importer-layer failures use domain exceptions, not FastAPI exceptions:
+
+- `ImporterError`: base importer contract failure
+- `ImporterParseError`: payload could not be parsed by the selected importer
+- `ImporterValidationError`: normalized output failed importer validation
+- `UnsupportedInputTypeError`: no importer is registered for an input type
+- `DuplicateInputTypeError`: more than one importer claims an input type
+
+The future API/service boundary maps these domain exceptions to HTTP responses,
+run error state, and user-facing messages. Importers should not raise
+`HTTPException` or know about response status codes.
+
+## Non-Goals
+
+This contract does not introduce scanner execution, live provider lookups,
+remote plugin discovery, database persistence, report generation, or ATT&CK
+inference. It only defines the local normalization boundary for uploaded input
+payloads.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - Core Workbench Schema: architecture/core-workbench-schema.md
       - Analysis Run Provider Schema: architecture/analysis-run-provider-schema.md
       - Template Repository Layer: architecture/template-service-layer.md
+      - Template Importer Contract: architecture/vpw-013-importer-contract.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md
   - VPW Template Execution Sequence: vpw_template_execution_sequence.md
   - Use Cases: use_cases.md


### PR DESCRIPTION
## Summary
- Adds the template Workbench importer contract with provider-free NormalizedOccurrence DTO and domain exceptions.
- Adds an input_type keyed ImporterRegistry with default mappings for the current local Workbench import formats through an offline legacy InputLoader adapter.
- Documents the VPW-013 importer boundary and links it into the MkDocs Architecture nav.

## Evidence
- ..............                                                           [100%]
14 passed in 0.06s -> 14 passed
- ........................................................................ [ 81%]
................                                                         [100%]
88 passed in 5.44s -> 88 passed
- All checks passed! -> passed
- 5 files already formatted -> passed
- python3 -m mkdocs build --clean -> passed
- Success: no issues found in 206 source files -> passed
- python3 -m ruff format --check backend
279 files already formatted
python3 -m ruff check backend
All checks passed!
cd backend && python3 -m mypy app src
Success: no issues found in 206 source files
python3 -m pytest backend/tests
============================= test session starts ==============================
platform darwin -- Python 3.11.2, pytest-9.0.3, pluggy-1.6.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/umutgoksular/Python CLI - CVE Priorisierung mit EPSS, KEV und ATT&CK copy/backend
configfile: pyproject.toml
plugins: cov-7.1.0, respx-0.23.1, anyio-4.13.0, asyncio-0.21.0, integration-0.2.3, mock-3.11.1, benchmark-4.0.0
asyncio: mode=Mode.STRICT
collected 595 items

backend/tests/api/test_app_guards.py ........                            [  1%]
backend/tests/api/test_template_auth_smoke.py .....                      [  2%]
backend/tests/api/test_template_backend_adapter.py ..........            [  3%]
backend/tests/api/test_template_core_workbench_models.py .....           [  4%]
backend/tests/api/test_template_importer_registry.py ..............      [  7%]
backend/tests/api/test_template_model_metadata.py ...                    [  7%]
backend/tests/api/test_template_projects.py ...                          [  8%]
backend/tests/api/test_template_run_provider_models.py ......            [  9%]
backend/tests/api/test_template_service_layer.py ....                    [  9%]
backend/tests/api/test_template_workbench_api_skeleton.py .......        [ 10%]
backend/tests/api/test_template_workbench_fixture_utils.py ....          [ 11%]
backend/tests/api/test_workbench_api.py ...................              [ 14%]
backend/tests/cli/test_analyze.py ...........................            [ 19%]
backend/tests/cli/test_compare.py ........                               [ 20%]
backend/tests/cli/test_data.py ...                                       [ 21%]
backend/tests/cli/test_doctor.py .........                               [ 22%]
backend/tests/cli/test_explain.py .......                                [ 23%]
backend/tests/cli/test_help.py .......                                   [ 25%]
backend/tests/cli/test_input_validate.py .......                         [ 26%]
backend/tests/cli/test_json_stdout_contracts.py .......                  [ 27%]
backend/tests/cli/test_report.py ...........                             [ 29%]
backend/tests/cli/test_runtime.py ..                                     [ 29%]
backend/tests/cli/test_snapshot_rollup.py .........                      [ 31%]
backend/tests/db/test_workbench_alembic.py ...                           [ 31%]
backend/tests/db/test_workbench_db.py .....                              [ 32%]
backend/tests/e2e/test_module_entrypoint.py .....                        [ 33%]
backend/tests/playwright/test_workbench_browser.py ss                    [ 33%]
backend/tests/services/test_workbench_governance.py ...                  [ 34%]
backend/tests/test_analysis_refactor.py ................                 [ 36%]
backend/tests/test_asset_context_rules.py ...                            [ 37%]
backend/tests/test_attack_enrichment.py ....                             [ 37%]
backend/tests/test_benchmark_regressions.py ..........                   [ 39%]
backend/tests/test_cache.py ....                                         [ 40%]
backend/tests/test_cli_attack.py .............                           [ 42%]
backend/tests/test_cli_data.py ..........                                [ 44%]
backend/tests/test_cli_state.py .............                            [ 46%]
backend/tests/test_evidence_bundle_verification.py .....                 [ 47%]
backend/tests/test_extension_sdk.py ....                                 [ 47%]
backend/tests/test_github_action_contract.py .....                       [ 48%]
backend/tests/test_github_alerts_normalization.py ...                    [ 49%]
backend/tests/test_input_fixtures.py ............................        [ 53%]
backend/tests/test_input_loader_contracts.py ....................        [ 57%]
backend/tests/test_input_loader_merge.py .                               [ 57%]
backend/tests/test_model_facade.py ..................................... [ 63%]
................                                                         [ 66%]
backend/tests/test_output_schemas.py .............                       [ 68%]
backend/tests/test_parser.py ...                                         [ 69%]
backend/tests/test_providers.py ........................                 [ 73%]
backend/tests/test_refactor_hygiene.py .....................             [ 76%]
backend/tests/test_remediation_service.py ......                         [ 77%]
backend/tests/test_report_io_helpers.py ..........                       [ 79%]
backend/tests/test_reporter.py .......                                   [ 80%]
backend/tests/test_reporting_format_helpers.py ....                      [ 81%]
backend/tests/test_rollup_regressions.py ..                              [ 81%]
backend/tests/test_runtime_config.py .....                               [ 82%]
backend/tests/test_scoring.py ...........................                [ 86%]
backend/tests/test_snapshot_diff_regressions.py ....                     [ 87%]
backend/tests/test_state_store.py .........                              [ 89%]
backend/tests/test_utils.py .                                            [ 89%]
backend/tests/test_v11_output_contracts.py .......................       [ 93%]
backend/tests/test_vex_matching.py ...........                           [ 94%]
backend/tests/test_waivers.py .....                                      [ 95%]
backend/tests/test_workbench_guardrail_helpers.py ............           [ 97%]
backend/tests/test_workbench_integration_contracts.py ..                 [ 98%]
backend/tests/utils/test_workbench_factories.py ...                      [ 98%]
backend/tests/web/test_workbench_pages.py ........                       [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.11.2-final-0 _______________

Name                                                                    Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------
backend/src/vuln_prioritizer/__init__.py                                    2      0   100%
backend/src/vuln_prioritizer/api/__init__.py                                0      0   100%
backend/src/vuln_prioritizer/api/app.py                                   175      8    95%   100, 152-153, 184, 300, 326, 330, 341
backend/src/vuln_prioritizer/api/deps.py                                   18      2    89%   17, 25
backend/src/vuln_prioritizer/api/routes.py                                 35      1    97%   178
backend/src/vuln_prioritizer/api/schemas.py                               545      1    99%   15
backend/src/vuln_prioritizer/api/security.py                                6      0   100%
backend/src/vuln_prioritizer/api/workbench_artifact_routes.py             112     10    91%   115-116, 137, 159, 177, 208, 254, 301, 336-337
backend/src/vuln_prioritizer/api/workbench_attack_detection_routes.py     210     20    90%   85, 120, 147, 150, 153, 198, 228, 236-237, 259, 264-269, 293, 312, 334, 377, 399, 439, 569, 582
backend/src/vuln_prioritizer/api/workbench_config_routes.py                77     11    86%   37, 65, 78, 94, 107, 128, 132-140, 156
backend/src/vuln_prioritizer/api/workbench_detection.py                   139     13    91%   80, 90, 110, 113, 177, 182-184, 189, 195, 225, 228, 235
backend/src/vuln_prioritizer/api/workbench_findings.py                     35     15    57%   45-58, 64-72, 78, 84
backend/src/vuln_prioritizer/api/workbench_github.py                       43      7    84%   22, 28, 34, 56, 69-70, 72
backend/src/vuln_prioritizer/api/workbench_import_routes.py               119      8    93%   199-207, 262, 266-267, 334, 359
backend/src/vuln_prioritizer/api/workbench_integration_routes.py          106      9    92%   54, 74, 96, 142, 201, 224, 251, 256, 259
backend/src/vuln_prioritizer/api/workbench_jobs.py                         77     18    77%   55, 66, 96, 118, 120, 122, 135-149, 168-174, 179
backend/src/vuln_prioritizer/api/workbench_payloads.py                     72      4    94%   163, 166-167, 174
backend/src/vuln_prioritizer/api/workbench_project_routes.py              113      3    97%   53, 91, 237
backend/src/vuln_prioritizer/api/workbench_provider_routes.py              26      1    96%   41
backend/src/vuln_prioritizer/api/workbench_providers.py                   178     44    75%   72-82, 102, 180, 220-224, 226, 247, 255, 258, 261-262, 278-286, 293-294, 301, 303, 326, 335-338, 351-364
backend/src/vuln_prioritizer/api/workbench_route_support.py               114     16    86%   40, 54, 56, 122, 124, 162, 176-177, 188-189, 211, 235, 238, 251, 253, 256
backend/src/vuln_prioritizer/api/workbench_support.py                       7      0   100%
backend/src/vuln_prioritizer/api/workbench_system_routes.py                55      1    98%   148
backend/src/vuln_prioritizer/api/workbench_tickets.py                     149     31    79%   29, 35, 46, 51, 59-60, 75, 78, 96-97, 103, 112, 114-129, 151, 158, 181-182, 271-272, 274, 318, 320
backend/src/vuln_prioritizer/api/workbench_uploads.py                     152     16    89%   47, 59, 65, 75-76, 91-92, 98, 108-109, 123, 173, 175, 178, 243, 255
backend/src/vuln_prioritizer/api/workbench_waivers.py                     135     16    88%   28, 32-33, 40-41, 60, 77, 79, 125, 147, 151, 156, 160, 165, 178, 182
backend/src/vuln_prioritizer/attack_enrichment.py                         118      9    92%   243-261, 284-285
backend/src/vuln_prioritizer/attack_sources.py                             13      0   100%
backend/src/vuln_prioritizer/cache.py                                      84     12    86%   32, 35, 80-83, 94-95, 115, 118-119, 121
backend/src/vuln_prioritizer/cli.py                                        55      4    93%   64-67, 88, 95
backend/src/vuln_prioritizer/cli_options.py                                85      0   100%
backend/src/vuln_prioritizer/cli_support/__init__.py                        0      0   100%
backend/src/vuln_prioritizer/cli_support/analysis.py                      114     21    82%   72, 80, 88, 96, 104, 112, 116-119, 127, 138, 145-146, 149, 157, 182-186, 207-212
backend/src/vuln_prioritizer/cli_support/attack_support.py                122     25    80%   35, 45, 209-237, 241-245, 255-256, 302, 334-376, 381, 390
backend/src/vuln_prioritizer/cli_support/common.py                        101     12    88%   146, 155-162, 190, 221-227
backend/src/vuln_prioritizer/cli_support/data_support.py                  101     13    87%   222, 247-249, 318-320, 325, 329, 407, 410-412
backend/src/vuln_prioritizer/cli_support/doctor_support.py                151     24    84%   75, 79, 117, 143-149, 156, 160, 166-168, 191-192, 294-295, 318-329, 346
backend/src/vuln_prioritizer/cli_support/extras.py                         97      6    94%   46-47, 54-55, 60-61
backend/src/vuln_prioritizer/cli_support/report_io.py                      29      0   100%
backend/src/vuln_prioritizer/cli_support/snapshot_rollup.py               266     28    89%   27-28, 30, 38-39, 53, 58-76, 84, 307, 355, 402, 410, 412, 445, 461, 466, 530
backend/src/vuln_prioritizer/cli_support/state.py                           8      1    88%   14
backend/src/vuln_prioritizer/commands/__init__.py                           0      0   100%
backend/src/vuln_prioritizer/commands/analysis.py                         129      7    95%   211, 219, 410, 485-486, 591, 665
backend/src/vuln_prioritizer/commands/attack.py                            60      2    97%   76, 173
backend/src/vuln_prioritizer/commands/data.py                             193     16    92%   372, 449, 523-524, 526-529, 622-623, 633, 648, 656, 663-664, 689
backend/src/vuln_prioritizer/commands/db.py                                30     11    63%   34-52
backend/src/vuln_prioritizer/commands/input.py                            119      6    95%   93-94, 195-196, 411, 420
backend/src/vuln_prioritizer/commands/report.py                            83      1    99%   115
backend/src/vuln_prioritizer/commands/snapshot.py                          64      2    97%   256, 297
backend/src/vuln_prioritizer/commands/state.py                            148     15    90%   96-97, 143-144, 175, 183-184, 234-235, 290-291, 341-342, 399-400
backend/src/vuln_prioritizer/commands/web.py                                7      1    86%   15
backend/src/vuln_prioritizer/config.py                                     24      0   100%
backend/src/vuln_prioritizer/db/__init__.py                                 5      0   100%
backend/src/vuln_prioritizer/db/alembic/__init__.py                         0      0   100%
backend/src/vuln_prioritizer/db/base.py                                     8      0   100%
backend/src/vuln_prioritizer/db/migrations.py                              53     13    75%   120-143
backend/src/vuln_prioritizer/db/models.py                                 410      0   100%
backend/src/vuln_prioritizer/db/repositories.py                            22      4    82%   41-44
backend/src/vuln_prioritizer/db/repository_artifacts.py                    39      0   100%
backend/src/vuln_prioritizer/db/repository_assets.py                       63      0   100%
backend/src/vuln_prioritizer/db/repository_attack.py                       92      5    95%   175, 181, 213-215
backend/src/vuln_prioritizer/db/repository_detection.py                    96      4    96%   49, 62-63, 117
backend/src/vuln_prioritizer/db/repository_findings.py                    141     13    91%   253, 255, 259, 261, 263-264, 266-267, 343-348, 353, 362, 371
backend/src/vuln_prioritizer/db/repository_jobs.py                         95      1    99%   137
backend/src/vuln_prioritizer/db/repository_projects.py                     58      1    98%   81
backend/src/vuln_prioritizer/db/repository_providers.py                    42      2    95%   73-74
backend/src/vuln_prioritizer/db/repository_security.py                     50      1    98%   126
backend/src/vuln_prioritizer/db/session.py                                 32      3    91%   58-60
backend/src/vuln_prioritizer/inputs/__init__.py                             2      0   100%
backend/src/vuln_prioritizer/inputs/_cve_support.py                        14      0   100%
backend/src/vuln_prioritizer/inputs/_occurrence_support.py                131     22    83%   55, 65, 104, 133-156, 216, 222
backend/src/vuln_prioritizer/inputs/_vex_support.py                       209     21    90%   130, 138, 167, 177, 249-250, 324, 330, 374, 399, 416, 418, 450, 462-467, 476-477
backend/src/vuln_prioritizer/inputs/_xml_support.py                       120     19    84%   26-28, 32, 37, 62-63, 73, 82-87, 110, 112, 147, 159, 167-168
backend/src/vuln_prioritizer/inputs/loader.py                             282     47    83%   109, 112, 152, 165, 274, 279, 337-370, 379, 388, 414, 419, 448, 453-454, 464, 516, 544, 553, 567, 580, 584, 595, 623-624, 651, 678, 706
backend/src/vuln_prioritizer/inputs/parsers/__init__.py                     5      0   100%
backend/src/vuln_prioritizer/inputs/parsers/common.py                     110      8    93%   25, 29, 35, 141, 143, 157, 163, 186
backend/src/vuln_prioritizer/inputs/parsers/sbom.py                        52      6    88%   34-44, 94-104, 134, 143
backend/src/vuln_prioritizer/inputs/parsers/scanner.py                     85      8    91%   160-169
backend/src/vuln_prioritizer/inputs/parsers/simple.py                      44      4    91%   26, 55, 63, 67
backend/src/vuln_prioritizer/inputs/parsers/xml.py                         39      0   100%
backend/src/vuln_prioritizer/inputs/sdk.py                                 34      3    91%   35, 39, 42
backend/src/vuln_prioritizer/model_base.py                                  4      0   100%
backend/src/vuln_prioritizer/models.py                                    395      2    99%   97, 105
backend/src/vuln_prioritizer/models_artifacts.py                           74      0   100%
backend/src/vuln_prioritizer/models_attack.py                              41      0   100%
backend/src/vuln_prioritizer/models_input.py                              134      0   100%
backend/src/vuln_prioritizer/models_provider.py                            63      0   100%
backend/src/vuln_prioritizer/models_remediation.py                         23      0   100%
backend/src/vuln_prioritizer/models_state.py                              129      0   100%
backend/src/vuln_prioritizer/models_waivers.py                             21      0   100%
backend/src/vuln_prioritizer/parser.py                                      8      0   100%
backend/src/vuln_prioritizer/provider_snapshot.py                          36      7    81%   28-31, 35-36, 63
backend/src/vuln_prioritizer/providers/__init__.py                          0      0   100%
backend/src/vuln_prioritizer/providers/attack.py                          100     11    89%   51, 53, 59, 69, 89, 171, 174, 179, 184, 202, 204
backend/src/vuln_prioritizer/providers/attack_metadata.py                  54      0   100%
backend/src/vuln_prioritizer/providers/attack_stix.py                      86      5    94%   77, 94, 97, 112, 135
backend/src/vuln_prioritizer/providers/ctid_mappings.py                    67     14    79%   23, 32, 36, 49-52, 56-61, 65-68, 72, 81-85, 138
backend/src/vuln_prioritizer/providers/epss.py                            101     15    85%   53-54, 67-68, 70, 86, 99-101, 130, 146-147, 154-155, 160
backend/src/vuln_prioritizer/providers/kev.py                              95      2    98%   53-54
backend/src/vuln_prioritizer/providers/nvd.py                             196     28    86%   95, 103-104, 122-123, 125-129, 141, 189, 191-192, 199-200, 205, 250, 276-279, 304-311
backend/src/vuln_prioritizer/providers/sdk.py                              42      0   100%
backend/src/vuln_prioritizer/reporter.py                                  185      8    96%   271, 343, 399-404, 458, 467-468
backend/src/vuln_prioritizer/reporting_evidence.py                        182      2    99%   358, 467
backend/src/vuln_prioritizer/reporting_executive.py                         5      0   100%
backend/src/vuln_prioritizer/reporting_executive_constants.py               5      0   100%
backend/src/vuln_prioritizer/reporting_executive_model.py                 518     25    95%   331, 479, 614, 1037, 1040, 1053-1054, 1096, 1113, 1234, 1236, 1469, 1471, 1477, 1511, 1513, 1546-1549, 1557-1567
backend/src/vuln_prioritizer/reporting_executive_renderer.py               19      0   100%
backend/src/vuln_prioritizer/reporting_executive_sections.py              332     36    89%   544, 594, 695, 892, 897, 982, 1000, 1004, 1007, 1011, 1026, 1131, 1142, 1179-1182, 1208-1209, 1223, 1345, 1365, 1382, 1395, 1404, 1424, 1470, 1490-1502
backend/src/vuln_prioritizer/reporting_executive_utils.py                 119     11    91%   15, 52-53, 63, 66-67, 69, 75, 89, 153, 157
backend/src/vuln_prioritizer/reporting_format.py                          198      0   100%
backend/src/vuln_prioritizer/reporting_html.py                              5      0   100%
backend/src/vuln_prioritizer/reporting_io.py                                7      0   100%
backend/src/vuln_prioritizer/reporting_markdown.py                        100     41    59%   117-126, 147-156, 332-542
backend/src/vuln_prioritizer/reporting_payloads.py                        146      4    97%   82, 201, 205, 208
backend/src/vuln_prioritizer/reporting_snapshot.py                         42      9    79%   56-89, 131-170
backend/src/vuln_prioritizer/reporting_state.py                            75      2    97%   153, 183
backend/src/vuln_prioritizer/runtime_config.py                            278     25    91%   255, 260-261, 403-477, 587
backend/src/vuln_prioritizer/sarif_validation.py                           44      1    98%   139
backend/src/vuln_prioritizer/scoring.py                                   100      7    93%   79, 119, 127, 180, 202, 218, 233
backend/src/vuln_prioritizer/services/__init__.py                           0      0   100%
backend/src/vuln_prioritizer/services/analysis.py                           8      0   100%
backend/src/vuln_prioritizer/services/analysis_attack.py                   32      1    97%   47
backend/src/vuln_prioritizer/services/analysis_filters.py                  29      0   100%
backend/src/vuln_prioritizer/services/analysis_inputs.py                   36     10    72%   33-34, 40-41, 47-48, 57-58, 66-67
backend/src/vuln_prioritizer/services/analysis_models.py                   91      0   100%
backend/src/vuln_prioritizer/services/analysis_pipeline.py                136     14    90%   148-149, 191, 229, 261, 364, 410, 520-523, 536, 560-561
backend/src/vuln_prioritizer/services/analysis_provider.py                 82      9    89%   167, 175, 178, 183-187, 189
backend/src/vuln_prioritizer/services/attack_enrichment.py                  3      0   100%
backend/src/vuln_prioritizer/services/contextualization.py                 48      3    94%   110-111, 117
backend/src/vuln_prioritizer/services/defensive_context.py                135     28    79%   49-52, 59-61, 86, 131-134, 136, 146-153, 160, 164, 191-192, 197, 216, 218
backend/src/vuln_prioritizer/services/enrichment.py                       102      5    95%   74, 221, 264, 314, 335
backend/src/vuln_prioritizer/services/prioritization.py                   152      7    95%   267, 288, 293, 301, 365, 368-369
backend/src/vuln_prioritizer/services/remediation.py                      179      6    97%   288, 291, 300, 330, 344, 359
backend/src/vuln_prioritizer/services/waivers.py                          206     26    87%   22, 26-27, 30, 33, 38, 41, 58-59, 143, 156-157, 173-174, 193, 201-202, 208-209, 214, 232, 235, 244, 253, 279, 288
backend/src/vuln_prioritizer/services/workbench_analysis.py               182     21    88%   96, 206, 208, 211, 237, 394, 397, 502-503, 509, 513, 517, 527-528, 542-551, 599-600
backend/src/vuln_prioritizer/services/workbench_artifacts.py              107     16    85%   62-66, 71-75, 90, 108, 113, 134, 139, 156
backend/src/vuln_prioritizer/services/workbench_attack.py                  70      0   100%
backend/src/vuln_prioritizer/services/workbench_executive_report.py         9      1    89%   23
backend/src/vuln_prioritizer/services/workbench_governance.py             363     37    90%   149, 221, 398, 411-418, 424-425, 431-432, 445, 452-457, 465-469, 528, 542, 548, 612, 615-620
backend/src/vuln_prioritizer/services/workbench_job_runner.py              74     46    38%   44, 66-173, 179, 184-188, 196-198, 202-213
backend/src/vuln_prioritizer/services/workbench_jobs.py                    27      2    93%   44-45
backend/src/vuln_prioritizer/services/workbench_reports.py                209     10    95%   65, 91, 127, 172, 237, 349, 401, 404, 481, 491
backend/src/vuln_prioritizer/state_store.py                               245     17    93%   152, 470-471, 489, 497, 499, 550, 574, 702, 710-712, 714, 739, 742, 755, 762
backend/src/vuln_prioritizer/utils.py                                      45      9    80%   17, 26, 28, 31-32, 44-46, 71
backend/src/vuln_prioritizer/web/__init__.py                                0      0   100%
backend/src/vuln_prioritizer/web/routes.py                                 19      0   100%
backend/src/vuln_prioritizer/web/view_models.py                            57     22    61%   136-160, 169, 172-178
backend/src/vuln_prioritizer/web/workbench_common.py                      142     59    58%   103, 133-138, 150-156, 162-163, 169-170, 177, 182-191, 195-203, 207, 223-235, 239-243, 257-271, 283
backend/src/vuln_prioritizer/web/workbench_governance.py                  197     54    73%   22, 187, 243, 288-299, 390, 394, 397, 400, 428-461, 475-510, 529, 557-585
backend/src/vuln_prioritizer/web/workbench_projects.py                    103     14    86%   229-256, 293, 312-313, 352
backend/src/vuln_prioritizer/web/workbench_reports.py                      64     12    81%   23, 46, 50-51, 74, 94-95, 120, 129-130, 164-165
backend/src/vuln_prioritizer/web/workbench_settings.py                    123     78    37%   23, 37-48, 94-117, 165-181, 192-210, 224-243, 252-256, 277-306, 317-336, 352, 360-361
backend/src/vuln_prioritizer/workbench_config.py                           58      2    97%   92, 103
-----------------------------------------------------------------------------------------------------
TOTAL                                                                   14596   1420    90%
Required test coverage of 90% reached. Total coverage: 90.27%
=========================== short test summary info ============================
SKIPPED [1] backend/tests/playwright/test_workbench_browser.py:113: Set VULN_PRIORITIZER_RUN_PLAYWRIGHT=1 or run `make playwright-check`.
SKIPPED [1] backend/tests/playwright/test_workbench_browser.py:286: Set VULN_PRIORITIZER_RUN_PLAYWRIGHT=1 or run `make playwright-check`.
======================= 593 passed, 2 skipped in 30.80s ======================== -> 593 passed, 2 skipped, coverage 90.27%

Fixes #119