### PR TITLE
[codex] Implement VPW-016 Trivy JSON parser

### DIFF
--- a/backend/app/importers/legacy.py
+++ b/backend/app/importers/legacy.py
@@ -120,6 +120,7 @@ def _normalize_occurrence(occurrence: InputOccurrence) -> NormalizedOccurrence:
 def _raw_evidence(occurrence: InputOccurrence) -> dict[str, Any]:
     return {
         "source_format": occurrence.source_format,
+        "source_id": occurrence.source_id,
         "source_record_id": occurrence.source_record_id,
         "purl": occurrence.purl,
         "package_type": occurrence.package_type,

--- a/backend/src/vuln_prioritizer/inputs/parsers/common.py
+++ b/backend/src/vuln_prioritizer/inputs/parsers/common.py
@@ -165,7 +165,10 @@ def as_string_list(value: object) -> list[str]:
 
 
 def load_json_object(path: Path, document_name: str) -> dict:
-    document = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{document_name} is invalid JSON: {exc.msg}.") from exc
     if not isinstance(document, dict):
         raise ValueError(f"{document_name} must be a top-level JSON object.")
     return document

--- a/backend/src/vuln_prioritizer/inputs/parsers/scanner.py
+++ b/backend/src/vuln_prioritizer/inputs/parsers/scanner.py
@@ -26,30 +26,29 @@ def parse_trivy_json(path: Path) -> ParsedInput:
     total_rows = 0
 
     for result_index, result in enumerate(dict_items(document.get("Results")), start=1):
-        target = result.get("Target")
-        package_type = result.get("Type")
+        target = first_present_string(result.get("Target"), document.get("ArtifactName"))
+        package_type = first_present_string(result.get("Type"))
         for vuln_index, vulnerability in enumerate(
             dict_items(result.get("Vulnerabilities")),
             start=1,
         ):
             total_rows += 1
-            cve_id = _cve_support.normalize_cve_or_warn(
-                vulnerability.get("VulnerabilityID"),
-                source_name="Trivy",
-                warnings=warnings,
-            )
+            source_id = first_present_string(vulnerability.get("VulnerabilityID"))
+            cve_id = _cve_support.first_normalized_cve(_trivy_cve_candidates(vulnerability))
             if cve_id is None:
+                _warn_non_cve_trivy_id(source_id, warnings)
                 continue
             occurrences.append(
                 InputOccurrence(
                     cve_id=cve_id,
                     source_format="trivy-json",
+                    source_id=source_id or cve_id,
                     component_name=vulnerability.get("PkgName"),
                     component_version=vulnerability.get("InstalledVersion"),
                     purl=dict_value(vulnerability.get("PkgIdentifier")).get("PURL"),
                     package_type=package_type,
                     file_path=vulnerability.get("PkgPath"),
-                    fix_versions=split_versions(vulnerability.get("FixedVersion")),
+                    fix_versions=_trivy_fix_versions(vulnerability),
                     source_record_id=f"result:{result_index}:vuln:{vuln_index}",
                     raw_severity=vulnerability.get("Severity"),
                     target_kind="image",
@@ -63,6 +62,30 @@ def parse_trivy_json(path: Path) -> ParsedInput:
         occurrences=occurrences,
         warnings=warnings,
     )
+
+
+def _trivy_cve_candidates(vulnerability: dict) -> list[str | None]:
+    candidates: list[str | None] = []
+    for field_name in ("VulnerabilityID", "CVE", "CVEID", "CVEs", "CVEIDs", "Aliases"):
+        value = vulnerability.get(field_name)
+        if isinstance(value, str):
+            candidates.append(value)
+            continue
+        if isinstance(value, list):
+            candidates.extend(str(item) for item in value if item is not None)
+    return candidates
+
+
+def _warn_non_cve_trivy_id(source_id: str | None, warnings: list[str]) -> None:
+    warnings.append(f"Ignored non-CVE Trivy vulnerability identifier: {source_id!r}")
+
+
+def _trivy_fix_versions(vulnerability: dict) -> list[str]:
+    for field_name in ("FixedVersion", "FixedVersions"):
+        versions = split_versions(vulnerability.get(field_name))
+        if versions:
+            return versions
+    return []
 
 
 def parse_grype_json(path: Path) -> ParsedInput:

--- a/backend/src/vuln_prioritizer/models_input.py
+++ b/backend/src/vuln_prioritizer/models_input.py
@@ -15,6 +15,7 @@ class InputItem(StrictModel):
 class InputOccurrence(StrictModel):
     cve_id: str
     source_format: str = "cve-list"
+    source_id: str | None = Field(default=None, exclude_if=lambda value: value is None)
     component_name: str | None = None
     component_version: str | None = None
     purl: str | None = None

--- a/backend/tests/test_trivy_json_parser.py
+++ b/backend/tests/test_trivy_json_parser.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vuln_prioritizer.inputs.loader import InputLoader
+from vuln_prioritizer.inputs.parsers.scanner import parse_trivy_json
+from vuln_prioritizer.models import InputOccurrence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = PROJECT_ROOT / "data" / "input_fixtures"
+
+
+def test_input_occurrence_serializes_source_id_only_when_present() -> None:
+    assert "source_id" not in InputOccurrence(cve_id="CVE-2024-0001").model_dump()
+    assert (
+        InputOccurrence(cve_id="CVE-2024-0001", source_id="GHSA-9m7r-4c2v-9j5j").model_dump()[
+            "source_id"
+        ]
+        == "GHSA-9m7r-4c2v-9j5j"
+    )
+
+
+def test_trivy_json_fixture_normalizes_os_and_library_occurrences() -> None:
+    parsed = InputLoader().load(
+        FIXTURE_DIR / "trivy_report.json",
+        input_format="trivy-json",
+    )
+
+    assert parsed.total_rows == 4
+    assert parsed.unique_cves == ["CVE-2024-3094", "CVE-2023-34362", "CVE-2024-4577"]
+    assert len(parsed.occurrences) == 3
+
+    os_occurrence = parsed.occurrences[0]
+    assert os_occurrence.cve_id == "CVE-2024-3094"
+    assert os_occurrence.source_id == "CVE-2024-3094"
+    assert os_occurrence.component_name == "xz"
+    assert os_occurrence.component_version == "5.6.0-r0"
+    assert os_occurrence.package_type == "apk"
+    assert os_occurrence.file_path == "/lib/apk/db/installed"
+    assert os_occurrence.fix_versions == ["5.6.1-r2"]
+    assert os_occurrence.target_kind == "image"
+    assert os_occurrence.target_ref == "ghcr.io/acme/demo-app:1.0.0 (alpine 3.19)"
+
+    library_occurrence = parsed.occurrences[1]
+    assert library_occurrence.cve_id == "CVE-2023-34362"
+    assert library_occurrence.component_name == "moveit-transfer"
+    assert library_occurrence.package_type == "pip"
+    assert library_occurrence.file_path == "requirements.txt"
+    assert library_occurrence.purl == "pkg:pypi/moveit-transfer@2023.0.0"
+
+
+def test_trivy_json_uses_cve_alias_and_keeps_non_cve_source_id(tmp_path: Path) -> None:
+    input_file = tmp_path / "trivy.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "Results": [
+                    {
+                        "Target": "service/requirements.txt",
+                        "Type": "pip",
+                        "Vulnerabilities": [
+                            {
+                                "VulnerabilityID": "GHSA-9m7r-4c2v-9j5j",
+                                "CVEs": ["CVE-2024-9999"],
+                                "PkgName": "demo-package",
+                                "InstalledVersion": "1.0.0",
+                                "FixedVersions": ["1.0.1", "1.0.2"],
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = parse_trivy_json(input_file)
+
+    assert parsed.warnings == []
+    assert len(parsed.occurrences) == 1
+    occurrence = parsed.occurrences[0]
+    assert occurrence.cve_id == "CVE-2024-9999"
+    assert occurrence.source_id == "GHSA-9m7r-4c2v-9j5j"
+    assert occurrence.fix_versions == ["1.0.1", "1.0.2"]
+    assert occurrence.target_ref == "service/requirements.txt"
+
+
+def test_trivy_json_skips_non_cve_without_alias_and_warns_source_id(tmp_path: Path) -> None:
+    input_file = tmp_path / "trivy.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "Results": [
+                    {
+                        "Vulnerabilities": [
+                            {
+                                "VulnerabilityID": "GHSA-2m57-hf25-phgg",
+                                "PkgName": "demo-package",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = parse_trivy_json(input_file)
+
+    assert parsed.total_rows == 1
+    assert parsed.occurrences == []
+    assert parsed.warnings == [
+        "Ignored non-CVE Trivy vulnerability identifier: 'GHSA-2m57-hf25-phgg'"
+    ]
+
+
+def test_trivy_json_tolerates_missing_optional_fields(tmp_path: Path) -> None:
+    input_file = tmp_path / "trivy.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "Results": [
+                    {
+                        "Class": "os-pkgs",
+                        "Vulnerabilities": [{"VulnerabilityID": "CVE-2024-0001"}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = parse_trivy_json(input_file)
+
+    assert len(parsed.occurrences) == 1
+    occurrence = parsed.occurrences[0]
+    assert occurrence.cve_id == "CVE-2024-0001"
+    assert occurrence.source_id == "CVE-2024-0001"
+    assert occurrence.component_name is None
+    assert occurrence.package_type is None
+    assert occurrence.fix_versions == []
+    assert occurrence.target_kind == "image"
+    assert occurrence.target_ref is None
+
+
+def test_trivy_json_rejects_broken_json_with_clear_error(tmp_path: Path) -> None:
+    input_file = tmp_path / "trivy.json"
+    input_file.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Trivy JSON is invalid JSON"):
+        parse_trivy_json(input_file)

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -40,7 +40,7 @@
 | --- | --- | --- | --- | --- | --- |
 | `cve-list` | `.txt`, `.csv` | yes | yes | `cve_id`, optional `asset_ref`, `component`, `version`, source line/row | Plain TXT and minimal CSV CVE lists; see [CVE List Import](cve-list-import.md). |
 | `generic-occurrence-csv` | CSV with `cve`/`cve_id` plus optional component, version, PURL, fix, target, asset, owner, service, severity columns | yes | yes | component, version, purl, fix versions, target, asset context, owner, service | Additive manual-occurrence format for normalized backlog and spreadsheet exports; see [Generic Occurrence CSV Import](generic-occurrence-csv-import.md). |
-| `trivy-json` | JSON with `Results` | yes | yes | component, version, purl, package type, path, fix versions, target image | Default target kind is `image`. |
+| `trivy-json` | JSON with `Results` | yes | yes | component, version, purl, package type, path, fix versions, target image, source ID | Default target kind is `image`; see [Trivy JSON Import](trivy-json-import.md). |
 | `grype-json` | JSON with `matches` | yes | yes | component, version, purl, package type, path, fix versions, target image | Keeps the first artifact location as current path evidence. |
 | `cyclonedx-json` | JSON with `bomFormat=CycloneDX` and vulnerabilities | yes | yes | component refs, purl, versions, dependency context when present | Used for SBOM+vuln exports, not plain BOMs without vulnerabilities. |
 | `spdx-json` | JSON with `spdxVersion` | yes | yes | package names, versions, file names when available | Current support is JSON only. |

--- a/docs/trivy-json-import.md
+++ b/docs/trivy-json-import.md
@@ -1,0 +1,94 @@
+# Trivy JSON Import
+
+The `trivy-json` input format imports known CVE occurrences from Trivy JSON
+reports. Use it for container image, filesystem, repository, and lockfile scans
+when Trivy can emit one JSON report for the target.
+
+See `examples/trivy-demo.json` for a checked-in sample adapted from
+`data/input_fixtures/trivy_report.json`.
+
+## Example
+
+```bash
+vuln-prioritizer analyze \
+  --input examples/trivy-demo.json \
+  --input-format trivy-json \
+  --format markdown
+```
+
+Auto-detection also selects `trivy-json` for JSON documents with a top-level
+`Results` array, but CI jobs should prefer `--input-format trivy-json` for
+reproducibility.
+
+## Supported Shape
+
+The importer expects the schema shape emitted by `trivy image`, `trivy fs`, and
+`trivy repo` when run with `--format json`: a top-level JSON object with
+`Results[]`. This repository does not pin support to a Trivy binary version; it
+tests the documented field shape below and ignores unknown newer fields.
+
+Each result may include:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `Target` | no | Target image, filesystem path, repository, lockfile, or scan target. Preserved as the occurrence target reference. |
+| `Type` | no | Trivy package type such as `apk`, `deb`, `pip`, `npm`, `maven`, or `composer`. Preserved as package type when present. |
+| `Class` | no | Trivy result class such as `os-pkgs` or `lang-pkgs`. Accepted in the source shape and otherwise ignored; it is not treated as a package ecosystem. |
+| `Vulnerabilities[]` | yes | Vulnerability records for the result. Empty or missing arrays produce no occurrences. |
+
+Each vulnerability may include:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `VulnerabilityID` | yes | Raw Trivy vulnerability identifier. Preserved as `source_id`; CVE IDs are normalized to uppercase for prioritization. |
+| `PkgName` | no | Affected package or component name. |
+| `InstalledVersion` | no | Installed package version. |
+| `FixedVersion` / `FixedVersions` | no | Fixed version information from Trivy. Strings can contain comma- or `|`-separated versions; arrays are preserved as version lists. |
+| `PkgPath` | no | Package database path, dependency file, or lockfile path. |
+| `PkgIdentifier.PURL` | no | Package URL used for package-level evidence and matching. |
+| `Severity` | no | Raw scanner severity. Preserved as source context; it does not replace CVSS, EPSS, KEV, or policy scoring. |
+
+When `VulnerabilityID` is not a CVE, compatibility fields such as `CVE`,
+`CVEID`, `CVEs`, `CVEIDs`, and `Aliases` are checked for a CVE identifier. If a
+CVE is found there, the occurrence keeps the original `VulnerabilityID` as
+`source_id` while using the CVE for prioritization.
+
+## Normalization
+
+- The default target kind is `image`.
+- `Result.Target` becomes the occurrence `target_ref`.
+- `Result.Type` becomes package type provenance.
+- `VulnerabilityID` must contain a CVE identifier to create a prioritized
+  occurrence, unless a compatible CVE alias field is present.
+- `VulnerabilityID` is preserved as `source_id` for the normalized occurrence.
+- `PkgName`, `InstalledVersion`, `PkgPath`, `PkgIdentifier.PURL`, raw severity,
+  `FixedVersion`, and `FixedVersions` are preserved as occurrence provenance
+  when present.
+- Top-level artifact metadata such as `ArtifactName` and `ArtifactType` is
+  accepted but not required for occurrence creation.
+
+## Non-CVE Identifiers
+
+The prioritization pipeline is CVE-first. Trivy findings whose
+`VulnerabilityID` is a GHSA, OSV, vendor advisory, or other non-CVE identifier
+are skipped with a warning when there is no CVE to prioritize. If the record
+also includes a CVE alias field, the importer creates a CVE occurrence and keeps
+the original non-CVE identifier in `source_id`.
+
+Keep those rows in the source report if they are useful for auditability, but
+expect the current `trivy-json` importer to create prioritized occurrences only
+for resolvable CVE IDs.
+
+## Errors and Warnings
+
+The importer performs local parsing and normalization only. It does not fetch
+NVD, EPSS, KEV, ATT&CK, GHSA, OSV, or vendor advisory data during import.
+
+- A non-JSON file is rejected unless the caller explicitly selects
+  `--input-format trivy-json`.
+- A JSON document without a top-level object is rejected.
+- Missing or empty `Results[]` creates no occurrences.
+- Missing or empty `Vulnerabilities[]` on a result creates no occurrences for
+  that result.
+- Invalid or non-CVE `VulnerabilityID` values are skipped and reported as
+  warnings.

--- a/examples/trivy-demo.json
+++ b/examples/trivy-demo.json
@@ -1,0 +1,54 @@
+{
+  "ArtifactName": "ghcr.io/acme/demo-app:1.0.0",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "ghcr.io/acme/demo-app:1.0.0 (alpine 3.19)",
+      "Class": "os-pkgs",
+      "Type": "apk",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-3094",
+          "PkgName": "xz",
+          "InstalledVersion": "5.6.0-r0",
+          "FixedVersion": "5.6.1-r2",
+          "Severity": "CRITICAL",
+          "PkgPath": "/lib/apk/db/installed",
+          "PkgIdentifier": {
+            "PURL": "pkg:apk/alpine/xz@5.6.0-r0?arch=x86_64"
+          }
+        },
+        {
+          "VulnerabilityID": "GHSA-9m7r-4c2v-9j5j",
+          "PkgName": "demo-only-package",
+          "InstalledVersion": "1.0.0",
+          "FixedVersion": "1.0.1",
+          "Severity": "HIGH",
+          "PkgIdentifier": {
+            "PURL": "pkg:npm/demo-only-package@1.0.0"
+          }
+        }
+      ]
+    },
+    {
+      "Target": "app/requirements.txt",
+      "Class": "lang-pkgs",
+      "Type": "pip",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2023-34362",
+          "PkgName": "moveit-transfer",
+          "InstalledVersion": "2023.0.0",
+          "FixedVersions": [
+            "2023.0.2"
+          ],
+          "Severity": "CRITICAL",
+          "PkgPath": "requirements.txt",
+          "PkgIdentifier": {
+            "PURL": "pkg:pypi/moveit-transfer@2023.0.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - Examples:
       - CVE List Import: cve-list-import.md
       - Generic Occurrence CSV Import: generic-occurrence-csv-import.md
+      - Trivy JSON Import: trivy-json-import.md
       - Base Report: example_report.md
       - Base Compare: example_compare.md
       - ATT&CK Report: example_attack_report.md


### PR DESCRIPTION
## Summary

Implements VPW-016 / issue #122 as the next execution slice after VPW-015.

- Extends Trivy JSON normalization with `source_id`, CVE alias handling, `FixedVersions` support, missing-field robustness, and clearer invalid JSON errors.
- Keeps CVE-first prioritization: non-CVE-only Trivy rows are skipped with a warning, while non-CVE `VulnerabilityID` values paired with CVE aliases keep the original ID as source evidence.
- Adds focused Trivy parser tests, `examples/trivy-demo.json`, and Trivy schema-assumption docs linked from the support matrix and MkDocs nav.

## Validation

- python3 -m pytest -q backend/tests/test_trivy_json_parser.py backend/tests/test_input_loader_contracts.py backend/tests/test_input_fixtures.py backend/tests/api/test_template_importer_registry.py backend/tests/cli/test_input_validate.py backend/tests/cli/test_analyze.py::test_cli_analyze_supports_trivy_vex_asset_context_and_custom_policy --no-cov
- python3 -m ruff format --check backend/src/vuln_prioritizer/models_input.py backend/src/vuln_prioritizer/inputs/parsers/common.py backend/src/vuln_prioritizer/inputs/parsers/scanner.py backend/app/importers/legacy.py backend/tests/test_trivy_json_parser.py
- python3 -m ruff check backend/src/vuln_prioritizer/models_input.py backend/src/vuln_prioritizer/inputs/parsers/common.py backend/src/vuln_prioritizer/inputs/parsers/scanner.py backend/app/importers/legacy.py backend/tests/test_trivy_json_parser.py
- python3 -m pytest -q backend/tests/api --no-cov
- python3 -m json.tool examples/trivy-demo.json >/dev/null
- make docs-check
- PYTHONPATH=backend/src python3 -m vuln_prioritizer.cli input inspect --input examples/trivy-demo.json --input-format trivy-json --format json
- git diff --check
- make check

Refs #122