### PR TITLE
VPW-018: implement secure import upload API

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app.api.routes import assets, findings, login, projects, runs, users, utils, workbench
+from app.api.routes import assets, findings, imports, login, projects, runs, users, utils, workbench
 
 api_router = APIRouter()
 api_router.include_router(login.router)
 api_router.include_router(projects.router)
 api_router.include_router(assets.router)
 api_router.include_router(runs.router)
+api_router.include_router(imports.router)
 api_router.include_router(findings.router)
 api_router.include_router(users.router)
 api_router.include_router(utils.router)

--- a/backend/app/api/routes/imports.py
+++ b/backend/app/api/routes/imports.py
@@ -1,0 +1,402 @@
+"""Template import upload API routes."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from sqlmodel import Session
+
+from app.api.deps import CurrentUser, SessionDep
+from app.api.routes.workbench_access import require_visible_project
+from app.core.config import Settings
+from app.importers import (
+    ImporterParseError,
+    ImporterValidationError,
+    UnsupportedInputTypeError,
+    build_importer_registry,
+)
+from app.importers.contracts import NormalizedOccurrence
+from app.models import AnalysisRun, AnalysisRunPublic, AnalysisRunStatus, FindingPriority
+from app.models.base import get_datetime_utc
+from app.repositories import AssetRepository, FindingRepository, RunRepository
+
+router = APIRouter(tags=["imports"])
+
+ALLOWED_UPLOAD_SUFFIXES = {
+    "cve-list": {".txt", ".csv"},
+    "generic-occurrence-csv": {".csv"},
+    "trivy-json": {".json"},
+    "grype-json": {".json"},
+    "cyclonedx-json": {".json"},
+    "spdx-json": {".json"},
+    "dependency-check-json": {".json"},
+    "github-alerts-json": {".json"},
+    "nessus-xml": {".nessus", ".xml"},
+    "openvas-xml": {".xml"},
+}
+ALLOWED_UPLOAD_MIME_HINTS = {
+    "cve-list": {"text/plain", "text/csv", "application/vnd.ms-excel"},
+    "generic-occurrence-csv": {"text/csv", "text/plain", "application/vnd.ms-excel"},
+    "trivy-json": {"application/json", "text/json"},
+    "grype-json": {"application/json", "text/json"},
+    "cyclonedx-json": {"application/json", "text/json"},
+    "spdx-json": {"application/json", "text/json"},
+    "dependency-check-json": {"application/json", "text/json"},
+    "github-alerts-json": {"application/json", "text/json"},
+    "nessus-xml": {"application/xml", "text/xml"},
+    "openvas-xml": {"application/xml", "text/xml"},
+}
+
+
+@router.post("/projects/{project_id}/imports", response_model=AnalysisRunPublic)
+async def import_project_upload(
+    project_id: uuid.UUID,
+    request: Request,
+    session: SessionDep,
+    current_user: CurrentUser,
+    input_type: str = Form(...),
+    file: UploadFile = File(...),
+) -> AnalysisRun:
+    """Securely upload, normalize, and persist one Workbench import file."""
+    require_visible_project(session, current_user, project_id)
+    normalized_input_type = _normalize_input_type(input_type)
+    _validate_input_type(normalized_input_type)
+    original_filename = file.filename or "upload"
+    _reject_unsafe_upload_filename(original_filename)
+    stored_filename = _sanitize_filename(original_filename)
+    _validate_upload_suffix(stored_filename, input_type=normalized_input_type)
+    _validate_mime_hint(file.content_type, input_type=normalized_input_type)
+
+    upload_bytes = await _read_bounded_upload(file, settings=_template_settings(request))
+    upload_sha256 = hashlib.sha256(upload_bytes).hexdigest()
+    job_id = str(uuid.uuid4())
+    job_history = [_job_status_entry("pending")]
+    run_repo = RunRepository(session)
+    run = run_repo.create_analysis_run(
+        project_id=project_id,
+        input_type=normalized_input_type,
+        filename=stored_filename,
+        status=AnalysisRunStatus.PENDING,
+        summary_json={
+            "import_job": _job_payload(
+                job_id=job_id,
+                status="pending",
+                status_history=job_history,
+            ),
+            "input_upload": _upload_summary(
+                input_type=normalized_input_type,
+                original_filename=original_filename,
+                stored_filename=stored_filename,
+                content_type=file.content_type,
+                size_bytes=len(upload_bytes),
+                sha256=upload_sha256,
+                path=None,
+            ),
+            "parse_errors": [],
+        },
+    )
+    upload_path = _store_upload(
+        request,
+        project_id=project_id,
+        run_id=run.id,
+        filename=stored_filename,
+        content=upload_bytes,
+    )
+    run.status = AnalysisRunStatus.RUNNING
+    job_history = [*job_history, _job_status_entry("running")]
+    run.summary_json = {
+        **run.summary_json,
+        "import_job": _job_payload(
+            job_id=job_id,
+            status="running",
+            status_history=job_history,
+        ),
+        "input_upload": {
+            **run.summary_json["input_upload"],
+            "path": str(upload_path),
+        },
+    }
+    session.flush()
+
+    try:
+        occurrences = build_importer_registry().parse(
+            normalized_input_type,
+            upload_bytes,
+            filename=stored_filename,
+        )
+    except (ImporterParseError, ImporterValidationError) as exc:
+        parse_errors = _parse_errors(
+            exc, filename=stored_filename, input_type=normalized_input_type
+        )
+        failed_history = [*job_history, _job_status_entry("failed")]
+        failed_run = run_repo.finish_analysis_run(
+            run.id,
+            status=AnalysisRunStatus.FAILED,
+            error_message=str(exc),
+            error_json={
+                "parse_errors": parse_errors,
+                "import_job": _job_payload(
+                    job_id=job_id,
+                    status="failed",
+                    status_history=failed_history,
+                ),
+            },
+            summary_json={
+                **run.summary_json,
+                "import_job": _job_payload(
+                    job_id=job_id,
+                    status="failed",
+                    status_history=failed_history,
+                ),
+                "parse_errors": parse_errors,
+            },
+        )
+        session.commit()
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Import parsing failed.",
+                "analysis_run_id": str(failed_run.id),
+                "parse_errors": parse_errors,
+            },
+        ) from exc
+
+    _persist_template_occurrences(
+        session=session,
+        project_id=project_id,
+        run_id=run.id,
+        occurrences=occurrences,
+    )
+    finished_run = run_repo.finish_analysis_run(
+        run.id,
+        status=AnalysisRunStatus.SUCCEEDED,
+        summary_json={
+            **run.summary_json,
+            "import_job": _job_payload(
+                job_id=job_id,
+                status="succeeded",
+                status_history=[*job_history, _job_status_entry("succeeded")],
+            ),
+            "occurrence_count": len(occurrences),
+            "finding_count": len(occurrences),
+            "input_sha256": upload_sha256,
+            "parse_errors": [],
+        },
+    )
+    session.commit()
+    return finished_run
+
+
+async def _read_bounded_upload(file: UploadFile, *, settings: Settings) -> bytes:
+    total = 0
+    chunks: list[bytes] = []
+    while chunk := await file.read(1024 * 1024):
+        total += len(chunk)
+        if total > settings.max_upload_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail="Upload exceeds configured limit.",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _persist_template_occurrences(
+    *,
+    session: Session,
+    project_id: uuid.UUID,
+    run_id: uuid.UUID,
+    occurrences: list[NormalizedOccurrence],
+) -> None:
+    asset_repo = AssetRepository(session)
+    finding_repo = FindingRepository(session)
+    run_repo = RunRepository(session)
+    for index, occurrence in enumerate(occurrences, start=1):
+        asset = (
+            asset_repo.upsert_asset(
+                project_id=project_id,
+                asset_key=occurrence.asset_ref,
+                name=occurrence.asset_ref,
+            )
+            if occurrence.asset_ref
+            else None
+        )
+        component = (
+            finding_repo.upsert_component(
+                name=occurrence.component,
+                version=occurrence.version,
+                purl=_string_evidence(occurrence.raw_evidence, "purl"),
+                ecosystem=_string_evidence(occurrence.raw_evidence, "package_type"),
+                package_type=_string_evidence(occurrence.raw_evidence, "package_type"),
+            )
+            if occurrence.component
+            else None
+        )
+        vulnerability = finding_repo.upsert_vulnerability(
+            cve_id=occurrence.cve,
+            source_id=occurrence.cve,
+            severity=_string_evidence(occurrence.raw_evidence, "severity"),
+        )
+        finding = finding_repo.create_or_update_finding(
+            project_id=project_id,
+            vulnerability_id=vulnerability.id,
+            cve_id=occurrence.cve,
+            component_id=component.id if component else None,
+            asset_id=asset.id if asset else None,
+            priority=FindingPriority.MEDIUM,
+            priority_rank=99,
+            operational_rank=index,
+            evidence_json={"import": dict(occurrence.raw_evidence)},
+        )
+        run_repo.add_finding_occurrence(
+            finding_id=finding.id,
+            analysis_run_id=run_id,
+            source=occurrence.source,
+            raw_reference=_string_evidence(occurrence.raw_evidence, "source_record_id"),
+            fix_version=occurrence.fix_version,
+            evidence_json=dict(occurrence.raw_evidence),
+        )
+
+
+def _store_upload(
+    request: Request,
+    *,
+    project_id: uuid.UUID,
+    run_id: uuid.UUID,
+    filename: str,
+    content: bytes,
+) -> Path:
+    upload_root = _template_settings(request).import_upload_dir_path.resolve(strict=False)
+    target_dir = upload_root / str(project_id) / str(run_id)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = (target_dir / filename).resolve(strict=False)
+    if not target_path.is_relative_to(upload_root):
+        raise HTTPException(status_code=422, detail="Upload path is not allowed.")
+    try:
+        with target_path.open("wb") as output:
+            output.write(content)
+    except Exception:
+        shutil.rmtree(target_dir, ignore_errors=True)
+        raise
+    return target_path
+
+
+def _upload_summary(
+    *,
+    input_type: str,
+    original_filename: str,
+    stored_filename: str,
+    content_type: str | None,
+    size_bytes: int,
+    sha256: str,
+    path: str | None,
+) -> dict[str, Any]:
+    return {
+        "input_type": input_type,
+        "original_filename": original_filename,
+        "stored_filename": stored_filename,
+        "content_type": content_type,
+        "size_bytes": size_bytes,
+        "sha256": sha256,
+        "path": path,
+    }
+
+
+def _job_payload(
+    *,
+    job_id: str,
+    status: str,
+    status_history: list[dict[str, str]],
+) -> dict[str, Any]:
+    timestamp = get_datetime_utc().isoformat()
+    return {
+        "id": job_id,
+        "status": status,
+        "updated_at": timestamp,
+        "status_history": status_history,
+    }
+
+
+def _job_status_entry(status: str) -> dict[str, str]:
+    return {
+        "status": status,
+        "created_at": get_datetime_utc().isoformat(),
+    }
+
+
+def _parse_errors(
+    exc: Exception,
+    *,
+    filename: str,
+    input_type: str,
+) -> list[dict[str, str]]:
+    return [
+        {
+            "input_type": input_type,
+            "filename": filename,
+            "message": str(exc),
+            "error_type": exc.__class__.__name__,
+        }
+    ]
+
+
+def _validate_input_type(input_type: str) -> None:
+    try:
+        build_importer_registry().get(input_type)
+    except UnsupportedInputTypeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+def _validate_upload_suffix(filename: str, *, input_type: str) -> None:
+    suffix = Path(filename).suffix.lower()
+    if suffix not in ALLOWED_UPLOAD_SUFFIXES.get(input_type, set()):
+        raise HTTPException(status_code=422, detail="File extension does not match input type.")
+
+
+def _validate_mime_hint(content_type: str | None, *, input_type: str) -> None:
+    normalized = (content_type or "").split(";", maxsplit=1)[0].strip().lower()
+    if normalized in {"", "application/octet-stream"}:
+        return
+    if normalized not in ALLOWED_UPLOAD_MIME_HINTS.get(input_type, set()):
+        raise HTTPException(
+            status_code=422, detail="Upload content type does not match input type."
+        )
+
+
+def _reject_unsafe_upload_filename(filename: str) -> None:
+    if "/" in filename or "\\" in filename or Path(filename).name != filename:
+        raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+    if any(ord(character) < 32 for character in filename):
+        raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+
+
+def _sanitize_filename(filename: str) -> str:
+    name = Path(filename).name.strip() or "upload"
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", name)
+    return sanitized or "upload"
+
+
+def _normalize_input_type(input_type: str) -> str:
+    normalized = input_type.strip().lower()
+    if not normalized:
+        raise HTTPException(status_code=422, detail="input_type is required.")
+    return normalized
+
+
+def _template_settings(request: Request) -> Settings:
+    candidate = getattr(request.app.state, "template_settings", None)
+    if isinstance(candidate, Settings):
+        return candidate
+    raise HTTPException(status_code=500, detail="Template settings are not configured.")
+
+
+def _string_evidence(evidence: Mapping[str, Any], key: str) -> str | None:
+    value = evidence.get(key)
+    return str(value) if value else None

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from os import environ
+from pathlib import Path
 from typing import Literal, cast
 from urllib.parse import quote_plus
 
@@ -26,6 +27,8 @@ class Settings:
     FRONTEND_HOST: str = "http://localhost:5173"
     BACKEND_CORS_ORIGINS: tuple[str, ...] = field(default_factory=tuple)
     SQLALCHEMY_DATABASE_URI: str = "sqlite:///./template.db"
+    IMPORT_UPLOAD_DIR: str = "data/template-import-uploads"
+    MAX_UPLOAD_MB: int = 25
 
     @property
     def all_cors_origins(self) -> tuple[str, ...]:
@@ -35,6 +38,16 @@ class Settings:
         if frontend_host and frontend_host not in origins:
             origins.append(frontend_host)
         return tuple(origins)
+
+    @property
+    def import_upload_dir_path(self) -> Path:
+        """Return the configured template import upload root."""
+        return Path(self.IMPORT_UPLOAD_DIR)
+
+    @property
+    def max_upload_bytes(self) -> int:
+        """Return the configured per-file upload limit in bytes."""
+        return self.MAX_UPLOAD_MB * 1024 * 1024
 
 
 def parse_cors_origins(raw_origins: str) -> tuple[str, ...]:
@@ -80,7 +93,20 @@ def load_settings() -> Settings:
         FRONTEND_HOST=environ.get("FRONTEND_HOST", "http://localhost:5173"),
         BACKEND_CORS_ORIGINS=parse_cors_origins(environ.get("BACKEND_CORS_ORIGINS", "")),
         SQLALCHEMY_DATABASE_URI=build_database_uri(),
+        IMPORT_UPLOAD_DIR=environ.get("IMPORT_UPLOAD_DIR", "data/template-import-uploads"),
+        MAX_UPLOAD_MB=_positive_int_from_env("MAX_UPLOAD_MB", 25),
     )
+
+
+def _positive_int_from_env(name: str, default: int) -> int:
+    raw_value = environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
 
 
 settings = load_settings()

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -57,6 +57,7 @@ class AnalysisRunStatus(StrEnum):
 
     PENDING = "pending"
     RUNNING = "running"
+    SUCCEEDED = "succeeded"
     COMPLETED = "completed"
     COMPLETED_WITH_ERRORS = "completed_with_errors"
     FAILED = "failed"

--- a/backend/src/vuln_prioritizer/api/schemas.py
+++ b/backend/src/vuln_prioritizer/api/schemas.py
@@ -313,6 +313,9 @@ class AnalysisRunSummary(StrictModel):
     attack_stix_spec_version: str | None = None
     defensive_context_sources: list[str] = Field(default_factory=list)
     defensive_context_hits: int = 0
+    lifecycle_status: str | None = None
+    input_uploads: list[dict[str, Any]] = Field(default_factory=list)
+    parse_errors: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class AnalysisRunResponse(StrictModel):

--- a/backend/src/vuln_prioritizer/api/workbench_import_routes.py
+++ b/backend/src/vuln_prioritizer/api/workbench_import_routes.py
@@ -78,6 +78,9 @@ async def import_findings(
     waiver_file: Annotated[UploadFile | None, File()] = None,
     defensive_context_file: Annotated[UploadFile | None, File()] = None,
 ) -> dict[str, Any]:
+    repo = WorkbenchRepository(session)
+    if repo.get_project(project_id) is None:
+        raise HTTPException(status_code=404, detail="Project not found.")
     upload_paths: list[Path] = []
     asset_context_path: Path | None = None
     vex_path: Path | None = None
@@ -130,6 +133,7 @@ async def import_findings(
                     item.filename or path.name
                     for item, path in zip(selected_files, upload_paths, strict=True)
                 ],
+                "content_types": [item.content_type for item in selected_files],
                 "input_count": len(upload_paths),
                 "locked_provider_data": locked_provider_data,
                 "attack_source": attack_source,
@@ -161,6 +165,9 @@ async def import_findings(
                 if len(upload_paths) > 1
                 else (selected_files[0].filename or upload_paths[0].name),
                 input_format=selected_formats if len(upload_paths) > 1 else selected_formats[0],
+                input_content_type=[item.content_type for item in selected_files]
+                if len(upload_paths) > 1
+                else selected_files[0].content_type,
                 provider_snapshot_file=snapshot_path,
                 locked_provider_data=locked_provider_data,
                 attack_source=attack_source,
@@ -175,18 +182,35 @@ async def import_findings(
                 "analysis_run_id": value.run.id,
                 "findings_count": value.run.metadata_json.get("findings_count", 0),
             },
+            preserve_side_effects_on=(WorkbenchAnalysisError,),
         )
         result.run.metadata_json = {**result.run.metadata_json, "job_id": job.id}
     except WorkbenchAnalysisError as exc:
-        _cleanup_saved_uploads(
-            *upload_paths,
-            asset_context_path,
-            vex_path,
-            waiver_path,
-            defensive_context_path,
-        )
+        if exc.analysis_run_id is None:
+            _cleanup_saved_uploads(
+                *upload_paths,
+                asset_context_path,
+                vex_path,
+                waiver_path,
+                defensive_context_path,
+            )
+        else:
+            failed_run = WorkbenchRepository(session).get_analysis_run(exc.analysis_run_id)
+            if failed_run is not None:
+                failed_run.metadata_json = {
+                    **failed_run.metadata_json,
+                    "job_id": exc.job_id,
+                }
         session.commit()
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        detail: Any = str(exc)
+        if exc.parse_errors:
+            detail = {
+                "message": str(exc),
+                "analysis_run_id": exc.analysis_run_id,
+                "job_id": exc.job_id,
+                "parse_errors": exc.parse_errors,
+            }
+        raise HTTPException(status_code=422, detail=detail) from exc
     except HTTPException:
         _cleanup_saved_uploads(
             *upload_paths,

--- a/backend/src/vuln_prioritizer/api/workbench_payloads.py
+++ b/backend/src/vuln_prioritizer/api/workbench_payloads.py
@@ -62,6 +62,9 @@ def _analysis_run_payload(run: Any) -> dict[str, Any]:
             "attack_stix_spec_version": run.metadata_json.get("attack_stix_spec_version"),
             "defensive_context_sources": run.metadata_json.get("defensive_context_sources", []),
             "defensive_context_hits": run.metadata_json.get("defensive_context_hits", 0),
+            "lifecycle_status": run.metadata_json.get("lifecycle_status"),
+            "input_uploads": run.metadata_json.get("input_uploads", []),
+            "parse_errors": run.metadata_json.get("parse_errors", []),
         },
     }
 

--- a/backend/src/vuln_prioritizer/api/workbench_uploads.py
+++ b/backend/src/vuln_prioritizer/api/workbench_uploads.py
@@ -28,11 +28,29 @@ ALLOWED_UPLOAD_SUFFIXES = {
     "nessus-xml": {".nessus", ".xml"},
     "openvas-xml": {".xml"},
 }
+ALLOWED_UPLOAD_MIME_HINTS = {
+    "cve-list": {"text/plain", "text/csv", "application/vnd.ms-excel"},
+    "generic-occurrence-csv": {"text/csv", "text/plain", "application/vnd.ms-excel"},
+    "trivy-json": {"application/json", "text/json"},
+    "grype-json": {"application/json", "text/json"},
+    "cyclonedx-json": {"application/json", "text/json"},
+    "spdx-json": {"application/json", "text/json"},
+    "dependency-check-json": {"application/json", "text/json"},
+    "github-alerts-json": {"application/json", "text/json"},
+    "nessus-xml": {"application/xml", "text/xml"},
+    "openvas-xml": {"application/xml", "text/xml"},
+}
 ALLOWED_CONTEXT_UPLOAD_SUFFIXES = {
     "asset-context": {".csv"},
     "vex": {".json"},
     "waiver": {".yml", ".yaml"},
     "defensive-context": {".json"},
+}
+ALLOWED_CONTEXT_UPLOAD_MIME_HINTS = {
+    "asset-context": {"text/csv", "text/plain", "application/vnd.ms-excel"},
+    "vex": {"application/json", "text/json"},
+    "waiver": {"application/yaml", "application/x-yaml", "text/yaml", "text/plain"},
+    "defensive-context": {"application/json", "text/json"},
 }
 SAFE_SNAPSHOT_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*[.]json$")
 SAFE_ATTACK_FILENAME_RE = SAFE_SNAPSHOT_FILENAME_RE
@@ -63,6 +81,7 @@ async def _save_upload(
     suffix = Path(sanitized).suffix.lower()
     if suffix not in ALLOWED_UPLOAD_SUFFIXES[input_format]:
         raise HTTPException(status_code=422, detail="File extension does not match input format.")
+    _validate_mime_hint(file.content_type, allowed=ALLOWED_UPLOAD_MIME_HINTS[input_format])
 
     target_dir = settings.upload_dir / uuid4().hex
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -96,6 +115,7 @@ async def _save_optional_context_upload(
     suffix = Path(sanitized).suffix.lower()
     if suffix not in allowed_suffixes:
         raise HTTPException(status_code=422, detail=f"{kind} file extension is not allowed.")
+    _validate_mime_hint(file.content_type, allowed=ALLOWED_CONTEXT_UPLOAD_MIME_HINTS[kind])
 
     target_dir = settings.upload_dir / uuid4().hex / "context"
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -121,6 +141,16 @@ def _reject_unsafe_upload_filename(filename: str) -> None:
         raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
     if any(ord(character) < 32 for character in filename):
         raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+
+
+def _validate_mime_hint(content_type: str | None, *, allowed: set[str]) -> None:
+    normalized = (content_type or "").split(";", maxsplit=1)[0].strip().lower()
+    if normalized in {"", "application/octet-stream"}:
+        return
+    if normalized not in allowed:
+        raise HTTPException(
+            status_code=422, detail="Upload content type does not match input format."
+        )
 
 
 def _artifact_response(path: Path, *, media_type: str) -> StreamingResponse:

--- a/backend/src/vuln_prioritizer/services/workbench_analysis.py
+++ b/backend/src/vuln_prioritizer/services/workbench_analysis.py
@@ -59,6 +59,20 @@ SUPPORTED_WORKBENCH_INPUT_FORMATS = {
 class WorkbenchAnalysisError(RuntimeError):
     """Raised when a Workbench import cannot be analyzed."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        parse_errors: list[dict[str, Any]] | None = None,
