### PR TITLE
VPW-026: implement provider snapshot replay evidence

### DIFF
--- a/backend/src/vuln_prioritizer/api/schemas.py
+++ b/backend/src/vuln_prioritizer/api/schemas.py
@@ -446,6 +446,33 @@ class ProviderStatusResponse(StrictModel):
     warnings: list[str] = Field(default_factory=list)
 
 
+class ProviderSnapshotRecordResponse(StrictModel):
+    id: str
+    created_at: str
+    content_hash: str | None = None
+    nvd_last_sync: str | None = None
+    epss_date: str | None = None
+    kev_catalog_version: str | None = None
+    snapshot_id: str | None = None
+    snapshot_format: str = "provider-snapshot.v1.json"
+    generated_at: str | None = None
+    selected_sources: list[str] = Field(default_factory=list)
+    requested_cves: int = 0
+    source_hashes: dict[str, str | None] = Field(default_factory=dict)
+    source_metadata: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    source_path: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class ProviderSnapshotListResponse(StrictModel):
+    items: list[ProviderSnapshotRecordResponse] = Field(default_factory=list)
+
+
+class ProviderSnapshotImportResponse(StrictModel):
+    imported: bool = True
+    item: ProviderSnapshotRecordResponse
+
+
 class AttackTechniqueSummary(StrictModel):
     technique_id: str
     name: str

--- a/backend/src/vuln_prioritizer/api/workbench_provider_routes.py
+++ b/backend/src/vuln_prioritizer/api/workbench_provider_routes.py
@@ -2,21 +2,34 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from vuln_prioritizer.api.deps import get_db_session, get_workbench_settings
 from vuln_prioritizer.api.schemas import (
+    ProviderSnapshotImportResponse,
+    ProviderSnapshotListResponse,
+    ProviderSnapshotRecordResponse,
     ProviderStatusResponse,
     ProviderUpdateJobRequest,
     ProviderUpdateJobResponse,
 )
 from vuln_prioritizer.api.workbench_providers import (
     _create_provider_update_job_record,
+    _persist_imported_provider_snapshot,
+    _provider_snapshot_payload,
     _provider_status_payload,
     _provider_update_job_payload,
+    _resolve_provider_snapshot_artifact_path,
+)
+from vuln_prioritizer.api.workbench_uploads import (
+    SAFE_SNAPSHOT_FILENAME_RE,
+    _read_bounded_upload,
+    _reject_unsafe_upload_filename,
 )
 from vuln_prioritizer.db.repositories import WorkbenchRepository
 from vuln_prioritizer.services.workbench_jobs import run_sync_workbench_job
@@ -37,6 +50,65 @@ def provider_status(
         settings=settings,
         latest_update_job=jobs[0] if jobs else None,
     )
+
+
+@provider_router.get("/providers/snapshots", response_model=ProviderSnapshotListResponse)
+def list_provider_snapshots(
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, Any]:
+    repo = WorkbenchRepository(session)
+    return {"items": [_provider_snapshot_payload(item) for item in repo.list_provider_snapshots()]}
+
+
+@provider_router.get(
+    "/providers/snapshots/{snapshot_id}",
+    response_model=ProviderSnapshotRecordResponse,
+)
+def get_provider_snapshot(
+    snapshot_id: str,
+    session: Annotated[Session, Depends(get_db_session)],
+) -> dict[str, Any]:
+    snapshot = _get_provider_snapshot_or_404(session, snapshot_id)
+    return _provider_snapshot_payload(snapshot)
+
+
+@provider_router.get("/providers/snapshots/{snapshot_id}/download")
+def download_provider_snapshot(
+    snapshot_id: str,
+    session: Annotated[Session, Depends(get_db_session)],
+    settings: Annotated[WorkbenchSettings, Depends(get_workbench_settings)],
+) -> FileResponse:
+    snapshot = _get_provider_snapshot_or_404(session, snapshot_id)
+    path = _resolve_provider_snapshot_artifact_path(snapshot, settings=settings)
+    return FileResponse(
+        path,
+        media_type="application/json",
+        filename=f"provider-snapshot-{snapshot.id}.json",
+    )
+
+
+@provider_router.post(
+    "/providers/snapshots/import",
+    response_model=ProviderSnapshotImportResponse,
+)
+async def import_provider_snapshot(
+    file: Annotated[UploadFile, File()],
+    session: Annotated[Session, Depends(get_db_session)],
+    settings: Annotated[WorkbenchSettings, Depends(get_workbench_settings)],
+) -> dict[str, Any]:
+    filename = file.filename or "provider-snapshot.json"
+    _reject_unsafe_upload_filename(filename)
+    if not SAFE_SNAPSHOT_FILENAME_RE.fullmatch(Path(filename).name):
+        raise HTTPException(status_code=422, detail="Provider snapshot filename must be JSON.")
+    content = await _read_bounded_upload(file, settings=settings)
+    snapshot = _persist_imported_provider_snapshot(
+        repo=WorkbenchRepository(session),
+        settings=settings,
+        filename=filename,
+        content=content,
+    )
+    session.commit()
+    return {"imported": True, "item": _provider_snapshot_payload(snapshot)}
 
 
 @provider_router.get("/providers/update-jobs")
@@ -83,3 +155,11 @@ def create_provider_update_job(
     )
     session.commit()
     return _provider_update_job_payload(job)
+
+
+def _get_provider_snapshot_or_404(session: Session, snapshot_id: str) -> Any:
+    repo = WorkbenchRepository(session)
+    for snapshot in repo.list_provider_snapshots():
+        if snapshot.id == snapshot_id:
+            return snapshot
+    raise HTTPException(status_code=404, detail="Provider snapshot not found.")

--- a/backend/src/vuln_prioritizer/api/workbench_providers.py
+++ b/backend/src/vuln_prioritizer/api/workbench_providers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -147,9 +148,12 @@ def _run_provider_snapshot_refresh(
         )
         warnings.extend(source_warnings)
 
