### PR TITLE
VPW-025: implement NVD provider fallback evidence

### DIFF
--- a/backend/src/vuln_prioritizer/providers/nvd.py
+++ b/backend/src/vuln_prioritizer/providers/nvd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import random
 import time
+from collections.abc import Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from threading import Lock
@@ -102,7 +103,7 @@ class NvdProvider:
                     continue
             except Exception as exc:  # noqa: BLE001 - provider should degrade gracefully
                 warnings_by_cve.setdefault(cve_id, []).append(
-                    f"NVD cache load failed for {cve_id}: {exc}"
+                    f"NVD cache load failed for {cve_id}: {self._safe_error_message(exc)}"
                 )
             pending_ids.append(cve_id)
 
@@ -117,19 +118,21 @@ class NvdProvider:
                     try:
                         resolved[cve_id] = futures[cve_id].result()
                     except Exception as exc:  # noqa: BLE001 - provider should degrade gracefully
+                        safe_error = self._safe_error_message(exc)
                         try:
                             stale = self._load_from_cache(cve_id, allow_expired=True)
                         except Exception:  # noqa: BLE001 - invalid stale cache is not recoverable
                             stale = None
                         if stale is not None:
                             warnings_by_cve.setdefault(cve_id, []).append(
-                                f"NVD lookup failed for {cve_id}; using expired cached data: {exc}"
+                                "NVD lookup failed for "
+                                f"{cve_id}; using expired cached data: {safe_error}"
                             )
                             resolved[cve_id] = stale
                             stale_cache_hits += 1
                         else:
                             warnings_by_cve.setdefault(cve_id, []).append(
-                                f"NVD lookup failed for {cve_id}: {exc}"
+                                f"NVD lookup failed for {cve_id}: {safe_error}"
                             )
                             resolved[cve_id] = NvdData(cve_id=cve_id)
                         failures += 1
@@ -201,8 +204,11 @@ class NvdProvider:
                 break
 
         if last_error is not None:
-            raise RuntimeError(str(last_error)) from last_error
+            raise RuntimeError(self._safe_error_message(last_error)) from last_error
         raise RuntimeError("NVD request failed without a response")
+
+    def _safe_error_message(self, exc: BaseException) -> str:
+        return _sanitize_error_message(str(exc), secrets=(self.api_key,))
 
     def _session_get(self, *, params: dict[str, str], headers: dict[str, str]) -> requests.Response:
         if self.session is not None:
@@ -290,14 +296,32 @@ def _extract_cvss(metrics: dict) -> tuple[float | None, str | None, str | None, 
         entries = metrics.get(metric_key) or []
         if not entries:
             continue
-        metric = entries[0] or {}
-        cvss_data = metric.get("cvssData") or {}
-        score = safe_float(cvss_data.get("baseScore"))
-        severity = cvss_data.get("baseSeverity") or metric.get("baseSeverity")
-        vector = cvss_data.get("vectorString")
-        if score is not None or severity:
-            return score, severity, versions[metric_key], vector
+        fallback: tuple[float | None, str | None, str | None, str | None] | None = None
+        for metric in _ordered_metric_entries(entries):
+            cvss_data = metric.get("cvssData") or {}
+            score = safe_float(cvss_data.get("baseScore"))
+            severity = cvss_data.get("baseSeverity") or metric.get("baseSeverity")
+            vector = cvss_data.get("vectorString")
+            candidate = (score, severity, versions[metric_key], vector)
+            if score is not None:
+                return candidate
+            if severity and fallback is None:
+                fallback = candidate
+        if fallback is not None:
+            return fallback
     return None, None, None, None
+
+
+def _ordered_metric_entries(entries: Sequence[dict]) -> list[dict]:
+    primary: list[dict] = []
+    secondary: list[dict] = []
+    for entry in entries:
+        metric = entry or {}
+        if str(metric.get("type") or "").lower() == "primary":
+            primary.append(metric)
+        else:
+            secondary.append(metric)
+    return primary + secondary
 
 
 def _retry_delay(response: requests.Response | None, attempt: int) -> float:
@@ -309,6 +333,14 @@ def _retry_delay(response: requests.Response | None, attempt: int) -> float:
         except ValueError:
             pass
     return float(attempt) + random.uniform(0.0, 0.25)
+
+
+def _sanitize_error_message(message: str, *, secrets: Sequence[str | None]) -> str:
+    redacted = message
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "<redacted>")
+    return redacted
 
 
 def has_nvd_content(item: NvdData) -> bool:

