### PR TITLE
VPW-024: implement KEV provider cache evidence

### DIFF
--- a/backend/src/vuln_prioritizer/api/schemas.py
+++ b/backend/src/vuln_prioritizer/api/schemas.py
@@ -247,6 +247,20 @@ class FindingStatusHistoryResponse(StrictModel):
     created_at: str
 
 
+class KevDetailResponse(StrictModel):
+    cve_id: str
+    in_kev: bool = False
+    vendor_project: str | None = None
+    product: str | None = None
+    vulnerability_name: str | None = None
+    short_description: str | None = None
+    date_added: str | None = None
+    required_action: str | None = None
+    due_date: str | None = None
+    known_ransomware_campaign_use: str | None = None
+    notes: str | None = None
+
+
 class AuditEventResponse(StrictModel):
     id: str
     project_id: str | None = None
@@ -374,6 +388,10 @@ class FindingResponse(StrictModel):
     status_history: list[FindingStatusHistoryResponse] | None = None
 
 
+class FindingDetailResponse(FindingResponse):
+    kev_detail: KevDetailResponse | None = None
+
+
 class FindingsListResponse(StrictModel):
     items: list[FindingResponse] = Field(default_factory=list)
     total: int
@@ -422,6 +440,7 @@ class ProviderStatusResponse(StrictModel):
     status: str
     snapshot: ProviderSnapshotStatus
     sources: list[ProviderSourceStatus] = Field(default_factory=list)
+    latest_update_job: ProviderUpdateJobResponse | None = None
     cache_dir: str
     snapshot_dir: str
     warnings: list[str] = Field(default_factory=list)

--- a/backend/src/vuln_prioritizer/api/workbench_import_routes.py
+++ b/backend/src/vuln_prioritizer/api/workbench_import_routes.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from vuln_prioritizer.api.deps import get_db_session, get_workbench_settings
 from vuln_prioritizer.api.schemas import (
     AnalysisRunResponse,
-    FindingResponse,
+    FindingDetailResponse,
     FindingsListResponse,
     FindingStatusUpdateRequest,
 )
@@ -335,7 +335,7 @@ def list_findings(
     }
 
 