-    output_path = settings.provider_snapshot_dir / f"workbench-provider-snapshot-{uuid4().hex}.json"
+    snapshot_id = uuid4().hex
+    output_path = settings.provider_snapshot_dir / f"provider-snapshot-{snapshot_id}.json"
+    source_hashes = _provider_cache_source_hashes(cache, selected_sources)
     report = ProviderSnapshotReport(
         metadata=ProviderSnapshotMetadata(
+            snapshot_id=snapshot_id,
             generated_at=iso_utc_now(),
             input_paths=[],
             input_format="workbench-current-findings",
@@ -159,7 +163,13 @@ def _run_provider_snapshot_refresh(
             cache_enabled=True,
             cache_only=payload.cache_only,
             cache_dir=str(settings.provider_cache_dir),
-            source_hashes=_provider_cache_source_hashes(cache, selected_sources),
+            source_hashes=source_hashes,
+            source_metadata=_provider_source_metadata(
+                selected_sources=selected_sources,
+                source_hashes=source_hashes,
+                source_counts=source_counts,
+                cache_only=payload.cache_only,
+            ),
             nvd_api_key_env=settings.nvd_api_key_env,
         ),
         items=[
@@ -467,6 +477,156 @@ def _provider_cache_source_hashes(
         for source in selected_sources
         if source in {"nvd", "epss", "kev"}
     }
+
+
+def _provider_source_metadata(
+    *,
+    selected_sources: list[str],
+    source_hashes: dict[str, str | None],
+    source_counts: dict[str, dict[str, int]],
+    cache_only: bool,
+) -> dict[str, dict[str, str | int | bool | None]]:
+    source_labels = {
+        "nvd": "NVD CVE API 2.0",
+        "epss": "FIRST EPSS API",
+        "kev": "CISA KEV catalog",
+    }
+    return {
+        source: {
+            "source": source_labels[source],
+            "record_count": source_counts.get(source, {}).get("records", 0),
+            "fetched_count": source_counts.get(source, {}).get("fetched", 0),
+            "fallback_from_previous_snapshot": source_counts.get(source, {}).get(
+                "fallback_from_previous_snapshot", 0
+            ),
+            "missing_count": source_counts.get(source, {}).get("missing", 0),
+            "cache_only": cache_only,
+            "cache_namespace_hash": source_hashes.get(source),
+        }
+        for source in selected_sources
+        if source in source_labels
+    }
+
+
+def _provider_snapshot_payload(snapshot: Any) -> dict[str, Any]:
+    metadata = snapshot.metadata_json if isinstance(snapshot.metadata_json, dict) else {}
+    return {
+        "id": snapshot.id,
+        "created_at": snapshot.created_at.isoformat(),
+        "content_hash": snapshot.content_hash,
+        "nvd_last_sync": snapshot.nvd_last_sync,
+        "epss_date": snapshot.epss_date,
+        "kev_catalog_version": snapshot.kev_catalog_version,
+        "snapshot_id": metadata.get("snapshot_id"),
+        "snapshot_format": metadata.get("snapshot_format", "provider-snapshot.v1.json"),
+        "generated_at": metadata.get("generated_at"),
+        "selected_sources": list(metadata.get("selected_sources", [])),
+        "requested_cves": int(metadata.get("requested_cves", 0) or 0),
+        "source_hashes": metadata.get("source_hashes", {}),
+        "source_metadata": metadata.get("source_metadata", {}),
+        "source_path": metadata.get("source_path") or metadata.get("output_path"),
+        "warnings": metadata.get("warnings", []),
+    }
+
+
+def _resolve_provider_snapshot_artifact_path(
+    snapshot: Any,
+    *,
+    settings: WorkbenchSettings,
+) -> Path:
+    metadata = snapshot.metadata_json if isinstance(snapshot.metadata_json, dict) else {}
+    value = (
+        metadata.get("source_path") or metadata.get("snapshot_path") or metadata.get("output_path")
+    )
+    if not isinstance(value, str) or not value.strip():
+        raise HTTPException(status_code=404, detail="Provider snapshot artifact path is missing.")
+    path = Path(value).resolve(strict=False)
+    allowed_roots = (
+        settings.provider_snapshot_dir.resolve(strict=False),
+        settings.provider_cache_dir.resolve(strict=False),
+    )
+    if not any(path.is_relative_to(root) for root in allowed_roots):
+        raise HTTPException(
+            status_code=403, detail="Provider snapshot artifact path is outside allowed roots."
+        )
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="Provider snapshot artifact is not available.")
+    return path
+
+
+def _persist_imported_provider_snapshot(
+    *,
+    repo: WorkbenchRepository,
+    settings: WorkbenchSettings,
+    filename: str,
+    content: bytes,
+) -> Any:
+    try:
+        payload = json.loads(content.decode("utf-8"))
+        _validate_provider_snapshot_v1_payload(payload)
+        report = ProviderSnapshotReport.model_validate(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid provider snapshot JSON: {exc}"
+        ) from exc
+
+    snapshot_id = report.metadata.snapshot_id or uuid4().hex
+    output_path = settings.provider_snapshot_dir / f"provider-snapshot-{snapshot_id}.json"
+    report = report.model_copy(
+        update={
+            "metadata": report.metadata.model_copy(
+                update={
+                    "snapshot_id": snapshot_id,
+                    "output_path": str(output_path),
+                }
+            )
+        }
+    )
+    document = generate_provider_snapshot_json(report).encode("utf-8")
+    content_hash = hashlib.sha256(document).hexdigest()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(document)
+    metadata_json = report.metadata.model_dump()
+    metadata_json.update(
+        {
+            "source_path": str(output_path),
+            "imported_filename": filename,
+            "item_count": len(report.items),
+            "warnings": report.warnings,
+            "missing": False,
+            "generated_by": "provider-snapshot-import",
+        }
+    )
+    return repo.get_or_create_provider_snapshot(
+        content_hash=content_hash,
+        nvd_last_sync=_latest_nvd_sync(item.nvd for item in report.items if item.nvd is not None),
+        epss_date=_latest_epss_date(item.epss for item in report.items if item.epss is not None),
+        kev_catalog_version=_latest_kev_date(
+            item.kev for item in report.items if item.kev is not None
+        ),
+        metadata_json=metadata_json,
+    )
+
+
+def _validate_provider_snapshot_v1_payload(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=422, detail="Provider snapshot JSON must be an object.")
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        raise HTTPException(status_code=422, detail="Provider snapshot JSON requires metadata.")
+    if metadata.get("snapshot_format") != "provider-snapshot.v1.json":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Provider snapshot import requires "
+                "metadata.snapshot_format=provider-snapshot.v1.json."
+            ),
+        )
+    if not isinstance(metadata.get("source_metadata"), dict):
+        raise HTTPException(
+            status_code=422,
+            detail="Provider snapshot import requires metadata.source_metadata.",
+        )
 
 
 def _provider_update_job_payload(job: Any) -> dict[str, Any]:

--- a/backend/src/vuln_prioritizer/commands/data.py
+++ b/backend/src/vuln_prioritizer/commands/data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, TypeVar, cast
+from uuid import uuid4
 
 import typer
 from dotenv import load_dotenv
@@ -570,8 +571,10 @@ def data_export_provider_snapshot(
             )
         warnings.extend(provider_warnings)
 
