### PR TITLE
VPW-022: define provider enrichment contract

### DIFF
--- a/backend/src/vuln_prioritizer/models.py
+++ b/backend/src/vuln_prioritizer/models.py
@@ -38,7 +38,12 @@ KevData = _models_provider.KevData
 NvdData = _models_provider.NvdData
 ParsedInput = _models_input.ParsedInput
 ProviderEvidence = _models_provider.ProviderEvidence
+ProviderCacheContract = _models_provider.ProviderCacheContract
+ProviderDataQualityFlag = _models_provider.ProviderDataQualityFlag
+ProviderEnrichmentResult = _models_provider.ProviderEnrichmentResult
 ProviderLookupDiagnostics = _models_provider.ProviderLookupDiagnostics
+ProviderSnapshot = _models_provider.ProviderSnapshot
+ProviderStatus = _models_provider.ProviderStatus
 RemediationComponent = _models_remediation.RemediationComponent
 RemediationPlan = _models_remediation.RemediationPlan
 

--- a/backend/src/vuln_prioritizer/models_provider.py
+++ b/backend/src/vuln_prioritizer/models_provider.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Literal
+
 from pydantic import Field
 
 from vuln_prioritizer.model_base import StrictModel
@@ -77,3 +79,55 @@ class ProviderLookupDiagnostics(StrictModel):
     empty_records: int = 0
     stale_cache_hits: int = 0
     degraded: bool = False
+
+
+class ProviderDataQualityFlag(StrictModel):
+    source: str
+    code: str
+    message: str
+    severity: Literal["info", "warning", "error"] = "warning"
+    cve_id: str | None = None
+
+
+class ProviderCacheContract(StrictModel):
+    source: str
+    cache_enabled: bool = False
+    namespace: str | None = None
+    key_template: str | None = None
+    ttl_seconds: int | None = None
+    stale_while_error: bool = True
+
+
+class ProviderStatus(StrictModel):
+    source: str
+    last_sync: str | None = None
+    requested: int = 0
+    cache_hit: bool = False
+    cache_miss: bool = False
+    cache_hits: int = 0
+    cache_misses: int = 0
+    stale_cache_hits: int = 0
+    network_fetches: int = 0
+    failures: int = 0
+    content_hits: int = 0
+    empty_records: int = 0
+    degraded: bool = False
+    cache: ProviderCacheContract
+    data_quality_flags: list[ProviderDataQualityFlag] = Field(default_factory=list)
+
+
+class ProviderSnapshot(StrictModel):
+    source: str
+    generated_at: str
+    requested_cves: int = 0
+    content_hits: int = 0
+    record_keys: list[str] = Field(default_factory=list)
+    status: ProviderStatus
+
+
+class ProviderEnrichmentResult(StrictModel):
+    source: str
+    records: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+    status: ProviderStatus
+    snapshot: ProviderSnapshot

--- a/backend/src/vuln_prioritizer/providers/sdk.py
+++ b/backend/src/vuln_prioritizer/providers/sdk.py
@@ -7,7 +7,7 @@ points, importing user supplied paths, or fetching executable code.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
@@ -15,9 +15,18 @@ import requests
 
 from vuln_prioritizer.cache import FileCache
 from vuln_prioritizer.config import DEFAULT_NVD_API_KEY_ENV
+from vuln_prioritizer.models_provider import (
+    ProviderCacheContract,
+    ProviderDataQualityFlag,
+    ProviderEnrichmentResult,
+    ProviderLookupDiagnostics,
+    ProviderSnapshot,
+    ProviderStatus,
+)
 from vuln_prioritizer.providers.epss import EpssProvider
 from vuln_prioritizer.providers.kev import KevProvider
 from vuln_prioritizer.providers.nvd import NvdProvider
+from vuln_prioritizer.utils import iso_utc_now
 
 STATIC_PROVIDER_EXTENSION_POLICY = "static-local-only"
 ProviderFetchResult = tuple[Mapping[str, Any], list[str]]
@@ -32,6 +41,19 @@ class CveProvider(Protocol):
         """Return provider data keyed by CVE identifier."""
 
 