--- a/backend/src/vuln_prioritizer/services/enrichment.py
+++ b/backend/src/vuln_prioritizer/services/enrichment.py
@@ -150,6 +150,7 @@ class EnrichmentService:
             epss_diagnostics=epss_diagnostics,
             kev_diagnostics=kev_diagnostics,
             provider_data_quality_flags=_provider_data_quality_flags(
+                nvd_results=nvd_results,
                 nvd=(nvd_diagnostics, nvd_warnings),
                 epss=(epss_diagnostics, epss_warnings),
                 kev=(kev_diagnostics, kev_warnings),
@@ -194,8 +195,24 @@ class EnrichmentService:
         live_results: dict[str, NvdData] = {}
         warnings: list[str] = []
         if missing_ids:
-            live_results, warnings = self.nvd.fetch_many(missing_ids)
-            self.last_nvd_diagnostics = self.nvd.last_diagnostics
+            try:
+                live_results, warnings = self.nvd.fetch_many(missing_ids)
+            except Exception as exc:  # noqa: BLE001 - NVD must not abort analysis/import
+                live_results = {cve_id: NvdData(cve_id=cve_id) for cve_id in missing_ids}
+                warnings = [f"NVD provider failed: {_safe_provider_error(exc, provider=self.nvd)}"]
+                self.last_nvd_diagnostics = NvdFetchDiagnostics(
+                    requested=len(missing_ids),
+                    failures=len(missing_ids) or 1,
+                    empty_records=len(missing_ids),
+                    degraded=True,
+                )
+            else:
+                provider_diagnostics = getattr(self.nvd, "last_diagnostics", None)
+                self.last_nvd_diagnostics = (
+                    provider_diagnostics
+                    if isinstance(provider_diagnostics, NvdFetchDiagnostics)
+                    else _build_nvd_fetch_diagnostics(cve_ids, live_results)
+                )
         else:
             self.last_nvd_diagnostics = NvdFetchDiagnostics(
                 requested=len(cve_ids),
@@ -325,6 +342,8 @@ def _snapshot_defensive_contexts(
 
 
 def _provider_data_quality_flags(
+    *,
+    nvd_results: dict[str, NvdData] | None = None,
     **sources: tuple[ProviderLookupDiagnostics, list[str]],
 ) -> dict[str, list[ProviderDataQualityFlag]]:
     flags_by_source: dict[str, list[ProviderDataQualityFlag]] = {}
@@ -336,7 +355,28 @@ def _provider_data_quality_flags(
         )
         if flags:
             flags_by_source[source] = flags
+    missing_cvss_flags = _nvd_missing_cvss_flags(nvd_results or {})
+    if missing_cvss_flags:
+        flags_by_source.setdefault("nvd", []).extend(missing_cvss_flags)
     return flags_by_source
+
+
+def _nvd_missing_cvss_flags(results: dict[str, NvdData]) -> list[ProviderDataQualityFlag]:
+    flags: list[ProviderDataQualityFlag] = []
+    for cve_id, item in results.items():
+        if has_nvd_content(item) and item.cvss_base_score is None and item.cvss_version is None:
+            flags.append(
+                ProviderDataQualityFlag(
+                    source="nvd",
+                    code="nvd_cvss_missing",
+                    message=(
+                        "NVD returned provider metadata without a CVSS base score "
+                        f"or version for {cve_id}."
+                    ),
+                    cve_id=cve_id,
+                )
+            )
+    return flags
 
 
 def _merge_provider_results(
@@ -381,3 +421,28 @@ def _build_fallback_diagnostics(
         content_hits=content_hits,
         empty_records=max(len(cve_ids) - content_hits, 0),
     )
+
+
+def _build_nvd_fetch_diagnostics(
+    cve_ids: list[str],
+    results: dict[str, NvdData],
+) -> NvdFetchDiagnostics:
+    fallback = _build_fallback_diagnostics(cve_ids, results, NvdData)
+    return NvdFetchDiagnostics(
+        requested=fallback.requested,
+        cache_hits=fallback.cache_hits,
+        network_fetches=fallback.network_fetches,
+        failures=fallback.failures,
+        content_hits=fallback.content_hits,
+        empty_records=fallback.empty_records,
+        stale_cache_hits=fallback.stale_cache_hits,
+        degraded=fallback.degraded,
+    )
+
+
+def _safe_provider_error(exc: BaseException, *, provider: object) -> str:
+    message = str(exc)
+    secret = getattr(provider, "api_key", None)
+    if isinstance(secret, str) and secret:
+        message = message.replace(secret, "<redacted>")
+    return message

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -266,6 +266,20 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
     detail_payload = detail.json()
     assert detail_payload["finding"]["cve_id"] == "CVE-2021-44228"
     assert detail_payload["finding"]["provider_evidence"]["nvd"]["cve_id"] == "CVE-2021-44228"
+    session_factory = create_session_factory(get_engine(client.app))
+    with session_factory() as session:
+        vulnerability = (
+            session.query(Vulnerability).filter(Vulnerability.cve_id == "CVE-2021-44228").one()
+        )
+        assert vulnerability.description
+        assert "Log4j" in vulnerability.description
+        assert vulnerability.cvss_score == 10.0
+        assert vulnerability.severity == "CRITICAL"
+        assert vulnerability.cwe == "CWE-20, CWE-400, CWE-502, CWE-917"
+        assert vulnerability.published_at == "2021-12-10T10:15:09.143"
+        assert vulnerability.modified_at == "2026-02-20T16:15:59.363"
+        assert vulnerability.provider_json["nvd"]["cve_id"] == "CVE-2021-44228"
+        assert "apiKey" not in json.dumps(vulnerability.provider_json)
     assert detail_payload["kev_detail"]["cve_id"] == "CVE-2021-44228"
     assert detail_payload["kev_detail"]["in_kev"] is True
     assert detail_payload["kev_detail"]["vendor_project"] == "Apache"

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -84,6 +84,24 @@ def test_kev_enrichment_response_example_matches_model() -> None:
     assert kev.vulnerability_name == "Example Product command injection vulnerability"
 
 
+def test_nvd_provider_record_example_matches_model() -> None:
+    payload = json.loads(
+        (DOCS_ROOT / "examples" / "example_nvd_provider_record.json").read_text(encoding="utf-8")
+    )
+
+    nvd = NvdData.model_validate(payload)
+
+    assert nvd.cve_id == "CVE-2026-2001"
+    assert nvd.cvss_version == "4.0"
+    assert nvd.cvss_vector.startswith("CVSS:4.0/")
+    assert nvd.reference_tags == {
+        "https://example.invalid/advisory/CVE-2026-2001": [
+            "Vendor Advisory",
+            "Patch",
+        ]
+    }
+
+
 def _install_fake_data_update_providers(monkeypatch: Any) -> None:
     def fake_nvd_fetch_many(
         self: NvdProvider,

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -27,9 +27,15 @@ from vuln_prioritizer.services.enrichment import EnrichmentService
 
 
 class FakeResponse:
-    def __init__(self, json_data: dict | None = None, status_code: int = 200) -> None:
+    def __init__(
+        self,
+        json_data: dict | None = None,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self._json_data = json_data or {}
         self.status_code = status_code
+        self.headers = headers or {}
 
     def json(self) -> dict:
         return self._json_data
@@ -94,6 +100,41 @@ def test_nvd_parse_payload_prefers_v40_and_collects_metadata() -> None:
     assert parsed.cwes == ["CWE-79"]
     assert parsed.references == ["https://example.com/advisory"]
     assert parsed.reference_tags == {"https://example.com/advisory": ["Vendor Advisory", "Patch"]}
+
+
+def test_nvd_parse_payload_uses_later_primary_v31_metric() -> None:
+    payload = {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "descriptions": [{"lang": "en", "value": "CVSS v3 fallback"}],
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "type": "Secondary",
+                                "cvssData": {"vectorString": "CVSS:3.1/AV:L/AC:H"},
+                            },
+                            {
+                                "type": "Primary",
+                                "cvssData": {
+                                    "baseScore": 7.4,
+                                    "baseSeverity": "HIGH",
+                                    "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N",
+                                },
+                            },
+                        ],
+                    },
+                }
+            }
+        ]
+    }
+
+    parsed = NvdProvider.parse_payload("CVE-2026-0002", payload)
+
+    assert parsed.cvss_base_score == 7.4
+    assert parsed.cvss_severity == "HIGH"
+    assert parsed.cvss_version == "3.1"
+    assert parsed.cvss_vector == "CVSS:3.1/AV:N/AC:H/PR:N/UI:N"
 
 
 def test_nvd_fetch_many_handles_missing_results() -> None:
