### PR TITLE
VPW-019: persist occurrences and deduplicate findings

### DIFF
--- a/backend/app/api/routes/imports.py
+++ b/backend/app/api/routes/imports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import shutil
 import uuid
@@ -168,7 +169,7 @@ async def import_project_upload(
             },
         ) from exc
 
-    _persist_template_occurrences(
+    persist_summary = _persist_template_occurrences(
         session=session,
         project_id=project_id,
         run_id=run.id,
@@ -184,8 +185,7 @@ async def import_project_upload(
                 status="succeeded",
                 status_history=[*job_history, _job_status_entry("succeeded")],
             ),
-            "occurrence_count": len(occurrences),
-            "finding_count": len(occurrences),
+            **persist_summary,
             "input_sha256": upload_sha256,
             "parse_errors": [],
         },
@@ -214,11 +214,17 @@ def _persist_template_occurrences(
     project_id: uuid.UUID,
     run_id: uuid.UUID,
     occurrences: list[NormalizedOccurrence],
-) -> None:
+) -> dict[str, Any]:
     asset_repo = AssetRepository(session)
     finding_repo = FindingRepository(session)
     run_repo = RunRepository(session)
+    decisions: list[dict[str, Any]] = []
+    created_count = 0
+    reused_count = 0
+    touched_finding_ids: set[str] = set()
     for index, occurrence in enumerate(occurrences, start=1):
