### PR TITLE
VPW-032 CVSS-only baseline comparison service

### DIFF
--- a/backend/src/vuln_prioritizer/api/schemas.py
+++ b/backend/src/vuln_prioritizer/api/schemas.py
@@ -76,6 +76,15 @@ class FindingStatusUpdateRequest(StrictModel):
     actor: str | None = None
 
 
+class BaselineComparisonResponse(StrictModel):
+    project_id: str | None = None
+    methodology: dict[str, Any]
+    summary: dict[str, int]
+    counts: dict[str, dict[str, int]]
+    top_changes: list[dict[str, Any]] = Field(default_factory=list)
+    comparisons: list[dict[str, Any]] = Field(default_factory=list)
+
+
 class ProviderUpdateJobRequest(StrictModel):
     sources: list[ProviderSourceName] = Field(default_factory=_default_provider_sources)
     cve_ids: list[str] = Field(default_factory=list)

--- a/backend/src/vuln_prioritizer/api/workbench_import_routes.py
+++ b/backend/src/vuln_prioritizer/api/workbench_import_routes.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from vuln_prioritizer.api.deps import get_db_session, get_workbench_settings
 from vuln_prioritizer.api.schemas import (
     AnalysisRunResponse,
+    BaselineComparisonResponse,
     FindingDetailResponse,
     FindingsListResponse,
     FindingStatusUpdateRequest,
@@ -34,6 +35,10 @@ from vuln_prioritizer.api.workbench_waivers import (
     _strip_or_none,
 )
 from vuln_prioritizer.db.repositories import WorkbenchRepository
+from vuln_prioritizer.models import PrioritizedFinding
+from vuln_prioritizer.services.baseline_comparison import (
+    build_cvss_baseline_comparison_payload,
+)
 from vuln_prioritizer.services.workbench_analysis import (
     WorkbenchAnalysisError,
     run_workbench_import,
@@ -335,6 +340,27 @@ def list_findings(
     }
 
 
+@router.get(
+    "/projects/{project_id}/baseline-comparison",
+    response_model=BaselineComparisonResponse,
+)
+def get_project_baseline_comparison(
+    project_id: str,
+    session: Annotated[Session, Depends(get_db_session)],
+    limit: int = Query(default=10, ge=0, le=100),
+) -> dict[str, Any]:
+    repo = WorkbenchRepository(session)
+    if repo.get_project(project_id) is None:
+        raise HTTPException(status_code=404, detail="Project not found.")
+    findings = repo.list_project_findings(project_id)
+    prioritized = [_prioritized_finding_from_workbench(finding) for finding in findings]
+    return build_cvss_baseline_comparison_payload(
+        prioritized,
+        project_id=project_id,
+        top_change_limit=limit,
+    )
+
+
 @router.get("/findings/{finding_id}", response_model=FindingDetailResponse)
 def get_finding(
     finding_id: str,
@@ -416,3 +442,26 @@ def explain_finding(
         "decision_explanation": decision_explanation,
         "explanation": finding.explanation_json,
     }
+
+
+def _prioritized_finding_from_workbench(finding: Any) -> PrioritizedFinding:
+    payload = finding.finding_json if isinstance(finding.finding_json, dict) else {}
+    if payload:
+        try:
+            return PrioritizedFinding.model_validate(payload)
+        except ValueError:
+            pass
+    return PrioritizedFinding(
+        cve_id=finding.cve_id,
+        description=getattr(finding.vulnerability, "description", None),
+        cvss_base_score=finding.cvss_base_score,
+        epss=finding.epss,
+        in_kev=finding.in_kev,
+        priority_label=finding.priority,
+        priority_rank=finding.priority_rank,
+        priority_state=finding.priority,
+        operational_rank=finding.operational_rank,
+        operational_score=int(finding.risk_score or 0),
+        rationale=finding.rationale or "Stored Workbench finding without raw rationale payload.",
+        recommended_action=finding.recommended_action or "Review the finding with the asset owner.",
+    )

--- a/backend/src/vuln_prioritizer/reporting_markdown.py
+++ b/backend/src/vuln_prioritizer/reporting_markdown.py
@@ -30,6 +30,9 @@ from vuln_prioritizer.reporting_format import (
     format_score,
     normalize_whitespace,
 )
+from vuln_prioritizer.services.baseline_comparison import (
+    build_cvss_baseline_comparison_payload,
+)
 
 
 def generate_markdown_report(
@@ -65,6 +68,7 @@ def generate_markdown_report(
     lines.extend(_attack_methodology_lines(context))
     lines.extend(["", "## Summary"])
     lines.extend(_summary_lines(context))
+    lines.extend(_baseline_comparison_section(findings))
     lines.extend(["", "## ATT&CK Context Summary"])
     lines.extend(_attack_summary_lines(context.attack_summary, context.attack_enabled))
     lines.extend(["", "## Warnings"])
@@ -233,6 +237,37 @@ def generate_markdown_report(
             )
 
     return "\n".join(lines) + "\n"
+
+
+def _baseline_comparison_section(findings: list[PrioritizedFinding]) -> list[str]:
+    comparison = build_cvss_baseline_comparison_payload(
+        findings,
+        top_change_limit=5,
+        include_comparisons=False,
+    )
+    summary = comparison["summary"]
+    methodology = comparison["methodology"]
+    lines = [
+        "",
+        "## CVSS-only Baseline Comparison",
+        f"- Changed rows: {summary['changed']}",
+        f"- Up: {summary['up']}",
+        f"- Down: {summary['down']}",
+        f"- Unchanged: {summary['unchanged']}",
+        "- Method limit: " + normalize_whitespace(str(methodology["limitations"])),
+    ]
+    top_changes = comparison["top_changes"]
+    if top_changes:
+        lines.extend(["", "### Top Baseline Changes"])
+        for item in top_changes:
+            lines.append(
+                "- "
+                + f"{item['cve_id']}: {item['old_priority']} "
+                + f"(rank {item['old_rank']}) -> {item['new_priority']} "
+                + f"(rank {item['new_rank']}); "
+                + normalize_whitespace(str(item["reason"]))
+            )
+    return lines
 
 
 def generate_compare_markdown(

--- a/backend/src/vuln_prioritizer/reporting_payloads.py
+++ b/backend/src/vuln_prioritizer/reporting_payloads.py
@@ -35,6 +35,9 @@ from vuln_prioritizer.models import (
     StateWaiverReport,
 )
 from vuln_prioritizer.reporting_format import _priority_display_label, normalize_whitespace
+from vuln_prioritizer.services.baseline_comparison import (
+    build_cvss_baseline_comparison_payload,
+)
 
 
 def generate_json_report(
@@ -54,6 +57,11 @@ def build_analysis_report_payload(
     return {
         "metadata": _context_metadata(context),
         "attack_summary": context.attack_summary.model_dump(),
+        "baseline_comparison": build_cvss_baseline_comparison_payload(
+            findings,
+            top_change_limit=5,
+            include_comparisons=False,
+        ),
         "findings": [finding.model_dump() for finding in findings],
     }
 
@@ -152,6 +160,9 @@ def generate_summary_markdown(
     governance_lines = _governance_summary_lines(metadata, findings)
     if governance_lines:
         lines.extend(["", "## Governance", *governance_lines])
+    comparison_lines = _baseline_comparison_summary_lines(report_payload)
+    if comparison_lines:
+        lines.extend(["", "## CVSS-only Baseline Comparison", *comparison_lines])
     lines.extend(["", "## Top Findings"])
     if findings:
         top_findings = findings[:5]
@@ -173,6 +184,41 @@ def generate_summary_markdown(
     else:
         lines.append("- No findings matched the current filters.")
     return "\n".join(lines) + "\n"
+
+
+def _baseline_comparison_summary_lines(report_payload: dict[str, Any]) -> list[str]:
+    comparison = report_payload.get("baseline_comparison")
+    if not isinstance(comparison, dict):
+        return []
+    raw_summary = comparison.get("summary")
+    summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
+    raw_methodology = comparison.get("methodology")
+    methodology: dict[str, Any] = raw_methodology if isinstance(raw_methodology, dict) else {}
+    lines = [
+        f"- Changed rows: {summary.get('changed', 0)}",
+        f"- Up: {summary.get('up', 0)}",
+        f"- Down: {summary.get('down', 0)}",
+        f"- Unchanged: {summary.get('unchanged', 0)}",
+    ]
+    limitation = methodology.get("limitations")
+    if limitation:
+        lines.append("- Method limit: " + normalize_whitespace(str(limitation)))
+    top_changes = comparison.get("top_changes")
+    if isinstance(top_changes, list) and top_changes:
+        lines.extend(["", "### Top Baseline Changes"])
+        for item in top_changes[:5]:
+            if not isinstance(item, dict):
+                continue
+            lines.append(
+                "- "
+                + f"{item.get('cve_id', 'N.A.')}: "
+                + f"{item.get('old_priority', 'N.A.')} "
+                + f"(rank {item.get('old_rank', 'N.A.')}) -> "
+                + f"{item.get('new_priority', 'N.A.')} "
+                + f"(rank {item.get('new_rank', 'N.A.')}); "
+                + normalize_whitespace(str(item.get("reason", "N.A.")))
+            )
+    return lines
 
 
 def _governance_summary_lines(metadata: dict[str, Any], findings: list[Any]) -> list[str]:

--- a/backend/src/vuln_prioritizer/services/baseline_comparison.py
+++ b/backend/src/vuln_prioritizer/services/baseline_comparison.py
@@ -1,0 +1,116 @@
+"""CVSS-only baseline comparison helpers."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from typing import Any
+
+from vuln_prioritizer.models import ComparisonFinding, PrioritizedFinding, PriorityPolicy
+from vuln_prioritizer.services.prioritization import PrioritizationService
+
+PRIORITY_ORDER = ("Critical", "High", "Medium", "Low")
+BASELINE_THRESHOLDS = {
+    "Critical": "CVSS >= 9.0",
+    "High": "7.0 <= CVSS < 9.0",
+    "Medium": "4.0 <= CVSS < 7.0",
+    "Low": "CVSS < 4.0 or missing CVSS",
+}
+METHODOLOGY_LIMITATION = (
+    "This comparison is a decision-support view, not an absolute truth. "
+    "It shows how the current enriched policy differs from a CVSS-only baseline "
+    "and still requires asset-owner validation."
+)
+
+
+def build_cvss_baseline_comparison_payload(
+    findings: Sequence[PrioritizedFinding],
+    *,
+    project_id: str | None = None,
+    policy: PriorityPolicy | None = None,
+    top_change_limit: int = 10,
+    include_comparisons: bool = True,
+) -> dict[str, Any]:
+    """Build a JSON-ready CVSS-only vs enriched comparison payload."""
+    comparisons = PrioritizationService(policy=policy).build_comparison(list(findings))
+    changed = [row for row in comparisons if row.changed]
+    payload: dict[str, Any] = {
+        "project_id": project_id,
+        "methodology": {
+            "baseline": "cvss-only",
+            "baseline_thresholds": BASELINE_THRESHOLDS,
+            "enriched": (
+                "Rule-based priority using CVSS, FIRST EPSS, CISA KEV, and supplied "
+                "context such as ATT&CK, VEX, waivers, and asset metadata when present."
+            ),
+            "limitations": METHODOLOGY_LIMITATION,
+        },
+        "summary": {
+            "total": len(comparisons),
+            "changed": len(changed),
+            "up": sum(1 for row in changed if row.delta_rank > 0),
+            "down": sum(1 for row in changed if row.delta_rank < 0),
+            "unchanged": len(comparisons) - len(changed),
+        },
+        "counts": {
+            "cvss_only": _counts_by_priority(comparisons, "cvss_only_label"),
+            "enriched": _counts_by_priority(comparisons, "enriched_label"),
+        },
+        "top_changes": [
+            _top_change_payload(row) for row in _top_changes(changed, limit=top_change_limit)
+        ],
+    }
+    if include_comparisons:
+        payload["comparisons"] = [row.model_dump() for row in comparisons]
+    return payload
+
+
+def _counts_by_priority(
+    comparisons: Sequence[ComparisonFinding],
+    attribute: str,
+) -> dict[str, int]:
+    counts = Counter(str(getattr(row, attribute)) for row in comparisons)
+    return {priority: counts.get(priority, 0) for priority in PRIORITY_ORDER}
+
+
+def _top_changes(
+    changed: Sequence[ComparisonFinding],
+    *,
+    limit: int,
+) -> list[ComparisonFinding]:
+    if limit <= 0:
+        return []
+    return sorted(
+        changed,
+        key=lambda row: (
+            -abs(row.delta_rank),
+            row.enriched_rank,
+            row.cvss_only_rank,
+            row.cve_id,
+        ),
+    )[:limit]
+
+
+def _top_change_payload(row: ComparisonFinding) -> dict[str, Any]:
+    return {
+        "cve_id": row.cve_id,
+        "old_priority": row.cvss_only_label,
+        "old_rank": row.cvss_only_rank,
+        "new_priority": row.enriched_label,
+        "new_rank": row.enriched_rank,
+        "delta_rank": row.delta_rank,
+        "direction": _direction(row.delta_rank),
+        "reason": row.change_reason,
+        "cvss": row.cvss_base_score,
+        "epss": row.epss,
+        "in_kev": row.in_kev,
+        "operational_rank": row.operational_rank,
+    }
+
+
+def _direction(delta_rank: int) -> str:
+    if delta_rank > 0:
+        return "up"
+    if delta_rank < 0:
+        return "down"
+    return "unchanged"

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -260,6 +260,26 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
         for item in items
     )
 
+    baseline_comparison = client.get(
+        f"/api/projects/{project['id']}/baseline-comparison",
+        params={"limit": 2},
+    )
+    assert baseline_comparison.status_code == 200
+    baseline_payload = baseline_comparison.json()
+    assert baseline_payload["project_id"] == project["id"]
+    assert baseline_payload["summary"]["total"] == len(EXPECTED_SAMPLE_CVES)
+    assert baseline_payload["summary"]["changed"] == len(
+        [item for item in baseline_payload["comparisons"] if item["changed"]]
+    )
+    assert set(baseline_payload["counts"]["cvss_only"]) == {"Critical", "High", "Medium", "Low"}
+    assert set(baseline_payload["counts"]["enriched"]) == {"Critical", "High", "Medium", "Low"}
+    assert len(baseline_payload["top_changes"]) <= 2
+    assert baseline_payload["top_changes"]
+    first_change = baseline_payload["top_changes"][0]
+    assert {"cve_id", "old_rank", "new_rank", "reason"} <= set(first_change)
+    assert "CVSS-only" in first_change["reason"]
+    assert "not an absolute truth" in baseline_payload["methodology"]["limitations"]
+
     filtered = client.get(
         f"/api/projects/{project['id']}/findings",
         params={"q": "CVE-2024-3094"},
@@ -377,6 +397,10 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
             analysis_payload = json.loads(report_download.text)
             assert analysis_payload["metadata"]["input_format"] == "cve-list"
             assert analysis_payload["metadata"]["locked_provider_data"] is True
+            assert analysis_payload["baseline_comparison"]["summary"]["total"] == len(
+                EXPECTED_SAMPLE_CVES
+            )
+            assert analysis_payload["baseline_comparison"]["top_changes"]
             assert {
                 finding["cve_id"] for finding in analysis_payload["findings"]
             } == EXPECTED_SAMPLE_CVES
@@ -403,6 +427,9 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
         if report_format == "csv":
             assert b"snapshot_locked" in report_download.content
             assert b"high" in report_download.content
+        if report_format == "markdown":
+            assert b"CVSS-only Baseline Comparison" in report_download.content
+            assert b"not an absolute truth" in report_download.content
 
     bundle = client.post(f"/api/analysis-runs/{run['id']}/evidence-bundle")
     assert bundle.status_code == 200

--- a/backend/tests/test_baseline_comparison.py
+++ b/backend/tests/test_baseline_comparison.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from vuln_prioritizer.models import PrioritizedFinding
+from vuln_prioritizer.services.baseline_comparison import (
+    build_cvss_baseline_comparison_payload,
+)
+
+
+def test_cvss_baseline_comparison_summarizes_counts_and_top_changes() -> None:
+    findings = [
+        _finding(
+            "CVE-2026-0001",
+            cvss=5.5,
+            epss=0.91,
+            in_kev=True,
+            priority_label="Critical",
+            priority_rank=1,
+        ),
+        _finding(
+            "CVE-2026-0002",
+            cvss=9.8,
+            epss=0.02,
+            priority_label="High",
+            priority_rank=2,
+        ),
+        _finding(
+            "CVE-2026-0003",
+            cvss=4.2,
+            epss=0.01,
+            priority_label="Medium",
+            priority_rank=3,
+        ),
+    ]
+
+    payload = build_cvss_baseline_comparison_payload(
+        findings,
+        project_id="project-1",
+        top_change_limit=2,
+    )
+
+    assert payload["project_id"] == "project-1"
+    assert payload["counts"]["cvss_only"] == {
+        "Critical": 1,
+        "High": 0,
+        "Medium": 2,
+        "Low": 0,
+    }
+    assert payload["counts"]["enriched"] == {
+        "Critical": 1,
+        "High": 1,
+        "Medium": 1,
+        "Low": 0,
+    }
+    assert payload["summary"] == {
+        "total": 3,
+        "changed": 2,
+        "up": 1,
+        "down": 1,
+        "unchanged": 1,
+    }
+    assert len(payload["top_changes"]) == 2
+    assert payload["top_changes"][0]["cve_id"] == "CVE-2026-0001"
+    assert payload["top_changes"][0]["old_priority"] == "Medium"
+    assert payload["top_changes"][0]["old_rank"] == 3
+    assert payload["top_changes"][0]["new_priority"] == "Critical"
+    assert payload["top_changes"][0]["new_rank"] == 1
+    assert payload["top_changes"][0]["direction"] == "up"
+    assert "KEV membership raises" in payload["top_changes"][0]["reason"]
+    assert "not an absolute truth" in payload["methodology"]["limitations"]
+    assert len(payload["comparisons"]) == 3
+
+
+def test_cvss_baseline_comparison_can_omit_full_rows_for_reports() -> None:
+    payload = build_cvss_baseline_comparison_payload(
+        [_finding("CVE-2026-0004", cvss=None, priority_label="Low", priority_rank=4)],
+        include_comparisons=False,
+    )
+
+    assert payload["summary"]["unchanged"] == 1
+    assert payload["top_changes"] == []
+    assert "comparisons" not in payload
+
+
+def _finding(
+    cve_id: str,
+    *,
+    cvss: float | None,
+    priority_label: str,
+    priority_rank: int,
+    epss: float | None = None,
+    in_kev: bool = False,
+) -> PrioritizedFinding:
+    return PrioritizedFinding(
+        cve_id=cve_id,
+        cvss_base_score=cvss,
+        epss=epss,
+        in_kev=in_kev,
+        priority_label=priority_label,
+        priority_rank=priority_rank,
+        rationale=f"{cve_id} test rationale.",
+        recommended_action="Review and remediate according to policy.",
+    )

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -268,6 +268,20 @@ def test_vpw_031_explanation_field_remains_schema_optional() -> None:
         assert "explanation" not in definition.get("required", [])
 
 
+def test_vpw_032_baseline_comparison_schema_and_example() -> None:
+    schema = _load_schema("analysis-report.schema.json")
+    payload = json.loads(
+        (DOCS_ROOT / "examples" / "example_baseline_comparison.json").read_text(encoding="utf-8")
+    )
+
+    assert "baseline_comparison" in schema["properties"]
+    assert "baseline_comparison" not in schema.get("required", [])
+    jsonschema.validate(payload, schema["$defs"]["baselineComparison"])
+    assert payload["top_changes"][0]["old_rank"] == 3
+    assert payload["top_changes"][0]["new_rank"] == 1
+    assert "not an absolute truth" in payload["methodology"]["limitations"]
+
+
 def _install_fake_data_update_providers(monkeypatch: Any) -> None:
     def fake_nvd_fetch_many(
         self: NvdProvider,

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -80,13 +80,18 @@ the `input normalize --format json` compatibility alias.
 `report evidence-bundle` is a ZIP transport over the analysis JSON contract. Its published machine contract is the `manifest.json` stored inside the bundle.
 `report verify-evidence-bundle` is the published integrity-report contract for saved evidence ZIP bundles.
 
+`baseline_comparison` is additive on analysis-style payloads. It compares
+CVSS-only priority bands with the enriched policy and includes priority counts,
+up/down/unchanged totals, top changes with old/new rank, and a methodology
+limitation stating that the view is decision support rather than absolute truth.
+
 ## JSON envelope contract
 
 All documented JSON exports include explicit metadata or top-level version fields. Analysis-style reports keep the richer `metadata` + `attack_summary` envelope, while helper and state commands publish smaller purpose-built contracts.
 
 Primary payload keys by command:
 
-- `analyze`: `findings`
+- `analyze`: `findings`, optional `baseline_comparison`
 - `compare`: `comparisons`
 - `explain`: `finding`, plus `nvd`, `epss`, `kev`, `attack`, and `comparison`
 - `doctor`: `checks`

--- a/docs/evidence/vpw-032-cvss-baseline-comparison.md
+++ b/docs/evidence/vpw-032-cvss-baseline-comparison.md
@@ -1,0 +1,74 @@
+# VPW-032 CVSS-only Baseline Comparison Evidence
+
+VPW-032 adds a Workbench project API and report summary for comparing the
+current enriched priority policy against a deterministic CVSS-only baseline.
+
+## API
+
+Endpoint:
+
+```text
+GET /api/projects/{project_id}/baseline-comparison?limit=10
+```
+
+Response shape:
+
+- `counts.cvss_only` and `counts.enriched` show Critical, High, Medium, and Low totals.
+- `summary` shows total, changed, up, down, and unchanged counts.
+- `top_changes[]` includes CVE ID, old/new priority, old/new rank, delta, direction, and reason.
+- `comparisons[]` includes the full machine-readable comparison rows.
+- `methodology.limitations` states that the comparison is decision support, not an absolute truth.
+
+Example response:
+
+```json
+{
+  "project_id": "project-1",
+  "summary": {
+    "total": 3,
+    "changed": 2,
+    "up": 1,
+    "down": 1,
+    "unchanged": 1
+  },
+  "top_changes": [
+    {
+      "cve_id": "CVE-2026-0001",
+      "old_priority": "Medium",
+      "old_rank": 3,
+      "new_priority": "Critical",
+      "new_rank": 1,
+      "reason": "KEV membership raises this CVE from the CVSS-only Medium baseline to Critical."
+    }
+  ]
+}
+```
+
+Full example artifact: `docs/examples/example_baseline_comparison.json`.
+
+## Report Excerpt
+
+Analysis Markdown and Workbench Markdown summaries now include:
+
+```text
+## CVSS-only Baseline Comparison
+- Changed rows: 2
+- Up: 1
+- Down: 1
+- Unchanged: 1
+- Method limit: This comparison is a decision-support view, not an absolute truth.
+```
+
+The analysis JSON payload includes `baseline_comparison` with the same summary
+and top-change data used by the Markdown report.
+
+## Validation Targets
+
+- Unit tests cover counts, up/down/unchanged totals, top changes, old/new ranks,
+  reasons, and report-sized payloads without full rows.
+- Workbench API tests cover the project comparison endpoint and report payload.
+- Schema tests validate the additive `baseline_comparison` analysis contract.
+- Generated client: this endpoint belongs to the existing legacy Workbench API
+  mounted by `vuln_prioritizer.api.app`; the generated React client currently
+  targets `backend/app/main.py` (`/api/v1`). The client generation check should
+  still be run to prove no unintended template-client drift.

--- a/docs/example_attack_report.md
+++ b/docs/example_attack_report.md
@@ -79,6 +79,17 @@
 - Low: 0
 - Active filters: None
 
+## CVSS-only Baseline Comparison
+- Changed rows: 2
+- Up: 2
+- Down: 0
+- Unchanged: 3
+- Method limit: This comparison is a decision-support view, not an absolute truth. It shows how the current enriched policy differs from a CVSS-only baseline and still requires asset-owner validation.
+
+### Top Baseline Changes
+- CVE-2020-1472: Medium (rank 3) -> Critical (rank 1); KEV membership raises this CVE from the CVSS-only Medium baseline to Critical.
+- CVE-2023-44487: High (rank 2) -> Critical (rank 1); KEV membership raises this CVE from the CVSS-only High baseline to Critical.
+
 ## ATT&CK Context Summary
 - CVEs with ATT&CK mappings: 3
 - Unmapped CVEs: 2

--- a/docs/example_report.md
+++ b/docs/example_report.md
@@ -64,6 +64,16 @@
 - Low: 0
 - Active filters: None
 
+## CVSS-only Baseline Comparison
+- Changed rows: 1
+- Up: 1
+- Down: 0
+- Unchanged: 3
+- Method limit: This comparison is a decision-support view, not an absolute truth. It shows how the current enriched policy differs from a CVSS-only baseline and still requires asset-owner validation.
+
+### Top Baseline Changes
+- CVE-2023-44487: High (rank 2) -> Critical (rank 1); KEV membership raises this CVE from the CVSS-only High baseline to Critical.
+
 ## ATT&CK Context Summary
 ATT&CK context was disabled for this export.
 

--- a/docs/examples/example_baseline_comparison.json
+++ b/docs/examples/example_baseline_comparison.json
@@ -1,0 +1,65 @@
+{
+  "counts": {
+    "cvss_only": {
+      "Critical": 1,
+      "High": 0,
+      "Low": 0,
+      "Medium": 2
+    },
+    "enriched": {
+      "Critical": 1,
+      "High": 1,
+      "Low": 0,
+      "Medium": 1
+    }
+  },
+  "methodology": {
+    "baseline": "cvss-only",
+    "baseline_thresholds": {
+      "Critical": "CVSS >= 9.0",
+      "High": "7.0 <= CVSS < 9.0",
+      "Low": "CVSS < 4.0 or missing CVSS",
+      "Medium": "4.0 <= CVSS < 7.0"
+    },
+    "enriched": "Rule-based priority using CVSS, FIRST EPSS, CISA KEV, and supplied context such as ATT&CK, VEX, waivers, and asset metadata when present.",
+    "limitations": "This comparison is a decision-support view, not an absolute truth. It shows how the current enriched policy differs from a CVSS-only baseline and still requires asset-owner validation."
+  },
+  "project_id": "project-1",
+  "summary": {
+    "changed": 2,
+    "down": 1,
+    "total": 3,
+    "unchanged": 1,
+    "up": 1
+  },
+  "top_changes": [
+    {
+      "cve_id": "CVE-2026-0001",
+      "cvss": 5.5,
+      "delta_rank": 2,
+      "direction": "up",
+      "epss": 0.91,
+      "in_kev": true,
+      "new_priority": "Critical",
+      "new_rank": 1,
+      "old_priority": "Medium",
+      "old_rank": 3,
+      "operational_rank": 0,
+      "reason": "KEV membership raises this CVE from the CVSS-only Medium baseline to Critical."
+    },
+    {
+      "cve_id": "CVE-2026-0002",
+      "cvss": 9.8,
+      "delta_rank": -1,
+      "direction": "down",
+      "epss": 0.02,
+      "in_kev": false,
+      "new_priority": "High",
+      "new_rank": 2,
+      "old_priority": "Critical",
+      "old_rank": 1,
+      "operational_rank": 0,
+      "reason": "CVSS alone would rate this CVE as Critical, but the enriched model lowers it to High because EPSS/KEV signals do not meet the higher threshold."
+    }
+  ]
+}

--- a/docs/examples/example_pr_comment.md
+++ b/docs/examples/example_pr_comment.md
@@ -64,6 +64,13 @@
 - Low: 0
 - Active filters: None
 
+## CVSS-only Baseline Comparison
+- Changed rows: 0
+- Up: 0
+- Down: 0
+- Unchanged: 2
+- Method limit: This comparison is a decision-support view, not an absolute truth. It shows how the current enriched policy differs from a CVSS-only baseline and still requires asset-owner validation.
+
 ## ATT&CK Context Summary
 ATT&CK context was disabled for this export.
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -147,6 +147,16 @@ The `compare` command still uses:
 - `CVSS-only`: Critical `>= 9.0`, High `>= 7.0`, Medium `>= 4.0`, Low otherwise
 - `Enriched`: the default CVSS/EPSS/KEV model above
 
+Workbench project comparison exposes the same baseline through
+`GET /api/projects/{project_id}/baseline-comparison`. The comparison reports
+counts per priority, up/down/unchanged rows, and top changes with old/new rank
+and the reason for the shift.
+
+This view is intentionally a decision-support lens, not an absolute truth. It
+shows how the current policy differs from a CVSS-only baseline; remediation
+owners still need to validate asset exposure, business criticality, compensating
+controls, and applicability.
+
 `compare` now additionally shows ATT&CK context:
 
 - mapped or unmapped state

--- a/docs/schemas/analysis-report.schema.json
+++ b/docs/schemas/analysis-report.schema.json
@@ -17,6 +17,9 @@
     "attack_summary": {
       "$ref": "#/$defs/attackSummary"
     },
+    "baseline_comparison": {
+      "$ref": "#/$defs/baselineComparison"
+    },
     "findings": {
       "type": "array",
       "items": {
@@ -203,6 +206,114 @@
         },
         "tactic_distribution": {
           "$ref": "#/$defs/integerMap"
+        }
+      }
+    },
+    "baselineComparison": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "methodology",
+        "summary",
+        "counts",
+        "top_changes"
+      ],
+      "properties": {
+        "project_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "methodology": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "baseline": {
+              "type": "string"
+            },
+            "baseline_thresholds": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "enriched": {
+              "type": "string"
+            },
+            "limitations": {
+              "type": "string"
+            }
+          }
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "changed": {
+              "type": "integer"
+            },
+            "up": {
+              "type": "integer"
+            },
+            "down": {
+              "type": "integer"
+            },
+            "unchanged": {
+              "type": "integer"
+            }
+          }
+        },
+        "counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          }
+        },
+        "top_changes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "cve_id": {
+                "type": "string"
+              },
+              "old_priority": {
+                "type": "string"
+              },
+              "old_rank": {
+                "type": "integer"
+              },
+              "new_priority": {
+                "type": "string"
+              },
+              "new_rank": {
+                "type": "integer"
+              },
+              "delta_rank": {
+                "type": "integer"
+              },
+              "direction": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unchanged"
+                ]
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - VPW-029 Provider Test Matrix: evidence/vpw-029-provider-testmatrix.md
       - VPW-030 Scoring Rules: evidence/vpw-030-scoring-rules.md
       - VPW-031 Explanation Engine: evidence/vpw-031-explanation-engine.md
+      - VPW-032 CVSS Baseline Comparison: evidence/vpw-032-cvss-baseline-comparison.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
Refs #138

## Summary
- add CVSS-only baseline comparison service and Workbench project API
- include comparison summaries in analysis JSON and Markdown reports
- document the methodology boundary and add VPW-032 evidence/example artifacts

## Definition of Done / Evidence
- counts per priority are returned for CVSS-only and enriched views
- top changes include CVE, old/new rank, direction, and reason
- reports include the comparison excerpt and explicitly state this is not an absolute truth
- API and schema tests cover the additive contract

## Validation
- `python3 -m pytest -q backend/tests/test_baseline_comparison.py backend/tests/test_output_schemas.py backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence --no-cov` -> 25 passed
- `python3 -m ruff check backend` -> passed
- `python3 -m ruff format --check backend` -> passed
- `cd backend && python3 -m mypy app src` -> passed
- `make frontend-generate-client` -> passed, no generated-client drift
- `make demo-sync-check` -> passed
- `git diff --check` -> passed
- `make check` -> 716 passed, 5 skipped, coverage 90.47%

## Residual Risk
- no DB migration; endpoint uses existing stored Workbench finding JSON with a defensive fallback for older rows
- generated React client currently targets the template `/api/v1` app; the legacy Workbench endpoint is covered by API tests instead