+    source_hashes = _provider_cache_source_hashes(cache, selected_sources)
     report = ProviderSnapshotReport(
         metadata=ProviderSnapshotMetadata(
+            snapshot_id=uuid4().hex,
             generated_at=iso_utc_now(),
             input_path=str(input[0]) if input else None,
             input_paths=[str(path) for path in (input or [])],
@@ -582,7 +585,15 @@ def data_export_provider_snapshot(
             cache_enabled=True,
             cache_only=cache_only,
             cache_dir=str(cache_dir),
-            source_hashes=_provider_cache_source_hashes(cache, selected_sources),
+            source_hashes=source_hashes,
+            source_metadata=_provider_source_metadata(
+                selected_sources=selected_sources,
+                source_hashes=source_hashes,
+                nvd_results=nvd_results,
+                epss_results=epss_results,
+                kev_results=kev_results,
+                cache_only=cache_only,
+            ),
             offline_kev_file=str(offline_kev_file) if offline_kev_file else None,
             nvd_api_key_env=nvd_api_key_env,
         ),
@@ -611,6 +622,41 @@ def _provider_cache_source_hashes(
         source: cache.inspect_namespace(source)["namespace_checksum"]
         for source in selected_sources
         if source in {"nvd", "epss", "kev"}
+    }
+
+
+def _provider_source_metadata(
+    *,
+    selected_sources: Sequence[str],
+    source_hashes: dict[str, str | None],
+    nvd_results: dict[str, NvdData],
+    epss_results: dict[str, EpssData],
+    kev_results: dict[str, KevData],
+    cache_only: bool,
+) -> dict[str, dict[str, str | int | bool | None]]:
+    record_counts = {
+        "nvd": sum(1 for item in nvd_results.values() if has_nvd_content(item)),
+        "epss": sum(
+            1
+            for item in epss_results.values()
+            if item.epss is not None or item.percentile is not None or item.date is not None
+        ),
+        "kev": sum(1 for item in kev_results.values() if item.in_kev),
+    }
+    source_labels = {
+        "nvd": "NVD CVE API 2.0",
+        "epss": "FIRST EPSS API",
+        "kev": "CISA KEV catalog",
+    }
+    return {
+        source: {
+            "source": source_labels[source],
+            "record_count": record_counts[source],
+            "cache_only": cache_only,
+            "cache_namespace_hash": source_hashes.get(source),
+        }
+        for source in selected_sources
+        if source in source_labels
     }
 
 

--- a/backend/src/vuln_prioritizer/models.py
+++ b/backend/src/vuln_prioritizer/models.py
@@ -298,6 +298,8 @@ class AnalysisContext(BaseModel):
     input_sources: list[InputSourceSummary] = Field(default_factory=list)
     merged_input_count: int = 1
     duplicate_cve_count: int = 0
+    provider_snapshot_id: str | None = None
+    provider_snapshot_hash: str | None = None
     provider_snapshot_file: str | None = None
     locked_provider_data: bool = False
     provider_snapshot_sources: list[str] = Field(default_factory=list)
@@ -377,6 +379,8 @@ class SnapshotMetadata(AnalysisContext):
 class ProviderSnapshotMetadata(StrictModel):
     schema_version: str = "1.2.0"
     artifact_kind: str = "provider-snapshot"
+    snapshot_format: str = "provider-snapshot.v1.json"
+    snapshot_id: str | None = None
     generated_at: str
     input_path: str | None = None
     input_paths: list[str] = Field(default_factory=list)
@@ -388,6 +392,7 @@ class ProviderSnapshotMetadata(StrictModel):
     cache_only: bool = False
     cache_dir: str | None = None
     source_hashes: dict[str, str | None] = Field(default_factory=dict)
+    source_metadata: dict[str, dict[str, str | int | bool | None]] = Field(default_factory=dict)
     offline_kev_file: str | None = None
     nvd_api_key_env: str | None = None
 

--- a/backend/src/vuln_prioritizer/reporter.py
+++ b/backend/src/vuln_prioritizer/reporter.py
@@ -253,8 +253,15 @@ def render_summary_panel(
         lines.append(f"Duplicate CVEs collapsed: {context.duplicate_cve_count}")
     if context.provider_snapshot_file:
         lines.append(f"Provider snapshot: {context.provider_snapshot_file}")
+    if context.provider_snapshot_id:
+        lines.append(f"Provider snapshot ID: {context.provider_snapshot_id}")
+    if context.provider_snapshot_hash:
+        lines.append(f"Provider snapshot hash: {context.provider_snapshot_hash}")
     if context.provider_snapshot_sources:
         lines.append("Provider snapshot sources: " + ", ".join(context.provider_snapshot_sources))
+    snapshot_generated_at = context.provider_freshness.get("provider_snapshot_generated_at")
+    if snapshot_generated_at:
+        lines.append(f"Provider snapshot generated at: {snapshot_generated_at}")
     if context.nvd_diagnostics.requested:
         diagnostics = context.nvd_diagnostics
         lines.append(

--- a/backend/src/vuln_prioritizer/reporting_evidence.py
+++ b/backend/src/vuln_prioritizer/reporting_evidence.py
@@ -240,6 +240,29 @@ def write_evidence_bundle(
                 "attack-navigator-layer",
             )
         )
+    provider_snapshot_bundle_path = None
+    provider_snapshot_path = resolve_analysis_input_path(
+        metadata.get("provider_snapshot_file") if isinstance(metadata, dict) else None,
+        analysis_path,
+    )
+    if provider_snapshot_path is not None:
+        provider_snapshot_bundle_path = "provider/provider-snapshot.json"
+        bundle_entries.append(
+            (
+                provider_snapshot_bundle_path,
+                provider_snapshot_path.read_bytes(),
+                "provider-snapshot",
+            )
+        )
+    elif (
+        isinstance(metadata, dict)
+        and metadata.get("provider_snapshot_file")
+        and warning_callback is not None
+    ):
+        warning_callback(
+            "Referenced provider snapshot could not be resolved; bundle will omit the "
+            "snapshot copy."
+        )
     reported_input_paths = analysis_input_paths(metadata)
     resolved_inputs = [
         resolved_input
@@ -281,7 +304,11 @@ def write_evidence_bundle(
         source_input_path=reported_input_paths[0] if reported_input_paths else None,
         source_input_paths=reported_input_paths,
         source_input_hashes=input_hashes,
-        provider_snapshot=provider_snapshot_manifest_entry(metadata, analysis_path=analysis_path),
+        provider_snapshot=provider_snapshot_manifest_entry(
+            metadata,
+            analysis_path=analysis_path,
+            bundle_path=provider_snapshot_bundle_path,
+        ),
         artifact_hashes={entry.path: entry.sha256 for entry in file_entries},
         findings_count=int(metadata.get("findings_count", 0)),
         kev_hits=int(metadata.get("kev_hits", 0)),
@@ -391,7 +418,12 @@ def input_hash_entry(path: Path) -> EvidenceBundleInputHash:
     )
 
 
-def provider_snapshot_manifest_entry(metadata: object, *, analysis_path: Path) -> dict[str, Any]:
+def provider_snapshot_manifest_entry(
+    metadata: object,
+    *,
+    analysis_path: Path,
+    bundle_path: str | None = None,
+) -> dict[str, Any]:
     if not isinstance(metadata, dict):
         return {}
     snapshot_path = metadata.get("provider_snapshot_file")
@@ -404,6 +436,7 @@ def provider_snapshot_manifest_entry(metadata: object, *, analysis_path: Path) -
         "id": metadata.get("provider_snapshot_id"),
         "sha256": snapshot_hash,
         "path": snapshot_path,
+        "bundle_path": bundle_path,
         "sources": metadata.get("provider_snapshot_sources", []),
     }
     return {key: value for key, value in entry.items() if value not in (None, "", [])}

--- a/backend/src/vuln_prioritizer/reporting_format.py
+++ b/backend/src/vuln_prioritizer/reporting_format.py
@@ -71,10 +71,28 @@ def _run_metadata_lines(context: AnalysisContext) -> list[str]:
         lines.append(f"- Provider snapshot file: `{context.provider_snapshot_file}`")
         snapshot_mode = "locked" if context.locked_provider_data else "fallback"
         lines.append(f"- Provider snapshot mode: `{snapshot_mode}`")
+    if context.provider_snapshot_id:
+        lines.append(f"- Provider snapshot ID: `{context.provider_snapshot_id}`")
+    if context.provider_snapshot_hash:
+        lines.append(f"- Provider snapshot hash: `{context.provider_snapshot_hash}`")
     if context.provider_snapshot_sources:
         lines.append(
             "- Provider snapshot sources: " + f"`{', '.join(context.provider_snapshot_sources)}`"
         )
+    snapshot_generated_at = context.provider_freshness.get("provider_snapshot_generated_at")
+    if snapshot_generated_at:
+        lines.append(f"- Provider snapshot generated at: `{snapshot_generated_at}`")
+    freshness_lines = [
+        (label, context.provider_freshness.get(field))
+        for label, field in (
+            ("NVD freshness", "nvd_freshness_at"),
+            ("EPSS freshness", "epss_freshness_at"),
+            ("KEV freshness", "kev_freshness_at"),
+        )
+    ]
+    for label, value in freshness_lines:
+        if value:
+            lines.append(f"- {label}: `{value}`")
     if context.merged_input_count > 1:
         lines.append(f"- Inputs merged: `{context.merged_input_count}`")
     if context.input_paths:

--- a/backend/src/vuln_prioritizer/services/analysis_pipeline.py
+++ b/backend/src/vuln_prioritizer/services/analysis_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from enum import StrEnum
 from pathlib import Path
@@ -277,6 +278,10 @@ def prepare_analysis(request: AnalysisRequest) -> tuple[list[PrioritizedFinding]
         input_sources=parsed_input.source_summaries,
         merged_input_count=parsed_input.merged_input_count,
         duplicate_cve_count=parsed_input.duplicate_cve_count,
+        provider_snapshot_id=(
+            provider_snapshot.metadata.snapshot_id if provider_snapshot is not None else None
+        ),
+        provider_snapshot_hash=_provider_snapshot_hash(request.provider_snapshot_file),
         provider_snapshot_file=(
             str(request.provider_snapshot_file) if request.provider_snapshot_file else None
         ),
@@ -359,6 +364,15 @@ def prepare_analysis(request: AnalysisRequest) -> tuple[list[PrioritizedFinding]
     return findings, context
 
 
+def _provider_snapshot_hash(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
 def prepare_explain(request: ExplainRequest) -> ExplainResult:
     context_profile = load_context_profile_or_exit(request.policy_profile, request.policy_file)
     if request.locked_provider_data and request.provider_snapshot_file is None:
@@ -430,6 +444,10 @@ def prepare_explain(request: ExplainRequest) -> ExplainResult:
         output_path=str(request.output) if request.output else None,
         output_format=_enum_value(request.format),
         generated_at=generated_at,
+        provider_snapshot_id=(
+            provider_snapshot.metadata.snapshot_id if provider_snapshot is not None else None
+        ),
+        provider_snapshot_hash=_provider_snapshot_hash(request.provider_snapshot_file),
         provider_snapshot_file=(
             str(request.provider_snapshot_file) if request.provider_snapshot_file else None
         ),

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -23,6 +23,7 @@ from vuln_prioritizer.workbench_config import WorkbenchSettings
 
 ROOT = Path(__file__).resolve().parents[3]
 DEMO_PROVIDER_SNAPSHOT = ROOT / "data" / "demo_provider_snapshot.json"
+EXAMPLE_PROVIDER_SNAPSHOT_V1 = ROOT / "docs" / "examples" / "example_provider_snapshot.v1.json"
 SAMPLE_CVES = ROOT / "data" / "sample_cves.txt"
 TRIVY_REPORT = ROOT / "data" / "input_fixtures" / "trivy_report.json"
 GRYPE_REPORT = ROOT / "data" / "input_fixtures" / "grype_report.json"
@@ -176,6 +177,24 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
     assert status_payload["snapshot"]["content_hash"]
     assert status_payload["snapshot"]["selected_sources"] == ["nvd", "epss", "kev"]
     assert {source["name"] for source in status_payload["sources"]} == {"nvd", "epss", "kev"}
+
+    snapshots = client.get("/api/providers/snapshots")
+    assert snapshots.status_code == 200
+    snapshot_items = snapshots.json()["items"]
+    current_snapshot = next(
+        item for item in snapshot_items if item["id"] == run["provider_snapshot_id"]
+    )
+    assert current_snapshot["snapshot_format"] == "provider-snapshot.v1.json"
+    assert current_snapshot["content_hash"] == status_payload["snapshot"]["content_hash"]
+    snapshot_detail = client.get(f"/api/providers/snapshots/{run['provider_snapshot_id']}")
+    assert snapshot_detail.status_code == 200
+    assert snapshot_detail.json()["id"] == run["provider_snapshot_id"]
+    snapshot_download = client.get(
+        f"/api/providers/snapshots/{run['provider_snapshot_id']}/download"
+    )
+    assert snapshot_download.status_code == 200
+    assert hashlib.sha256(snapshot_download.content).hexdigest() == current_snapshot["content_hash"]
+    assert snapshot_download.json()["metadata"]["artifact_kind"] == "provider-snapshot"
 
     project_runs = client.get(f"/api/projects/{project['id']}/runs")
     assert project_runs.status_code == 200
@@ -360,6 +379,7 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
         names = set(archive.namelist())
         assert {"analysis.json", "report.html", "summary.md", "manifest.json"} <= names
         assert "input/sample.txt" in names
+        assert "provider/provider-snapshot.json" in names
 
         analysis_payload = json.loads(archive.read("analysis.json"))
         assert analysis_payload["metadata"]["input_format"] == "cve-list"
@@ -377,8 +397,15 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
             manifest["provider_snapshot"]["sha256"]
             == analysis_payload["metadata"]["provider_snapshot_hash"]
         )
+        assert manifest["provider_snapshot"]["bundle_path"] == "provider/provider-snapshot.json"
         manifest_files = {item["path"]: item for item in manifest["files"]}
-        for artifact_name in ["analysis.json", "report.html", "summary.md", "input/sample.txt"]:
+        for artifact_name in [
+            "analysis.json",
+            "report.html",
+            "summary.md",
+            "input/sample.txt",
+            "provider/provider-snapshot.json",
+        ]:
             assert artifact_name in manifest_files
             assert (
                 manifest_files[artifact_name]["sha256"]
@@ -479,6 +506,55 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
     assert deleted_bundle.status_code == 200
     assert deleted_bundle.json()["artifact_removed"] is True
     assert client.get(bundle_payload["download_url"]).status_code == 404
+
+
+def test_workbench_imports_provider_snapshot_artifact(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+
+    imported = client.post(
+        "/api/providers/snapshots/import",
+        files={
+            "file": (
+                "provider-snapshot.v1.json",
+                EXAMPLE_PROVIDER_SNAPSHOT_V1.read_bytes(),
+                "application/json",
+            )
+        },
+    )
+
+    assert imported.status_code == 200, imported.text
+    payload = imported.json()
+    assert payload["imported"] is True
+    assert payload["item"]["snapshot_format"] == "provider-snapshot.v1.json"
+    assert payload["item"]["content_hash"]
+
+    listed = client.get("/api/providers/snapshots")
+    assert listed.status_code == 200
+    assert payload["item"]["id"] in {item["id"] for item in listed.json()["items"]}
+
+    downloaded = client.get(f"/api/providers/snapshots/{payload['item']['id']}/download")
+    assert downloaded.status_code == 200
+    assert hashlib.sha256(downloaded.content).hexdigest() == payload["item"]["content_hash"]
+    assert downloaded.json()["metadata"]["snapshot_format"] == "provider-snapshot.v1.json"
+
+    legacy = client.post(
+        "/api/providers/snapshots/import",
+        files={
+            "file": (
+                "legacy-provider-snapshot.json",
+                DEMO_PROVIDER_SNAPSHOT.read_bytes(),
+                "application/json",
+            )
+        },
+    )
+    assert legacy.status_code == 422
+    assert "metadata.snapshot_format=provider-snapshot.v1.json" in legacy.text
+
+    invalid = client.post(
+        "/api/providers/snapshots/import",
+        files={"file": ("bad.json", b"{not-json", "application/json")},
+    )
+    assert invalid.status_code == 422
 
 
 def test_project_artifact_cleanup_is_scoped_and_enforces_disk_cap(tmp_path: Path) -> None:

--- a/backend/tests/cli/test_explain.py
+++ b/backend/tests/cli/test_explain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -24,6 +25,7 @@ def _write_provider_snapshot(snapshot_file: Path) -> None:
             ProviderSnapshotReport(
                 metadata=ProviderSnapshotMetadata(
                     generated_at="2026-04-22T12:00:00Z",
+                    snapshot_id="explain-provider-snapshot",
                     input_path="inline:CVE-2021-44228",
                     input_paths=[],
                     input_format="cve-list",
@@ -192,6 +194,11 @@ def test_cli_explain_supports_locked_provider_snapshot_replay(
     assert result.exit_code == 0
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert payload["metadata"]["provider_snapshot_file"] == str(snapshot_file)
+    assert payload["metadata"]["provider_snapshot_id"] == "explain-provider-snapshot"
+    assert (
+        payload["metadata"]["provider_snapshot_hash"]
+        == hashlib.sha256(snapshot_file.read_bytes()).hexdigest()
+    )
     assert payload["metadata"]["locked_provider_data"] is True
     assert payload["metadata"]["provider_snapshot_sources"] == ["nvd", "epss", "kev"]
 

--- a/backend/tests/test_evidence_bundle_verification.py
+++ b/backend/tests/test_evidence_bundle_verification.py
@@ -15,6 +15,10 @@ from _cli_helpers import (
 )
 
 from vuln_prioritizer.cli import app
+from vuln_prioritizer.models import EpssData, KevData, NvdData
+from vuln_prioritizer.providers.epss import EpssProvider
+from vuln_prioritizer.providers.kev import KevProvider
+from vuln_prioritizer.providers.nvd import NvdProvider
 
 
 def test_cli_verify_evidence_bundle_succeeds_for_clean_bundle(
@@ -198,6 +202,132 @@ def test_cli_evidence_bundle_includes_all_multi_input_sources(
     assert manifest["source_input_paths"] == [str(first_input), str(second_input)]
     assert manifest["source_input_path"] == str(first_input)
     assert {"input/001-cves-a.txt", "input/002-cves-b.txt"} <= names
+
+
+def test_cli_evidence_bundle_includes_provider_snapshot_and_replays_offline(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    input_file = _write_input_file(tmp_path)
+    snapshot_file = tmp_path / "provider-snapshot.json"
+    analysis_file = tmp_path / "analysis.json"
+    bundle_file = tmp_path / "evidence.zip"
+
+    def fake_nvd_fetch_many(
+        self: NvdProvider,  # noqa: ARG001
+        cve_ids: list[str],
+        *,
+        refresh: bool = False,  # noqa: ARG001
+    ) -> tuple[dict[str, NvdData], list[str]]:
+        return (
+            {
+                cve_id: NvdData(
+                    cve_id=cve_id,
+                    description=f"{cve_id} snapshot description",
+                    cvss_base_score=9.0,
+                    cvss_severity="CRITICAL",
+                    cvss_version="3.1",
+                )
+                for cve_id in cve_ids
+            },
+            [],
+        )
+
+    def fake_epss_fetch_many(
+        self: EpssProvider,  # noqa: ARG001
+        cve_ids: list[str],
+        *,
+        refresh: bool = False,  # noqa: ARG001
+    ) -> tuple[dict[str, EpssData], list[str]]:
+        return (
+            {
+                cve_id: EpssData(cve_id=cve_id, epss=0.5, percentile=0.9, date="2026-04-29")
+                for cve_id in cve_ids
+            },
+            [],
+        )
+
+    def fake_kev_fetch_many(
+        self: KevProvider,  # noqa: ARG001
+        cve_ids: list[str],
+        offline_file: Path | None = None,  # noqa: ARG001
+        *,
+        refresh: bool = False,  # noqa: ARG001
+    ) -> tuple[dict[str, KevData], list[str]]:
+        return ({cve_id: KevData(cve_id=cve_id, in_kev=False) for cve_id in cve_ids}, [])
+
+    monkeypatch.setattr(NvdProvider, "fetch_many", fake_nvd_fetch_many)
+    monkeypatch.setattr(EpssProvider, "fetch_many", fake_epss_fetch_many)
+    monkeypatch.setattr(KevProvider, "fetch_many", fake_kev_fetch_many)
+
+    export_result = runner.invoke(
+        app,
+        [
+            "data",
+            "export-provider-snapshot",
+            "--input",
+            str(input_file),
+            "--output",
+            str(snapshot_file),
+            "--cache-dir",
+            str(tmp_path / "cache"),
+        ],
+    )
+    assert export_result.exit_code == 0
+
+    def fail_fetch_many(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("live provider should not be called during locked replay")
+
+    monkeypatch.setattr(NvdProvider, "fetch_many", fail_fetch_many)
+    monkeypatch.setattr(EpssProvider, "fetch_many", fail_fetch_many)
+    monkeypatch.setattr(KevProvider, "fetch_many", fail_fetch_many)
+
+    analyze_result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "--input",
+            str(input_file),
+            "--output",
+            str(analysis_file),
+            "--format",
+            "json",
+            "--provider-snapshot-file",
+            str(snapshot_file),
+            "--locked-provider-data",
+        ],
+    )
+    assert analyze_result.exit_code == 0
+
+    bundle_result = runner.invoke(
+        app,
+        [
+            "report",
+            "evidence-bundle",
+            "--input",
+            str(analysis_file),
+            "--output",
+            str(bundle_file),
+        ],
+    )
+    assert bundle_result.exit_code == 0
+
+    with zipfile.ZipFile(bundle_file) as archive:
+        names = set(archive.namelist())
+        manifest = json.loads(archive.read("manifest.json"))
+        bundled_snapshot = json.loads(archive.read("provider/provider-snapshot.json"))
+
+    assert "provider/provider-snapshot.json" in names
+    assert bundled_snapshot["metadata"]["snapshot_format"] == "provider-snapshot.v1.json"
+    assert manifest["provider_snapshot"]["bundle_path"] == "provider/provider-snapshot.json"
+    assert (
+        manifest["provider_snapshot"]["sha256"]
+        == manifest["artifact_hashes"]["provider/provider-snapshot.json"]
+    )
+    assert any(
+        item["path"] == "provider/provider-snapshot.json" and item["kind"] == "provider-snapshot"
+        for item in manifest["files"]
+    )
 
 
 def _build_evidence_bundle(monkeypatch, tmp_path: Path) -> Path:

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -16,7 +16,7 @@ from typer.testing import CliRunner
 
 from vuln_prioritizer.cache import FileCache
 from vuln_prioritizer.cli import app
-from vuln_prioritizer.models import EpssData, KevData, NvdData
+from vuln_prioritizer.models import EpssData, KevData, NvdData, ProviderSnapshotReport
 from vuln_prioritizer.providers.epss import EpssProvider
 from vuln_prioritizer.providers.kev import KevProvider
 from vuln_prioritizer.providers.nvd import NvdProvider
@@ -100,6 +100,19 @@ def test_nvd_provider_record_example_matches_model() -> None:
             "Patch",
         ]
     }
+
+
+def test_provider_snapshot_v1_example_matches_schema_and_model() -> None:
+    payload = json.loads(
+        (DOCS_ROOT / "examples" / "example_provider_snapshot.v1.json").read_text(encoding="utf-8")
+    )
+
+    jsonschema.validate(payload, _load_schema("provider-snapshot-report.schema.json"))
+    snapshot = ProviderSnapshotReport.model_validate(payload)
+
+    assert snapshot.metadata.snapshot_format == "provider-snapshot.v1.json"
+    assert snapshot.metadata.snapshot_id == "example-provider-snapshot-v1"
+    assert snapshot.metadata.source_metadata["nvd"]["source"] == "NVD CVE API 2.0"
 
 
 def _install_fake_data_update_providers(monkeypatch: Any) -> None:
@@ -491,7 +504,10 @@ def test_provider_snapshot_json_matches_published_schema(monkeypatch, tmp_path: 
     assert result.exit_code == 0
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     jsonschema.validate(payload, _load_schema("provider-snapshot-report.schema.json"))
+    assert payload["metadata"]["snapshot_format"] == "provider-snapshot.v1.json"
+    assert payload["metadata"]["snapshot_id"]
     assert set(payload["metadata"]["source_hashes"]) == {"nvd", "epss", "kev"}
+    assert payload["metadata"]["source_metadata"]["nvd"]["record_count"] == 2
     assert payload["items"][0]["kev"]["vulnerability_name"] == (
         "Apache Log4j2 remote code execution vulnerability"
     )

--- a/backend/tests/test_reporting_format_helpers.py
+++ b/backend/tests/test_reporting_format_helpers.py
@@ -73,9 +73,17 @@ def test_metadata_and_summary_lines_include_optional_workbench_fields() -> None:
         generated_at="2026-04-24T10:00:00Z",
         merged_input_count=2,
         duplicate_cve_count=1,
+        provider_snapshot_id="snapshot-artifact-1",
+        provider_snapshot_hash="f" * 64,
         provider_snapshot_file="snapshot.json",
         locked_provider_data=True,
         provider_snapshot_sources=["nvd", "epss", "kev"],
+        provider_freshness={
+            "provider_snapshot_generated_at": "2026-04-24T09:00:00Z",
+            "nvd_freshness_at": "2026-04-24T09:00:00Z",
+            "epss_freshness_at": "2026-04-24T09:00:00Z",
+            "kev_freshness_at": "2026-04-24T09:00:00Z",
+        },
         attack_enabled=True,
         attack_source="ctid-mappings-explorer",
         attack_mapping_file="attack/mapping.json",
@@ -153,6 +161,10 @@ def test_metadata_and_summary_lines_include_optional_workbench_fields() -> None:
     summary = "\n".join(_summary_lines(context))
 
     assert "- Provider snapshot mode: `locked`" in metadata
+    assert "- Provider snapshot ID: `snapshot-artifact-1`" in metadata
+    assert f"- Provider snapshot hash: `{'f' * 64}`" in metadata
+    assert "- Provider snapshot generated at: `2026-04-24T09:00:00Z`" in metadata
+    assert "- NVD freshness: `2026-04-24T09:00:00Z`" in metadata
     assert "- Inputs merged: `2`" in metadata
     assert "- NVD diagnostics: `requested=2" in metadata
     assert "- EPSS data-quality flags: `provider_missing_data`" in metadata

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -195,6 +195,9 @@ detail behavior is documented in
 The NVD-specific CVE API, fallback, CVSS parsing, and missing-CVSS
 data-quality behavior is documented in
 [VPW-025 NVD Provider Fallback](vpw-025-nvd-provider-fallback.md).
+The provider snapshot format, Workbench import/export API, locked replay, and
+evidence-bundle inclusion behavior is documented in
+[VPW-026 Provider Snapshot Replay](vpw-026-provider-snapshot-replay.md).
 
 The current `data` command tree is intentionally small:
 

--- a/docs/architecture/vpw-026-provider-snapshot-replay.md
+++ b/docs/architecture/vpw-026-provider-snapshot-replay.md
@@ -1,0 +1,57 @@
+# VPW-026 Provider Snapshot Replay
+
+VPW-026 defines provider snapshots as replayable evidence artifacts for NVD,
+EPSS, KEV, and local defensive context overlays.
+
+## Format
+
+Provider snapshots use the additive `provider-snapshot.v1.json` format marker in
+`metadata.snapshot_format`. The public JSON schema remains
+`provider-snapshot-report.schema.json` and documents:
+
+- `snapshot_id`
+- `source_hashes`
+- per-source `source_metadata`
+- requested CVE count and selected sources
+- optional cache/offline-source settings
+
+A concise example is published at
+[`docs/examples/example_provider_snapshot.v1.json`](../examples/example_provider_snapshot.v1.json).
+
+## Replay
+
+CLI and Workbench replay use `--provider-snapshot-file` plus
+`--locked-provider-data` when live providers must not be used. Locked replay
+requires complete coverage for the selected provider sources. When unlocked,
+snapshot data may be used as a fallback and missing data can still resolve from
+live/cache providers.
+
+Analysis metadata records:
+
+- `provider_snapshot_id`
+- `provider_snapshot_hash`
+- `provider_snapshot_file`
+- `provider_snapshot_sources`
+- `provider_freshness.provider_snapshot_generated_at`
+
+## Workbench API
+
+Workbench exposes provider snapshot artifacts through:
+
+- `GET /api/providers/snapshots`
+- `GET /api/providers/snapshots/{snapshot_id}`
+- `GET /api/providers/snapshots/{snapshot_id}/download`
+- `POST /api/providers/snapshots/import`
+
+Imports validate the explicit v1 contract, including
+`metadata.snapshot_format = provider-snapshot.v1.json` and
+`metadata.source_metadata`, store a canonical copy under the configured provider
+snapshot directory, and persist the content hash before the snapshot can be used
+for locked replay.
+
+## Evidence Bundles
+
+Evidence bundles include the resolved provider snapshot JSON as
+`provider/provider-snapshot.json` when the analysis metadata references a
+readable snapshot artifact. The manifest records the snapshot ID, hash, original
+path, bundle path, and selected sources.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -241,6 +241,9 @@ Current provider freshness contract:
 - `--fail-on-stale-provider-data` returns exit code `1` after writing requested output when provider data is stale
 - live lookups use the current run timestamp for freshness
 - locked provider-snapshot replay uses the snapshot `generated_at` timestamp for selected snapshot sources
+- analysis-style metadata includes provider snapshot identity when available:
+  `provider_snapshot_id`, `provider_snapshot_hash`, `provider_snapshot_file`, and
+  `provider_snapshot_sources`
 - analysis-style metadata may include `provider_freshness`, `max_provider_age_hours`, `provider_stale`, and `provider_stale_sources`
 
 ### Provider enrichment service
@@ -249,6 +252,9 @@ Current provider service contract:
 
 - built-in NVD, EPSS, and KEV providers can be adapted to the shared
   `ProviderEnrichmentClient.enrich(cve_ids, **kwargs)` interface
+- provider snapshots use the additive `provider-snapshot.v1.json` format marker
+  in `metadata.snapshot_format`, plus `snapshot_id`, `source_hashes`, and
+  per-source `source_metadata`
 - NVD uses the CVE API 2.0 per requested CVE, sends an optional API key only
   through the configured request header, redacts configured key values from
   warnings, and degrades to cache or empty records instead of aborting analysis
@@ -265,6 +271,11 @@ Current provider service contract:
   `data_quality_flags`
 - provider snapshot metadata includes `source_hashes`, a map from selected
   provider source to the local cache namespace SHA-256 checksum or `null`
+- Workbench exposes provider snapshot list/detail/download/import API routes;
+  import accepts only explicit `provider-snapshot.v1.json` snapshots containing
+  `metadata.snapshot_format` and `metadata.source_metadata`, and evidence
+  bundles include the resolved provider snapshot JSON as
+  `provider/provider-snapshot.json` when a replay snapshot is part of the run
 - analysis-style metadata may include `provider_data_quality_flags`, keyed by
   source, when recoverable provider problems such as missing EPSS records,
   stale cache fallback, or provider warnings were observed

--- a/docs/examples/example_provider_snapshot.v1.json
+++ b/docs/examples/example_provider_snapshot.v1.json
@@ -1,0 +1,95 @@
+{
+  "items": [
+    {
+      "cve_id": "CVE-2026-2001",
+      "epss": {
+        "cve_id": "CVE-2026-2001",
+        "date": "2026-04-29",
+        "epss": 0.91,
+        "percentile": 0.99
+      },
+      "kev": {
+        "cve_id": "CVE-2026-2001",
+        "date_added": "2026-04-29",
+        "due_date": "2026-05-20",
+        "in_kev": true,
+        "product": "Example Product",
+        "required_action": "Apply vendor update.",
+        "vendor_project": "Example Vendor",
+        "vulnerability_name": "Example Product remote code execution vulnerability"
+      },
+      "nvd": {
+        "cve_id": "CVE-2026-2001",
+        "cvss_base_score": 9.8,
+        "cvss_severity": "CRITICAL",
+        "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H",
+        "cvss_version": "4.0",
+        "cwes": [
+          "CWE-79"
+        ],
+        "description": "Example NVD CVE record used to validate replay contracts.",
+        "last_modified": "2026-04-29T12:00:00.000",
+        "published": "2026-04-29T00:00:00.000",
+        "reference_tags": {
+          "https://example.invalid/advisory/CVE-2026-2001": [
+            "Vendor Advisory"
+          ]
+        },
+        "references": [
+          "https://example.invalid/advisory/CVE-2026-2001"
+        ],
+        "vulnerability_status": "Analyzed"
+      }
+    }
+  ],
+  "metadata": {
+    "artifact_kind": "provider-snapshot",
+    "cache_dir": ".cache/vuln-prioritizer",
+    "cache_enabled": true,
+    "cache_only": true,
+    "generated_at": "2026-04-29T12:00:00+00:00",
+    "input_format": "cve-list",
+    "input_path": "data/sample_cves.txt",
+    "input_paths": [
+      "data/sample_cves.txt"
+    ],
+    "nvd_api_key_env": "NVD_API_KEY",
+    "offline_kev_file": null,
+    "output_path": "provider-snapshot.v1.json",
+    "requested_cves": 1,
+    "schema_version": "1.2.0",
+    "selected_sources": [
+      "nvd",
+      "epss",
+      "kev"
+    ],
+    "snapshot_format": "provider-snapshot.v1.json",
+    "snapshot_id": "example-provider-snapshot-v1",
+    "source_hashes": {
+      "epss": "9c1a6f62b0ad34627b1ce37ff0b4f2210a6eb547c7f82ea139e5e7ace41f9b0d",
+      "kev": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "nvd": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    "source_metadata": {
+      "epss": {
+        "cache_namespace_hash": "9c1a6f62b0ad34627b1ce37ff0b4f2210a6eb547c7f82ea139e5e7ace41f9b0d",
+        "cache_only": true,
+        "record_count": 1,
+        "source": "FIRST EPSS API"
+      },
+      "kev": {
+        "cache_namespace_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "cache_only": true,
+        "record_count": 1,
+        "source": "CISA KEV catalog"
+      },
+      "nvd": {
+        "cache_namespace_hash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        "cache_only": true,
+        "record_count": 1,
+        "source": "NVD CVE API 2.0"
+      }
+    }
+  },
+  "warnings": []
+}

--- a/docs/schemas/analysis-report.schema.json
+++ b/docs/schemas/analysis-report.schema.json
@@ -257,6 +257,12 @@
         "provider_snapshot_file": {
           "$ref": "#/$defs/nullableString"
         },
+        "provider_snapshot_id": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "provider_snapshot_hash": {
+          "$ref": "#/$defs/nullableString"
+        },
         "locked_provider_data": {
           "type": "boolean"
         },
@@ -415,6 +421,23 @@
         },
         "provider_freshness": {
           "type": "object",
+          "properties": {
+            "nvd_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "epss_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "kev_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "provider_snapshot_generated_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "lookup_completed_at": {
+              "$ref": "#/$defs/nullableString"
+            }
+          },
           "additionalProperties": {
             "type": [
               "string",

--- a/docs/schemas/compare-report.schema.json
+++ b/docs/schemas/compare-report.schema.json
@@ -257,6 +257,12 @@
         "provider_snapshot_file": {
           "$ref": "#/$defs/nullableString"
         },
+        "provider_snapshot_id": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "provider_snapshot_hash": {
+          "$ref": "#/$defs/nullableString"
+        },
         "locked_provider_data": {
           "type": "boolean"
         },
@@ -403,6 +409,23 @@
         },
         "provider_freshness": {
           "type": "object",
+          "properties": {
+            "nvd_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "epss_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "kev_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "provider_snapshot_generated_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "lookup_completed_at": {
+              "$ref": "#/$defs/nullableString"
+            }
+          },
           "additionalProperties": {
             "type": [
               "string",

--- a/docs/schemas/explain-report.schema.json
+++ b/docs/schemas/explain-report.schema.json
@@ -281,6 +281,12 @@
         "provider_snapshot_file": {
           "$ref": "#/$defs/nullableString"
         },
+        "provider_snapshot_id": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "provider_snapshot_hash": {
+          "$ref": "#/$defs/nullableString"
+        },
         "locked_provider_data": {
           "type": "boolean"
         },
@@ -439,6 +445,23 @@
         },
         "provider_freshness": {
           "type": "object",
+          "properties": {
+            "nvd_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "epss_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "kev_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "provider_snapshot_generated_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "lookup_completed_at": {
+              "$ref": "#/$defs/nullableString"
+            }
+          },
           "additionalProperties": {
             "type": [
               "string",

--- a/docs/schemas/provider-snapshot-report.schema.json
+++ b/docs/schemas/provider-snapshot-report.schema.json
@@ -221,6 +221,7 @@
       "required": [
         "schema_version",
         "artifact_kind",
+        "snapshot_format",
         "generated_at",
         "input_path",
         "input_paths",
@@ -231,6 +232,7 @@
         "cache_enabled",
         "cache_dir",
         "source_hashes",
+        "source_metadata",
         "offline_kev_file",
         "nvd_api_key_env"
       ],
@@ -240,6 +242,12 @@
         },
         "artifact_kind": {
           "const": "provider-snapshot"
+        },
+        "snapshot_format": {
+          "const": "provider-snapshot.v1.json"
+        },
+        "snapshot_id": {
+          "$ref": "#/$defs/nullableString"
         },
         "generated_at": {
           "type": "string"
@@ -276,6 +284,15 @@
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/nullableString"
+          }
+        },
+        "source_metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": ["string", "integer", "boolean", "null"]
+            }
           }
         },
         "offline_kev_file": {

--- a/docs/schemas/snapshot-report.schema.json
+++ b/docs/schemas/snapshot-report.schema.json
@@ -227,6 +227,12 @@
         "provider_snapshot_file": {
           "$ref": "#/$defs/nullableString"
         },
+        "provider_snapshot_id": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "provider_snapshot_hash": {
+          "$ref": "#/$defs/nullableString"
+        },
         "locked_provider_data": {
           "type": "boolean"
         },
@@ -376,6 +382,23 @@
         },
         "provider_freshness": {
           "type": "object",
+          "properties": {
+            "nvd_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "epss_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "kev_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "provider_snapshot_generated_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "lookup_completed_at": {
+              "$ref": "#/$defs/nullableString"
+            }
+          },
           "additionalProperties": {
             "type": [
               "string",
@@ -445,6 +468,12 @@
           "type": "integer"
         },
         "provider_snapshot_file": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "provider_snapshot_id": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "provider_snapshot_hash": {
           "$ref": "#/$defs/nullableString"
         },
         "locked_provider_data": {
@@ -599,6 +628,23 @@
         },
         "provider_freshness": {
           "type": "object",
+          "properties": {
+            "nvd_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "epss_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "kev_freshness_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "provider_snapshot_generated_at": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "lookup_completed_at": {
+              "$ref": "#/$defs/nullableString"
+            }
+          },
           "additionalProperties": {
             "type": [
               "string",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - EPSS Provider Cache: architecture/vpw-023-epss-provider-cache.md
       - KEV Provider Cache: architecture/vpw-024-kev-provider-cache.md
       - NVD Provider Fallback: architecture/vpw-025-nvd-provider-fallback.md
+      - Provider Snapshot Replay: architecture/vpw-026-provider-snapshot-replay.md
       - Template Repository Layer: architecture/template-service-layer.md
       - Template Importer Contract: architecture/vpw-013-importer-contract.md
   - Full Stack Template Migration: full_stack_fastapi_template_migration.md


### PR DESCRIPTION
## Summary
- add provider-snapshot.v1.json identity metadata, source metadata, schema docs, and example artifact
- add Workbench provider snapshot list/detail/download/import APIs with strict v1 import validation
- include provider snapshot JSON in evidence bundles and render snapshot id/hash/freshness in reports

## Verification
- python3 -m ruff check backend/src/vuln_prioritizer/services/analysis_pipeline.py backend/src/vuln_prioritizer/api/workbench_providers.py backend/tests/cli/test_explain.py backend/tests/api/test_workbench_api.py
- python3 -m mypy backend/src/vuln_prioritizer/services/analysis_pipeline.py backend/src/vuln_prioritizer/api/workbench_providers.py
- python3 -m pytest -q backend/tests/test_evidence_bundle_verification.py backend/tests/test_output_schemas.py backend/tests/test_reporting_format_helpers.py backend/tests/cli/test_explain.py backend/tests/api/test_workbench_api.py --no-cov
- make docs-check
- make check
- make demo-evidence-bundle-check
- git diff --check

Refs #132