### PR TITLE
VPW-029 provider contract tests and offline demo snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DEMO_EVIDENCE_ANALYSIS_FILE := build/v1.0-demo-analysis.json
 DEMO_EVIDENCE_BUNDLE_FILE := build/v1.0-demo-evidence-bundle.zip
 DEMO_EVIDENCE_VERIFICATION_FILE := build/v1.0-demo-evidence-bundle-verification.json
 
-.PHONY: install test lint format fix typecheck check benchmark-check playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-generate-client frontend-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke docker-postgres-migration-smoke dependency-audit demo-sync-check demo-sync-check-temp package package-check package-check-temp pipx-source-smoke release-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
+.PHONY: install test lint format fix typecheck check benchmark-check playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-generate-client frontend-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke docker-postgres-migration-smoke dependency-audit provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-check package-check-temp pipx-source-smoke release-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
 
 install:
 	$(PYTHON) -m pip install -e "$(BACKEND_DIR)[dev]"
@@ -69,6 +69,18 @@ docs-check:
 
 docs-serve:
 	$(PYTHON) -m mkdocs serve
+
+provider-snapshot-validate:
+	$(PYTHON) -m pytest -q $(BACKEND_TESTS)/test_output_schemas.py::test_provider_snapshot_v1_example_matches_schema_and_model $(BACKEND_TESTS)/test_output_schemas.py::test_demo_provider_snapshot_matches_schema_and_model $(BACKEND_TESTS)/test_provider_snapshot_contract.py --no-cov
+	$(PYTHON) -c 'import json, jsonschema; from pathlib import Path; schema = json.loads(Path("docs/schemas/provider-snapshot-report.schema.json").read_text(encoding="utf-8")); paths = ("docs/examples/example_provider_snapshot.v1.json", "data/demo_provider_snapshot.json"); [jsonschema.validate(json.loads(Path(path).read_text(encoding="utf-8")), schema) or print(f"{path}: OK") for path in paths]'
+
+provider-testmatrix:
+	$(PYTHON) -m pytest -q $(BACKEND_TESTS)/test_provider_response_contracts.py $(BACKEND_TESTS)/test_provider_contract.py $(BACKEND_TESTS)/test_provider_snapshot_contract.py $(BACKEND_TESTS)/test_cli_data.py::test_data_export_provider_snapshot_cache_only_uses_local_cache $(BACKEND_TESTS)/test_output_schemas.py::test_demo_provider_snapshot_matches_schema_and_model $(BACKEND_TESTS)/api/test_workbench_api.py::test_online_shop_demo_import_uses_demo_snapshot_without_network_or_keys $(BACKEND_TESTS)/test_evidence_bundle_verification.py --no-cov
+
+demo-offline-no-key-proof:
+	mkdir -p build
+	env -u NVD_API_KEY HTTP_PROXY=http://127.0.0.1:9 HTTPS_PROXY=http://127.0.0.1:9 ALL_PROXY=http://127.0.0.1:9 $(DEMO_ENV) $(PYTHON) -m vuln_prioritizer.cli analyze --input data/sample_cves.txt --output build/vpw-029-demo-offline-no-key-proof.json --format json $(DEMO_PROVIDER_FLAGS)
+	$(PYTHON) -c 'import json; from pathlib import Path; payload = json.loads(Path("build/vpw-029-demo-offline-no-key-proof.json").read_text(encoding="utf-8")); diagnostics = payload["metadata"]["provider_diagnostics"]; assert payload["metadata"]["provider_snapshot_file"] == "data/demo_provider_snapshot.json"; assert payload["metadata"]["locked_provider_data"] is True; assert all(item.get("network_fetches", 0) == 0 for item in diagnostics.values()); print("build/vpw-029-demo-offline-no-key-proof.json: OK")'
 
 actionlint-check:
 	docker run --rm -v "$$(pwd):/repo" -w /repo rhysd/actionlint:1.7.12 -color .github/workflows/*.yml .github/examples/*.yml

--- a/backend/src/vuln_prioritizer/provider_snapshot.py
+++ b/backend/src/vuln_prioritizer/provider_snapshot.py
@@ -16,6 +16,28 @@ if TYPE_CHECKING:
     from vuln_prioritizer.models import ProviderSnapshotItem
 
 
+_REQUIRED_PROVIDER_SNAPSHOT_KEYS = {"metadata", "items", "warnings"}
+_REQUIRED_PROVIDER_SNAPSHOT_METADATA_KEYS = {
+    "schema_version",
+    "artifact_kind",
+    "snapshot_format",
+    "generated_at",
+    "input_path",
+    "input_paths",
+    "input_format",
+    "selected_sources",
+    "requested_cves",
+    "output_path",
+    "cache_enabled",
+    "cache_dir",
+    "source_hashes",
+    "source_metadata",
+    "offline_kev_file",
+    "nvd_api_key_env",
+}
+_PROVIDER_SNAPSHOT_FORMAT = "provider-snapshot.v1.json"
+
+
 def generate_provider_snapshot_json(report: ProviderSnapshotReport) -> str:
     """Serialize a provider snapshot report as stable JSON."""
     return json.dumps(report.model_dump(), indent=2, sort_keys=True)
@@ -30,10 +52,44 @@ def load_provider_snapshot(path: Path) -> ProviderSnapshotReport:
     except json.JSONDecodeError as exc:
         raise ValueError(f"{path} is not valid JSON: {exc.msg}.") from exc
 
+    _validate_explicit_provider_snapshot_v1(payload, path=path)
+
     try:
         return ProviderSnapshotReport.model_validate(payload)
     except ValidationError as exc:
         raise ValueError(f"{path} is not a valid provider snapshot: {exc}") from exc
+
+
+def _validate_explicit_provider_snapshot_v1(payload: object, *, path: Path) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} is not a valid provider snapshot: expected a JSON object.")
+
+    missing_top_level = sorted(_REQUIRED_PROVIDER_SNAPSHOT_KEYS - set(payload))
+    if missing_top_level:
+        raise ValueError(
+            f"{path} is not a valid provider snapshot: missing required top-level "
+            f"field(s): {', '.join(missing_top_level)}."
+        )
+
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError(
+            f"{path} is not a valid provider snapshot: metadata must be a JSON object."
+        )
+
+    missing_metadata = sorted(_REQUIRED_PROVIDER_SNAPSHOT_METADATA_KEYS - set(metadata))
+    if missing_metadata:
+        raise ValueError(
+            f"{path} is not a valid provider snapshot: missing required metadata "
+            f"field(s): {', '.join(missing_metadata)}."
+        )
+
+    snapshot_format = metadata.get("snapshot_format")
+    if snapshot_format != _PROVIDER_SNAPSHOT_FORMAT:
+        raise ValueError(
+            f"{path} is not a valid provider snapshot: metadata.snapshot_format must be "
+            f"{_PROVIDER_SNAPSHOT_FORMAT}."
+        )
 
 
 def snapshot_items_by_cve(report: ProviderSnapshotReport) -> dict[str, ProviderSnapshotItem]:

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -19,6 +19,9 @@ from vuln_prioritizer.db import (
     WorkbenchRepository,
     create_session_factory,
 )
+from vuln_prioritizer.providers.epss import EpssProvider
+from vuln_prioritizer.providers.kev import KevProvider
+from vuln_prioritizer.providers.nvd import NvdProvider
 from vuln_prioritizer.workbench_config import WorkbenchSettings
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -525,6 +528,39 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
     assert client.get(bundle_payload["download_url"]).status_code == 404
 
 
+def test_online_shop_demo_import_uses_demo_snapshot_without_network_or_keys(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("NVD_API_KEY", raising=False)
+
+    def _fail_live_provider(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("online-shop-demo must use locked provider snapshot replay")
+
+    monkeypatch.setattr(NvdProvider, "fetch_many", _fail_live_provider)
+    monkeypatch.setattr(EpssProvider, "fetch_many", _fail_live_provider)
+    monkeypatch.setattr(KevProvider, "fetch_many", _fail_live_provider)
+
+    client = _client(tmp_path)
+    project = _create_project(client)
+    run = _import_sample(client, project["id"])
+
+    assert run["status"] == "completed"
+    assert run["provider_snapshot_id"]
+    assert run["summary"]["findings_count"] == len(EXPECTED_SAMPLE_CVES)
+    assert run["summary"]["provider_snapshot_id"] == run["provider_snapshot_id"]
+
+    provider_status = client.get("/api/providers/status")
+    assert provider_status.status_code == 200
+    payload = provider_status.json()
+    assert payload["status"] == "ok"
+    assert payload["snapshot"]["selected_sources"] == ["nvd", "epss", "kev"]
+
+    snapshot_detail = client.get(f"/api/providers/snapshots/{run['provider_snapshot_id']}")
+    assert snapshot_detail.status_code == 200
+    assert snapshot_detail.json()["snapshot_format"] == "provider-snapshot.v1.json"
+
+
 def test_workbench_imports_provider_snapshot_artifact(tmp_path: Path) -> None:
     client = _client(tmp_path)
 
@@ -559,7 +595,17 @@ def test_workbench_imports_provider_snapshot_artifact(tmp_path: Path) -> None:
         files={
             "file": (
                 "legacy-provider-snapshot.json",
-                DEMO_PROVIDER_SNAPSHOT.read_bytes(),
+                json.dumps(
+                    {
+                        "items": [],
+                        "metadata": {
+                            "artifact_kind": "provider-snapshot",
+                            "generated_at": "2026-04-21T12:00:00+00:00",
+                            "schema_version": "1.2.0",
+                        },
+                        "warnings": [],
+                    }
+                ).encode("utf-8"),
                 "application/json",
             )
         },

--- a/backend/tests/live/test_provider_live_contracts.py
+++ b/backend/tests/live/test_provider_live_contracts.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from vuln_prioritizer.providers.epss import EpssProvider
+from vuln_prioritizer.providers.kev import KevProvider
+from vuln_prioritizer.providers.nvd import NvdProvider
+
+pytestmark = pytest.mark.live_network
+
+
+def _require_live_provider_tests() -> None:
+    if os.getenv("VPW_RUN_LIVE_PROVIDER_TESTS") != "1":
+        pytest.skip("Set VPW_RUN_LIVE_PROVIDER_TESTS=1 to run optional live provider checks.")
+
+
+def test_live_epss_provider_contract_smoke() -> None:
+    _require_live_provider_tests()
+
+    records, warnings = EpssProvider().fetch_many(["CVE-2021-44228"])
+
+    assert warnings == []
+    assert records["CVE-2021-44228"].cve_id == "CVE-2021-44228"
+    assert records["CVE-2021-44228"].epss is not None
+
+
+def test_live_kev_provider_contract_smoke() -> None:
+    _require_live_provider_tests()
+
+    records, warnings = KevProvider().fetch_many(["CVE-2021-44228"])
+
+    assert warnings == []
+    assert records["CVE-2021-44228"].in_kev is True
+
+
+def test_live_nvd_provider_contract_smoke() -> None:
+    _require_live_provider_tests()
+
+    records, warnings = NvdProvider.from_env().fetch_many(["CVE-2021-44228"])
+
+    assert warnings == []
+    assert records["CVE-2021-44228"].cve_id == "CVE-2021-44228"
+    assert records["CVE-2021-44228"].description

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -115,6 +115,21 @@ def test_provider_snapshot_v1_example_matches_schema_and_model() -> None:
     assert snapshot.metadata.source_metadata["nvd"]["source"] == "NVD CVE API 2.0"
 
 
+def test_demo_provider_snapshot_matches_schema_and_model() -> None:
+    payload = json.loads((DATA_ROOT / "demo_provider_snapshot.json").read_text(encoding="utf-8"))
+
+    jsonschema.validate(payload, _load_schema("provider-snapshot-report.schema.json"))
+    snapshot = ProviderSnapshotReport.model_validate(payload)
+
+    assert snapshot.metadata.snapshot_format == "provider-snapshot.v1.json"
+    assert snapshot.metadata.snapshot_id == "online-shop-demo-provider-snapshot-2026-04-21"
+    assert snapshot.metadata.cache_only is True
+    assert snapshot.metadata.source_metadata["nvd"]["record_count"] == 7
+    assert snapshot.metadata.source_metadata["epss"]["record_count"] == 7
+    assert snapshot.metadata.source_metadata["kev"]["record_count"] == 6
+    assert len(snapshot.items) == 7
+
+
 def _install_fake_data_update_providers(monkeypatch: Any) -> None:
     def fake_nvd_fetch_many(
         self: NvdProvider,

--- a/backend/tests/test_provider_response_contracts.py
+++ b/backend/tests/test_provider_response_contracts.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from paths import DATA_ROOT
+
+from vuln_prioritizer.providers.epss import EpssProvider
+from vuln_prioritizer.providers.kev import KevProvider
+from vuln_prioritizer.providers.nvd import NvdProvider
+
+FIXTURE_ROOT = DATA_ROOT / "provider_contract_fixtures" / "v1"
+
+
+class FixtureResponse:
+    status_code = 200
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FixtureSession:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kwargs: Any) -> FixtureResponse:
+        self.calls.append({"url": url, **kwargs})
+        return FixtureResponse(self.payload)
+
+
+def _load_fixture(provider: str, path: Path, *, required_keys: set[str]) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    missing = sorted(required_keys - set(payload))
+    if missing:
+        raise AssertionError(
+            f"{provider} provider fixture {path} is missing required key(s): " + ", ".join(missing)
+        )
+    return payload
+
+
+def test_epss_fixture_response_maps_to_epss_data_contract() -> None:
+    payload = _load_fixture(
+        "epss",
+        FIXTURE_ROOT / "epss_first_response.json",
+        required_keys={"data"},
+    )
+    session = FixtureSession(payload)
+    provider = EpssProvider(session=session)
+
+    records, warnings = provider.fetch_many(["CVE-2026-2001"])
+
+    assert warnings == []
+    assert session.calls[0]["params"] == {"cve": "CVE-2026-2001"}
+    assert records["CVE-2026-2001"].epss == 0.73456
+    assert records["CVE-2026-2001"].percentile == 0.98765
+    assert records["CVE-2026-2001"].date == "2026-04-21"
+    assert provider.last_diagnostics.content_hits == 1
+    assert provider.last_diagnostics.network_fetches == 1
+
+
+def test_kev_fixture_catalog_maps_to_kev_data_contract() -> None:
+    fixture_path = FIXTURE_ROOT / "kev_catalog.json"
+    _load_fixture("kev", fixture_path, required_keys={"vulnerabilities"})
+
+    records, warnings = KevProvider().fetch_many(["CVE-2026-2001"], offline_file=fixture_path)
+
+    assert warnings == []
+    assert records["CVE-2026-2001"].in_kev is True
+    assert records["CVE-2026-2001"].vendor_project == "Example Vendor"
+    assert records["CVE-2026-2001"].product == "Example Product"
+    assert records["CVE-2026-2001"].due_date == "2026-05-12"
+
+
+def test_nvd_fixture_response_maps_to_nvd_data_contract() -> None:
+    payload = _load_fixture(
+        "nvd",
+        FIXTURE_ROOT / "nvd_cve_api_2_0_response.json",
+        required_keys={"vulnerabilities"},
+    )
+
+    record = NvdProvider.parse_payload("CVE-2026-2001", payload)
+
+    assert record.cve_id == "CVE-2026-2001"
+    assert record.description == (
+        "Example Product allows command injection through a crafted request."
+    )
+    assert record.cvss_base_score == 9.3
+    assert record.cvss_severity == "CRITICAL"
+    assert record.cvss_version == "4.0"
+    assert record.cvss_vector.startswith("CVSS:4.0/")
+    assert record.cwes == ["CWE-78"]
+    assert record.reference_tags == {
+        "https://example.invalid/advisory/CVE-2026-2001": ["Vendor Advisory", "Patch"]
+    }
+
+
+def test_provider_contract_fixture_schema_failures_include_provider_and_path() -> None:
+    fixture_path = FIXTURE_ROOT / "invalid" / "epss_missing_data.json"
+
+    with pytest.raises(AssertionError) as exc_info:
+        _load_fixture("epss", fixture_path, required_keys={"data"})
+
+    message = str(exc_info.value)
+    assert "epss provider fixture" in message
+    assert str(fixture_path) in message
+    assert "data" in message

--- a/backend/tests/test_provider_snapshot_contract.py
+++ b/backend/tests/test_provider_snapshot_contract.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vuln_prioritizer.provider_snapshot import load_provider_snapshot
+
+
+def test_provider_snapshot_missing_required_v1_fields_fails_clearly(tmp_path: Path) -> None:
+    snapshot_file = tmp_path / "provider-snapshot.json"
+    snapshot_file.write_text(
+        json.dumps(
+            {
+                "items": [],
+                "metadata": {
+                    "artifact_kind": "provider-snapshot",
+                    "generated_at": "2026-04-21T12:00:00+00:00",
+                    "schema_version": "1.2.0",
+                },
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        load_provider_snapshot(snapshot_file)
+
+    message = str(exc_info.value)
+    assert str(snapshot_file) in message
+    assert "missing required metadata field(s)" in message
+    assert "snapshot_format" in message
+    assert "source_hashes" in message
+    assert "source_metadata" in message
+
+
+def test_provider_snapshot_rejects_wrong_snapshot_format(tmp_path: Path) -> None:
+    snapshot_file = tmp_path / "provider-snapshot.json"
+    metadata = {
+        "artifact_kind": "provider-snapshot",
+        "cache_dir": ".cache/vuln-prioritizer",
+        "cache_enabled": True,
+        "generated_at": "2026-04-21T12:00:00+00:00",
+        "input_format": "cve-list",
+        "input_path": None,
+        "input_paths": [],
+        "nvd_api_key_env": "NVD_API_KEY",
+        "offline_kev_file": None,
+        "output_path": str(snapshot_file),
+        "requested_cves": 0,
+        "schema_version": "1.2.0",
+        "selected_sources": ["nvd", "epss", "kev"],
+        "snapshot_format": "provider-snapshot.legacy.json",
+        "source_hashes": {"nvd": None, "epss": None, "kev": None},
+        "source_metadata": {},
+    }
+    snapshot_file.write_text(
+        json.dumps({"items": [], "metadata": metadata, "warnings": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="metadata.snapshot_format must be"):
+        load_provider_snapshot(snapshot_file)

--- a/data/demo_provider_snapshot.json
+++ b/data/demo_provider_snapshot.json
@@ -840,7 +840,34 @@
       "nvd",
       "epss",
       "kev"
-    ]
+    ],
+    "snapshot_format": "provider-snapshot.v1.json",
+    "snapshot_id": "online-shop-demo-provider-snapshot-2026-04-21",
+    "source_hashes": {
+      "epss": null,
+      "kev": null,
+      "nvd": null
+    },
+    "source_metadata": {
+      "epss": {
+        "cache_namespace_hash": null,
+        "cache_only": true,
+        "record_count": 7,
+        "source": "FIRST EPSS API"
+      },
+      "kev": {
+        "cache_namespace_hash": null,
+        "cache_only": true,
+        "record_count": 6,
+        "source": "CISA KEV catalog"
+      },
+      "nvd": {
+        "cache_namespace_hash": null,
+        "cache_only": true,
+        "record_count": 7,
+        "source": "NVD CVE API 2.0"
+      }
+    }
   },
   "warnings": []
 }

--- a/data/provider_contract_fixtures/v1/epss_first_response.json
+++ b/data/provider_contract_fixtures/v1/epss_first_response.json
@@ -1,0 +1,17 @@
+{
+  "access": "public",
+  "data": [
+    {
+      "cve": "CVE-2026-2001",
+      "date": "2026-04-21",
+      "epss": "0.73456",
+      "percentile": "0.98765"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "status": "OK",
+  "status-code": 200,
+  "total": 1,
+  "version": "1.0"
+}

--- a/data/provider_contract_fixtures/v1/invalid/epss_missing_data.json
+++ b/data/provider_contract_fixtures/v1/invalid/epss_missing_data.json
@@ -1,0 +1,5 @@
+{
+  "status": "OK",
+  "status-code": 200,
+  "version": "1.0"
+}

--- a/data/provider_contract_fixtures/v1/kev_catalog.json
+++ b/data/provider_contract_fixtures/v1/kev_catalog.json
@@ -1,0 +1,20 @@
+{
+  "catalogVersion": "2026.04.21",
+  "count": 1,
+  "dateReleased": "2026-04-21T00:00:00Z",
+  "title": "CISA Known Exploited Vulnerabilities Catalog subset fixture",
+  "vulnerabilities": [
+    {
+      "cveID": "CVE-2026-2001",
+      "dateAdded": "2026-04-21",
+      "dueDate": "2026-05-12",
+      "knownRansomwareCampaignUse": "Unknown",
+      "notes": "Synthetic VPW provider-contract fixture.",
+      "product": "Example Product",
+      "requiredAction": "Apply updates per vendor instructions.",
+      "shortDescription": "Example Product command injection vulnerability.",
+      "vendorProject": "Example Vendor",
+      "vulnerabilityName": "Example Product command injection vulnerability"
+    }
+  ]
+}

--- a/data/provider_contract_fixtures/v1/nvd_cve_api_2_0_response.json
+++ b/data/provider_contract_fixtures/v1/nvd_cve_api_2_0_response.json
@@ -1,0 +1,60 @@
+{
+  "format": "NVD_CVE",
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "timestamp": "2026-04-21T12:00:00.000",
+  "totalResults": 1,
+  "version": "2.0",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Example Product allows command injection through a crafted request."
+          }
+        ],
+        "id": "CVE-2026-2001",
+        "lastModified": "2026-04-21T12:00:00.000",
+        "metrics": {
+          "cvssMetricV40": [
+            {
+              "cvssData": {
+                "baseScore": 9.3,
+                "baseSeverity": "CRITICAL",
+                "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+              },
+              "source": "nvd@nist.gov",
+              "type": "Primary"
+            }
+          ]
+        },
+        "published": "2026-04-21T10:00:00.000",
+        "references": [
+          {
+            "source": "example.invalid",
+            "tags": [
+              "Vendor Advisory",
+              "Patch"
+            ],
+            "url": "https://example.invalid/advisory/CVE-2026-2001"
+          }
+        ],
+        "sourceIdentifier": "security@example.invalid",
+        "vulnStatus": "Analyzed",
+        "weaknesses": [
+          {
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-78"
+              }
+            ],
+            "source": "nvd@nist.gov",
+            "type": "Primary"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/architecture/vpw-026-provider-snapshot-replay.md
+++ b/docs/architecture/vpw-026-provider-snapshot-replay.md
@@ -17,6 +17,8 @@ Provider snapshots use the additive `provider-snapshot.v1.json` format marker in
 
 A concise example is published at
 [`docs/examples/example_provider_snapshot.v1.json`](../examples/example_provider_snapshot.v1.json).
+The offline Workbench demo snapshot at `data/demo_provider_snapshot.json` must
+also satisfy the same explicit v1 metadata contract.
 
 ## Replay
 
@@ -55,3 +57,11 @@ Evidence bundles include the resolved provider snapshot JSON as
 `provider/provider-snapshot.json` when the analysis metadata references a
 readable snapshot artifact. The manifest records the snapshot ID, hash, original
 path, bundle path, and selected sources.
+
+## VPW-029 Offline Contract Tests
+
+VPW-029 adds versioned provider response fixtures under
+`data/provider_contract_fixtures/v1` and validates the demo snapshot with
+`make provider-snapshot-validate`. The no-key/no-network demo proof is
+`make demo-offline-no-key-proof`, which runs locked snapshot replay and asserts
+that provider diagnostics report `network_fetches = 0`.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -289,8 +289,10 @@ Current provider service contract:
   to Low without visible evidence
 - cache contract metadata includes namespace, raw key template, TTL seconds,
   and whether expired cache may be used on provider failure
-- required tests for this contract use fake providers or monkeypatching, not
-  live provider APIs
+- required tests for this contract use versioned fixtures under
+  `data/provider_contract_fixtures/v1`, fake providers, or monkeypatching, not
+  live provider APIs; live provider smoke tests are marked `live_network` and
+  skipped unless explicitly enabled
 
 ### Defensive context semantics
 

--- a/docs/evidence/vpw-029-provider-testmatrix.md
+++ b/docs/evidence/vpw-029-provider-testmatrix.md
@@ -1,0 +1,41 @@
+# VPW-029 Provider Test Matrix
+
+VPW-029 keeps provider behavior reproducible without live API availability. Required
+CI tests use checked-in fixtures, fake sessions, or locked provider snapshots. Live
+provider checks are optional and must be enabled explicitly.
+
+## Versioned Fixtures
+
+| Source | Fixture | Contract covered |
+| --- | --- | --- |
+| NVD | `data/provider_contract_fixtures/v1/nvd_cve_api_2_0_response.json` | CVE API 2.0 response shape, CVSS 4.0 parsing, CWE extraction, reference tags. |
+| EPSS | `data/provider_contract_fixtures/v1/epss_first_response.json` | FIRST EPSS response shape, score/date parsing, diagnostics. |
+| KEV | `data/provider_contract_fixtures/v1/kev_catalog.json` | CISA KEV catalog shape, alias normalization, offline file loading. |
+| Negative | `data/provider_contract_fixtures/v1/invalid/epss_missing_data.json` | Clear fixture failure messages including provider and path. |
+
+## Required Matrix
+
+| Capability | Required proof | Command |
+| --- | --- | --- |
+| Provider response contracts | NVD, EPSS, and KEV fixture-backed tests parse into provider DTOs. | `python3 -m pytest -q backend/tests/test_provider_response_contracts.py --no-cov` |
+| Shared provider adapter | NVD/EPSS/KEV adapter status, snapshot fields, cache flags, and degraded data-quality flags. | `python3 -m pytest -q backend/tests/test_provider_contract.py --no-cov` |
+| Snapshot v1 schema | Example and demo provider snapshots validate against the published schema and Pydantic model. | `make provider-snapshot-validate` |
+| Cache-only export | `data export-provider-snapshot --cache-only` uses local cache and does not refresh providers. | `python3 -m pytest -q backend/tests/test_cli_data.py::test_data_export_provider_snapshot_cache_only_uses_local_cache --no-cov` |
+| Locked replay | Analysis uses `data/demo_provider_snapshot.json` with `--locked-provider-data`. | `make demo-offline-no-key-proof` |
+| Workbench demo import | `online-shop-demo` imports with no `NVD_API_KEY` and patched provider fetchers that would fail if live calls were made. | `python3 -m pytest -q backend/tests/api/test_workbench_api.py::test_online_shop_demo_import_uses_demo_snapshot_without_network_or_keys --no-cov` |
+| Evidence bundle | Evidence ZIP contains `provider/provider-snapshot.json` and verification metadata. | `python3 -m pytest -q backend/tests/test_evidence_bundle_verification.py --no-cov` |
+| Optional live APIs | Real NVD/EPSS/KEV smoke checks are skipped by default. | `VPW_RUN_LIVE_PROVIDER_TESTS=1 python3 -m pytest -q backend/tests/live --no-cov` |
+
+## Offline Demo Snapshot
+
+`data/demo_provider_snapshot.json` is the authoritative locked replay artifact for
+the `online-shop-demo` flow. It is an explicit `provider-snapshot.v1.json`
+artifact with:
+
+- `metadata.snapshot_id = online-shop-demo-provider-snapshot-2026-04-21`
+- `metadata.snapshot_format = provider-snapshot.v1.json`
+- `metadata.cache_only = true`
+- `metadata.source_metadata` for NVD, EPSS, and KEV
+
+The demo no-key proof writes `build/vpw-029-demo-offline-no-key-proof.json` and
+asserts that every provider diagnostic reports `network_fetches = 0`.

--- a/docs/example_attack_compare.md
+++ b/docs/example_attack_compare.md
@@ -10,7 +10,8 @@
 - Output path: `docs/example_attack_compare.md`
 - Provider snapshot file: `data/demo_provider_snapshot.json`
 - Provider snapshot mode: `locked`
-- Provider snapshot hash: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- Provider snapshot ID: `online-shop-demo-provider-snapshot-2026-04-21`
+- Provider snapshot hash: `d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f`
 - Provider snapshot sources: `nvd, epss, kev`
 - Provider snapshot generated at: `2026-04-21T12:00:00+00:00`
 - NVD freshness: `2026-04-21T12:00:00+00:00`

--- a/docs/example_attack_explain.json
+++ b/docs/example_attack_explain.json
@@ -873,8 +873,8 @@
       "provider_snapshot_generated_at": "2026-04-21T12:00:00+00:00"
     },
     "provider_snapshot_file": "data/demo_provider_snapshot.json",
-    "provider_snapshot_hash": "a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b",
-    "provider_snapshot_id": null,
+    "provider_snapshot_hash": "d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f",
+    "provider_snapshot_id": "online-shop-demo-provider-snapshot-2026-04-21",
     "provider_snapshot_sources": [
       "nvd",
       "epss",

--- a/docs/example_attack_report.md
+++ b/docs/example_attack_report.md
@@ -10,7 +10,8 @@
 - Output path: `docs/example_attack_report.md`
 - Provider snapshot file: `data/demo_provider_snapshot.json`
 - Provider snapshot mode: `locked`
-- Provider snapshot hash: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- Provider snapshot ID: `online-shop-demo-provider-snapshot-2026-04-21`
+- Provider snapshot hash: `d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f`
 - Provider snapshot sources: `nvd, epss, kev`
 - Provider snapshot generated at: `2026-04-21T12:00:00+00:00`
 - NVD freshness: `2026-04-21T12:00:00+00:00`

--- a/docs/example_compare.md
+++ b/docs/example_compare.md
@@ -10,7 +10,8 @@
 - Output path: `docs/example_compare.md`
 - Provider snapshot file: `data/demo_provider_snapshot.json`
 - Provider snapshot mode: `locked`
-- Provider snapshot hash: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- Provider snapshot ID: `online-shop-demo-provider-snapshot-2026-04-21`
+- Provider snapshot hash: `d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f`
 - Provider snapshot sources: `nvd, epss, kev`
 - Provider snapshot generated at: `2026-04-21T12:00:00+00:00`
 - NVD freshness: `2026-04-21T12:00:00+00:00`

--- a/docs/example_explain.json
+++ b/docs/example_explain.json
@@ -594,8 +594,8 @@
       "provider_snapshot_generated_at": "2026-04-21T12:00:00+00:00"
     },
     "provider_snapshot_file": "data/demo_provider_snapshot.json",
-    "provider_snapshot_hash": "a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b",
-    "provider_snapshot_id": null,
+    "provider_snapshot_hash": "d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f",
+    "provider_snapshot_id": "online-shop-demo-provider-snapshot-2026-04-21",
     "provider_snapshot_sources": [
       "nvd",
       "epss",

--- a/docs/example_report.md
+++ b/docs/example_report.md
@@ -10,7 +10,8 @@
 - Output path: `docs/example_report.md`
 - Provider snapshot file: `data/demo_provider_snapshot.json`
 - Provider snapshot mode: `locked`
-- Provider snapshot hash: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- Provider snapshot ID: `online-shop-demo-provider-snapshot-2026-04-21`
+- Provider snapshot hash: `d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f`
 - Provider snapshot sources: `nvd, epss, kev`
 - Provider snapshot generated at: `2026-04-21T12:00:00+00:00`
 - NVD freshness: `2026-04-21T12:00:00+00:00`

--- a/docs/examples/example_pr_comment.md
+++ b/docs/examples/example_pr_comment.md
@@ -10,7 +10,8 @@
 - Output path: `docs/examples/example_pr_comment.md`
 - Provider snapshot file: `data/demo_provider_snapshot.json`
 - Provider snapshot mode: `locked`
-- Provider snapshot hash: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- Provider snapshot ID: `online-shop-demo-provider-snapshot-2026-04-21`
+- Provider snapshot hash: `d05f5901b8ea1434b59cb4d079313c16114663291e3133258375e77e87ee1d8f`
 - Provider snapshot sources: `nvd, epss, kev`
 - Provider snapshot generated at: `2026-04-21T12:00:00+00:00`
 - NVD freshness: `2026-04-21T12:00:00+00:00`

--- a/docs/workbench-offline-demo.md
+++ b/docs/workbench-offline-demo.md
@@ -12,6 +12,9 @@ This runbook keeps the Workbench demo reproducible without live provider calls. 
 
 ```bash
 make install
+make provider-snapshot-validate
+make provider-testmatrix
+make demo-offline-no-key-proof
 python3 -m pytest -q backend/tests/api/test_workbench_api.py backend/tests/web/test_workbench_pages.py --no-cov
 make docker-demo-smoke
 make docker-postgres-migration-smoke
@@ -50,6 +53,46 @@ If `pip-audit` is unavailable or advisory data cannot be reached, record that as
 | Docker demo smoke | `make docker-demo-smoke` output showing `/api/v1/workbench/status` returns `{"status":"ok"}` before teardown. |
 | Dependency audit | `make dependency-audit` result, or a documented exception when `pip-audit` or advisory data is unavailable. |
 | Demo evidence bundle | `make demo-evidence-bundle-check` output plus `build/v1.0-demo-evidence-bundle-verification.json` showing `ok=true`. |
+| Provider test matrix | `make provider-testmatrix` plus `docs/evidence/vpw-029-provider-testmatrix.md`. |
+| Offline/no-key proof | `make demo-offline-no-key-proof` output plus `build/vpw-029-demo-offline-no-key-proof.json` showing locked replay and provider `network_fetches=0`. |
+
+## Updating the Demo Provider Snapshot
+
+Only update `data/demo_provider_snapshot.json` as an intentional release task.
+The snapshot must remain a valid explicit `provider-snapshot.v1.json` artifact
+and must not depend on reviewer API keys or live provider availability.
+
+1. Refresh provider cache from a controlled maintainer environment:
+
+   ```bash
+   PYTHONPATH=backend/src python3 -m vuln_prioritizer.cli data update \
+     --input data/sample_cves.txt \
+     --cache-dir .cache/vuln-prioritizer \
+     --offline-kev-file data/input_fixtures/kev_catalog.json
+   ```
+
+2. Export the locked replay artifact:
+
+   ```bash
+   PYTHONPATH=backend/src python3 -m vuln_prioritizer.cli data export-provider-snapshot \
+     --input data/sample_cves.txt \
+     --output data/demo_provider_snapshot.json \
+     --cache-dir .cache/vuln-prioritizer \
+     --cache-only
+   ```
+
+3. Re-run the offline proof and generated demo artifacts:
+
+   ```bash
+   make provider-snapshot-validate
+   make demo-offline-no-key-proof
+   make demo-sync-check
+   make demo-evidence-bundle-check
+   ```
+
+4. Review the snapshot diff before committing. Expected changes are provider
+   dates, source hashes, provider records, and generated demo artifact hashes.
+   Do not commit secrets, local private paths, or customer scanner exports.
 
 ## Screenshot Evidence List
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - GitHub Summary Templates: examples/github_action_summary_templates.md
   - Historical Appendix:
       - Full Stack Template Baseline Evidence: evidence/full_stack_fastapi_template_baseline.md
+      - VPW-029 Provider Test Matrix: evidence/vpw-029-provider-testmatrix.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary

Refs #135. Depends on #222.

- Add versioned VPW provider contract fixtures for NVD, FIRST EPSS, and CISA KEV.
- Validate explicit `provider-snapshot.v1.json` metadata for loaded provider snapshots and update the checked-in demo snapshot.
- Add offline/no-key demo proof, Workbench import coverage, optional live-provider smoke tests, and VPW-029 evidence docs.

## Verification

- `make provider-snapshot-validate` -> 4 passed; schema validation OK for `docs/examples/example_provider_snapshot.v1.json` and `data/demo_provider_snapshot.json`.
- `make provider-testmatrix` -> 21 passed.
- `make demo-offline-no-key-proof` -> OK; `build/vpw-029-demo-offline-no-key-proof.json` has locked replay and provider `network_fetches=0`.
- `make demo-sync-check` -> passed.
- `make docs-check` -> passed.
- `make check` -> 695 passed, 5 skipped, coverage 90.42%.
- `git diff --check` -> passed.

## Residual Risk

- Optional live-provider tests remain skipped unless `VPW_RUN_LIVE_PROVIDER_TESTS=1`.
- The generated proof file under `build/` is local evidence and is not committed.