@@ -291,6 +332,80 @@ def test_nvd_fetch_many_degrades_gracefully_and_keeps_warning_order() -> None:
     )
 
 
+def test_nvd_fetch_many_retries_rate_limited_response(monkeypatch) -> None:  # noqa: ANN001
+    sleep_calls: list[float] = []
+
+    class Session:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            self.calls += 1
+            if self.calls == 1:
+                return FakeResponse(status_code=429, headers={"Retry-After": "0"})
+            return FakeResponse(
+                {
+                    "vulnerabilities": [
+                        {
+                            "cve": {
+                                "descriptions": [{"lang": "en", "value": "Retried NVD record"}],
+                                "metrics": {
+                                    "cvssMetricV40": [
+                                        {
+                                            "cvssData": {
+                                                "baseScore": 8.7,
+                                                "baseSeverity": "HIGH",
+                                            }
+                                        }
+                                    ]
+                                },
+                            }
+                        }
+                    ]
+                }
+            )
+
+    monkeypatch.setattr(
+        "vuln_prioritizer.providers.nvd.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+    session = Session()
+    provider = NvdProvider(session=session, max_retries=2)
+
+    results, warnings = provider.fetch_many(["CVE-2026-0204"])
+
+    assert warnings == []
+    assert session.calls == 2
+    assert sleep_calls == [0.0]
+    assert results["CVE-2026-0204"].description == "Retried NVD record"
+    assert results["CVE-2026-0204"].cvss_version == "4.0"
+
+
+def test_nvd_api_key_from_env_is_sent_and_redacted_from_warnings(monkeypatch) -> None:  # noqa: ANN001
+    secret = "nvd-secret-value"
+
+    class Session:
+        def __init__(self) -> None:
+            self.headers: list[dict[str, str]] = []
+
+        def get(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            self.headers.append(kwargs["headers"])
+            raise requests.RequestException(f"transport failure for apiKey={secret}")
+
+    monkeypatch.setenv("VPW_NVD_TEST_API_KEY", secret)
+    session = Session()
+    provider = NvdProvider.from_env(api_key_env="VPW_NVD_TEST_API_KEY", session=session)
+
+    results, warnings = provider.fetch_many(["CVE-2026-0205"])
+
+    assert session.headers == [{"apiKey": secret}]
+    assert results["CVE-2026-0205"] == NvdData(cve_id="CVE-2026-0205")
+    assert len(warnings) == 1
+    assert secret not in warnings[0]
+    assert "apiKey=<redacted>" in warnings[0]
+    assert provider.last_diagnostics.degraded is True
+
+
 def test_enrichment_service_tracks_last_nvd_diagnostics() -> None:
     class Session:
         def get(self, *args, **kwargs):  # noqa: ANN002, ANN003
@@ -358,6 +473,164 @@ def test_enrichment_service_tracks_last_nvd_diagnostics() -> None:
         failures=0,
         content_hits=1,
     )
+
+
+def test_enrichment_service_nvd_failure_records_data_quality_flags() -> None:
+    class ExplodingNvdProvider:
+        api_key = "nvd-secret-value"
+
+        def fetch_many(self, cve_ids):  # noqa: ANN001, ARG002
+            raise RuntimeError("invalid NVD cache for nvd-secret-value")
+
+    class StubEpssProvider:
+        last_diagnostics = ProviderLookupDiagnostics(
+            requested=1,
+            network_fetches=1,
+            content_hits=0,
+            empty_records=1,
+        )
+
+        def fetch_many(self, cve_ids):  # noqa: ANN001
+            return ({cve_id: EpssData(cve_id=cve_id) for cve_id in cve_ids}, [])
+
+    class StubKevProvider:
+        last_diagnostics = ProviderLookupDiagnostics(
+            requested=1,
+            network_fetches=1,
+            content_hits=0,
+            empty_records=1,
+        )
+
+        def fetch_many(self, cve_ids, offline_file=None):  # noqa: ANN001, ARG002
+            return ({cve_id: KevData(cve_id=cve_id) for cve_id in cve_ids}, [])
+
+    class StubAttackProvider:
+        def fetch_many(  # noqa: ANN001
+            self,
+            cve_ids,
+            *,
+            enabled: bool,
+            source: str,
+            mapping_file,
+            technique_metadata_file,
+            offline_file,
+        ):
+            return (
+                {cve_id: AttackData(cve_id=cve_id) for cve_id in cve_ids},
+                {
+                    "source": source if enabled else "none",
+                    "mapping_file": None,
+                    "technique_metadata_file": None,
+                    "source_version": None,
+                    "attack_version": None,
+                    "domain": None,
+                    "mapping_framework": None,
+                    "mapping_framework_version": None,
+                },
+                [],
+            )
+
+    service = EnrichmentService(use_cache=False)
+    service.nvd = ExplodingNvdProvider()
+    service.epss = StubEpssProvider()
+    service.kev = StubKevProvider()
+    service.attack = StubAttackProvider()
+
+    result = service.enrich(["CVE-2026-0401"], attack_enabled=False)
+
+    assert result.nvd["CVE-2026-0401"] == NvdData(cve_id="CVE-2026-0401")
+    assert result.warnings == ["NVD provider failed: invalid NVD cache for <redacted>"]
+    assert result.nvd_diagnostics.failures == 1
+    assert result.nvd_diagnostics.empty_records == 1
+    assert [flag.code for flag in result.provider_data_quality_flags["nvd"]] == [
+        "provider_failure",
+        "provider_missing_data",
+        "provider_warning",
+    ]
+    assert "nvd-secret-value" not in result.model_dump_json()
+
+
+def test_enrichment_service_flags_nvd_missing_cvss() -> None:
+    class StubNvdProvider:
+        last_diagnostics = NvdFetchDiagnostics(
+            requested=1,
+            network_fetches=1,
+            content_hits=1,
+        )
+
+        def fetch_many(self, cve_ids):  # noqa: ANN001
+            return (
+                {
+                    cve_id: NvdData(
+                        cve_id=cve_id,
+                        description="NVD record without CVSS metrics",
+                        published="2026-04-29T00:00:00.000",
+                    )
+                    for cve_id in cve_ids
+                },
+                [],
+            )
+
+    class StubEpssProvider:
+        last_diagnostics = ProviderLookupDiagnostics(
+            requested=1,
+            network_fetches=1,
+            content_hits=0,
+            empty_records=1,
+        )
+
+        def fetch_many(self, cve_ids):  # noqa: ANN001
+            return ({cve_id: EpssData(cve_id=cve_id) for cve_id in cve_ids}, [])
+
+    class StubKevProvider:
+        last_diagnostics = ProviderLookupDiagnostics(
+            requested=1,
+            network_fetches=1,
+            content_hits=0,
+            empty_records=1,
+        )
+
+        def fetch_many(self, cve_ids, offline_file=None):  # noqa: ANN001, ARG002
+            return ({cve_id: KevData(cve_id=cve_id) for cve_id in cve_ids}, [])
+
+    class StubAttackProvider:
+        def fetch_many(  # noqa: ANN001
+            self,
+            cve_ids,
+            *,
+            enabled: bool,
+            source: str,
+            mapping_file,
+            technique_metadata_file,
+            offline_file,
+        ):
+            return (
+                {cve_id: AttackData(cve_id=cve_id) for cve_id in cve_ids},
+                {
+                    "source": source if enabled else "none",
+                    "mapping_file": None,
+                    "technique_metadata_file": None,
+                    "source_version": None,
+                    "attack_version": None,
+                    "domain": None,
+                    "mapping_framework": None,
+                    "mapping_framework_version": None,
+                },
+                [],
+            )
+
+    service = EnrichmentService(use_cache=False)
+    service.nvd = StubNvdProvider()
+    service.epss = StubEpssProvider()
+    service.kev = StubKevProvider()
+    service.attack = StubAttackProvider()
+
+    result = service.enrich(["CVE-2026-0402"], attack_enabled=False)
+
+    flags = result.provider_data_quality_flags["nvd"]
+    assert [flag.code for flag in flags] == ["nvd_cvss_missing"]
+    assert flags[0].cve_id == "CVE-2026-0402"
+    assert "without a CVSS base score or version" in flags[0].message
 
 
 def test_enrichment_service_epss_failure_records_data_quality_flags() -> None:

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -192,6 +192,9 @@ The EPSS-specific batch/cache/freshness behavior is documented in
 The KEV-specific JSON/CSV normalization, fixture, source-hash, and Workbench
 detail behavior is documented in
 [VPW-024 KEV Provider Cache](vpw-024-kev-provider-cache.md).
+The NVD-specific CVE API, fallback, CVSS parsing, and missing-CVSS
+data-quality behavior is documented in
+[VPW-025 NVD Provider Fallback](vpw-025-nvd-provider-fallback.md).
 
 The current `data` command tree is intentionally small:
 

--- a/docs/architecture/vpw-025-nvd-provider-fallback.md
+++ b/docs/architecture/vpw-025-nvd-provider-fallback.md
@@ -1,0 +1,55 @@
+# VPW-025 NVD Provider Fallback
+
+VPW-025 keeps NVD enrichment deterministic and non-blocking for CLI and
+Workbench imports.
+
+## Provider Behavior
+
+- NVD lookups use the NVD CVE API 2.0 endpoint once per requested CVE.
+- `NVD_API_KEY` remains optional. When configured, the key is sent only in the
+  `apiKey` request header.
+- Unauthenticated demo and local runs continue through provider snapshots or
+  the local NVD cache.
+- HTTP 429 and transient 5xx responses use bounded retry behavior and honor
+  `Retry-After` when present.
+- Provider errors degrade into warnings, diagnostics, and data-quality flags;
+  they do not abort analysis or Workbench imports.
+- If live lookup fails and an expired cache entry exists, the provider returns
+  that stale entry and marks stale-cache diagnostics.
+
+## NVD Record Mapping
+
+The NVD record is normalized into `NvdData` and persisted through provider
+evidence:
+
+- `description`
+- `cvss_base_score`, `cvss_severity`, `cvss_version`, `cvss_vector`
+- `vulnerability_status`
+- `published`, `last_modified`
+- `cwes`
+- `references`, `reference_tags`
+
+Workbench imports copy the same NVD evidence into `Vulnerability` rows for
+description, CVSS, severity, CWE, published/modified timestamps, and
+`provider_json`.
+
+## Data Quality
+
+NVD metadata without CVSS base score and version is still useful context, but
+it is incomplete for prioritization. These records add:
+
+```json
+{
+  "source": "nvd",
+  "code": "nvd_cvss_missing",
+  "cve_id": "CVE-2026-0402"
+}
+```
+
+This flag is additive to provider-level flags such as `provider_failure`,
+`provider_missing_data`, `provider_warning`, and `stale_cache`.
+
+## Example
+
+A standalone NVD provider record example is published at
+[`docs/examples/example_nvd_provider_record.json`](../examples/example_nvd_provider_record.json).

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -249,8 +249,13 @@ Current provider service contract:
 
 - built-in NVD, EPSS, and KEV providers can be adapted to the shared
   `ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` interface
+- NVD uses the CVE API 2.0 per requested CVE, sends an optional API key only
+  through the configured request header, redacts configured key values from
+  warnings, and degrades to cache or empty records instead of aborting analysis
 - provider failures degrade into `ProviderStatus` and data-quality flags before
   optional CI gates decide whether to fail the process
+- NVD records with provider metadata but no CVSS base score/version add an
+  `nvd_cvss_missing` data-quality flag with the affected `cve_id`
 - KEV provider data includes CISA catalog details such as
   `vulnerability_name`, `vendor_project`, `product`, `date_added`, `due_date`,
   and `required_action` when present in JSON, CSV, cache, or locked snapshot

--- a/docs/examples/example_nvd_provider_record.json
+++ b/docs/examples/example_nvd_provider_record.json
@@ -1,0 +1,23 @@
+{
+  "cve_id": "CVE-2026-2001",
+  "description": "Example NVD CVE record used to validate provider evidence contracts.",
+  "cvss_base_score": 9.8,
+  "cvss_severity": "CRITICAL",
+  "cvss_version": "4.0",
+  "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H",
+  "vulnerability_status": "Analyzed",
+  "published": "2026-04-29T00:00:00.000",
+  "last_modified": "2026-04-29T12:00:00.000",
+  "cwes": [
+    "CWE-79"
+  ],
+  "references": [
+    "https://example.invalid/advisory/CVE-2026-2001"
+  ],
+  "reference_tags": {
+    "https://example.invalid/advisory/CVE-2026-2001": [
+      "Vendor Advisory",
+      "Patch"
+    ]
+  }
+}

--- a/docs/schemas/provider-snapshot-report.schema.json
+++ b/docs/schemas/provider-snapshot-report.schema.json
@@ -58,6 +58,12 @@
             "cvss_version": {
               "$ref": "#/$defs/nullableString"
             },
+            "cvss_vector": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "vulnerability_status": {
+              "$ref": "#/$defs/nullableString"
+            },
             "published": {
               "$ref": "#/$defs/nullableString"
             },
@@ -69,6 +75,12 @@
             },
             "references": {
               "$ref": "#/$defs/stringArray"
+            },
+            "reference_tags": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+              }
             }
           }
         }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Provider Cache Status Snapshots: architecture/vpw-022-provider-cache-status-snapshots.md
       - EPSS Provider Cache: architecture/vpw-023-epss-provider-cache.md
       - KEV Provider Cache: architecture/vpw-024-kev-provider-cache.md