+        analysis_run_id: str | None = None,
+        job_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.parse_errors = parse_errors or []
+        self.analysis_run_id = analysis_run_id
+        self.job_id = job_id
+
 
 @dataclass(frozen=True, slots=True)
 class WorkbenchImportResult:
@@ -83,12 +97,17 @@ def run_workbench_import(
     vex_file: Path | None = None,
     waiver_file: Path | None = None,
     defensive_context_file: Path | None = None,
+    input_content_type: str | list[str | None] | None = None,
 ) -> WorkbenchImportResult:
     """Analyze an uploaded file and persist the Workbench run."""
     input_paths, original_filenames, input_formats = _normalize_workbench_import_inputs(
         input_path=input_path,
         original_filename=original_filename,
         input_format=input_format,
+    )
+    input_content_types = _normalize_optional_metadata_values(
+        input_content_type,
+        expected_count=len(input_paths),
     )
 
     repo = WorkbenchRepository(session)
@@ -112,6 +131,16 @@ def run_workbench_import(
         input_path="\n".join(str(path) for path in input_paths),
         status="running",
         provider_snapshot_id=provider_snapshot.id if provider_snapshot is not None else None,
+        metadata_json={
+            "input_uploads": _input_upload_metadata(
+                input_paths=input_paths,
+                original_filenames=original_filenames,
+                input_formats=input_formats,
+                input_content_types=input_content_types,
+            ),
+            "parse_errors": [],
+            "lifecycle_status": "running",
+        },
     )
     session.flush()
 