+        dedup_parts = _dedup_key_parts(project_id, occurrence)
+        dedup_key = _finding_dedup_key(dedup_parts)
         asset = (
             asset_repo.upsert_asset(
                 project_id=project_id,
@@ -241,28 +247,120 @@ def _persist_template_occurrences(
         )
         vulnerability = finding_repo.upsert_vulnerability(
             cve_id=occurrence.cve,
-            source_id=occurrence.cve,
+            source_id=dedup_parts["source_id"],
             severity=_string_evidence(occurrence.raw_evidence, "severity"),
         )
+        existing_finding = finding_repo.get_project_finding_by_dedup_key(
+            project_id=project_id,
+            dedup_key=dedup_key,
+        )
+        if existing_finding is None:
+            existing_finding = finding_repo.get_project_finding_by_identity(
+                project_id=project_id,
+                vulnerability_id=vulnerability.id,
+                component_id=component.id if component else None,
+                asset_id=asset.id if asset else None,
+            )
+        action = "reused" if existing_finding is not None else "created"
         finding = finding_repo.create_or_update_finding(
             project_id=project_id,
             vulnerability_id=vulnerability.id,
             cve_id=occurrence.cve,
+            dedup_key=dedup_key,
             component_id=component.id if component else None,
             asset_id=asset.id if asset else None,
             priority=FindingPriority.MEDIUM,
             priority_rank=99,
             operational_rank=index,
-            evidence_json={"import": dict(occurrence.raw_evidence)},
+            evidence_json={
+                "import": dict(occurrence.raw_evidence),
+                "dedup": {
+                    "key": dedup_key,
+                    "key_version": "vpw019-v1",
+                    "action": action,
+                    "parts": dedup_parts,
+                },
+            },
         )
+        if action == "created":
+            created_count += 1
+        else:
+            reused_count += 1
+        touched_finding_ids.add(str(finding.id))
         run_repo.add_finding_occurrence(
             finding_id=finding.id,
             analysis_run_id=run_id,
             source=occurrence.source,
             raw_reference=_string_evidence(occurrence.raw_evidence, "source_record_id"),
             fix_version=occurrence.fix_version,
-            evidence_json=dict(occurrence.raw_evidence),
+            evidence_json={
+                **dict(occurrence.raw_evidence),
+                "dedup_key": dedup_key,
+                "dedup_action": action,
+            },
         )
+        decisions.append(
+            {
+                "action": action,
+                "dedup_key": dedup_key,
+                "finding_id": str(finding.id),
+                "cve": occurrence.cve,
+                "source_id": dedup_parts["source_id"],
+                "component_identity": dedup_parts["component_identity"],
+                "asset_ref": dedup_parts["asset_ref"],
+            }
+        )
+
+    return {
+        "occurrence_count": len(occurrences),
+        "finding_count": len(touched_finding_ids),
+        "dedup_summary": {
+            "key_version": "vpw019-v1",
+            "created_findings": created_count,
+            "reused_findings": reused_count,
+            "decision_count": len(decisions),
+            "decisions": decisions,
+        },
+    }
+
+
+def _dedup_key_parts(project_id: uuid.UUID, occurrence: NormalizedOccurrence) -> dict[str, str]:
+    source_id = _normalized_identity_value(
+        _string_evidence(occurrence.raw_evidence, "source_id")
+        or _string_evidence(occurrence.raw_evidence, "vulnerability_id")
+        or occurrence.cve
+    )
+    purl = _normalized_identity_value(_string_evidence(occurrence.raw_evidence, "purl"))
+    component_identity = purl
+    if component_identity == "__none__" and occurrence.component:
+        component_identity = "|".join(
+            [
+                "component",
+                _normalized_identity_value(occurrence.component),
+                _normalized_identity_value(occurrence.version),
+                _normalized_identity_value(
+                    _string_evidence(occurrence.raw_evidence, "package_type")
+                ),
+            ]
+        )
+    return {
+        "project_id": str(project_id),
+        "source_id": source_id,
+        "component_identity": component_identity,
+        "asset_ref": _normalized_identity_value(occurrence.asset_ref),
+    }
+
+
+def _finding_dedup_key(parts: Mapping[str, str]) -> str:
+    material = json.dumps(parts, sort_keys=True, separators=(",", ":"))
+    return "vpw019:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _normalized_identity_value(value: str | None) -> str:
+    if value is None:
+        return "__none__"
+    normalized = value.strip()
+    return normalized or "__none__"
 
 
 def _store_upload(

--- a/backend/app/repositories/findings.py
+++ b/backend/app/repositories/findings.py
@@ -96,6 +96,7 @@ class FindingRepository:
         project_id: uuid.UUID,
         vulnerability_id: uuid.UUID,
         cve_id: str,
+        dedup_key: str | None = None,
         priority: FindingPriority | str,
         component_id: uuid.UUID | None = None,
         asset_id: uuid.UUID | None = None,
@@ -111,19 +112,18 @@ class FindingRepository:
         evidence_json: dict[str, Any] | None = None,
     ) -> Finding:
         """Create or update a finding by project/vulnerability/component/asset identity."""
-        filters: list[Any] = [
-            Finding.project_id == project_id,
-            Finding.vulnerability_id == vulnerability_id,
-        ]
-        filters.append(
-            col(Finding.component_id).is_(None)
-            if component_id is None
-            else Finding.component_id == component_id
+        finding = (
+            self.get_project_finding_by_dedup_key(project_id=project_id, dedup_key=dedup_key)
+            if dedup_key is not None
+            else None
         )
-        filters.append(
-            col(Finding.asset_id).is_(None) if asset_id is None else Finding.asset_id == asset_id
-        )
-        finding = self.session.exec(select(Finding).where(*filters)).first()
+        if finding is None:
+            finding = self.get_project_finding_by_identity(
+                project_id=project_id,
+                vulnerability_id=vulnerability_id,
+                component_id=component_id,
+                asset_id=asset_id,
+            )
         if finding is None:
             finding = Finding(
                 project_id=project_id,
@@ -131,12 +131,15 @@ class FindingRepository:
                 component_id=component_id,
                 asset_id=asset_id,
                 cve_id=cve_id,
+                dedup_key=dedup_key or str(uuid.uuid4()),
                 status=FindingStatus(status),
                 priority=FindingPriority(priority),
                 priority_rank=priority_rank,
             )
             self.session.add(finding)
 
+        if dedup_key is not None:
+            finding.dedup_key = dedup_key
         finding.cve_id = cve_id
         finding.priority = FindingPriority(priority)
         finding.priority_rank = priority_rank
@@ -152,6 +155,42 @@ class FindingRepository:
         finding.last_seen_at = get_datetime_utc()
         self.session.flush()
         return finding
+
+    def get_project_finding_by_dedup_key(
+        self,
+        *,
+        project_id: uuid.UUID,
+        dedup_key: str,
+    ) -> Finding | None:
+        """Return a project finding by its stable import dedup key."""
+        statement = select(Finding).where(
+            Finding.project_id == project_id,
+            Finding.dedup_key == dedup_key,
+        )
+        return self.session.exec(statement).first()
+
+    def get_project_finding_by_identity(
+        self,
+        *,
+        project_id: uuid.UUID,
+        vulnerability_id: uuid.UUID,
+        component_id: uuid.UUID | None = None,
+        asset_id: uuid.UUID | None = None,
+    ) -> Finding | None:
+        """Return a finding by project/vulnerability/component/asset identity."""
+        filters: list[Any] = [
+            Finding.project_id == project_id,
+            Finding.vulnerability_id == vulnerability_id,
+        ]
+        filters.append(
+            col(Finding.component_id).is_(None)
+            if component_id is None
+            else Finding.component_id == component_id
+        )
+        filters.append(
+            col(Finding.asset_id).is_(None) if asset_id is None else Finding.asset_id == asset_id
+        )
+        return self.session.exec(select(Finding).where(*filters)).first()
 
     def get_finding(self, finding_id: uuid.UUID) -> Finding | None:
         """Return a finding by primary key."""

--- a/backend/tests/api/test_template_core_workbench_models.py
+++ b/backend/tests/api/test_template_core_workbench_models.py
@@ -205,6 +205,7 @@ def test_core_workbench_dedup_constraints_and_indexes_exist(migrated_engine: Eng
         _has_unique_constraint_or_index(inspector, "component", ("name", "version", "ecosystem"))
     )
     assert _has_unique_constraint_or_index(inspector, "vulnerability", ("cve_id",))
+    assert _has_unique_constraint_or_index(inspector, "finding", ("project_id", "dedup_key"))
     assert _has_unique_constraint_or_index(
         inspector,
         "finding",

--- a/backend/tests/api/test_template_import_upload_api.py
+++ b/backend/tests/api/test_template_import_upload_api.py
@@ -6,12 +6,14 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from sqlmodel import Session
+from sqlmodel import Session, select
 from utils.template_workbench import (
     TemplateApiEnv,
     auth_headers,
     create_project_via_api,
 )
+
+from app import models as app_models
 
 
 def test_valid_cve_list_upload_creates_analysis_run_and_stores_sha256(
@@ -38,6 +40,10 @@ def test_valid_cve_list_upload_creates_analysis_run_and_stores_sha256(
     assert payload["filename"] == "Team_Scan__prod_.txt"
     assert payload["status"] == "succeeded"
     assert payload["summary_json"]["input_sha256"] == expected_sha256
+    assert payload["summary_json"]["occurrence_count"] == 2
+    assert payload["summary_json"]["finding_count"] == 2
+    assert payload["summary_json"]["dedup_summary"]["created_findings"] == 2
+    assert payload["summary_json"]["dedup_summary"]["reused_findings"] == 0
     assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
     assert payload["summary_json"]["input_upload"]["original_filename"] == "Team Scan (prod).txt"
     assert payload["summary_json"]["input_upload"]["stored_filename"] == "Team_Scan__prod_.txt"
@@ -66,6 +72,119 @@ def test_valid_cve_list_upload_creates_analysis_run_and_stores_sha256(
     )
     assert findings.status_code == 200
     assert findings.json()["count"] == 2
+
+
+def test_double_import_deduplicates_findings_and_appends_occurrences(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    project_id = uuid.UUID(project["id"])
+    content = "\n".join(
+        [
+            "cve_id,asset_ref,component,version,purl,severity",
+            "CVE-2024-3094,build-host-1,xz,5.6.0,pkg:apk/alpine/xz@5.6.0-r0,CRITICAL",
+            "CVE-2024-4577,web-tier,php-cgi,8.3.7,pkg:deb/debian/php-cgi@8.3.7,HIGH",
+            "",
+        ]
+    ).encode()
+
+    first = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "generic-occurrence-csv"},
+        files={"file": ("occurrences.csv", content, "text/csv")},
+    )
+    assert first.status_code == 200, first.text
+    first_payload = first.json()
+    assert first_payload["summary_json"]["dedup_summary"]["created_findings"] == 2
+    assert first_payload["summary_json"]["dedup_summary"]["reused_findings"] == 0
+    assert {
+        item["action"] for item in first_payload["summary_json"]["dedup_summary"]["decisions"]
+    } == {"created"}
+
+    first_findings, first_occurrence_count = _finding_state(template_api_env, project_id)
+    first_seen = {finding.cve_id: finding.first_seen_at for finding in first_findings}
+    first_last_seen = {finding.cve_id: finding.last_seen_at for finding in first_findings}
+    first_dedup_keys = {finding.cve_id: finding.dedup_key for finding in first_findings}
+
+    second = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "generic-occurrence-csv"},
+        files={"file": ("occurrences.csv", content, "text/csv")},
+    )
+    assert second.status_code == 200, second.text
+    second_payload = second.json()
+    dedup_summary = second_payload["summary_json"]["dedup_summary"]
+    assert second_payload["summary_json"]["occurrence_count"] == 2
+    assert second_payload["summary_json"]["finding_count"] == 2
+    assert dedup_summary["created_findings"] == 0
+    assert dedup_summary["reused_findings"] == 2
+    assert dedup_summary["decision_count"] == 2
+    assert {item["action"] for item in dedup_summary["decisions"]} == {"reused"}
+    assert all(item["dedup_key"].startswith("vpw019:") for item in dedup_summary["decisions"])
+    assert all(
+        item["asset_ref"] in {"build-host-1", "web-tier"} for item in dedup_summary["decisions"]
+    )
+
+    second_findings, second_occurrence_count = _finding_state(template_api_env, project_id)
+    assert len(first_findings) == 2
+    assert first_occurrence_count == 2
+    assert len(second_findings) == 2
+    assert second_occurrence_count == 4
+    assert {finding.cve_id: finding.first_seen_at for finding in second_findings} == first_seen
+    assert {finding.cve_id: finding.dedup_key for finding in second_findings} == first_dedup_keys
+    assert all(
+        finding.last_seen_at > first_last_seen[finding.cve_id] for finding in second_findings
+    )
+
+    findings = template_api_env.client.get(
+        f"/api/v1/projects/{project['id']}/findings/",
+        headers=headers,
+    )
+    assert findings.status_code == 200
+    assert findings.json()["count"] == 2
+
+
+def test_same_cve_on_different_assets_creates_distinct_findings(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    project_id = uuid.UUID(project["id"])
+    content = "\n".join(
+        [
+            "cve_id,asset_ref,component,version,purl,severity",
+            "CVE-2024-3094,build-host-1,xz,5.6.0,pkg:apk/alpine/xz@5.6.0-r0,CRITICAL",
+            "CVE-2024-3094,build-host-2,xz,5.6.0,pkg:apk/alpine/xz@5.6.0-r0,CRITICAL",
+            "",
+        ]
+    ).encode()
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "generic-occurrence-csv"},
+        files={"file": ("same-cve-assets.csv", content, "text/csv")},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["summary_json"]["finding_count"] == 2
+    assert payload["summary_json"]["dedup_summary"]["created_findings"] == 2
+    assert {
+        item["asset_ref"] for item in payload["summary_json"]["dedup_summary"]["decisions"]
+    } == {"build-host-1", "build-host-2"}
+
+    findings, occurrence_count = _finding_state(template_api_env, project_id)
+    assert len(findings) == 2
+    assert occurrence_count == 2
+    assert len({finding.dedup_key for finding in findings}) == 2
 
 
 @pytest.mark.parametrize(
@@ -215,3 +334,25 @@ def _run_count(template_api_env: TemplateApiEnv, project_id: uuid.UUID) -> int:
         return len(
             template_api_env.repositories.RunRepository(session).list_analysis_runs(project_id)
         )
+
+
+def _finding_state(
+    template_api_env: TemplateApiEnv,
+    project_id: uuid.UUID,
+) -> tuple[list[app_models.Finding], int]:
+    with Session(template_api_env.engine) as session:
+        findings = list(
+            session.exec(
+                select(app_models.Finding)
+                .where(app_models.Finding.project_id == project_id)
+                .order_by(app_models.Finding.cve_id)
+            )
+        )
+        occurrence_count = len(
+            session.exec(
+                select(app_models.FindingOccurrence)
+                .join(app_models.Finding)
+                .where(app_models.Finding.project_id == project_id)
+            ).all()
+        )
+        return findings, occurrence_count

--- a/docs/architecture/analysis-run-provider-schema.md
+++ b/docs/architecture/analysis-run-provider-schema.md
@@ -140,6 +140,33 @@ Constraints and indexes:
 `grype`. `raw_reference` preserves the scanner or input reference needed for
 auditable traceability.
 
+## Import Deduplication
+
+Template import persistence uses a stable finding dedup key before each
+occurrence is attached to a run. The key material is:
+
+- `project_id`
+- CVE/source identifier, preferring importer `source_id` when present and
+  falling back to the normalized CVE
+- component identity, preferring PURL and falling back to
+  component/version/package type
+- `asset_ref`, or an explicit empty marker when no asset is present
+
+The stored `finding.dedup_key` is a `vpw019:` SHA-256 digest of that canonical
+material. The unhashed parts are written to `analysis_run.summary_json` under
+`dedup_summary.decisions` so each import run records whether a finding was
+created or reused. Re-importing the same normalized occurrences therefore adds
+new `finding_occurrence` rows for the new run while keeping the existing
+`finding.first_seen_at` and updating `finding.last_seen_at`.
+
+Edge cases:
+
+- The same CVE on a different asset is a different finding.
+- The same CVE on the same asset but a different PURL or component identity is
+  a different finding.
+- A missing component or asset participates in the key through an explicit
+  `__none__` marker, so minimal CVE-list uploads deduplicate across runs.
+
 ## Relationship Contract
 
 The expected graph is:

--- a/docs/architecture/core-workbench-schema.md
+++ b/docs/architecture/core-workbench-schema.md
@@ -144,6 +144,14 @@ Constraints and indexes:
 - index on `(project_id, status)`
 - indexes on `(project_id, asset_id)` and `(project_id, vulnerability_id)`
 
+The import path uses `(project_id, dedup_key)` as the primary duplicate guard.
+The key is deterministic for normalized input occurrences and uses project,
+CVE/source identifier, component identity, and asset reference. PURL is the
+preferred component identity; otherwise the key falls back to component name,
+version, and package type. Missing component or asset context is represented by
+an explicit empty marker so repeated minimal CVE-list imports reuse the same
+finding instead of relying on SQL NULL uniqueness behavior.
+
 ## Persistence Contract
 
 A single project must be able to persist and retrieve a connected graph:


### PR DESCRIPTION
## Summary
- add deterministic VPW-019 finding dedup keys based on project, CVE/source id, component/PURL identity, and asset ref
- persist dedup decisions in finding evidence, occurrence evidence, and run summary_json
- add duplicate-import and same-CVE/different-asset integration coverage, plus docs for edge cases and DB constraint evidence

## Issue
- Addresses #125
- Stacked on #212 / branch `codex/vpw-018-import-upload-api` because VPW-019 depends on the VPW-018 import upload endpoint.

## Verification
- `python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py backend/tests/api/test_template_core_workbench_models.py --no-cov` -> 14 passed
- `make check` -> 636 passed, 2 skipped, coverage 90.19%
- `make docs-check` -> passed; pre-existing mkdocs info: `architecture/vpw-011-api-skeleton.md` is not in nav
- `make frontend-generate-client && make frontend-lint && make frontend-build` -> passed, no generated client diff
- `make docker-demo-smoke` -> passed

## Evidence Notes
- No Alembic migration needed: existing template schema already has `uq_finding_project_dedup_key` on `(project_id, dedup_key)` and finding occurrences are already modeled per run.
- Residual risk: existing pre-VPW-019 local template DB rows may have random dedup keys; the import path now repairs matching identity rows when touched, but this PR does not include a historical backfill migration.