+class ProviderEnrichmentClient(Protocol):
+    """Uniform enrichment service contract exposed to analysis flows."""
+
+    @property
+    def source(self) -> str:
+        """Stable provider source name."""
+        ...
+
+    def enrich(self, cve_ids: Sequence[str], **kwargs: Any) -> ProviderEnrichmentResult:
+        """Return provider records, status, snapshot DTO, and data-quality flags."""
+        ...
+
+
 @dataclass(frozen=True)
 class ProviderDefinition:
     """Declarative contract for a locally registered enrichment provider."""
@@ -40,8 +62,77 @@ class ProviderDefinition:
     provider: CveProvider
     source_kind: str
     cache_namespace: str | None = None
+    cache_key_template: str | None = "{cve_id}"
+    cache_ttl_seconds: int | None = None
+    stale_while_error: bool = True
     offline_capable: bool = False
     remote_code_loading: bool = False
+
+
+@dataclass(frozen=True)
+class ProviderClientAdapter:
+    """Adapter that exposes the VPW provider service contract over fetch_many providers."""
+
+    definition: ProviderDefinition
+    cache: FileCache | None = None
+
+    @property
+    def source(self) -> str:
+        return self.definition.name
+
+    def enrich(self, cve_ids: Sequence[str], **kwargs: Any) -> ProviderEnrichmentResult:
+        """Enrich CVEs without letting provider failures abort the caller."""
+
+        requested_cves = list(cve_ids)
+        completed_at = iso_utc_now()
+        warnings: list[str]
+        records: Mapping[str, Any]
+        try:
+            records, warnings = self.definition.provider.fetch_many(requested_cves, **kwargs)
+            diagnostics = provider_diagnostics_from_any(
+                getattr(self.definition.provider, "last_diagnostics", None),
+                requested_count=len(requested_cves),
+                record_count=len(records),
+            )
+        except Exception as exc:  # noqa: BLE001 - provider contract degrades by design
+            records = {}
+            warnings = [f"{self.source} provider failed: {exc}"]
+            diagnostics = ProviderLookupDiagnostics(
+                requested=len(requested_cves),
+                failures=len(requested_cves) or 1,
+                empty_records=len(requested_cves),
+                degraded=True,
+            )
+
+        cache_contract = provider_cache_contract(self.definition, cache=self.cache)
+        flags = provider_data_quality_flags(
+            source=self.source,
+            diagnostics=diagnostics,
+            warnings=warnings,
+        )
+        status = provider_status_from_diagnostics(
+            source=self.source,
+            diagnostics=diagnostics,
+            cache_contract=cache_contract,
+            cache=self.cache,
+            completed_at=completed_at,
+            data_quality_flags=flags,
+        )
+        snapshot = ProviderSnapshot(
+            source=self.source,
+            generated_at=completed_at,
+            requested_cves=len(requested_cves),
+            content_hits=status.content_hits,
+            record_keys=sorted(str(key) for key in records),
+            status=status,
+        )
+        return ProviderEnrichmentResult(
+            source=self.source,
+            records=dict(records),
+            warnings=list(warnings),
+            status=status,
+            snapshot=snapshot,
+        )
 
 
 def validate_provider_definition(definition: ProviderDefinition) -> None:
@@ -49,6 +140,15 @@ def validate_provider_definition(definition: ProviderDefinition) -> None:
 
     if not definition.name or definition.name.strip() != definition.name:
         raise ValueError("Provider names must be non-empty and trimmed.")
+    if definition.cache_namespace is not None and (
+        not definition.cache_namespace
+        or definition.cache_namespace.strip() != definition.cache_namespace
+    ):
+        raise ValueError("Provider cache namespaces must be non-empty and trimmed.")
+    if definition.cache_key_template is not None and not definition.cache_key_template.strip():
+        raise ValueError("Provider cache key templates must not be blank.")
+    if definition.cache_ttl_seconds is not None and definition.cache_ttl_seconds < 0:
+        raise ValueError("Provider cache TTL must not be negative.")
     if definition.remote_code_loading:
         raise ValueError("Provider definitions must not load remote code.")
     if not hasattr(definition.provider, "fetch_many"):