@@ -164,8 +193,27 @@ def run_workbench_import(
         AnalysisInputError,
         AnalysisNoFindingsError,
     ) as exc:
-        repo.finish_analysis_run(run.id, status="failed", error_message=str(exc))
-        raise WorkbenchAnalysisError(str(exc)) from exc
+        parse_errors = _input_parse_errors(
+            exc,
+            input_paths=input_paths,
+            original_filenames=original_filenames,
+            input_formats=input_formats,
+        )
+        repo.finish_analysis_run(
+            run.id,
+            status="failed",
+            error_message=str(exc),
+            metadata_json={
+                **run.metadata_json,
+                "parse_errors": parse_errors,
+                "lifecycle_status": "failed",
+            },
+        )
+        raise WorkbenchAnalysisError(
+            str(exc),
+            parse_errors=parse_errors,
+            analysis_run_id=run.id,
+        ) from exc
 
     payload = build_analysis_report_payload(findings, context)
     _attach_workbench_metadata(
@@ -183,7 +231,12 @@ def run_workbench_import(
     repo.finish_analysis_run(
         run.id,
         status="completed",
-        metadata_json=payload.get("metadata", {}),
+        metadata_json={
+            **run.metadata_json,
+            **payload.get("metadata", {}),
+            "parse_errors": [],
+            "lifecycle_status": "succeeded",
+        },
         attack_summary_json=payload.get("attack_summary", {}),
         summary_json=payload,
     )
@@ -212,6 +265,72 @@ def _normalize_workbench_import_inputs(
             "Unsupported Workbench input format: " + ", ".join(sorted(set(unsupported))) + "."
         )
     return input_paths, original_filenames, input_formats
+
+
+def _normalize_optional_metadata_values(
+    value: str | list[str | None] | None,
+    *,
+    expected_count: int,
+) -> list[str | None]:
+    values = value if isinstance(value, list) else [value] if value is not None else []
+    if len(values) != expected_count:
+        return [None] * expected_count
+    return [str(item) if item else None for item in values]
+
+
+def _input_upload_metadata(
+    *,
+    input_paths: list[Path],
+    original_filenames: list[str],
+    input_formats: list[str],
+    input_content_types: list[str | None],
+) -> list[dict[str, Any]]:
+    uploads: list[dict[str, Any]] = []
+    for path, original_filename, input_format, content_type in zip(
+        input_paths,
+        original_filenames,
+        input_formats,
+        input_content_types,
+        strict=True,
+    ):
+        content = path.read_bytes()
+        uploads.append(
+            {
+                "input_format": input_format,
+                "original_filename": original_filename,
+                "stored_filename": path.name,
+                "path": str(path),
+                "size_bytes": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "content_type": content_type,
+            }
+        )
+    return uploads
+
+
+def _input_parse_errors(
+    exc: Exception,
+    *,
+    input_paths: list[Path],
+    original_filenames: list[str],
+    input_formats: list[str],
+) -> list[dict[str, Any]]:
+    message = str(exc)
+    return [
+        {
+            "input_format": input_format,
+            "filename": original_filename,
+            "stored_filename": path.name,
+            "message": message,
+            "error_type": exc.__class__.__name__,
+        }
+        for path, original_filename, input_format in zip(
+            input_paths,
+            original_filenames,
+            input_formats,
+            strict=True,
+        )
+    ]
 
 
 def _effective_workbench_input_type(input_formats: list[str]) -> str:

--- a/backend/src/vuln_prioritizer/services/workbench_job_runner.py
+++ b/backend/src/vuln_prioritizer/services/workbench_job_runner.py
@@ -118,6 +118,10 @@ def execute_queued_workbench_job(
         original_filenames = _job_payload_list(
             payload.get("original_filenames") or payload.get("original_filename")
         )
+        content_types = cast(
+            list[str | None],
+            _job_payload_list(payload.get("content_types") or payload.get("content_type")),
+        )
         if not input_paths:
             raise WorkbenchAnalysisError("Queued import job is missing input_paths.")
         if len(input_formats) != len(input_paths):
@@ -137,6 +141,7 @@ def execute_queued_workbench_job(
             input_path=input_paths,
             original_filename=original_filenames,
             input_format=input_formats,
+            input_content_type=content_types if content_types else None,
             provider_snapshot_file=_queued_job_optional_artifact_path(
                 payload.get("provider_snapshot_file"),
                 settings=settings,

--- a/backend/src/vuln_prioritizer/services/workbench_jobs.py
+++ b/backend/src/vuln_prioritizer/services/workbench_jobs.py
@@ -23,6 +23,7 @@ def run_sync_workbench_job(
     payload_json: dict[str, Any] | None = None,
     idempotency_key: str | None = None,
     worker_id: str = "sync",
+    preserve_side_effects_on: tuple[type[Exception], ...] = (),
     operation: Callable[[WorkbenchRepository, WorkbenchJob], T],
     result: Callable[[T], dict[str, Any]],
 ) -> tuple[WorkbenchJob, T]:
@@ -49,8 +50,13 @@ def run_sync_workbench_job(
     try:
         value = operation(repo, job)
     except Exception as exc:
-        nested.rollback()
+        if preserve_side_effects_on and isinstance(exc, preserve_side_effects_on):
+            nested.commit()
+        else:
+            nested.rollback()
         session.refresh(job)
+        if hasattr(exc, "job_id"):
+            setattr(exc, "job_id", job.id)
         repo.fail_workbench_job(job, error_message=str(exc), retryable=False)
         session.commit()
         raise

--- a/backend/tests/api/test_template_import_upload_api.py
+++ b/backend/tests/api/test_template_import_upload_api.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session
+from utils.template_workbench import (
+    TemplateApiEnv,
+    auth_headers,
+    create_project_via_api,
+)
+
+
+def test_valid_cve_list_upload_creates_analysis_run_and_stores_sha256(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    content = b"CVE-2024-3094\nCVE-2021-44228\n"
+    expected_sha256 = hashlib.sha256(content).hexdigest()
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list"},
+        files={"file": ("Team Scan (prod).txt", content, "text/plain")},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["project_id"] == project["id"]
+    assert payload["input_type"] == "cve-list"
+    assert payload["filename"] == "Team_Scan__prod_.txt"
+    assert payload["status"] == "succeeded"
+    assert payload["summary_json"]["input_sha256"] == expected_sha256
+    assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
+    assert payload["summary_json"]["input_upload"]["original_filename"] == "Team Scan (prod).txt"
+    assert payload["summary_json"]["input_upload"]["stored_filename"] == "Team_Scan__prod_.txt"
+    assert payload["summary_json"]["input_upload"]["path"].startswith(str(upload_dir))
+    assert Path(payload["summary_json"]["input_upload"]["path"]).read_bytes() == content
+    assert payload["summary_json"]["import_job"]["status"] == "succeeded"
+    assert [item["status"] for item in payload["summary_json"]["import_job"]["status_history"]] == [
+        "pending",
+        "running",
+        "succeeded",
+    ]
+    assert payload["summary_json"]["parse_errors"] == []
+
+    runs = template_api_env.client.get(
+        f"/api/v1/projects/{project['id']}/runs/",
+        headers=headers,
+    )
+    assert runs.status_code == 200
+    assert runs.json()["count"] == 1
+    assert runs.json()["data"][0]["id"] == payload["id"]
+    assert runs.json()["data"][0]["status"] == "succeeded"
+
+    findings = template_api_env.client.get(
+        f"/api/v1/projects/{project['id']}/findings/",
+        headers=headers,
+    )
+    assert findings.status_code == 200
+    assert findings.json()["count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("input_type", "filename", "content_type", "detail"),
+    [
+        ("unknown", "scan.txt", "text/plain", "Unsupported input type"),
+        ("cve-list", "scan.json", "text/plain", "File extension does not match input type"),
+        (
+            "cve-list",
+            "scan.txt",
+            "application/json",
+            "Upload content type does not match input type",
+        ),
+    ],
+)
+def test_upload_rejects_unknown_input_type_bad_extension_and_mime(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+    input_type: str,
+    filename: str,
+    content_type: str,
+    detail: str,
+) -> None:
+    _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": input_type},
+        files={"file": (filename, b"CVE-2024-3094\n", content_type)},
+    )
+
+    assert response.status_code == 422
+    assert detail in response.text
+    assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
+
+
+def test_upload_rejects_oversized_file_without_persisting_run_or_file(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path, max_upload_mb=1)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list"},
+        files={"file": ("large.txt", b"A" * (1024 * 1024 + 1), "text/plain")},
+    )
+
+    assert response.status_code == 413
+    assert "Upload exceeds configured limit" in response.text
+    assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
+    assert not upload_dir.exists()
+
+
+def test_upload_rejects_path_traversal_filename(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    outside = tmp_path / "evil.txt"
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list"},
+        files={"file": ("../../evil.txt", b"CVE-2024-3094\n", "text/plain")},
+    )
+
+    assert response.status_code == 422
+    assert "Upload filename is not allowed" in response.text
+    assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
+    assert not outside.exists()
+    assert not upload_dir.exists()
+
+
+def test_parse_errors_are_structured_and_failed_run_is_persisted(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    content = b"CVE-2024-3094\nnot-a-cve\n"
+    expected_sha256 = hashlib.sha256(content).hexdigest()
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list"},
+        files={"file": ("bad.txt", content, "text/plain")},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["message"] == "Import parsing failed."
+    assert detail["analysis_run_id"]
+    assert detail["parse_errors"][0]["input_type"] == "cve-list"
+    assert detail["parse_errors"][0]["filename"] == "bad.txt"
+    assert "line 2" in detail["parse_errors"][0]["message"]
+    assert "not-a-cve" in detail["parse_errors"][0]["message"]
+
+    run = template_api_env.client.get(
+        f"/api/v1/runs/{detail['analysis_run_id']}",
+        headers=headers,
+    )
+    assert run.status_code == 200
+    payload = run.json()
+    assert payload["status"] == "failed"
+    assert [item["status"] for item in payload["error_json"]["import_job"]["status_history"]] == [
+        "pending",
+        "running",
+        "failed",
+    ]
+    assert payload["error_json"]["parse_errors"] == detail["parse_errors"]
+    assert payload["summary_json"]["parse_errors"] == detail["parse_errors"]
+    assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
+    assert Path(payload["summary_json"]["input_upload"]["path"]).is_relative_to(upload_dir)
+    assert Path(payload["summary_json"]["input_upload"]["path"]).read_bytes() == content
+
+
+def _configure_upload_dir(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+    *,
+    max_upload_mb: int = 25,
+) -> Path:
+    upload_dir = tmp_path / "template-import-uploads"
+    active_settings = template_api_env.client.app.state.template_settings
+    template_api_env.client.app.state.template_settings = replace(
+        active_settings,
+        IMPORT_UPLOAD_DIR=str(upload_dir),
+        MAX_UPLOAD_MB=max_upload_mb,
+    )
+    return upload_dir.resolve(strict=False)
+
+
+def _run_count(template_api_env: TemplateApiEnv, project_id: uuid.UUID) -> int:
+    with Session(template_api_env.engine) as session:
+        return len(
+            template_api_env.repositories.RunRepository(session).list_analysis_runs(project_id)
+        )

--- a/backend/tests/api/test_template_workbench_api_skeleton.py
+++ b/backend/tests/api/test_template_workbench_api_skeleton.py
@@ -34,6 +34,7 @@ def test_vpw011_openapi_exposes_workbench_domain_routes_without_items() -> None:
         "/api/v1/projects/{project_id}",
         "/api/v1/projects/{project_id}/assets/",
         "/api/v1/assets/{asset_id}",
+        "/api/v1/projects/{project_id}/imports",
         "/api/v1/projects/{project_id}/runs/",
         "/api/v1/runs/{run_id}",
         "/api/v1/projects/{project_id}/findings/",
@@ -86,6 +87,14 @@ def test_vpw011_domain_routes_require_auth(template_api_env: TemplateApiEnv) -> 
         ),
         ("patch", f"/api/v1/assets/{asset_id}", {"json": {"name": "Renamed API"}}),
         ("get", f"/api/v1/projects/{project_id}/runs/", {}),
+        (
+            "post",
+            f"/api/v1/projects/{project_id}/imports",
+            {
+                "data": {"input_type": "cve-list"},
+                "files": {"file": ("sample.txt", b"CVE-2024-3094\n", "text/plain")},
+            },
+        ),
         ("get", f"/api/v1/runs/{run_id}", {}),
         (
             "get",

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -1821,6 +1821,9 @@ def test_workbench_rejects_unsupported_and_oversized_uploads(tmp_path: Path) -> 
     assert "Upload filename is not allowed" in path_traversal.text
     assert not (tmp_path / "trivy.json").exists()
 
+    existing_upload_paths = {
+        path.relative_to(settings.upload_dir) for path in settings.upload_dir.rglob("*")
+    }
     context_path_traversal = client.post(
         f"/api/projects/{project['id']}/imports",
         data={"input_format": "cve-list"},
@@ -1831,7 +1834,9 @@ def test_workbench_rejects_unsupported_and_oversized_uploads(tmp_path: Path) -> 
     )
     assert context_path_traversal.status_code == 422
     assert "Upload filename is not allowed" in context_path_traversal.text
-    assert not any(settings.upload_dir.rglob("*"))
+    assert {path.relative_to(settings.upload_dir) for path in settings.upload_dir.rglob("*")} == (
+        existing_upload_paths
+    )
 
     oversized = client.post(
         f"/api/projects/{project['id']}/imports",

--- a/docs/architecture/analysis-run-provider-schema.md
+++ b/docs/architecture/analysis-run-provider-schema.md
@@ -45,6 +45,7 @@ Expected values:
 
 - `pending`: run was created but processing has not started
 - `running`: parser or enrichment work is active
+- `succeeded`: template import route finished successfully and produced persisted run evidence
 - `completed`: run finished successfully
 - `completed_with_errors`: run produced usable output but retained recoverable
   errors or degraded provider evidence

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -262,6 +262,7 @@ Workbench API changes are additive:
 - `GET /api/projects/{project_id}/audit-events` and `GET /api/audit-events` expose audit records
 - `GET /api/tokens` lists token metadata without token values; `DELETE /api/tokens/{id}` revokes tokens
 - `GET /api/diagnostics` exposes local runtime diagnostics and is token-gated once active tokens exist
+- `POST /api/v1/projects/{project_id}/imports` accepts a JWT-gated template Workbench upload, validates input type, extension, MIME hint, filename, and upload size, persists the uploaded file under the configured import upload root, and records upload SHA-256 plus structured `parse_errors` in the returned `AnalysisRun`
 - `POST /api/projects/{project_id}/imports` accepts single-upload and additive multi-upload imports for all CLI input formats
 - `GET /api/jobs`, `GET /api/jobs/{id}`, `POST /api/jobs`, and `POST /api/jobs/{id}/retry` expose durable local job state for compatible synchronous operations
 - `DELETE /api/reports/{id}` and `DELETE /api/evidence-bundles/{id}` remove managed artifacts after checksum validation

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -93,7 +93,7 @@ export const AnalysisRunPublicSchema = {
 
 export const AnalysisRunStatusSchema = {
     description: 'Import or analysis run lifecycle state.',
-    enum: ['pending', 'running', 'completed', 'completed_with_errors', 'failed', 'cancelled'],
+    enum: ['pending', 'running', 'succeeded', 'completed', 'completed_with_errors', 'failed', 'cancelled'],
     title: 'AnalysisRunStatus',
     type: 'string'
 } as const;
@@ -414,6 +414,23 @@ export const AssetsPublicSchema = {
     },
     required: ['data', 'count'],
     title: 'AssetsPublic',
+    type: 'object'
+} as const;
+
+export const Body_imports_import_project_uploadSchema = {
+    properties: {
+        file: {
+            contentMediaType: 'application/octet-stream',
+            title: 'File',
+            type: 'string'
+        },
+        input_type: {
+            title: 'Input Type',
+            type: 'string'
+        }
+    },
+    required: ['input_type', 'file'],
+    title: 'Body_imports-import_project_upload',
     type: 'object'
 } as const;
 

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { AssetsUpdateAssetData, AssetsUpdateAssetResponse, AssetsReadProjectAssetsData, AssetsReadProjectAssetsResponse, AssetsCreateProjectAssetData, AssetsCreateProjectAssetResponse, FindingsReadFindingData, FindingsReadFindingResponse, FindingsReadProjectFindingsData, FindingsReadProjectFindingsResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, ProjectsReadProjectsResponse, ProjectsCreateProjectData, ProjectsCreateProjectResponse, ProjectsDeleteProjectData, ProjectsDeleteProjectResponse, ProjectsReadProjectData, ProjectsReadProjectResponse, ProjectsUpdateProjectData, ProjectsUpdateProjectResponse, RunsReadProjectRunsData, RunsReadProjectRunsResponse, RunsReadRunData, RunsReadRunResponse, UsersReadUserMeResponse, UtilsHealthCheckResponse, WorkbenchTemplateWorkbenchStatusResponse } from './types.gen';
+import type { AssetsUpdateAssetData, AssetsUpdateAssetResponse, AssetsReadProjectAssetsData, AssetsReadProjectAssetsResponse, AssetsCreateProjectAssetData, AssetsCreateProjectAssetResponse, FindingsReadFindingData, FindingsReadFindingResponse, FindingsReadProjectFindingsData, FindingsReadProjectFindingsResponse, ImportsImportProjectUploadData, ImportsImportProjectUploadResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, ProjectsReadProjectsResponse, ProjectsCreateProjectData, ProjectsCreateProjectResponse, ProjectsDeleteProjectData, ProjectsDeleteProjectResponse, ProjectsReadProjectData, ProjectsReadProjectResponse, ProjectsUpdateProjectData, ProjectsUpdateProjectResponse, RunsReadProjectRunsData, RunsReadProjectRunsResponse, RunsReadRunData, RunsReadRunResponse, UsersReadUserMeResponse, UtilsHealthCheckResponse, WorkbenchTemplateWorkbenchStatusResponse } from './types.gen';
 
 export class AssetsService {
     /**
@@ -121,6 +121,32 @@ export class FindingsService {
                 offset: data.offset,
                 sort: data.sort
             },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
+
+export class ImportsService {
+    /**
+     * Import Project Upload
+     * Securely upload, normalize, and persist one Workbench import file.
+     * @param data The data for the request.
+     * @param data.projectId
+     * @param data.formData
+     * @returns AnalysisRunPublic Successful Response
+     * @throws ApiError
+     */
+    public static importProjectUpload(data: ImportsImportProjectUploadData): CancelablePromise<ImportsImportProjectUploadResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/projects/{project_id}/imports',
+            path: {
+                project_id: data.projectId
+            },
+            formData: data.formData,
+            mediaType: 'multipart/form-data',
             errors: {
                 422: 'Validation Error'
             }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -32,7 +32,7 @@ export type AnalysisRunsPublic = {
 /**
  * Import or analysis run lifecycle state.
  */
-export type AnalysisRunStatus = 'pending' | 'running' | 'completed' | 'completed_with_errors' | 'failed' | 'cancelled';
+export type AnalysisRunStatus = 'pending' | 'running' | 'succeeded' | 'completed' | 'completed_with_errors' | 'failed' | 'cancelled';
 
 /**
  * Asset creation payload.
@@ -101,6 +101,11 @@ export type AssetUpdate = {
     name?: (string | null);
     owner?: (string | null);
     target_ref?: (string | null);
+};
+
+export type Body_imports_import_project_upload = {
+    file: string;
+    input_type: string;
 };
 
 export type Body_login_login_access_token = {
@@ -294,6 +299,13 @@ export type FindingsReadProjectFindingsData = {
 };
 
 export type FindingsReadProjectFindingsResponse = (FindingsPublic);
+
+export type ImportsImportProjectUploadData = {
+    formData: Body_imports_import_project_upload;
+    projectId: string;
+};
+
+export type ImportsImportProjectUploadResponse = (AnalysisRunPublic);
 
 export type LoginLoginAccessTokenData = {
     formData: Body_login_login_access_token;


### PR DESCRIPTION
## Summary
- adds the template `/api/v1/projects/{project_id}/imports` upload route with JWT/project visibility gating
- validates input type, extension, MIME hint, upload size, and path-safe filenames before storing uploads under a configured root
- records upload SHA256, status history, parse errors, and failed-run evidence in AnalysisRun payloads; hardens the legacy Workbench upload path with MIME hints and persisted upload metadata

## Evidence
- `python3 -m pytest -q tests/api/test_template_import_upload_api.py tests/api/test_template_workbench_api_skeleton.py tests/api/test_template_importer_registry.py tests/api/test_template_cve_list_importer.py tests/api/test_template_generic_occurrence_csv_importer.py tests/api/test_workbench_api.py::test_workbench_rejects_unsupported_and_oversized_uploads tests/api/test_app_guards.py::test_upload_size_guard_rejects_oversized_import_upload --no-cov`
- `python3 -m pytest -q tests/api --no-cov`
- `python3 -m pytest -q tests/db/test_workbench_db.py tests/db/test_workbench_alembic.py --no-cov`
- `python3 -m pytest -q tests/test_refactor_hygiene.py --no-cov`
- `make check`
- `make docs-check`

Closes #124 after review/merge evidence is accepted.