-@router.get("/findings/{finding_id}")
+@router.get("/findings/{finding_id}", response_model=FindingDetailResponse)
 def get_finding(
     finding_id: str,
     session: Annotated[Session, Depends(get_db_session)],
@@ -346,7 +346,7 @@ def get_finding(
     return _finding_payload(finding, include_detail=True)
 
 
-@router.patch("/findings/{finding_id}", response_model=FindingResponse)
+@router.patch("/findings/{finding_id}", response_model=FindingDetailResponse)
 def update_finding_status(
     finding_id: str,
     payload: FindingStatusUpdateRequest,

--- a/backend/src/vuln_prioritizer/api/workbench_payloads.py
+++ b/backend/src/vuln_prioritizer/api/workbench_payloads.py
@@ -110,11 +110,42 @@ def _finding_payload(finding: Any, *, include_detail: bool = False) -> dict[str,
     }
     if include_detail:
         payload["finding"] = finding.finding_json
+        payload["kev_detail"] = _finding_kev_detail(finding)
         payload["occurrences"] = [item.evidence_json for item in finding.occurrences]
         payload["status_history"] = [
             _finding_status_history_payload(item) for item in getattr(finding, "status_history", [])
         ]
     return payload
+
+
+def _finding_kev_detail(finding: Any) -> dict[str, Any] | None:
+    raw_finding = finding.finding_json if isinstance(finding.finding_json, dict) else {}
+    evidence = raw_finding.get("provider_evidence")
+    kev = evidence.get("kev") if isinstance(evidence, dict) else None
+    if not isinstance(kev, dict):
+        vulnerability = getattr(finding, "vulnerability", None)
+        provider_json = getattr(vulnerability, "provider_json", None)
+        kev = provider_json.get("kev") if isinstance(provider_json, dict) else None
+    if not isinstance(kev, dict):
+        return None
+
+    allowed_keys = {
+        "cve_id",
+        "in_kev",
+        "vendor_project",
+        "product",
+        "vulnerability_name",
+        "short_description",
+        "date_added",
+        "required_action",
+        "due_date",
+        "known_ransomware_campaign_use",
+        "notes",
+    }
+    detail = {key: kev.get(key) for key in allowed_keys if key in kev}
+    detail.setdefault("cve_id", finding.cve_id)
+    detail.setdefault("in_kev", bool(finding.in_kev))
+    return detail
 
 
 def _finding_status_history_payload(item: Any) -> dict[str, Any]:

--- a/backend/src/vuln_prioritizer/api/workbench_provider_routes.py
+++ b/backend/src/vuln_prioritizer/api/workbench_provider_routes.py
@@ -30,8 +30,13 @@ def provider_status(
     session: Annotated[Session, Depends(get_db_session)],
     settings: Annotated[WorkbenchSettings, Depends(get_workbench_settings)],
 ) -> dict[str, Any]:
-    snapshot = WorkbenchRepository(session).get_latest_provider_snapshot()
-    return _provider_status_payload(snapshot, settings=settings)
+    repo = WorkbenchRepository(session)
+    jobs = repo.list_provider_update_jobs()
+    return _provider_status_payload(
+        repo.get_latest_provider_snapshot(),
+        settings=settings,
+        latest_update_job=jobs[0] if jobs else None,
+    )
 
 
 @provider_router.get("/providers/update-jobs")

--- a/backend/src/vuln_prioritizer/api/workbench_providers.py
+++ b/backend/src/vuln_prioritizer/api/workbench_providers.py
@@ -15,6 +15,7 @@ from vuln_prioritizer.api.schemas import (
     ProviderSourceStatus,
     ProviderStatusResponse,
     ProviderUpdateJobRequest,
+    ProviderUpdateJobResponse,
 )
 from vuln_prioritizer.cache import FileCache
 from vuln_prioritizer.config import DEFAULT_CACHE_TTL_HOURS
@@ -158,6 +159,7 @@ def _run_provider_snapshot_refresh(
             cache_enabled=True,
             cache_only=payload.cache_only,
             cache_dir=str(settings.provider_cache_dir),
+            source_hashes=_provider_cache_source_hashes(cache, selected_sources),
             nvd_api_key_env=settings.nvd_api_key_env,
         ),
         items=[
@@ -201,6 +203,7 @@ def _run_provider_snapshot_refresh(
         "snapshot_created": True,
         "snapshot_path": str(output_path),
         "snapshot_sha256": content_hash,
+        "source_hashes": report.metadata.source_hashes,
         "selected_sources": selected_sources,
         "requested_cves": len(cve_ids),
         "cache_only": payload.cache_only,
@@ -381,13 +384,32 @@ def _latest_kev_date(records: Any) -> str | None:
     return sorted(values)[-1] if values else None
 
 
-def _provider_status_payload(snapshot: Any, *, settings: WorkbenchSettings) -> dict[str, Any]:
+def _provider_status_payload(
+    snapshot: Any,
+    *,
+    settings: WorkbenchSettings,
+    latest_update_job: Any | None = None,
+) -> dict[str, Any]:
     metadata = snapshot.metadata_json if snapshot is not None else {}
     selected_sources = metadata.get("selected_sources", []) if isinstance(metadata, dict) else []
     locked_provider_data = (
         bool(metadata.get("locked_provider_data")) if isinstance(metadata, dict) else False
     )
     warnings = list(metadata.get("warnings", [])) if isinstance(metadata, dict) else []
+    latest_update_job_payload = (
+        ProviderUpdateJobResponse.model_validate(_provider_update_job_payload(latest_update_job))
+        if latest_update_job is not None
+        else None
+    )
+    latest_update_failed = False
+    if latest_update_job_payload is not None and latest_update_job_payload.status == "failed":
+        latest_update_failed = True
+        failed_detail = (
+            latest_update_job_payload.error_message
+            or latest_update_job_payload.metadata.get("detail")
+            or "Provider refresh failed."
+        )
+        warnings.append(f"Latest provider update failed: {failed_detail}")
     snapshot_status = ProviderSnapshotStatus(
         id=snapshot.id if snapshot is not None else None,
         content_hash=snapshot.content_hash if snapshot is not None else None,
@@ -424,13 +446,27 @@ def _provider_status_payload(snapshot: Any, *, settings: WorkbenchSettings) -> d
     if snapshot is None:
         warnings.append("No provider snapshot has been recorded by a Workbench import yet.")
     return ProviderStatusResponse(
-        status="degraded" if snapshot is None or snapshot_status.missing else "ok",
+        status="degraded"
+        if snapshot is None or snapshot_status.missing or latest_update_failed
+        else "ok",
         snapshot=snapshot_status,
         sources=sources,
+        latest_update_job=latest_update_job_payload,
         cache_dir=str(settings.provider_cache_dir),
         snapshot_dir=str(settings.provider_snapshot_dir),
         warnings=warnings,
     ).model_dump()
+
+
+def _provider_cache_source_hashes(
+    cache: FileCache,
+    selected_sources: list[str],
+) -> dict[str, str | None]:
+    return {
+        source: cache.inspect_namespace(source)["namespace_checksum"]
+        for source in selected_sources
+        if source in {"nvd", "epss", "kev"}
+    }
 
 
 def _provider_update_job_payload(job: Any) -> dict[str, Any]:

--- a/backend/src/vuln_prioritizer/commands/data.py
+++ b/backend/src/vuln_prioritizer/commands/data.py
@@ -582,6 +582,7 @@ def data_export_provider_snapshot(
             cache_enabled=True,
             cache_only=cache_only,
             cache_dir=str(cache_dir),
+            source_hashes=_provider_cache_source_hashes(cache, selected_sources),
             offline_kev_file=str(offline_kev_file) if offline_kev_file else None,
             nvd_api_key_env=nvd_api_key_env,
         ),
@@ -600,6 +601,17 @@ def data_export_provider_snapshot(
     write_output(output, generate_provider_snapshot_json(report))
     console.print(f"[green]Wrote provider snapshot output to {output}[/green]")
     print_warnings(warnings)
+
+
+def _provider_cache_source_hashes(
+    cache: FileCache,
+    selected_sources: Sequence[str],
+) -> dict[str, str | None]:
+    return {
+        source: cache.inspect_namespace(source)["namespace_checksum"]
+        for source in selected_sources
+        if source in {"nvd", "epss", "kev"}
+    }
 
 
 def load_cached_provider_records(

--- a/backend/src/vuln_prioritizer/models.py
+++ b/backend/src/vuln_prioritizer/models.py
@@ -387,6 +387,7 @@ class ProviderSnapshotMetadata(StrictModel):
     cache_enabled: bool = False
     cache_only: bool = False
     cache_dir: str | None = None
+    source_hashes: dict[str, str | None] = Field(default_factory=dict)
     offline_kev_file: str | None = None
     nvd_api_key_env: str | None = None
 

--- a/backend/src/vuln_prioritizer/models_provider.py
+++ b/backend/src/vuln_prioritizer/models_provider.py
@@ -36,6 +36,7 @@ class KevData(StrictModel):
     in_kev: bool = False
     vendor_project: str | None = None
     product: str | None = None
+    vulnerability_name: str | None = None
     short_description: str | None = None
     date_added: str | None = None
     required_action: str | None = None

--- a/backend/src/vuln_prioritizer/providers/kev.py
+++ b/backend/src/vuln_prioritizer/providers/kev.py
@@ -135,14 +135,33 @@ class KevProvider:
             index[cve_id] = KevData(
                 cve_id=cve_id,
                 in_kev=True,
-                vendor_project=vulnerability.get("vendorProject"),
-                product=vulnerability.get("product"),
-                short_description=vulnerability.get("shortDescription"),
-                date_added=vulnerability.get("dateAdded"),
-                required_action=vulnerability.get("requiredAction"),
-                due_date=vulnerability.get("dueDate"),
-                known_ransomware_campaign_use=vulnerability.get("knownRansomwareCampaignUse"),
-                notes=vulnerability.get("notes"),
+                vendor_project=_first_present(vulnerability, "vendorProject", "vendor_project"),
+                product=_first_present(vulnerability, "product"),
+                vulnerability_name=_first_present(
+                    vulnerability,
+                    "vulnerabilityName",
+                    "vulnerability_name",
+                    "name",
+                ),
+                short_description=_first_present(
+                    vulnerability,
+                    "shortDescription",
+                    "short_description",
+                    "description",
+                ),
+                date_added=_first_present(vulnerability, "dateAdded", "date_added"),
+                required_action=_first_present(
+                    vulnerability,
+                    "requiredAction",
+                    "required_action",
+                ),
+                due_date=_first_present(vulnerability, "dueDate", "due_date"),
+                known_ransomware_campaign_use=_first_present(
+                    vulnerability,
+                    "knownRansomwareCampaignUse",
+                    "known_ransomware_campaign_use",
+                ),
+                notes=_first_present(vulnerability, "notes"),
             )
         return index
 
@@ -162,3 +181,11 @@ class KevProvider:
             "catalog",
             {cve_id: item.model_dump() for cve_id, item in index.items()},
         )
+
+
+def _first_present(vulnerability: dict, *keys: str) -> str | None:
+    for key in keys:
+        value = vulnerability.get(key)
+        if value is not None and str(value).strip():
+            return str(value)
+    return None

--- a/backend/src/vuln_prioritizer/web/templates/findings/detail.html
+++ b/backend/src/vuln_prioritizer/web/templates/findings/detail.html
@@ -63,6 +63,29 @@
       </tbody>
     </table>
   </div>
+  {% set kev_detail = finding.finding_json.get("provider_evidence", {}).get("kev") if finding.finding_json else {} %}
+  {% if kev_detail and kev_detail.get("in_kev") %}
+    <section class="subsection">
+      <div class="section-head compact">
+        <p class="eyebrow">CISA KEV</p>
+        <h2>Known exploited vulnerability</h2>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <tbody>
+            <tr><th>Vendor / project</th><td>{{ kev_detail.get("vendor_project") or "N.A." }}</td></tr>
+            <tr><th>Product</th><td>{{ kev_detail.get("product") or "N.A." }}</td></tr>
+            <tr><th>Vulnerability</th><td>{{ kev_detail.get("vulnerability_name") or kev_detail.get("short_description") or "N.A." }}</td></tr>
+            <tr><th>Date added</th><td>{{ kev_detail.get("date_added") or "N.A." }}</td></tr>
+            <tr><th>Due date</th><td>{{ kev_detail.get("due_date") or "N.A." }}</td></tr>
+            <tr><th>Required action</th><td>{{ kev_detail.get("required_action") or "N.A." }}</td></tr>
+            <tr><th>Ransomware use</th><td>{{ kev_detail.get("known_ransomware_campaign_use") or "N.A." }}</td></tr>
+            <tr><th>Notes</th><td>{{ kev_detail.get("notes") or "N.A." }}</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {% endif %}
   <section class="subsection">
     <div class="section-head compact">
       <p class="eyebrow">Lifecycle</p>

--- a/backend/src/vuln_prioritizer/web/workbench_projects.py
+++ b/backend/src/vuln_prioritizer/web/workbench_projects.py
@@ -73,9 +73,11 @@ def dashboard(
     project = repo.get_project(project_id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found.")
+    provider_jobs = repo.list_provider_update_jobs()
     provider_status = _provider_status_payload(
         repo.get_latest_provider_snapshot(),
         settings=get_workbench_settings(request),
+        latest_update_job=provider_jobs[0] if provider_jobs else None,
     )
     model = dashboard_model(
         project,

--- a/backend/src/vuln_prioritizer/web/workbench_settings.py
+++ b/backend/src/vuln_prioritizer/web/workbench_settings.py
@@ -21,8 +21,11 @@ def project_settings(
     project = repo.get_project(project_id)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found.")
+    provider_jobs = repo.list_provider_update_jobs()
     provider_status = _provider_status_payload(
-        repo.get_latest_provider_snapshot(), settings=settings
+        repo.get_latest_provider_snapshot(),
+        settings=settings,
+        latest_update_job=provider_jobs[0] if provider_jobs else None,
     )
     config_history = repo.list_project_config_snapshots(project.id, limit=20)
     latest_config = config_history[0] if config_history else None
@@ -57,9 +60,7 @@ def project_settings(
                 "settings": settings,
                 "database_url_display": _redacted_database_url(settings.database_url),
                 "provider_status": provider_status,
-                "provider_jobs": [
-                    _provider_update_job_payload(job) for job in repo.list_provider_update_jobs()
-                ],
+                "provider_jobs": [_provider_update_job_payload(job) for job in provider_jobs],
                 "workbench_jobs": repo.list_workbench_jobs(project_id=project.id, limit=20),
                 "api_tokens": repo.list_api_tokens(),
                 "artifact_retention": repo.get_project_artifact_retention(project.id),
@@ -109,8 +110,11 @@ def create_api_token_form(
         message=f"API token {token.name!r} was created from settings.",
     )
     session.commit()
+    provider_jobs = repo.list_provider_update_jobs()
     provider_status = _provider_status_payload(
-        repo.get_latest_provider_snapshot(), settings=settings
+        repo.get_latest_provider_snapshot(),
+        settings=settings,
+        latest_update_job=provider_jobs[0] if provider_jobs else None,
     )
     config_history = repo.list_project_config_snapshots(project.id, limit=20)
     latest_config = config_history[0] if config_history else None
@@ -125,9 +129,7 @@ def create_api_token_form(
                 "settings": settings,
                 "database_url_display": _redacted_database_url(settings.database_url),
                 "provider_status": provider_status,
-                "provider_jobs": [
-                    _provider_update_job_payload(job) for job in repo.list_provider_update_jobs()
-                ],
+                "provider_jobs": [_provider_update_job_payload(job) for job in provider_jobs],
                 "workbench_jobs": repo.list_workbench_jobs(project_id=project.id, limit=20),
                 "api_tokens": repo.list_api_tokens(),
                 "artifact_retention": repo.get_project_artifact_retention(project.id),

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 
+from vuln_prioritizer.api import workbench_providers
 from vuln_prioritizer.api.app import create_app, get_engine
 from vuln_prioritizer.db import (
     ApiToken,
@@ -265,6 +266,12 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
     detail_payload = detail.json()
     assert detail_payload["finding"]["cve_id"] == "CVE-2021-44228"
     assert detail_payload["finding"]["provider_evidence"]["nvd"]["cve_id"] == "CVE-2021-44228"
+    assert detail_payload["kev_detail"]["cve_id"] == "CVE-2021-44228"
+    assert detail_payload["kev_detail"]["in_kev"] is True
+    assert detail_payload["kev_detail"]["vendor_project"] == "Apache"
+    assert detail_payload["kev_detail"]["product"] == "Log4j2"
+    assert detail_payload["kev_detail"]["due_date"] == "2021-12-24"
+    assert "Apply updates" in detail_payload["kev_detail"]["required_action"]
     assert detail_payload["occurrences"][0]["source_format"] == "cve-list"
     assert detail_payload["occurrences"][0]["source_record_id"] == "line:1"
 
@@ -308,6 +315,14 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
             assert {
                 finding["cve_id"] for finding in analysis_payload["findings"]
             } == EXPECTED_SAMPLE_CVES
+            log4shell_report = next(
+                finding
+                for finding in analysis_payload["findings"]
+                if finding["cve_id"] == "CVE-2021-44228"
+            )
+            report_kev = log4shell_report["provider_evidence"]["kev"]
+            assert report_kev["due_date"] == "2021-12-24"
+            assert "Apply updates" in report_kev["required_action"]
         if report_format == "sarif":
             sarif_payload = json.loads(report_download.text)
             assert sarif_payload["runs"][0]["tool"]["driver"]["name"] == (
@@ -1443,7 +1458,12 @@ def test_workbench_api_tokens_config_provider_jobs_and_github_preview(
     assert job_payload["metadata"]["snapshot_created"] is True
     assert job_payload["metadata"]["new_snapshot_id"]
     assert job_payload["metadata"]["new_snapshot_hash"]
+    assert set(job_payload["metadata"]["source_hashes"]) == {"nvd", "epss", "kev"}
+    kev_source_hash = job_payload["metadata"]["source_hashes"]["kev"]
+    assert kev_source_hash is None or len(kev_source_hash) == 64
     assert Path(job_payload["metadata"]["snapshot_path"]).is_file()
+    snapshot_payload = json.loads(Path(job_payload["metadata"]["snapshot_path"]).read_text())
+    assert snapshot_payload["metadata"]["source_hashes"] == job_payload["metadata"]["source_hashes"]
 
     provider_status = client.get("/api/providers/status")
     assert provider_status.status_code == 200
@@ -1451,6 +1471,7 @@ def test_workbench_api_tokens_config_provider_jobs_and_github_preview(
         provider_status.json()["snapshot"]["content_hash"]
         == job_payload["metadata"]["new_snapshot_hash"]
     )
+    assert provider_status.json()["latest_update_job"]["id"] == job_payload["id"]
 
     saved_config = client.post(
         f"/api/projects/{project['id']}/settings/config",
@@ -1763,6 +1784,44 @@ def test_workbench_api_tokens_config_provider_jobs_and_github_preview(
     assert listed_after_revoke.status_code == 200
     token_states = {item["id"]: item["active"] for item in listed_after_revoke.json()["items"]}
     assert token_states[token_payload["id"]] is False
+
+
+def test_workbench_provider_status_surfaces_latest_failed_update(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    client = _client(tmp_path)
+    project = _create_project(client)
+    run = _import_sample(client, project["id"])
+
+    before_status = client.get("/api/providers/status")
+    assert before_status.status_code == 200
+    previous_snapshot_hash = before_status.json()["snapshot"]["content_hash"]
+    assert before_status.json()["snapshot"]["id"] == run["provider_snapshot_id"]
+
+    def fail_provider_records_for_snapshot(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("forced KEV provider failure")
+
+    monkeypatch.setattr(
+        workbench_providers,
+        "_provider_records_for_snapshot",
+        fail_provider_records_for_snapshot,
+    )
+
+    job = client.post("/api/providers/update-jobs", json={"sources": ["kev"]})
+    assert job.status_code == 200, job.text
+    job_payload = job.json()
+    assert job_payload["status"] == "failed"
+    assert job_payload["metadata"]["previous_snapshot_hash"] == previous_snapshot_hash
+
+    provider_status = client.get("/api/providers/status")
+    assert provider_status.status_code == 200
+    status_payload = provider_status.json()
+    assert status_payload["status"] == "degraded"
+    assert status_payload["snapshot"]["content_hash"] == previous_snapshot_hash
+    assert status_payload["latest_update_job"]["id"] == job_payload["id"]
+    assert status_payload["latest_update_job"]["status"] == "failed"
+    assert any("forced KEV provider failure" in warning for warning in status_payload["warnings"])
 
 
 def test_workbench_csv_report_escapes_spreadsheet_formulas(tmp_path: Path) -> None:

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -67,3 +68,26 @@ def test_file_cache_inspect_namespace_reports_valid_expired_and_invalid_document
     assert status["invalid_count"] == 1
     assert status["latest_cached_at"] is not None
     assert status["namespace_checksum"] is not None
+
+
+def test_file_cache_namespace_checksum_matches_sha256_of_cache_documents(
+    tmp_path: Path,
+) -> None:
+    cache = FileCache(tmp_path / "cache", ttl_hours=24)
+    path = cache._path_for("kev", "catalog")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    document = json.dumps(
+        {
+            "key": "catalog",
+            "cached_at": "2026-04-29T00:00:00+00:00",
+            "payload": {"CVE-2026-1001": {"cve_id": "CVE-2026-1001", "in_kev": True}},
+        },
+        sort_keys=True,
+    )
+    path.write_text(document, encoding="utf-8")
+
+    expected = hashlib.sha256()
+    expected.update(path.name.encode("utf-8"))
+    expected.update(document.encode("utf-8"))
+
+    assert cache.inspect_namespace("kev")["namespace_checksum"] == expected.hexdigest()

--- a/backend/tests/test_cli_data.py
+++ b/backend/tests/test_cli_data.py
@@ -65,7 +65,15 @@ def _install_fake_data_update_providers(monkeypatch: Any) -> None:
     ) -> tuple[dict[str, KevData], list[str]]:
         assert refresh is True
         results = {
-            cve_id: KevData(cve_id=cve_id, in_kev=(cve_id == "CVE-2021-44228"))
+            cve_id: KevData(
+                cve_id=cve_id,
+                in_kev=(cve_id == "CVE-2021-44228"),
+                vulnerability_name=(
+                    "Apache Log4j2 remote code execution vulnerability"
+                    if cve_id == "CVE-2021-44228"
+                    else None
+                ),
+            )
             for cve_id in cve_ids
         }
         catalog = {cve_id: item.model_dump() for cve_id, item in results.items()}
@@ -441,10 +449,18 @@ def test_data_export_provider_snapshot_writes_replay_artifact(monkeypatch, tmp_p
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert payload["metadata"]["artifact_kind"] == "provider-snapshot"
     assert payload["metadata"]["selected_sources"] == ["nvd", "epss", "kev"]
+    assert set(payload["metadata"]["source_hashes"]) == {"nvd", "epss", "kev"}
+    assert all(
+        isinstance(value, str) and len(value) == 64
+        for value in payload["metadata"]["source_hashes"].values()
+    )
     assert [item["cve_id"] for item in payload["items"]] == ["CVE-2021-44228", "CVE-2024-3094"]
     assert all(item["nvd"] is not None for item in payload["items"])
     assert all(item["epss"] is not None for item in payload["items"])
     assert all(item["kev"] is not None for item in payload["items"])
+    assert payload["items"][0]["kev"]["vulnerability_name"] == (
+        "Apache Log4j2 remote code execution vulnerability"
+    )
 
 
 def test_data_export_provider_snapshot_cache_only_uses_local_cache(
@@ -476,7 +492,13 @@ def test_data_export_provider_snapshot_cache_only_uses_local_cache(
     cache.set_json(
         "kev",
         "catalog",
-        {"CVE-2021-44228": KevData(cve_id="CVE-2021-44228", in_kev=True).model_dump()},
+        {
+            "CVE-2021-44228": KevData(
+                cve_id="CVE-2021-44228",
+                in_kev=True,
+                vulnerability_name="Cached Log4j2 KEV vulnerability",
+            ).model_dump()
+        },
     )
 
     result = runner.invoke(
@@ -498,9 +520,12 @@ def test_data_export_provider_snapshot_cache_only_uses_local_cache(
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     first_item, second_item = payload["items"]
     assert payload["metadata"]["cache_only"] is True
+    assert payload["metadata"]["source_hashes"]["kev"]
+    assert len(payload["metadata"]["source_hashes"]["kev"]) == 64
     assert first_item["nvd"] is not None
     assert first_item["epss"] is not None
     assert first_item["kev"]["in_kev"] is True
+    assert first_item["kev"]["vulnerability_name"] == "Cached Log4j2 KEV vulnerability"
     assert second_item["nvd"] is None
     assert second_item["epss"] is None
     assert second_item["kev"]["in_kev"] is False

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -71,6 +71,19 @@ def test_contracts_schema_list_matches_schema_directory() -> None:
     assert sorted(documented_names) == schema_names
 
 
+def test_kev_enrichment_response_example_matches_model() -> None:
+    payload = json.loads(
+        (DOCS_ROOT / "examples" / "example_kev_enrichment_response.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    kev = KevData.model_validate(payload)
+
+    assert kev.in_kev is True
+    assert kev.vulnerability_name == "Example Product command injection vulnerability"
+
+
 def _install_fake_data_update_providers(monkeypatch: Any) -> None:
     def fake_nvd_fetch_many(
         self: NvdProvider,
@@ -119,7 +132,15 @@ def _install_fake_data_update_providers(monkeypatch: Any) -> None:
     ) -> tuple[dict[str, KevData], list[str]]:
         assert refresh is True
         results = {
-            cve_id: KevData(cve_id=cve_id, in_kev=(cve_id == "CVE-2021-44228"))
+            cve_id: KevData(
+                cve_id=cve_id,
+                in_kev=(cve_id == "CVE-2021-44228"),
+                vulnerability_name=(
+                    "Apache Log4j2 remote code execution vulnerability"
+                    if cve_id == "CVE-2021-44228"
+                    else None
+                ),
+            )
             for cve_id in cve_ids
         }
         assert self.cache is not None
@@ -452,3 +473,7 @@ def test_provider_snapshot_json_matches_published_schema(monkeypatch, tmp_path: 
     assert result.exit_code == 0
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     jsonschema.validate(payload, _load_schema("provider-snapshot-report.schema.json"))
+    assert set(payload["metadata"]["source_hashes"]) == {"nvd", "epss", "kev"}
+    assert payload["items"][0]["kev"]["vulnerability_name"] == (
+        "Apache Log4j2 remote code execution vulnerability"
+    )

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -616,6 +616,7 @@ def test_kev_fetch_many_from_offline_json(tmp_path: Path) -> None:
                         "cveID": "CVE-2021-44228",
                         "vendorProject": "Apache",
                         "product": "Log4j",
+                        "vulnerabilityName": "Apache Log4j2 remote code execution vulnerability",
                         "shortDescription": "Apache Log4j2 remote code execution.",
                         "dateAdded": "2021-12-10",
                         "requiredAction": "Patch now",
@@ -637,6 +638,10 @@ def test_kev_fetch_many_from_offline_json(tmp_path: Path) -> None:
 
     assert warnings == []
     assert results["CVE-2021-44228"].in_kev is True
+    assert (
+        results["CVE-2021-44228"].vulnerability_name
+        == "Apache Log4j2 remote code execution vulnerability"
+    )
     assert results["CVE-2021-44228"].short_description == "Apache Log4j2 remote code execution."
     assert results["CVE-2021-44228"].known_ransomware_campaign_use == "Known"
     assert results["CVE-2021-44228"].notes == "Frequently exploited in the wild."
@@ -650,9 +655,11 @@ def test_kev_fetch_many_from_offline_csv_normalizes_aliases_and_skips_invalid_ro
     kev_file.write_text(
         "\n".join(
             [
-                "cveId,vendorProject,product,shortDescription",
-                "CVE-2026-0001,Example Vendor,Example Product,CSV KEV entry",
-                "not-a-cve,Ignored Vendor,Ignored Product,Invalid row",
+                "cveId,vendorProject,product,vulnerability_name,shortDescription,dateAdded,dueDate,requiredAction",
+                "CVE-2026-0001,Example Vendor,Example Product,CSV vulnerability,"
+                "CSV KEV entry,2026-04-29,2026-05-20,Patch CSV asset",
+                "not-a-cve,Ignored Vendor,Ignored Product,Invalid row,"
+                "Invalid row,2026-04-29,2026-05-20,Ignore",
             ]
         )
         + "\n",
@@ -668,8 +675,36 @@ def test_kev_fetch_many_from_offline_csv_normalizes_aliases_and_skips_invalid_ro
     assert warnings == []
     assert results["CVE-2026-0001"].in_kev is True
     assert results["CVE-2026-0001"].vendor_project == "Example Vendor"
+    assert results["CVE-2026-0001"].vulnerability_name == "CSV vulnerability"
     assert results["CVE-2026-0001"].short_description == "CSV KEV entry"
+    assert results["CVE-2026-0001"].date_added == "2026-04-29"
+    assert results["CVE-2026-0001"].due_date == "2026-05-20"
+    assert results["CVE-2026-0001"].required_action == "Patch CSV asset"
     assert results["CVE-2026-0002"].in_kev is False
+
+
+def test_kev_provider_loads_checked_in_offline_fixtures() -> None:
+    provider = KevProvider()
+    json_results, json_warnings = provider.fetch_many(
+        ["CVE-2026-1001"],
+        offline_file=DATA_ROOT / "input_fixtures" / "kev_catalog.json",
+    )
+    csv_results, csv_warnings = provider.fetch_many(
+        ["CVE-2026-1001"],
+        offline_file=DATA_ROOT / "input_fixtures" / "kev_catalog.csv",
+    )
+
+    assert json_warnings == []
+    assert csv_warnings == []
+    assert json_results["CVE-2026-1001"].in_kev is True
+    assert csv_results["CVE-2026-1001"].in_kev is True
+    assert (
+        json_results["CVE-2026-1001"].vulnerability_name
+        == "Example Product command injection vulnerability"
+    )
+    assert csv_results["CVE-2026-1001"].required_action == (
+        "Apply the vendor update or remove affected systems."
+    )
 
 
 def test_kev_refresh_stores_offline_catalog_and_reuses_cache(tmp_path: Path) -> None:
@@ -709,6 +744,43 @@ def test_kev_refresh_stores_offline_catalog_and_reuses_cache(tmp_path: Path) -> 
     assert cached_results["CVE-2026-0003"].product == "Cached Product"
     assert cached_provider.last_diagnostics.cache_hits == 1
     assert cached_provider.last_diagnostics.network_fetches == 0
+
+
+def test_kev_live_catalog_stores_cache_with_namespace_checksum(tmp_path: Path) -> None:
+    class Session:
+        def get(self, url: str, **kwargs):  # noqa: ARG002, ANN003
+            return FakeResponse(
+                {
+                    "vulnerabilities": [
+                        {
+                            "cveID": "CVE-2026-1002",
+                            "vendorProject": "Live Vendor",
+                            "product": "Live Product",
+                            "vulnerabilityName": "Live Product KEV vulnerability",
+                            "dateAdded": "2026-04-29",
+                            "dueDate": "2026-05-20",
+                            "requiredAction": "Apply live update.",
+                        }
+                    ]
+                }
+            )
+
+    cache = FileCache(tmp_path / "cache", ttl_hours=24)
+    provider = KevProvider(session=Session(), cache=cache)
+
+    results, warnings = provider.fetch_many(["CVE-2026-1002"])
+
+    assert warnings == []
+    assert results["CVE-2026-1002"].vulnerability_name == "Live Product KEV vulnerability"
+    status = cache.inspect_namespace("kev")
+    assert status["file_count"] == 1
+    assert status["valid_count"] == 1
+    assert isinstance(status["namespace_checksum"], str)
+    assert len(status["namespace_checksum"]) == 64
+    cached_catalog = cache.get_json("kev", "catalog")
+    assert cached_catalog["CVE-2026-1002"]["vulnerability_name"] == (
+        "Live Product KEV vulnerability"
+    )
 
 
 def test_kev_fetch_many_degrades_for_missing_offline_file(tmp_path: Path) -> None:

--- a/backend/tests/web/test_workbench_pages.py
+++ b/backend/tests/web/test_workbench_pages.py
@@ -295,11 +295,23 @@ def test_web_import_report_page_and_finding_detail(tmp_path: Path) -> None:
     assert filtered.status_code == 200
     assert "CVE-2024-3094" in filtered.text
     assert "Showing 1-1 of 1 findings." in filtered.text
-    detail_link = BeautifulSoup(findings.text, "html.parser").select_one("td a")
+    findings_soup = BeautifulSoup(findings.text, "html.parser")
+    detail_link = next(
+        (
+            anchor
+            for anchor in findings_soup.select("td a")
+            if anchor.get_text(strip=True) == "CVE-2021-44228"
+        ),
+        None,
+    )
     assert detail_link is not None
     detail = client.get(str(detail_link["href"]))
     assert detail.status_code == 200
     assert "Why this priority?" in detail.text
+    assert "Known exploited vulnerability" in detail.text
+    assert "Log4j2" in detail.text
+    assert "2021-12-24" in detail.text
+    assert "Required action" in detail.text
 
     intelligence = client.get(
         f"/projects/{project_id}/vulnerabilities",

--- a/data/input_fixtures/kev_catalog.csv
+++ b/data/input_fixtures/kev_catalog.csv
@@ -1,0 +1,2 @@
+cveID,vendorProject,product,vulnerabilityName,shortDescription,dateAdded,dueDate,requiredAction,knownRansomwareCampaignUse,notes
+CVE-2026-1001,Example Vendor,Example Product,Example Product command injection vulnerability,Example Product command injection.,2026-04-29,2026-05-20,Apply the vendor update or remove affected systems.,Unknown,Sanitized VPW-024 fixture.

--- a/data/input_fixtures/kev_catalog.json
+++ b/data/input_fixtures/kev_catalog.json
@@ -1,0 +1,16 @@
+{
+  "vulnerabilities": [
+    {
+      "cveID": "CVE-2026-1001",
+      "vendorProject": "Example Vendor",
+      "product": "Example Product",
+      "vulnerabilityName": "Example Product command injection vulnerability",
+      "shortDescription": "Example Product command injection.",
+      "dateAdded": "2026-04-29",
+      "dueDate": "2026-05-20",
+      "requiredAction": "Apply the vendor update or remove affected systems.",
+      "knownRansomwareCampaignUse": "Unknown",
+      "notes": "Sanitized VPW-024 fixture."
+    }
+  ]
+}

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -189,6 +189,9 @@ The shared provider enrichment contract is documented in
 [VPW-022 Provider Cache, Status and Snapshots](vpw-022-provider-cache-status-snapshots.md).
 The EPSS-specific batch/cache/freshness behavior is documented in
 [VPW-023 EPSS Provider Cache](vpw-023-epss-provider-cache.md).
+The KEV-specific JSON/CSV normalization, fixture, source-hash, and Workbench
+detail behavior is documented in
+[VPW-024 KEV Provider Cache](vpw-024-kev-provider-cache.md).
 
 The current `data` command tree is intentionally small:
 

--- a/docs/architecture/vpw-024-kev-provider-cache.md
+++ b/docs/architecture/vpw-024-kev-provider-cache.md
@@ -1,0 +1,19 @@
+# VPW-024 KEV Provider Cache
+
+VPW-024 normalizes CISA Known Exploited Vulnerabilities (KEV) catalog data from JSON or CSV into the shared `KevData` provider model.
+
+The provider accepts CISA-style JSON with a `vulnerabilities` array and CSV files with CISA-compatible headers. The normalized fields are `cve_id`, `vendor_project`, `product`, `vulnerability_name`, `short_description`, `date_added`, `due_date`, `required_action`, `known_ransomware_campaign_use`, and `notes`.
+
+Checked-in offline fixtures live in:
+
+- `data/input_fixtures/kev_catalog.json`
+- `data/input_fixtures/kev_catalog.csv`
+- `docs/examples/example_kev_enrichment_response.json`
+
+The cache stores the KEV catalog under namespace `kev` and key `catalog`. `data verify`, `data status`, Workbench provider refresh jobs, and provider snapshot exports inspect the namespace checksum rather than requiring live CISA access in CI.
+
+Provider snapshot metadata includes `source_hashes` keyed by selected provider source. The values are SHA-256 namespace checksums from the local cache when cache documents exist, or `null` when a selected namespace has no cached documents yet.
+
+Workbench finding detail responses include a typed `kev_detail` object for detail views while retaining the existing raw `finding.provider_evidence.kev` payload. The HTML finding detail page renders the same KEV metadata so required action and due dates are visible during triage.
+
+Provider refresh failures do not replace the last valid snapshot. The latest provider update job remains visible in `/api/providers/status`; failed latest jobs degrade the status response and add an explicit warning while preserving the previous snapshot identity.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -251,9 +251,15 @@ Current provider service contract:
   `ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` interface
 - provider failures degrade into `ProviderStatus` and data-quality flags before
   optional CI gates decide whether to fail the process
+- KEV provider data includes CISA catalog details such as
+  `vulnerability_name`, `vendor_project`, `product`, `date_added`, `due_date`,
+  and `required_action` when present in JSON, CSV, cache, or locked snapshot
+  sources
 - `ProviderStatus` includes `source`, `last_sync`, `cache_hit`, `cache_miss`,
   cache counters, stale-cache counters, network/failure counters, and
   `data_quality_flags`
+- provider snapshot metadata includes `source_hashes`, a map from selected
+  provider source to the local cache namespace SHA-256 checksum or `null`
 - analysis-style metadata may include `provider_data_quality_flags`, keyed by
   source, when recoverable provider problems such as missing EPSS records,
   stale cache fallback, or provider warnings were observed

--- a/docs/examples/example_kev_enrichment_response.json
+++ b/docs/examples/example_kev_enrichment_response.json
@@ -1,0 +1,13 @@
+{
+  "cve_id": "CVE-2026-1001",
+  "in_kev": true,
+  "vendor_project": "Example Vendor",
+  "product": "Example Product",
+  "vulnerability_name": "Example Product command injection vulnerability",
+  "short_description": "Example Product command injection.",
+  "date_added": "2026-04-29",
+  "due_date": "2026-05-20",
+  "required_action": "Apply the vendor update or remove affected systems.",
+  "known_ransomware_campaign_use": "Unknown",
+  "notes": "Sanitized VPW-024 fixture."
+}

--- a/docs/schemas/analysis-report.schema.json
+++ b/docs/schemas/analysis-report.schema.json
@@ -1076,6 +1076,9 @@
         "product": {
           "$ref": "#/$defs/nullableString"
         },
+        "vulnerability_name": {
+          "$ref": "#/$defs/nullableString"
+        },
         "short_description": {
           "$ref": "#/$defs/nullableString"
         },

--- a/docs/schemas/explain-report.schema.json
+++ b/docs/schemas/explain-report.schema.json
@@ -1168,6 +1168,9 @@
         "product": {
           "$ref": "#/$defs/nullableString"
         },
+        "vulnerability_name": {
+          "$ref": "#/$defs/nullableString"
+        },
         "short_description": {
           "$ref": "#/$defs/nullableString"
         },

--- a/docs/schemas/provider-snapshot-report.schema.json
+++ b/docs/schemas/provider-snapshot-report.schema.json
@@ -122,6 +122,12 @@
             "product": {
               "$ref": "#/$defs/nullableString"
             },
+            "vulnerability_name": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "short_description": {
+              "$ref": "#/$defs/nullableString"
+            },
             "date_added": {
               "$ref": "#/$defs/nullableString"
             },
@@ -129,6 +135,12 @@
               "$ref": "#/$defs/nullableString"
             },
             "due_date": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "known_ransomware_campaign_use": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "notes": {
               "$ref": "#/$defs/nullableString"
             }
           }
@@ -206,6 +218,7 @@
         "output_path",
         "cache_enabled",
         "cache_dir",
+        "source_hashes",
         "offline_kev_file",
         "nvd_api_key_env"
       ],
@@ -246,6 +259,12 @@
         },
         "cache_dir": {
           "$ref": "#/$defs/nullableString"
+        },
+        "source_hashes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/nullableString"
+          }
         },
         "offline_kev_file": {
           "$ref": "#/$defs/nullableString"

--- a/docs/schemas/snapshot-report.schema.json
+++ b/docs/schemas/snapshot-report.schema.json
@@ -1260,6 +1260,9 @@
         "product": {
           "$ref": "#/$defs/nullableString"
         },
+        "vulnerability_name": {
+          "$ref": "#/$defs/nullableString"
+        },
         "short_description": {
           "$ref": "#/$defs/nullableString"
         },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Analysis Run Provider Schema: architecture/analysis-run-provider-schema.md
       - Provider Cache Status Snapshots: architecture/vpw-022-provider-cache-status-snapshots.md
       - EPSS Provider Cache: architecture/vpw-023-epss-provider-cache.md
+      - KEV Provider Cache: architecture/vpw-024-kev-provider-cache.md
       - Template Repository Layer: architecture/template-service-layer.md
       - Template Importer Contract: architecture/vpw-013-importer-contract.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md


### PR DESCRIPTION
Refs #130

Stacked on #217 / codex/vpw-023-epss-provider-cache.

## Scope
- Normalize CISA KEV JSON/CSV fields including vulnerability_name aliases.
- Persist provider snapshot source_hashes from local cache namespace checksums.
- Expose typed KEV detail in Workbench finding detail API/PATCH responses and render KEV metadata in the HTML detail page.
- Surface the latest provider update job in /api/providers/status and degrade status on failed latest refresh while preserving the last valid snapshot.
- Add checked-in KEV JSON/CSV fixtures, focused example response, schemas, contracts, and architecture docs.

## Validation
- python3 -m pytest -q backend/tests/test_providers.py::test_kev_fetch_many_from_offline_json backend/tests/test_providers.py::test_kev_fetch_many_from_offline_csv_normalizes_aliases_and_skips_invalid_rows backend/tests/test_providers.py::test_kev_provider_loads_checked_in_offline_fixtures backend/tests/test_providers.py::test_kev_live_catalog_stores_cache_with_namespace_checksum backend/tests/test_cache.py::test_file_cache_namespace_checksum_matches_sha256_of_cache_documents backend/tests/test_cli_data.py::test_data_export_provider_snapshot_writes_replay_artifact backend/tests/test_cli_data.py::test_data_export_provider_snapshot_cache_only_uses_local_cache backend/tests/test_output_schemas.py::test_kev_enrichment_response_example_matches_model backend/tests/test_output_schemas.py::test_provider_snapshot_json_matches_published_schema backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence backend/tests/api/test_workbench_api.py::test_workbench_api_tokens_config_provider_jobs_and_github_preview backend/tests/api/test_workbench_api.py::test_workbench_provider_status_surfaces_latest_failed_update backend/tests/web/test_workbench_pages.py::test_web_import_report_page_and_finding_detail --no-cov
- make check
- make docs-check

## Residual risk
- Tests use checked-in fixtures/fakes and do not call live CISA feeds.
- Template React/generated client surface is not changed in this slice; this PR covers the current packaged Workbench/API/CLI provider surfaces for VPW-024.