### PR TITLE
[codex] Implement VPW-015 generic occurrence CSV importer

### DIFF
--- a/backend/app/importers/__init__.py
+++ b/backend/app/importers/__init__.py
@@ -9,6 +9,10 @@ from app.importers.contracts import (
     NormalizedOccurrence,
 )
 from app.importers.cve_list import CVE_LIST_INPUT_TYPE, CveListImporter
+from app.importers.generic_occurrence_csv import (
+    GENERIC_OCCURRENCE_CSV_INPUT_TYPE,
+    GenericOccurrenceCsvImporter,
+)
 from app.importers.legacy import (
     DEFAULT_IMPORT_INPUT_TYPES,
     LegacyInputLoaderImporter,
@@ -26,6 +30,8 @@ __all__ = [
     "CVE_LIST_INPUT_TYPE",
     "DEFAULT_IMPORT_INPUT_TYPES",
     "CveListImporter",
+    "GENERIC_OCCURRENCE_CSV_INPUT_TYPE",
+    "GenericOccurrenceCsvImporter",
     "Importer",
     "ImporterError",
     "ImporterParseError",

--- a/backend/app/importers/generic_occurrence_csv.py
+++ b/backend/app/importers/generic_occurrence_csv.py
@@ -1,0 +1,283 @@
+"""Generic occurrence CSV importer for the template Workbench import boundary."""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from dataclasses import dataclass
+
+from app.importers.contracts import (
+    ImporterParseError,
+    ImporterValidationError,
+    InputPayload,
+    NormalizedOccurrence,
+)
+
+GENERIC_OCCURRENCE_CSV_INPUT_TYPE = "generic-occurrence-csv"
+_CVE_PATTERN = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+_COMMENT_PREFIX = "#"
+_CSV_DELIMITERS = ",;\t|"
+_KNOWN_FIELDS = {
+    "asset_business_service",
+    "asset_criticality",
+    "asset_environment",
+    "asset_exposure",
+    "asset_id",
+    "asset_owner",
+    "asset_ref",
+    "business_service",
+    "component",
+    "component_name",
+    "component_version",
+    "criticality",
+    "cve",
+    "cve_id",
+    "dependency_path",
+    "ecosystem",
+    "environment",
+    "exposure",
+    "file_path",
+    "fix_version",
+    "fix_versions",
+    "fixed_versions",
+    "installed_version",
+    "owner",
+    "package_type",
+    "path",
+    "purl",
+    "raw_severity",
+    "scanner",
+    "service",
+    "severity",
+    "target",
+    "target_kind",
+    "target_ref",
+    "version",
+    "vulnerability_id",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GenericOccurrenceCsvImporter:
+    """Parse generic occurrence CSV inputs into normalized occurrences."""
+
+    input_type: str = GENERIC_OCCURRENCE_CSV_INPUT_TYPE
+
+    def parse(
+        self,
+        payload: InputPayload,
+        *,
+        filename: str | None = None,
+    ) -> list[NormalizedOccurrence]:
+        if _filename_suffix(filename) not in {"", ".csv"}:
+            raise ImporterParseError("generic-occurrence-csv supports .csv inputs.")
+        text = _payload_to_text(payload)
+        field_map, rows = _read_csv_rows(text)
+        cve_field = _first_field(field_map, "cve_id", "cve", "vulnerability_id")
+        if cve_field is None:
+            raise ImporterParseError(
+                "generic-occurrence-csv input must contain a cve_id, cve, "
+                "or vulnerability_id column."
+            )
+
+        unknown_fields = tuple(
+            sorted(
+                original
+                for normalized, original in field_map.items()
+                if normalized not in _KNOWN_FIELDS
+            )
+        )
+        occurrences: list[NormalizedOccurrence] = []
+        row_errors: list[str] = []
+        for line_number, row in rows:
+            raw_cve = _csv_value(row, cve_field)
+            cve = _normalize_cve(raw_cve, line_number=line_number, errors=row_errors)
+            if cve is None:
+                continue
+            occurrences.append(
+                NormalizedOccurrence(
+                    cve=cve,
+                    asset_ref=_first_csv_optional(
+                        row, field_map, "asset_ref", "target_ref", "target"
+                    ),
+                    component=_first_csv_optional(row, field_map, "component_name", "component"),
+                    version=_first_csv_optional(
+                        row,
+                        field_map,
+                        "component_version",
+                        "version",
+                        "installed_version",
+                    ),
+                    source=GENERIC_OCCURRENCE_CSV_INPUT_TYPE,
+                    fix_version=_first_fix_version(row, field_map),
+                    raw_evidence=_raw_evidence(row, field_map, line_number, unknown_fields),
+                )
+            )
+
+        if row_errors:
+            raise ImporterParseError("generic-occurrence-csv row errors: " + "; ".join(row_errors))
+        return occurrences
+
+
+def _payload_to_text(payload: InputPayload) -> str:
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ImporterParseError("generic-occurrence-csv input must be UTF-8 text.") from exc
+    raise ImporterValidationError("generic-occurrence-csv payload must be bytes or string")
+
+
+def _filename_suffix(filename: str | None) -> str:
+    if not filename or "." not in filename:
+        return ""
+    return "." + filename.rsplit(".", 1)[1].strip().lower()
+
+
+def _read_csv_rows(text: str) -> tuple[dict[str, str], list[tuple[int, dict[str, str]]]]:
+    try:
+        dialect = csv.Sniffer().sniff(_csv_sample(text), delimiters=_CSV_DELIMITERS)
+    except csv.Error:
+        dialect = csv.excel
+
+    reader = csv.reader(io.StringIO(text), dialect=dialect)
+    header: list[str] | None = None
+    rows: list[tuple[int, dict[str, str]]] = []
+    previous_line_number = 0
+    try:
+        for record in reader:
+            line_number = previous_line_number + 1
+            previous_line_number = reader.line_num
+            if _ignored_csv_record(record):
+                continue
+            if header is None:
+                header = record
+                continue
+            if len(record) > len(header):
+                raise ImporterParseError(
+                    "generic-occurrence-csv row errors: "
+                    f"line {line_number}: expected {len(header)} columns, got {len(record)}"
+                )
+            rows.append((line_number, _csv_row(header, record)))
+    except csv.Error as exc:
+        raise ImporterParseError(
+            f"generic-occurrence-csv parse error near line {reader.line_num}: {exc}"
+        ) from exc
+
+    if not header:
+        raise ImporterParseError("generic-occurrence-csv input is missing a header row.")
+    field_map = {field.strip().lower(): field for field in header if field}
+    return field_map, rows
+
+
+def _csv_sample(text: str) -> str:
+    sample = "\n".join(
+        line
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith(_COMMENT_PREFIX)
+    )
+    return sample or text
+
+
+def _ignored_csv_record(record: list[str]) -> bool:
+    if not record or all(not value.strip() for value in record):
+        return True
+    return record[0].strip().startswith(_COMMENT_PREFIX)
+
+
+def _csv_row(header: list[str], record: list[str]) -> dict[str, str]:
+    row = {field: "" for field in header}
+    for index, value in enumerate(record):
+        row[header[index]] = value
+    return row
+
+
+def _normalize_cve(value: str, *, line_number: int, errors: list[str]) -> str | None:
+    candidate = value.strip().upper()
+    if not _CVE_PATTERN.fullmatch(candidate):
+        errors.append(f"line {line_number}: invalid CVE identifier {value!r}")
+        return None
+    return candidate
+
+
+def _first_fix_version(row: dict[str, str], field_map: dict[str, str]) -> str | None:
+    value = _first_csv_optional(row, field_map, "fix_version", "fix_versions", "fixed_versions")
+    if value is None:
+        return None
+    for separator in (",", "|"):
+        if separator in value:
+            return next((item.strip() for item in value.split(separator) if item.strip()), None)
+    return value
+
+
+def _first_csv_optional(row: dict[str, str], field_map: dict[str, str], *fields: str) -> str | None:
+    for field in fields:
+        value = _csv_optional(row, field_map, field)
+        if value is not None:
+            return value
+    return None
+
+
+def _first_field(field_map: dict[str, str], *fields: str) -> str | None:
+    for field in fields:
+        mapped = field_map.get(field)
+        if mapped is not None:
+            return mapped
+    return None
+
+
+def _csv_optional(row: dict[str, str], field_map: dict[str, str], field_name: str) -> str | None:
+    mapped = field_map.get(field_name)
+    if mapped is None:
+        return None
+    value = _csv_value(row, mapped)
+    return value or None
+
+
+def _csv_value(row: dict[str, str], field_name: str) -> str:
+    return (row.get(field_name) or "").strip()
+
+
+def _unknown_column_values(row: dict[str, str], unknown_fields: tuple[str, ...]) -> dict[str, str]:
+    return {field: value for field in unknown_fields if (value := _csv_value(row, field))}
+
+
+def _raw_evidence(
+    row: dict[str, str],
+    field_map: dict[str, str],
+    line_number: int,
+    unknown_fields: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "input_type": GENERIC_OCCURRENCE_CSV_INPUT_TYPE,
+        "line_number": line_number,
+        "source_record_id": f"row:{line_number}",
+        "scanner": _csv_optional(row, field_map, "scanner"),
+        "severity": _first_csv_optional(row, field_map, "severity", "raw_severity"),
+        "purl": _csv_optional(row, field_map, "purl"),
+        "owner": _first_csv_optional(row, field_map, "owner", "asset_owner"),
+        "business_service": _first_csv_optional(
+            row,
+            field_map,
+            "business_service",
+            "service",
+            "asset_business_service",
+        ),
+        "target_kind": _csv_optional(row, field_map, "target_kind"),
+        "target_ref": _first_csv_optional(row, field_map, "target_ref", "target", "asset_ref"),
+        "asset_id": _csv_optional(row, field_map, "asset_id"),
+        "asset_criticality": _first_csv_optional(
+            row, field_map, "criticality", "asset_criticality"
+        ),
+        "asset_exposure": _first_csv_optional(row, field_map, "exposure", "asset_exposure"),
+        "asset_environment": _first_csv_optional(
+            row, field_map, "environment", "asset_environment"
+        ),
+        "package_type": _first_csv_optional(row, field_map, "package_type", "ecosystem"),
+        "file_path": _first_csv_optional(row, field_map, "file_path", "path"),
+        "dependency_path": _csv_optional(row, field_map, "dependency_path"),
+        "unknown_columns": _unknown_column_values(row, unknown_fields),
+    }

--- a/backend/app/importers/legacy.py
+++ b/backend/app/importers/legacy.py
@@ -15,6 +15,7 @@ from app.importers.contracts import (
     NormalizedOccurrence,
 )
 from app.importers.cve_list import CveListImporter
+from app.importers.generic_occurrence_csv import GenericOccurrenceCsvImporter
 from vuln_prioritizer.cli_options import InputFormat
 from vuln_prioritizer.inputs.loader import InputLoader
 from vuln_prioritizer.models_input import InputOccurrence
@@ -77,9 +78,13 @@ def default_importers() -> tuple[Importer, ...]:
     legacy_importers = tuple(
         LegacyInputLoaderImporter(input_type)
         for input_type in DEFAULT_IMPORT_INPUT_TYPES
-        if input_type != InputFormat.cve_list.value
+        if input_type
+        not in {
+            InputFormat.cve_list.value,
+            InputFormat.generic_occurrence_csv.value,
+        }
     )
-    return (CveListImporter(), *legacy_importers)
+    return (CveListImporter(), GenericOccurrenceCsvImporter(), *legacy_importers)
 
 
 def _write_payload(path: Path, payload: InputPayload) -> None:

--- a/backend/src/vuln_prioritizer/inputs/loader.py
+++ b/backend/src/vuln_prioritizer/inputs/loader.py
@@ -724,6 +724,7 @@ INPUT_PARSER_DEFINITIONS: tuple[InputParserDefinition, ...] = (
         parser=parse_generic_occurrence_csv,
         file_suffixes=(".csv",),
         media_types=("text/csv",),
+        fixture_names=("generic_occurrences.csv",),
     ),
     # Scanner and advisory exports.
     InputParserDefinition(

--- a/backend/src/vuln_prioritizer/inputs/parsers/simple.py
+++ b/backend/src/vuln_prioritizer/inputs/parsers/simple.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import io
 from pathlib import Path
 
 from vuln_prioritizer.models import InputOccurrence, ParsedInput
@@ -16,6 +17,47 @@ from .common import (
     normalize_asset_exposure,
     split_versions,
 )
+
+_COMMENT_PREFIX = "#"
+_CSV_DELIMITERS = ",;\t|"
+_GENERIC_OCCURRENCE_FIELDS = {
+    "asset_business_service",
+    "asset_criticality",
+    "asset_environment",
+    "asset_exposure",
+    "asset_id",
+    "asset_owner",
+    "asset_ref",
+    "business_service",
+    "component",
+    "component_name",
+    "component_version",
+    "criticality",
+    "cve",
+    "cve_id",
+    "dependency_path",
+    "ecosystem",
+    "environment",
+    "exposure",
+    "file_path",
+    "fix_version",
+    "fix_versions",
+    "fixed_versions",
+    "installed_version",
+    "owner",
+    "package_type",
+    "path",
+    "purl",
+    "raw_severity",
+    "scanner",
+    "service",
+    "severity",
+    "target",
+    "target_kind",
+    "target_ref",
+    "version",
+    "vulnerability_id",
+}
 
 
 def parse_cve_list(path: Path) -> ParsedInput:
@@ -61,32 +103,20 @@ def _read_cve_txt(path: Path) -> list[tuple[int, str, None, None, None]]:
     with path.open("r", encoding="utf-8") as handle:
         for line_number, line in enumerate(handle, start=1):
             value = line.strip()
-            if not value or value.startswith("#"):
+            if not value or value.startswith(_COMMENT_PREFIX):
                 continue
             rows.append((line_number, value, None, None, None))
     return rows
 
 
 def _read_cve_csv(path: Path) -> list[tuple[int, str, str | None, str | None, str | None]]:
-    indexed_lines = [
-        (line_number, line)
-        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
-        if line.strip() and not line.strip().startswith("#")
-    ]
-    if not indexed_lines:
-        raise ValueError("CSV input is missing a header row.")
-
-    reader = csv.DictReader([line for _, line in indexed_lines])
-    if not reader.fieldnames:
-        raise ValueError("CSV input is missing a header row.")
-    field_map = {field.strip().lower(): field for field in reader.fieldnames if field}
+    field_map, csv_rows = _read_csv_records(path, document_name="CSV input")
     cve_field = first_existing_field(field_map, "cve_id", "cve")
     if cve_field is None:
         raise ValueError("CSV input must contain a 'cve_id' or 'cve' column.")
 
     rows: list[tuple[int, str, str | None, str | None, str | None]] = []
-    data_line_numbers = [line_number for line_number, _ in indexed_lines[1:]]
-    for row, row_number in zip(reader, data_line_numbers, strict=True):
+    for row_number, row in csv_rows:
         value = (row.get(cve_field) or "").strip()
         if not value:
             continue
@@ -109,74 +139,81 @@ def parse_generic_occurrence_csv(path: Path) -> ParsedInput:
     warnings: list[str] = []
     occurrences: list[InputOccurrence] = []
     total_rows = 0
-    with path.open("r", encoding="utf-8", newline="") as handle:
-        reader = csv.DictReader(handle)
-        if not reader.fieldnames:
-            raise ValueError("generic-occurrence-csv is missing a header row.")
-        field_map = {field.strip().lower(): field for field in reader.fieldnames if field}
-        cve_field = first_existing_field(field_map, "cve_id", "cve", "vulnerability_id")
-        if cve_field is None:
-            raise ValueError("generic-occurrence-csv must contain a cve_id or cve column.")
+    field_map, rows = _read_csv_records(path, document_name="generic-occurrence-csv")
+    unknown_fields = tuple(
+        sorted(
+            original
+            for normalized, original in field_map.items()
+            if normalized not in _GENERIC_OCCURRENCE_FIELDS
+        )
+    )
+    if unknown_fields:
+        warnings.append(
+            "Ignored unknown generic-occurrence-csv columns: " + ", ".join(unknown_fields) + "."
+        )
+    cve_field = first_existing_field(field_map, "cve_id", "cve", "vulnerability_id")
+    if cve_field is None:
+        raise ValueError("generic-occurrence-csv must contain a cve_id or cve column.")
 
-        for row_number, row in enumerate(reader, start=2):
-            total_rows += 1
-            cve_id = normalize_cve_id(row.get(cve_field))
-            if cve_id is None:
-                warnings.append(
-                    f"Ignored invalid CVE identifier at line {row_number}: {row.get(cve_field)!r}"
-                )
-                continue
-            target_kind = csv_value(row, field_map, "target_kind") or "generic"
-            target_ref = csv_value(row, field_map, "target_ref", "target", "asset_ref")
-            occurrences.append(
-                InputOccurrence(
-                    cve_id=cve_id,
-                    source_format="generic-occurrence-csv",
-                    component_name=csv_value(row, field_map, "component_name", "component"),
-                    component_version=csv_value(
-                        row,
-                        field_map,
-                        "component_version",
-                        "version",
-                        "installed_version",
-                    ),
-                    purl=csv_value(row, field_map, "purl"),
-                    package_type=csv_value(row, field_map, "package_type", "ecosystem"),
-                    file_path=csv_value(row, field_map, "file_path", "path"),
-                    dependency_path=csv_value(row, field_map, "dependency_path"),
-                    fix_versions=split_versions(
-                        csv_value(row, field_map, "fix_versions", "fixed_versions", "fix_version")
-                    ),
-                    source_record_id=f"row:{row_number}",
-                    raw_severity=csv_value(row, field_map, "severity", "raw_severity"),
-                    target_kind=target_kind.lower(),
-                    target_ref=target_ref,
-                    asset_id=csv_value(row, field_map, "asset_id"),
-                    asset_criticality=normalize_asset_criticality(
-                        csv_value(row, field_map, "criticality", "asset_criticality"),
-                        warnings=warnings,
-                        row_number=row_number,
-                    ),
-                    asset_exposure=normalize_asset_exposure(
-                        csv_value(row, field_map, "exposure", "asset_exposure"),
-                        warnings=warnings,
-                        row_number=row_number,
-                    ),
-                    asset_environment=normalize_asset_environment(
-                        csv_value(row, field_map, "environment", "asset_environment"),
-                        warnings=warnings,
-                        row_number=row_number,
-                    ),
-                    asset_owner=csv_value(row, field_map, "owner", "asset_owner"),
-                    asset_business_service=csv_value(
-                        row,
-                        field_map,
-                        "business_service",
-                        "service",
-                        "asset_business_service",
-                    ),
-                )
+    for row_number, row in rows:
+        total_rows += 1
+        cve_id = normalize_cve_id(row.get(cve_field))
+        if cve_id is None:
+            warnings.append(
+                f"Ignored invalid CVE identifier at line {row_number}: {row.get(cve_field)!r}"
             )
+            continue
+        target_kind = csv_value(row, field_map, "target_kind") or "generic"
+        target_ref = csv_value(row, field_map, "target_ref", "target", "asset_ref")
+        occurrences.append(
+            InputOccurrence(
+                cve_id=cve_id,
+                source_format="generic-occurrence-csv",
+                component_name=csv_value(row, field_map, "component_name", "component"),
+                component_version=csv_value(
+                    row,
+                    field_map,
+                    "component_version",
+                    "version",
+                    "installed_version",
+                ),
+                purl=csv_value(row, field_map, "purl"),
+                package_type=csv_value(row, field_map, "package_type", "ecosystem"),
+                file_path=csv_value(row, field_map, "file_path", "path"),
+                dependency_path=csv_value(row, field_map, "dependency_path"),
+                fix_versions=split_versions(
+                    csv_value(row, field_map, "fix_versions", "fixed_versions", "fix_version")
+                ),
+                source_record_id=f"row:{row_number}",
+                raw_severity=csv_value(row, field_map, "severity", "raw_severity"),
+                target_kind=target_kind.lower(),
+                target_ref=target_ref,
+                asset_id=csv_value(row, field_map, "asset_id"),
+                asset_criticality=normalize_asset_criticality(
+                    csv_value(row, field_map, "criticality", "asset_criticality"),
+                    warnings=warnings,
+                    row_number=row_number,
+                ),
+                asset_exposure=normalize_asset_exposure(
+                    csv_value(row, field_map, "exposure", "asset_exposure"),
+                    warnings=warnings,
+                    row_number=row_number,
+                ),
+                asset_environment=normalize_asset_environment(
+                    csv_value(row, field_map, "environment", "asset_environment"),
+                    warnings=warnings,
+                    row_number=row_number,
+                ),
+                asset_owner=csv_value(row, field_map, "owner", "asset_owner"),
+                asset_business_service=csv_value(
+                    row,
+                    field_map,
+                    "business_service",
+                    "service",
+                    "asset_business_service",
+                ),
+            )
+        )
 
     return ParsedInput(
         input_format="generic-occurrence-csv",
@@ -184,3 +221,64 @@ def parse_generic_occurrence_csv(path: Path) -> ParsedInput:
         occurrences=occurrences,
         warnings=warnings,
     )
+
+
+def _read_csv_records(
+    path: Path,
+    *,
+    document_name: str,
+) -> tuple[dict[str, str], list[tuple[int, dict[str, str]]]]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        dialect = csv.Sniffer().sniff(_csv_sample(text), delimiters=_CSV_DELIMITERS)
+    except csv.Error:
+        dialect = csv.excel
+
+    reader = csv.reader(io.StringIO(text), dialect=dialect)
+    header: list[str] | None = None
+    rows: list[tuple[int, dict[str, str]]] = []
+    previous_line_number = 0
+    try:
+        for record in reader:
+            line_number = previous_line_number + 1
+            previous_line_number = reader.line_num
+            if _ignored_csv_record(record):
+                continue
+            if header is None:
+                header = record
+                continue
+            if len(record) > len(header):
+                raise ValueError(
+                    f"{document_name} row at line {line_number} has {len(record)} columns; "
+                    f"expected {len(header)}."
+                )
+            rows.append((line_number, _csv_row(header, record)))
+    except csv.Error as exc:
+        raise ValueError(f"{document_name} parse error near line {reader.line_num}: {exc}") from exc
+
+    if not header:
+        raise ValueError(f"{document_name} is missing a header row.")
+    field_map = {field.strip().lower(): field for field in header if field}
+    return field_map, rows
+
+
+def _csv_sample(text: str) -> str:
+    sample = "\n".join(
+        line
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith(_COMMENT_PREFIX)
+    )
+    return sample or text
+
+
+def _ignored_csv_record(record: list[str]) -> bool:
+    if not record or all(not value.strip() for value in record):
+        return True
+    return record[0].strip().startswith(_COMMENT_PREFIX)
+
+
+def _csv_row(header: list[str], record: list[str]) -> dict[str, str]:
+    row = {field: "" for field in header}
+    for index, value in enumerate(record):
+        row[header[index]] = value
+    return row

--- a/backend/tests/api/test_template_generic_occurrence_csv_importer.py
+++ b/backend/tests/api/test_template_generic_occurrence_csv_importer.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.importers import (
+    GenericOccurrenceCsvImporter,
+    ImporterParseError,
+    build_importer_registry,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_DIR = PROJECT_ROOT / "data" / "input_fixtures"
+
+
+def test_generic_occurrence_csv_importer_accepts_demo_fixture() -> None:
+    importer = GenericOccurrenceCsvImporter()
+
+    occurrences = importer.parse(
+        (FIXTURE_DIR / "generic_occurrences.csv").read_text(encoding="utf-8"),
+        filename="generic_occurrences.csv",
+    )
+
+    assert [(item.cve, item.asset_ref, item.component, item.version) for item in occurrences] == [
+        ("CVE-2024-3094", "build-host-1", "xz", "5.6.0"),
+        ("CVE-2024-4577", "web-tier", "php-cgi", "8.3.7"),
+    ]
+    assert occurrences[0].fix_version == "5.6.1-r2"
+    assert occurrences[0].raw_evidence["scanner"] == "trivy"
+    assert occurrences[0].raw_evidence["severity"] == "CRITICAL"
+    assert occurrences[0].raw_evidence["purl"] == "pkg:apk/alpine/xz@5.6.0-r0"
+    assert occurrences[0].raw_evidence["owner"] == "team-platform"
+    assert occurrences[0].raw_evidence["business_service"] == "payments"
+    assert occurrences[0].raw_evidence["unknown_columns"] == {
+        "notes": "owner says, urgent",
+        "ticket_url": "SEC-1001",
+    }
+
+
+def test_generic_occurrence_csv_importer_sniffs_semicolon_dialect() -> None:
+    importer = GenericOccurrenceCsvImporter()
+
+    occurrences = importer.parse(
+        (FIXTURE_DIR / "generic_occurrences_semicolon.csv").read_text(encoding="utf-8"),
+        filename="generic_occurrences_semicolon.csv",
+    )
+
+    assert [item.cve for item in occurrences] == ["CVE-2024-3094"]
+    assert occurrences[0].raw_evidence["scanner"] == "trivy"
+
+
+def test_generic_occurrence_csv_importer_accepts_quoted_multiline_values() -> None:
+    importer = GenericOccurrenceCsvImporter()
+
+    occurrences = importer.parse(
+        'cve_id,asset_ref,notes\nCVE-2024-3094,build-host-1,"line one\nline two"\n',
+        filename="generic.csv",
+    )
+
+    assert len(occurrences) == 1
+    assert occurrences[0].asset_ref == "build-host-1"
+    assert occurrences[0].raw_evidence["line_number"] == 2
+    assert occurrences[0].raw_evidence["unknown_columns"] == {"notes": "line one\nline two"}
+
+
+def test_generic_occurrence_csv_importer_accepts_compatibility_aliases() -> None:
+    importer = GenericOccurrenceCsvImporter()
+
+    occurrences = importer.parse(
+        "\n".join(
+            [
+                "vulnerability_id,target_ref,component,installed_version,fixed_versions,"
+                "raw_severity,asset_owner,service,target_kind,asset_id,criticality,exposure,"
+                "environment,ecosystem,path,dependency_path",
+                "CVE-2022-22965,checkout-api,spring-webmvc,5.3.17,5.3.18,HIGH,"
+                "appsec,checkout,service,asset-1,critical,public,prod,maven,pom.xml,"
+                "root > spring-webmvc",
+            ]
+        ),
+        filename="generic.csv",
+    )
+
+    assert len(occurrences) == 1
+    occurrence = occurrences[0]
+    assert occurrence.cve == "CVE-2022-22965"
+    assert occurrence.asset_ref == "checkout-api"
+    assert occurrence.component == "spring-webmvc"
+    assert occurrence.version == "5.3.17"
+    assert occurrence.fix_version == "5.3.18"
+    assert occurrence.raw_evidence["severity"] == "HIGH"
+    assert occurrence.raw_evidence["owner"] == "appsec"
+    assert occurrence.raw_evidence["business_service"] == "checkout"
+    assert occurrence.raw_evidence["target_kind"] == "service"
+    assert occurrence.raw_evidence["asset_id"] == "asset-1"
+    assert occurrence.raw_evidence["asset_criticality"] == "critical"
+    assert occurrence.raw_evidence["asset_exposure"] == "public"
+    assert occurrence.raw_evidence["asset_environment"] == "prod"
+    assert occurrence.raw_evidence["package_type"] == "maven"
+    assert occurrence.raw_evidence["file_path"] == "pom.xml"
+    assert occurrence.raw_evidence["dependency_path"] == "root > spring-webmvc"
+
+
+def test_generic_occurrence_csv_importer_collects_row_specific_errors() -> None:
+    importer = GenericOccurrenceCsvImporter()
+
+    with pytest.raises(ImporterParseError) as exc_info:
+        importer.parse(
+            (FIXTURE_DIR / "generic_occurrences_invalid.csv").read_text(encoding="utf-8"),
+            filename="/private/tmp/generic_occurrences_invalid.csv",
+        )
+
+    message = str(exc_info.value)
+    assert "line 2" in message
+    assert "line 3" in message
+    assert "not-a-cve" in message
+    assert "/private/tmp" not in message
+
+
+def test_generic_occurrence_csv_importer_requires_cve_id_column() -> None:
+    importer = GenericOccurrenceCsvImporter()
+
+    with pytest.raises(ImporterParseError, match="cve_id, cve, or vulnerability_id column"):
+        importer.parse(
+            (FIXTURE_DIR / "generic_occurrences_missing_cve.csv").read_text(encoding="utf-8"),
+            filename="/private/tmp/generic_occurrences_missing_cve.csv",
+        )
+
+
+def test_default_registry_uses_template_generic_occurrence_importer() -> None:
+    registry = build_importer_registry()
+
+    assert isinstance(registry.get("generic-occurrence-csv"), GenericOccurrenceCsvImporter)
+    assert [
+        item.cve
+        for item in registry.parse(
+            "generic-occurrence-csv",
+            "cve_id,asset_ref\nCVE-2024-3094,build-host-1\n",
+            filename="generic.csv",
+        )
+    ] == ["CVE-2024-3094"]

--- a/backend/tests/test_extension_sdk.py
+++ b/backend/tests/test_extension_sdk.py
@@ -47,7 +47,7 @@ def test_builtin_input_parser_definitions_are_static_local_contracts() -> None:
     for definition in loader.INPUT_PARSER_DEFINITIONS:
         validate_input_parser_definition(definition)
         assert definition.remote_code_loading is False
-        assert definition.fixture_names or definition.name == "generic-occurrence-csv"
+        assert definition.fixture_names
 
 
 def test_input_parser_sdk_rejects_remote_code_loading_and_duplicates() -> None:

--- a/backend/tests/test_input_loader_contracts.py
+++ b/backend/tests/test_input_loader_contracts.py
@@ -271,6 +271,52 @@ def test_generic_occurrence_csv_preserves_component_target_and_asset_context(
     assert any("unknown asset environment" in warning for warning in parsed.warnings)
 
 
+def test_generic_occurrence_csv_sniffs_semicolon_dialect_and_warns_unknowns(
+    tmp_path: Path,
+) -> None:
+    loader_module = _load_loader_module()
+    input_file = tmp_path / "generic.csv"
+    input_file.write_text(
+        "\n".join(
+            [
+                "# comment before header",
+                "cve_id;asset_ref;component_name;component_version;scanner;ticket_url",
+                "CVE-2024-3094;build-host-1;xz;5.6.0;trivy;SEC-1001",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = loader_module.InputLoader().load(
+        input_file,
+        input_format="generic-occurrence-csv",
+    )
+
+    assert parsed.unique_cves == ["CVE-2024-3094"]
+    assert parsed.occurrences[0].target_ref == "build-host-1"
+    assert any("ticket_url" in warning for warning in parsed.warnings)
+
+
+def test_generic_occurrence_csv_accepts_quoted_multiline_values(tmp_path: Path) -> None:
+    loader_module = _load_loader_module()
+    input_file = tmp_path / "generic.csv"
+    input_file.write_text(
+        "cve_id,asset_ref,component_name,notes\n"
+        'CVE-2024-3094,build-host-1,xz,"line one\nline two"\n',
+        encoding="utf-8",
+    )
+
+    parsed = loader_module.InputLoader().load(
+        input_file,
+        input_format="generic-occurrence-csv",
+    )
+
+    assert parsed.unique_cves == ["CVE-2024-3094"]
+    assert parsed.occurrences[0].target_ref == "build-host-1"
+    assert parsed.occurrences[0].source_record_id == "row:2"
+    assert any("notes" in warning for warning in parsed.warnings)
+
+
 def test_plain_cve_csv_auto_detects_as_cve_list(tmp_path: Path) -> None:
     loader_module = _load_loader_module()
     input_file = tmp_path / "cves.csv"

--- a/data/input_fixtures/generic_occurrences.csv
+++ b/data/input_fixtures/generic_occurrences.csv
@@ -1,0 +1,3 @@
+cve_id,asset_ref,component_name,component_version,purl,scanner,fix_version,severity,owner,business_service,ticket_url,notes
+CVE-2024-3094,build-host-1,xz,5.6.0,pkg:apk/alpine/xz@5.6.0-r0,trivy,5.6.1-r2,CRITICAL,team-platform,payments,SEC-1001,"owner says, urgent"
+CVE-2024-4577,web-tier,php-cgi,8.3.7,pkg:generic/php-cgi@8.3.7,manual,8.3.8,HIGH,team-web,checkout,SEC-1002,

--- a/data/input_fixtures/generic_occurrences_invalid.csv
+++ b/data/input_fixtures/generic_occurrences_invalid.csv
@@ -1,0 +1,3 @@
+cve_id,asset_ref,component_name,component_version,purl,scanner,fix_version,severity,owner,business_service
+not-a-cve,build-host-1,xz,5.6.0,pkg:apk/alpine/xz@5.6.0-r0,trivy,5.6.1-r2,CRITICAL,team-platform,payments
+,web-tier,php-cgi,8.3.7,pkg:generic/php-cgi@8.3.7,manual,8.3.8,HIGH,team-web,checkout

--- a/data/input_fixtures/generic_occurrences_missing_cve.csv
+++ b/data/input_fixtures/generic_occurrences_missing_cve.csv
@@ -1,0 +1,2 @@
+asset_ref,component_name,component_version
+build-host-1,xz,5.6.0

--- a/data/input_fixtures/generic_occurrences_semicolon.csv
+++ b/data/input_fixtures/generic_occurrences_semicolon.csv
@@ -1,0 +1,2 @@
+cve_id;asset_ref;component_name;component_version;purl;scanner;fix_version;severity;owner;business_service
+CVE-2024-3094;build-host-1;xz;5.6.0;pkg:apk/alpine/xz@5.6.0-r0;trivy;5.6.1-r2;CRITICAL;team-platform;payments

--- a/docs/generic-occurrence-csv-import.md
+++ b/docs/generic-occurrence-csv-import.md
@@ -1,0 +1,94 @@
+# Generic Occurrence CSV Import
+
+The `generic-occurrence-csv` input format is for normalized vulnerability
+occurrences from spreadsheets, backlog exports, and scanners that do not have a
+dedicated parser. It records where a known CVE appears and preserves local
+component, asset, owner, service, severity, and fix-version context.
+
+Use it when `cve-list` is too small for the source data, but the source can
+export one CSV row per affected occurrence.
+
+See `examples/generic-occurrences.csv` for a checked-in sample.
+
+## Example
+
+```csv
+cve_id,asset_ref,component_name,component_version,purl,scanner,fix_version,severity,owner,business_service
+CVE-2021-44228,web-prod-01,log4j-core,2.14.1,pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1,manual-backlog,2.17.1,critical,platform-team,checkout
+CVE-2022-22965,checkout-api,spring-webmvc,5.3.17,pkg:maven/org.springframework/spring-webmvc@5.3.17,manual-backlog,5.3.18,high,appsec,checkout
+```
+
+## Columns
+
+| Column | Required | Notes |
+| --- | --- | --- |
+| `cve_id` | yes | CVE identifier. `cve` and `vulnerability_id` are accepted as aliases. |
+| `asset_ref` | no | Local asset, host, workload, image, repository, or service reference. Used as `target_ref` when `target_ref` is not present. |
+| `component_name` | no | Affected component or package name. `component` is accepted as an alias. |
+| `component_version` | no | Installed or affected version. `version` and `installed_version` are accepted as aliases. |
+| `purl` | no | Package URL for package-level matching and evidence. |
+| `scanner` | no | Source scanner or export name. The template importer preserves it in raw evidence; the legacy CLI parser treats it as accepted metadata. |
+| `fix_version` | no | Fixed version. `fix_versions` and `fixed_versions` are accepted; multiple versions can be separated with commas or `|`. |
+| `severity` | no | Raw source severity. Preserved as source-provided severity context, not as a replacement for CVSS, EPSS, KEV, or policy scoring. `raw_severity` is accepted as an alias. |
+| `owner` | no | Asset or service owner. `asset_owner` is accepted as an alias. |
+| `business_service` | no | Business service. `service` and `asset_business_service` are accepted as aliases. |
+
+Additional supported columns include `target_kind`, `target_ref`, `target`,
+`asset_id`, `criticality`, `asset_criticality`, `exposure`, `asset_exposure`,
+`environment`, `asset_environment`, `package_type`, `ecosystem`, `file_path`,
+`path`, and `dependency_path`.
+
+## Required Fields
+
+The only required logical field is a CVE column:
+
+- Use `cve_id` for new files.
+- `cve` and `vulnerability_id` are accepted for compatibility.
+- Empty CVE cells are treated as invalid rows and skipped with a warning.
+
+All other columns are optional. Rows without `asset_ref`, `target_ref`, or
+`target` still import as generic occurrences, but asset-context and VEX matching
+will have less local context to match against.
+
+## Normalization
+
+- The file suffix must be `.csv`.
+- CVE IDs are trimmed and normalized to uppercase.
+- `target_kind` defaults to `generic` when omitted.
+- `asset_ref` is used only as a fallback target reference when `target_ref` or
+  `target` is absent.
+- `component_name`, `component_version`, `purl`, owner, service, raw severity,
+  and fix-version data are preserved as occurrence provenance.
+- `fix_version`, `fix_versions`, and `fixed_versions` are split on commas and
+  `|` into normalized fix-version lists.
+- Asset criticality values accept `low`, `medium`, `high`, `critical`, plus
+  `med` and `crit` aliases.
+- Asset exposure values accept `internal`, `dmz`, `internet-facing`, plus
+  `private`, `internet`, `external`, and `public` aliases.
+- Asset environment values accept `prod`, `staging`, `test`, `dev`, plus
+  `production`, `stage`, `qa`, and `development` aliases.
+
+## Unknown Columns
+
+Unknown columns are not treated as fatal errors. The template importer stores
+non-empty unknown values under `raw_evidence["unknown_columns"]`. The legacy CLI
+loader emits a warning naming unknown columns because its occurrence model has
+no raw evidence bag.
+
+Move any field that must affect prioritization, asset matching, or VEX matching
+into one of the documented supported columns.
+
+## Errors and Warnings
+
+The parser performs local validation only. It does not fetch NVD, EPSS, KEV, or
+ATT&CK data during import.
+
+- A non-CSV file is rejected.
+- A missing header row is an error.
+- A header without `cve_id`, `cve`, or `vulnerability_id` is an error.
+- Invalid CVE identifiers are skipped and reported as warnings with the source
+  line number.
+- Unknown asset criticality, exposure, or environment values are ignored and
+  reported as warnings with the row number.
+- Unknown columns are warned or preserved as raw evidence, depending on the
+  import surface.

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -39,7 +39,7 @@
 | `--input-format` | Auto-detect | `analyze` / `compare` | `attack coverage` / `navigator-layer` | Normalized provenance currently preserved | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `cve-list` | `.txt`, `.csv` | yes | yes | `cve_id`, optional `asset_ref`, `component`, `version`, source line/row | Plain TXT and minimal CSV CVE lists; see [CVE List Import](cve-list-import.md). |
-| `generic-occurrence-csv` | CSV with `cve`/`cve_id` plus optional component, version, PURL, fix, target, asset, owner, service, severity columns | yes | yes | component, version, purl, fix versions, target, asset context, owner, service | Additive manual-occurrence format for normalized backlog and spreadsheet exports. |
+| `generic-occurrence-csv` | CSV with `cve`/`cve_id` plus optional component, version, PURL, fix, target, asset, owner, service, severity columns | yes | yes | component, version, purl, fix versions, target, asset context, owner, service | Additive manual-occurrence format for normalized backlog and spreadsheet exports; see [Generic Occurrence CSV Import](generic-occurrence-csv-import.md). |
 | `trivy-json` | JSON with `Results` | yes | yes | component, version, purl, package type, path, fix versions, target image | Default target kind is `image`. |
 | `grype-json` | JSON with `matches` | yes | yes | component, version, purl, package type, path, fix versions, target image | Keeps the first artifact location as current path evidence. |
 | `cyclonedx-json` | JSON with `bomFormat=CycloneDX` and vulnerabilities | yes | yes | component refs, purl, versions, dependency context when present | Used for SBOM+vuln exports, not plain BOMs without vulnerabilities. |

--- a/examples/generic-occurrences.csv
+++ b/examples/generic-occurrences.csv
@@ -1,0 +1,4 @@
+cve_id,asset_ref,component_name,component_version,purl,scanner,fix_version,severity,owner,business_service
+CVE-2021-44228,web-prod-01,log4j-core,2.14.1,pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1,manual-backlog,2.17.1,critical,platform-team,checkout
+CVE-2022-22965,checkout-api,spring-webmvc,5.3.17,pkg:maven/org.springframework/spring-webmvc@5.3.17,manual-backlog,5.3.18,high,appsec,checkout
+CVE-2023-44487,edge-proxy,nghttp2,1.52.0,pkg:generic/nghttp2@1.52.0,scanner-export,1.57.0,medium,network-team,edge

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Historical Engineering Roadmap V3: workbench-engineering-roadmap-attack-ttp-v3.md
   - Examples:
       - CVE List Import: cve-list-import.md
+      - Generic Occurrence CSV Import: generic-occurrence-csv-import.md
       - Base Report: example_report.md
       - Base Compare: example_compare.md
       - ATT&CK Report: example_attack_report.md


### PR DESCRIPTION
## Summary

Implements VPW-015 / issue #121 as the next execution slice after VPW-014.

- Adds a first-class generic-occurrence-csv Workbench importer with required CVE validation, dialect sniffing, row-specific errors, compatibility aliases, optional evidence fields, and unknown-column preservation.
- Hardens the CLI/input-loader CSV path for dialect sniffing, comments, quoted multiline values, unknown-column warnings, and fixture metadata.
- Adds fixtures, examples, support-matrix/docs coverage, and regression tests for semicolon dialects, required headers, invalid rows, aliases, unknown columns, and multiline CSV values.

## Validation

- python3 -m pytest -q backend/tests/api/test_template_generic_occurrence_csv_importer.py backend/tests/api/test_template_importer_registry.py backend/tests/test_input_loader_contracts.py backend/tests/test_extension_sdk.py --no-cov
- python3 -m ruff format --check backend/app/importers/generic_occurrence_csv.py backend/src/vuln_prioritizer/inputs/parsers/simple.py backend/tests/api/test_template_generic_occurrence_csv_importer.py backend/tests/test_input_loader_contracts.py backend/tests/test_extension_sdk.py backend/app/importers/__init__.py backend/app/importers/legacy.py backend/src/vuln_prioritizer/inputs/loader.py
- python3 -m ruff check backend/app/importers/generic_occurrence_csv.py backend/src/vuln_prioritizer/inputs/parsers/simple.py backend/tests/api/test_template_generic_occurrence_csv_importer.py backend/tests/test_input_loader_contracts.py backend/tests/test_extension_sdk.py backend/app/importers/__init__.py backend/app/importers/legacy.py backend/src/vuln_prioritizer/inputs/loader.py
- python3 -m pytest -q backend/tests/api --no-cov
- make docs-check
- PYTHONPATH=backend/src python3 -m vuln_prioritizer.cli input inspect --input examples/generic-occurrences.csv --input-format generic-occurrence-csv --format json
- git diff --check
- make check

Refs #121