@@ -67,6 +167,19 @@ def build_provider_registry(
             raise ValueError(f"Duplicate provider name: {definition.name}")
         registry[definition.name] = definition
     return registry
+
+
+def build_provider_clients(
+    definitions: tuple[ProviderDefinition, ...],
+    *,
+    cache: FileCache | None = None,
+) -> Mapping[str, ProviderEnrichmentClient]:
+    """Build uniform enrichment clients from static provider definitions."""
+
+    return {
+        name: ProviderClientAdapter(definition=definition, cache=cache)
+        for name, definition in build_provider_registry(definitions).items()
+    }
 
 
 def builtin_provider_definitions(
@@ -91,6 +204,7 @@ def builtin_provider_definitions(
             ),
             source_kind="nvd",
             cache_namespace="nvd",
+            cache_key_template="{cve_id}",
             offline_capable=True,
         ),
         ProviderDefinition(
@@ -98,6 +212,7 @@ def builtin_provider_definitions(
             provider=cast(CveProvider, EpssProvider(session=shared_session, cache=cache)),
             source_kind="epss",
             cache_namespace="epss",
+            cache_key_template="{cve_id}",
             offline_capable=True,
         ),
         ProviderDefinition(
@@ -105,17 +220,171 @@ def builtin_provider_definitions(
             provider=cast(CveProvider, KevProvider(session=shared_session, cache=cache)),
             source_kind="kev",
             cache_namespace="kev",
+            cache_key_template="catalog",
             offline_capable=True,
         ),
     )
 
 
+def provider_cache_contract(
+    definition: ProviderDefinition,
+    *,
+    cache: FileCache | None = None,
+) -> ProviderCacheContract:
+    """Return the declared cache contract for a provider definition."""
+
+    ttl_seconds = definition.cache_ttl_seconds
+    if ttl_seconds is None and cache is not None:
+        ttl_seconds = int(cache.ttl.total_seconds())
+    return ProviderCacheContract(
+        source=definition.name,
+        cache_enabled=cache is not None and definition.cache_namespace is not None,
+        namespace=definition.cache_namespace,
+        key_template=definition.cache_key_template,
+        ttl_seconds=ttl_seconds,
+        stale_while_error=definition.stale_while_error,
+    )
+
+
+def provider_status_from_diagnostics(
+    *,
+    source: str,
+    diagnostics: ProviderLookupDiagnostics,
+    cache_contract: ProviderCacheContract,
+    completed_at: str,
+    data_quality_flags: Sequence[ProviderDataQualityFlag] = (),
+    cache: FileCache | None = None,
+) -> ProviderStatus:
+    """Build the source status DTO from normalized lookup diagnostics."""
+
+    latest_cached_at = None
+    if cache is not None and cache_contract.namespace:
+        latest_cached_at = cache.latest_cached_at(cache_contract.namespace)
+    cache_misses = max(diagnostics.requested - diagnostics.cache_hits, 0)
+    return ProviderStatus(
+        source=source,
+        last_sync=latest_cached_at or completed_at,
+        requested=diagnostics.requested,
+        cache_hit=diagnostics.cache_hits > 0 or diagnostics.stale_cache_hits > 0,
+        cache_miss=cache_misses > 0,
+        cache_hits=diagnostics.cache_hits,
+        cache_misses=cache_misses,
+        stale_cache_hits=diagnostics.stale_cache_hits,
+        network_fetches=diagnostics.network_fetches,
+        failures=diagnostics.failures,
+        content_hits=diagnostics.content_hits,
+        empty_records=diagnostics.empty_records,
+        degraded=diagnostics.degraded or diagnostics.failures > 0,
+        cache=cache_contract,
+        data_quality_flags=list(data_quality_flags),
+    )
+
+
+def provider_data_quality_flags(
+    *,
+    source: str,
+    diagnostics: ProviderLookupDiagnostics,
+    warnings: Sequence[str] = (),
+) -> list[ProviderDataQualityFlag]:
+    """Convert recoverable provider problems into data-quality flags."""
+
+    flags: list[ProviderDataQualityFlag] = []
+    if diagnostics.failures:
+        flags.append(
+            ProviderDataQualityFlag(
+                source=source,
+                code="provider_failure",
+                message=f"{source} lookup degraded with {diagnostics.failures} failure(s).",
+            )
+        )
+    if diagnostics.stale_cache_hits:
+        flags.append(
+            ProviderDataQualityFlag(
+                source=source,
+                code="stale_cache",
+                message=(
+                    f"{source} used expired cached data for "
+                    f"{diagnostics.stale_cache_hits} requested CVE(s)."
+                ),
+            )
+        )
+    for warning in warnings:
+        flags.append(
+            ProviderDataQualityFlag(
+                source=source,
+                code="provider_warning",
+                message=str(warning),
+            )
+        )
+    if diagnostics.degraded and not flags:
+        flags.append(
+            ProviderDataQualityFlag(
+                source=source,
+                code="provider_degraded",
+                message=f"{source} provider marked the lookup as degraded.",
+            )
+        )
+    return flags
+
+
+def provider_diagnostics_from_any(
+    value: Any,
+    *,
+    requested_count: int,
+    record_count: int = 0,
+) -> ProviderLookupDiagnostics:
+    """Normalize provider-specific diagnostics into the shared DTO."""
+
+    content_hits = _int_attr(value, "content_hits", record_count)
+    empty_records = _int_attr(value, "empty_records", max(requested_count - content_hits, 0))
+    failures = _int_attr(value, "failures", 0)
+    stale_cache_hits = _int_attr(value, "stale_cache_hits", 0)
+    degraded = _bool_attr(value, "degraded", failures > 0 or stale_cache_hits > 0)
+    return ProviderLookupDiagnostics(
+        requested=_int_attr(value, "requested", requested_count),
+        cache_hits=_int_attr(value, "cache_hits", 0),
+        network_fetches=_int_attr(value, "network_fetches", 0),
+        failures=failures,
+        content_hits=content_hits,
+        empty_records=empty_records,
+        stale_cache_hits=stale_cache_hits,
+        degraded=degraded,
+    )
+
+
+def _int_attr(value: Any, name: str, default: int) -> int:
+    try:
+        raw = getattr(value, name)
+    except AttributeError:
+        raw = default
+    if raw is None:
+        return default
+    return int(raw)
+
+
+def _bool_attr(value: Any, name: str, default: bool) -> bool:
+    try:
+        raw = getattr(value, name)
+    except AttributeError:
+        raw = default
+    if raw is None:
+        return default
+    return bool(raw)
+
+
 __all__ = [
     "CveProvider",
+    "ProviderClientAdapter",
     "ProviderDefinition",
+    "ProviderEnrichmentClient",
     "ProviderFetchResult",
     "STATIC_PROVIDER_EXTENSION_POLICY",
+    "build_provider_clients",
     "build_provider_registry",
     "builtin_provider_definitions",
+    "provider_cache_contract",
+    "provider_data_quality_flags",
+    "provider_diagnostics_from_any",
+    "provider_status_from_diagnostics",
     "validate_provider_definition",
 ]

--- a/backend/tests/test_provider_contract.py
+++ b/backend/tests/test_provider_contract.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vuln_prioritizer.cache import FileCache
+from vuln_prioritizer.models import ProviderLookupDiagnostics
+from vuln_prioritizer.providers.sdk import (
+    ProviderClientAdapter,
+    ProviderDefinition,
+    build_provider_clients,
+    provider_cache_contract,
+    validate_provider_definition,
+)
+
+
+class FakeProvider:
+    def __init__(
+        self,
+        *,
+        diagnostics: ProviderLookupDiagnostics | None = None,
+        warnings: list[str] | None = None,
+    ) -> None:
+        self.last_diagnostics = diagnostics or ProviderLookupDiagnostics()
+        self.warnings = warnings or []
+        self.calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def fetch_many(
+        self,
+        cve_ids: Sequence[str],
+        **kwargs: Any,
+    ) -> tuple[Mapping[str, Any], list[str]]:
+        self.calls.append((list(cve_ids), kwargs))
+        return ({cve_id: {"source": kwargs.get("source", "fake")} for cve_id in cve_ids}, [])
+
+
+class WarningProvider(FakeProvider):
+    def fetch_many(
+        self,
+        cve_ids: Sequence[str],
+        **kwargs: Any,
+    ) -> tuple[Mapping[str, Any], list[str]]:
+        self.calls.append((list(cve_ids), kwargs))
+        return ({cve_id: {"source": "stale"} for cve_id in cve_ids}, self.warnings)
+
+
+class ExplodingProvider:
+    last_diagnostics = ProviderLookupDiagnostics()
+
+    def fetch_many(
+        self,
+        cve_ids: Sequence[str],
+        **kwargs: Any,
+    ) -> tuple[Mapping[str, Any], list[str]]:
+        raise RuntimeError("provider offline")
+
+
+def test_provider_client_adapter_exposes_enrich_status_and_snapshot_contract(
+    tmp_path: Path,
+) -> None:
+    cache = FileCache(tmp_path / "cache", ttl_hours=2)
+    cache.set_json("fake", "CVE-2026-0001", {"cached": True})
+    provider = FakeProvider(
+        diagnostics=ProviderLookupDiagnostics(
+            requested=2,
+            cache_hits=1,
+            network_fetches=1,
+            content_hits=2,
+        )
+    )
+    definition = ProviderDefinition(
+        name="fake",
+        provider=provider,
+        source_kind="fixture",
+        cache_namespace="fake",
+        cache_key_template="{cve_id}",
+    )
+
+    result = ProviderClientAdapter(definition=definition, cache=cache).enrich(
+        ["CVE-2026-0001", "CVE-2026-0002"],
+        refresh=True,
+        source="unit-test",
+    )
+
+    assert provider.calls == [
+        (
+            ["CVE-2026-0001", "CVE-2026-0002"],
+            {"refresh": True, "source": "unit-test"},
+        )
+    ]
+    assert result.source == "fake"
+    assert result.status.source == "fake"
+    assert result.status.last_sync == cache.latest_cached_at("fake")
+    assert result.status.cache_hit is True
+    assert result.status.cache_miss is True
+    assert result.status.cache_hits == 1
+    assert result.status.cache_misses == 1
+    assert result.status.data_quality_flags == []
+    assert result.status.cache.namespace == "fake"
+    assert result.status.cache.key_template == "{cve_id}"
+    assert result.status.cache.ttl_seconds == 7200
+    assert result.snapshot.source == "fake"
+    assert result.snapshot.requested_cves == 2
+    assert result.snapshot.content_hits == 2
+    assert result.snapshot.record_keys == ["CVE-2026-0001", "CVE-2026-0002"]
+
+
+def test_provider_clients_share_enrich_contract_for_nvd_epss_and_kev() -> None:
+    definitions = tuple(
+        ProviderDefinition(
+            name=name,
+            provider=FakeProvider(
+                diagnostics=ProviderLookupDiagnostics(
+                    requested=1,
+                    network_fetches=1,
+                    content_hits=1,
+                )
+            ),
+            source_kind=name,
+            cache_namespace=name,
+            cache_key_template="catalog" if name == "kev" else "{cve_id}",
+        )
+        for name in ("nvd", "epss", "kev")
+    )
+
+    clients = build_provider_clients(definitions)
+
+    assert set(clients) == {"nvd", "epss", "kev"}
+    for source, client in clients.items():
+        result = client.enrich(["CVE-2026-0001"])
+        assert result.source == source
+        assert result.status.source == source
+        assert result.status.network_fetches == 1
+        assert result.status.content_hits == 1
+        assert result.snapshot.record_keys == ["CVE-2026-0001"]
+
+
+def test_provider_failure_becomes_data_quality_flags_without_abort() -> None:
+    definition = ProviderDefinition(
+        name="nvd",
+        provider=ExplodingProvider(),
+        source_kind="nvd",
+        cache_namespace="nvd",
+    )
+
+    result = ProviderClientAdapter(definition=definition).enrich(["CVE-2026-0001"])
+
+    assert result.records == {}
+    assert result.warnings == ["nvd provider failed: provider offline"]
+    assert result.status.degraded is True
+    assert result.status.failures == 1
+    assert result.status.empty_records == 1
+    assert [flag.code for flag in result.status.data_quality_flags] == [
+        "provider_failure",
+        "provider_warning",
+    ]
+    assert result.status.data_quality_flags[0].message == "nvd lookup degraded with 1 failure(s)."
+
+
+def test_stale_cache_diagnostics_become_data_quality_flags() -> None:
+    provider = WarningProvider(
+        diagnostics=ProviderLookupDiagnostics(
+            requested=1,
+            failures=1,
+            content_hits=1,
+            stale_cache_hits=1,
+            degraded=True,
+        ),
+        warnings=["EPSS lookup failed; using expired cached data"],
+    )
+    definition = ProviderDefinition(
+        name="epss",
+        provider=provider,
+        source_kind="epss",
+        cache_namespace="epss",
+    )
+
+    result = ProviderClientAdapter(definition=definition).enrich(["CVE-2026-0001"])
+
+    assert result.records == {"CVE-2026-0001": {"source": "stale"}}
+    assert result.status.cache_hit is True
+    assert result.status.stale_cache_hits == 1
+    assert result.status.degraded is True
+    assert [flag.code for flag in result.status.data_quality_flags] == [
+        "provider_failure",
+        "stale_cache",
+        "provider_warning",
+    ]
+
+
+def test_provider_cache_contract_validation() -> None:
+    provider = FakeProvider()
+    definition = ProviderDefinition(
+        name="kev",
+        provider=provider,
+        source_kind="kev",
+        cache_namespace="kev",
+        cache_key_template="catalog",
+        cache_ttl_seconds=3600,
+        stale_while_error=True,
+    )
+
+    validate_provider_definition(definition)
+    contract = provider_cache_contract(definition)
+
+    assert contract.source == "kev"
+    assert contract.cache_enabled is False
+    assert contract.namespace == "kev"
+    assert contract.key_template == "catalog"
+    assert contract.ttl_seconds == 3600
+    assert contract.stale_while_error is True
+
+    with pytest.raises(ValueError, match="cache TTL"):
+        validate_provider_definition(
+            ProviderDefinition(
+                name="bad",
+                provider=provider,
+                source_kind="fixture",
+                cache_ttl_seconds=-1,
+            )
+        )

--- a/docs/architecture/analysis-run-provider-schema.md
+++ b/docs/architecture/analysis-run-provider-schema.md
@@ -223,6 +223,89 @@ nullable for that reason.
 }
 ```
 
+## Provider Enrichment Service Contract
+
+VPW-022 defines the provider service boundary used by provider enrichment code.
+Existing NVD, EPSS, and KEV clients still own their source-specific
+`fetch_many(...)` implementation, but callers can use the shared
+`ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` contract through
+`ProviderClientAdapter`.
+
+The shared result contains:
+
+- `records`: provider records keyed by CVE
+- `warnings`: provider warnings suitable for report metadata
+- `status`: source status with `source`, `last_sync`, `cache_hit`,
+  `cache_miss`, `cache_hits`, `cache_misses`, `stale_cache_hits`,
+  `network_fetches`, `failures`, `content_hits`, `empty_records`, and
+  `degraded`
+- `snapshot`: in-memory DTO with `source`, `generated_at`, `requested_cves`,
+  `content_hits`, `record_keys`, and the same status object
+- `data_quality_flags`: stored under `status.data_quality_flags`
+
+Provider failures must degrade into status and data-quality flags rather than
+aborting the caller by default. Optional CLI or workflow gates may still fail a
+pipeline after output is written, but the provider contract must first preserve
+the failure as structured evidence.
+
+Example status DTO:
+
+```json
+{
+  "source": "epss",
+  "last_sync": "2026-04-29T10:15:00+00:00",
+  "requested": 1,
+  "cache_hit": true,
+  "cache_miss": false,
+  "cache_hits": 0,
+  "cache_misses": 0,
+  "stale_cache_hits": 1,
+  "network_fetches": 0,
+  "failures": 1,
+  "content_hits": 1,
+  "empty_records": 0,
+  "degraded": true,
+  "cache": {
+    "source": "epss",
+    "cache_enabled": true,
+    "namespace": "epss",
+    "key_template": "{cve_id}",
+    "ttl_seconds": 86400,
+    "stale_while_error": true
+  },
+  "data_quality_flags": [
+    {
+      "source": "epss",
+      "code": "stale_cache",
+      "message": "epss used expired cached data for 1 requested CVE(s).",
+      "severity": "warning",
+      "cve_id": null
+    }
+  ]
+}
+```
+
+Cache contract:
+
+- NVD and EPSS use cache namespace `nvd` / `epss` and a raw key template of
+  `{cve_id}`; the filesystem cache hashes that raw key before writing JSON.
+- KEV uses namespace `kev` and key template `catalog`.
+- TTL comes from `FileCache.ttl` unless a provider definition overrides
+  `cache_ttl_seconds`.
+- Expired cache entries are not returned for normal reads. Providers may retry
+  with `allow_expired=True` after live lookup failure and must mark the status
+  with `stale_cache_hits` plus data-quality flags.
+
+Timeout and retry contract:
+
+- NVD and EPSS use `HTTP_TIMEOUT_SECONDS` and `HTTP_MAX_RETRIES`.
+- NVD retries transient HTTP status codes with response-aware backoff.
+- EPSS retries transient HTTP status codes with bounded incremental delay.
+- KEV uses the shared timeout and falls back from the CISA feed to the GitHub
+  mirror before reporting degraded catalog status.
+- CI tests for this contract use fake providers or monkeypatched provider
+  methods only; required tests must not depend on live provider availability.
+
 ## Migration Contract
 
 The template Alembic head under `backend/app/alembic` must create the three

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -185,6 +185,9 @@ Terminal tables, panels, warning phrasing, and Markdown table layout are intenti
 
 NVD, EPSS, and KEV remain live/cache-backed data sources.
 
+The shared provider enrichment contract is documented in
+[VPW-022 Provider Cache, Status and Snapshots](vpw-022-provider-cache-status-snapshots.md).
+
 The current `data` command tree is intentionally small:
 
 - `data status` inspects namespace counts, timestamps, and local ATT&CK metadata

--- a/docs/architecture/vpw-022-provider-cache-status-snapshots.md
+++ b/docs/architecture/vpw-022-provider-cache-status-snapshots.md
@@ -1,0 +1,82 @@
+# VPW-022 Provider Cache, Status and Snapshots
+
+## Scope
+
+VPW-022 defines the provider enrichment service contract for NVD, EPSS, and KEV.
+It does not add a scanner, change scoring, add a provider API route, or change
+provider snapshot persistence.
+
+The source-specific provider implementations still own `fetch_many(...)`.
+Callers that need a uniform boundary use
+`ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` through
+`ProviderClientAdapter`.
+
+## Provider Service Result
+
+`enrich(...)` returns a `ProviderEnrichmentResult` with:
+
+- `source`: provider source name, such as `nvd`, `epss`, or `kev`
+- `records`: provider records keyed by CVE
+- `warnings`: provider warnings preserved as evidence
+- `status`: `ProviderStatus` DTO
+- `snapshot`: in-memory `ProviderSnapshot` DTO for the lookup
+
+Provider failures are data-quality evidence. The adapter catches provider
+exceptions and returns degraded status plus `provider_failure` and
+`provider_warning` flags. It does not abort the caller by default.
+
+## Provider Status DTO
+
+`ProviderStatus` exposes:
+
+- `source`
+- `last_sync`
+- `requested`
+- `cache_hit` / `cache_miss`
+- `cache_hits`, `cache_misses`, `stale_cache_hits`
+- `network_fetches`, `failures`, `content_hits`, `empty_records`
+- `degraded`
+- `cache`
+- `data_quality_flags`
+
+`last_sync` is the latest provider cache timestamp when cache metadata exists.
+Otherwise it is the lookup completion timestamp. Consumers must inspect
+`degraded`, `failures`, `stale_cache_hits`, and `data_quality_flags` before
+treating the data as fresh.
+
+## Cache Contract
+
+The cache contract is explicit in `ProviderCacheContract`:
+
+- NVD namespace: `nvd`, key template `{cve_id}`
+- EPSS namespace: `epss`, key template `{cve_id}`
+- KEV namespace: `kev`, key template `catalog`
+- TTL comes from `FileCache.ttl` unless a provider definition overrides it with
+  `cache_ttl_seconds`
+- `stale_while_error` means a provider may retry with expired cache after a
+  live lookup failure
+
+The filesystem cache hashes the raw key before writing JSON files. The raw key
+template is still part of the contract so snapshots and status evidence can be
+reviewed without depending on filesystem paths.
+
+## Timeout and Retry
+
+- NVD uses the shared HTTP timeout, retries transient 429/5xx responses, and
+  applies response-aware backoff.
+- EPSS uses the shared HTTP timeout, chunks requests by URL length, and retries
+  transient 429/5xx responses with bounded incremental delay.
+- KEV uses the shared HTTP timeout and falls back from the CISA feed to the
+  GitHub mirror before reporting degraded catalog status.
+
+CI tests for this contract must use fake providers, cached fixtures, or
+monkeypatched provider methods. Required tests must not depend on NVD, FIRST, or
+CISA availability.
+
+## Persistence Boundary
+
+This contract is in-memory and service-facing. Durable provider snapshot tables
+remain governed by [Analysis Run Provider Schema](analysis-run-provider-schema.md).
+Adding a public `/api/v1/providers/...` route, a new durable status table, or a
+new OpenAPI response model is a separate issue and must regenerate client/schema
+artifacts as needed.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -243,6 +243,22 @@ Current provider freshness contract:
 - locked provider-snapshot replay uses the snapshot `generated_at` timestamp for selected snapshot sources
 - analysis-style metadata may include `provider_freshness`, `max_provider_age_hours`, `provider_stale`, and `provider_stale_sources`
 
+### Provider enrichment service
+
+Current provider service contract:
+
+- built-in NVD, EPSS, and KEV providers can be adapted to the shared
+  `ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` interface
+- provider failures degrade into `ProviderStatus` and data-quality flags before
+  optional CI gates decide whether to fail the process
+- `ProviderStatus` includes `source`, `last_sync`, `cache_hit`, `cache_miss`,
+  cache counters, stale-cache counters, network/failure counters, and
+  `data_quality_flags`
+- cache contract metadata includes namespace, raw key template, TTL seconds,
+  and whether expired cache may be used on provider failure
+- required tests for this contract use fake providers or monkeypatching, not
+  live provider APIs
+
 ### Defensive context semantics
 
 Current defensive-context contract:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Model Import Registry: architecture/model-imports.md
       - Core Workbench Schema: architecture/core-workbench-schema.md
       - Analysis Run Provider Schema: architecture/analysis-run-provider-schema.md
+      - Provider Cache Status Snapshots: architecture/vpw-022-provider-cache-status-snapshots.md
       - Template Repository Layer: architecture/template-service-layer.md
       - Template Importer Contract: architecture/vpw-013-importer-contract.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md


### PR DESCRIPTION
Addresses #128.

Stacked on VPW-021 / PR #215 (`codex/vpw-021-parser-fixture-matrix`).

## Scope
- Adds `ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` and `ProviderClientAdapter` over existing `fetch_many` providers.
- Adds provider DTOs: `ProviderCacheContract`, `ProviderDataQualityFlag`, `ProviderStatus`, `ProviderSnapshot`, and `ProviderEnrichmentResult`.
- Extends provider definitions with cache key template, TTL, and stale-while-error policy metadata.
- Converts provider failures and stale-cache diagnostics into data-quality flags instead of aborting callers.
- Adds offline unit tests for the provider contract, shared NVD/EPSS/KEV client shape, failure degradation, stale-cache flags, and cache contract validation.
- Adds VPW-022 architecture docs and contracts notes for cache keys, TTL, stale handling, timeout, and retry behavior.

## Validation
- `python3 -m pytest -q backend/tests/test_provider_contract.py --no-cov` -> 5 passed
- `python3 -m pytest -q backend/tests/test_provider_contract.py backend/tests/test_extension_sdk.py backend/tests/test_providers.py --no-cov` -> 33 passed
- `python3 -m ruff check backend/src/vuln_prioritizer/models_provider.py backend/src/vuln_prioritizer/models.py backend/src/vuln_prioritizer/providers/sdk.py backend/tests/test_provider_contract.py` -> passed
- `python3 -m mypy backend/src/vuln_prioritizer/models_provider.py backend/src/vuln_prioritizer/providers/sdk.py backend/tests/test_provider_contract.py` -> passed
- `git diff --check` -> passed
- `make docs-check` -> passed
- `make check` -> 651 passed, 2 skipped, coverage 90.22%

## Notes
- No OpenAPI/client generation needed because no provider API route or response model was added.
- No DB migration needed; this is an in-memory SDK/DTO contract and docs/test slice.
- CI-required tests remain offline/fake-provider based and do not depend on live NVD/FIRST/CISA availability.