+      - NVD Provider Fallback: architecture/vpw-025-nvd-provider-fallback.md
       - Template Repository Layer: architecture/template-service-layer.md
       - Template Importer Contract: architecture/vpw-013-importer-contract.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md


### PR DESCRIPTION
## Summary
- harden NVD provider warnings so configured API keys are redacted while header-based auth still works
- make NVD provider failures non-blocking in enrichment and add nvd_cvss_missing quality flags
- improve CVSS metric selection, add mock retry/API-key/missing-CVSS tests, and document the NVD provider record contract

## Verification
- python3 -m ruff check backend/src/vuln_prioritizer/providers/nvd.py backend/src/vuln_prioritizer/services/enrichment.py backend/tests/test_providers.py backend/tests/test_output_schemas.py backend/tests/api/test_workbench_api.py
- python3 -m mypy backend/src/vuln_prioritizer/providers/nvd.py backend/src/vuln_prioritizer/services/enrichment.py
- python3 -m pytest -q backend/tests/test_providers.py::test_nvd_parse_payload_prefers_v40_and_collects_metadata backend/tests/test_providers.py::test_nvd_parse_payload_uses_later_primary_v31_metric backend/tests/test_providers.py::test_nvd_fetch_many_retries_rate_limited_response backend/tests/test_providers.py::test_nvd_api_key_from_env_is_sent_and_redacted_from_warnings backend/tests/test_providers.py::test_nvd_fetch_many_degrades_gracefully_and_keeps_warning_order backend/tests/test_providers.py::test_enrichment_service_nvd_failure_records_data_quality_flags backend/tests/test_providers.py::test_enrichment_service_flags_nvd_missing_cvss backend/tests/test_providers.py::test_enrichment_service_tracks_last_nvd_diagnostics backend/tests/test_output_schemas.py::test_nvd_provider_record_example_matches_model backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence --no-cov
- python3 -m pytest -q backend/tests/test_providers.py backend/tests/test_output_schemas.py backend/tests/api/test_workbench_api.py --no-cov
- make check
- make docs-check

Refs #131