### PR TITLE
VPW-048: Implement Markdown technical report generator

### DIFF
--- a/backend/app/alembic/versions/20260429_0004_report_metadata.py
+++ b/backend/app/alembic/versions/20260429_0004_report_metadata.py
@@ -1,0 +1,65 @@
+"""add template report metadata table
+
+Revision ID: 20260429_0004
+Revises: 20260428_0003
+Create Date: 2026-04-29 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+
+revision = "20260429_0004"
+down_revision = "20260428_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "report",
+        sa.Column("kind", sqlmodel.sql.sqltypes.AutoString(length=80), nullable=False),
+        sa.Column("format", sqlmodel.sql.sqltypes.AutoString(length=40), nullable=False),
+        sa.Column("filename", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=False),
+        sa.Column("content_type", sqlmodel.sql.sqltypes.AutoString(length=120), nullable=False),
+        sa.Column("sha256", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("analysis_run_id", sa.Uuid(), nullable=False),
+        sa.Column("path", sa.String(length=1000), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["analysis_run_id"], ["analysis_run.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_report_analysis_run_id"),
+        "report",
+        ["analysis_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_report_analysis_run_created_at",
+        "report",
+        ["analysis_run_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(op.f("ix_report_project_id"), "report", ["project_id"], unique=False)
+    op.create_index(
+        "ix_report_project_created_at",
+        "report",
+        ["project_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_report_project_created_at", table_name="report")
+    op.drop_index(op.f("ix_report_project_id"), table_name="report")
+    op.drop_index("ix_report_analysis_run_created_at", table_name="report")
+    op.drop_index(op.f("ix_report_analysis_run_id"), table_name="report")
+    op.drop_table("report")

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -11,6 +11,7 @@ from app.api.routes import (
     login,
     projects,
     providers,
+    reports,
     runs,
     users,
     utils,
@@ -23,6 +24,7 @@ api_router.include_router(projects.router)
 api_router.include_router(assets.router)
 api_router.include_router(providers.router)
 api_router.include_router(runs.router)
+api_router.include_router(reports.router)
 api_router.include_router(imports.router)
 api_router.include_router(findings.router)
 api_router.include_router(users.router)

--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -1,0 +1,128 @@
+"""Report API routes for template Workbench analysis runs."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from starlette.responses import FileResponse
+
+from app.api.deps import CurrentUser, SessionDep
+from app.api.routes.workbench_access import require_visible_project
+from app.core.config import Settings
+from app.models import Report, ReportCreate, ReportPublic, ReportsPublic
+from app.repositories import ReportRepository, RunRepository
+from app.services import ReportGenerationError, ReportService
+
+router = APIRouter(tags=["reports"])
+
+
+@router.post("/runs/{run_id}/reports", response_model=ReportPublic)
+def create_run_report(
+    run_id: uuid.UUID,
+    payload: ReportCreate,
+    request: Request,
+    session: SessionDep,
+    current_user: CurrentUser,
+) -> ReportPublic:
+    """Create a Markdown technical report for a completed visible analysis run."""
+    if payload.format != "markdown":
+        raise HTTPException(status_code=422, detail="Only markdown reports are supported.")
+    run = RunRepository(session).get_analysis_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Analysis run not found")
+    project = require_visible_project(session, current_user, run.project_id)
+    try:
+        report = ReportService(session, _template_settings(request)).create_markdown_report(
+            run=run,
+            project=project,
+        )
+    except ReportGenerationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    session.commit()
+    session.refresh(report)
+    return _report_public(report, request)
+
+
+@router.get("/runs/{run_id}/reports", response_model=ReportsPublic)
+def read_run_reports(
+    run_id: uuid.UUID,
+    request: Request,
+    session: SessionDep,
+    current_user: CurrentUser,
+) -> ReportsPublic:
+    """List report metadata for a visible analysis run."""
+    run = RunRepository(session).get_analysis_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Analysis run not found")
+    require_visible_project(session, current_user, run.project_id)
+    reports = ReportRepository(session).list_run_reports(run.id)
+    return ReportsPublic(
+        data=[_report_public(report, request) for report in reports],
+        count=len(reports),
+    )
+
+
+@router.get("/reports/{report_id}/download")
+def download_report(
+    report_id: uuid.UUID,
+    request: Request,
+    session: SessionDep,
+    current_user: CurrentUser,
+) -> FileResponse:
+    """Download a visible report after root and checksum validation."""
+    report = ReportRepository(session).get_report(report_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    require_visible_project(session, current_user, report.project_id)
+    report_path = _validated_report_path(report, _template_settings(request))
+    response = FileResponse(
+        report_path,
+        filename=report.filename,
+        media_type=report.content_type,
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+def _report_public(report: Report, request: Request) -> ReportPublic:
+    settings = _template_settings(request)
+    return ReportPublic(
+        id=report.id,
+        project_id=report.project_id,
+        analysis_run_id=report.analysis_run_id,
+        kind=report.kind,
+        format=report.format,
+        filename=report.filename,
+        content_type=report.content_type,
+        sha256=report.sha256,
+        size_bytes=report.size_bytes,
+        metadata_json=report.metadata_json,
+        created_at=report.created_at,
+        download_url=f"{settings.API_V1_STR}/reports/{report.id}/download",
+    )
+
+
+def _validated_report_path(report: Report, settings: Settings) -> Path:
+    root = settings.report_dir_path.resolve(strict=False)
+    try:
+        resolved = Path(report.path).resolve(strict=True)
+        resolved.relative_to(root)
+    except (FileNotFoundError, ValueError) as exc:
+        raise HTTPException(status_code=404, detail="Report artifact not found") from exc
+
+    if not resolved.is_file():
+        raise HTTPException(status_code=404, detail="Report artifact not found")
+    digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    if digest != report.sha256:
+        raise HTTPException(status_code=409, detail="Report artifact checksum mismatch")
+    return resolved
+
+
+def _template_settings(request: Request) -> Settings:
+    candidate = getattr(request.app.state, "template_settings", None)
+    if isinstance(candidate, Settings):
+        return candidate
+    raise HTTPException(status_code=500, detail="Template settings are not configured.")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,7 @@ class Settings:
     BACKEND_CORS_ORIGINS: tuple[str, ...] = field(default_factory=tuple)
     SQLALCHEMY_DATABASE_URI: str = "sqlite:///./template.db"
     IMPORT_UPLOAD_DIR: str = "data/template-import-uploads"
+    REPORT_DIR: str = "data/template-reports"
     PROVIDER_SNAPSHOT_DIR: str = "data"
     PROVIDER_CACHE_DIR: str = "data/template-provider-cache"
     MAX_UPLOAD_MB: int = 25
@@ -45,6 +46,11 @@ class Settings:
     def import_upload_dir_path(self) -> Path:
         """Return the configured template import upload root."""
         return Path(self.IMPORT_UPLOAD_DIR)
+
+    @property
+    def report_dir_path(self) -> Path:
+        """Return the configured template report artifact root."""
+        return Path(self.REPORT_DIR)
 
     @property
     def provider_snapshot_dir_path(self) -> Path:
@@ -106,6 +112,7 @@ def load_settings() -> Settings:
         BACKEND_CORS_ORIGINS=parse_cors_origins(environ.get("BACKEND_CORS_ORIGINS", "")),
         SQLALCHEMY_DATABASE_URI=build_database_uri(),
         IMPORT_UPLOAD_DIR=environ.get("IMPORT_UPLOAD_DIR", "data/template-import-uploads"),
+        REPORT_DIR=environ.get("REPORT_DIR", "data/template-reports"),
         PROVIDER_SNAPSHOT_DIR=environ.get("PROVIDER_SNAPSHOT_DIR", "data"),
         PROVIDER_CACHE_DIR=environ.get("PROVIDER_CACHE_DIR", "data/template-provider-cache"),
         MAX_UPLOAD_MB=_positive_int_from_env("MAX_UPLOAD_MB", 25),

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -52,6 +52,7 @@ from app.models.providers import (
     ProviderUpdateJobPublic,
 )
 from app.models.registry import import_table_models
+from app.models.reports import Report, ReportBase, ReportCreate, ReportPublic, ReportsPublic
 from app.models.runs import (
     AnalysisRun,
     AnalysisRunBase,
@@ -113,6 +114,11 @@ __all__ = [
     "ProviderSourceStatusPublic",
     "ProviderStatusPublic",
     "ProviderUpdateJobPublic",
+    "Report",
+    "ReportBase",
+    "ReportCreate",
+    "ReportPublic",
+    "ReportsPublic",
     "Token",
     "TokenPayload",
     "User",

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -9,6 +9,7 @@ TABLE_MODEL_MODULES = (
     "app.models.vulnerabilities",
     "app.models.findings",
     "app.models.runs",
+    "app.models.reports",
 )
 
 

--- a/backend/app/models/reports.py
+++ b/backend/app/models/reports.py
@@ -1,0 +1,77 @@
+"""Report artifact metadata models."""
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from sqlalchemy import JSON, Column, DateTime, Index, Integer, String
+from sqlmodel import Field, SQLModel
+
+from app.models.base import get_datetime_utc
+
+
+class ReportCreate(SQLModel):
+    """Request payload for creating a run report."""
+
+    format: Literal["markdown"] = "markdown"
+
+
+class ReportBase(SQLModel):
+    """Shared persisted report metadata fields."""
+
+    kind: str = Field(max_length=80)
+    format: str = Field(max_length=40)
+    filename: str = Field(max_length=500)
+    content_type: str = Field(max_length=120)
+    sha256: str = Field(min_length=64, max_length=64)
+    size_bytes: int = Field(sa_column=Column(Integer, nullable=False))
+    metadata_json: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class Report(ReportBase, table=True):
+    """Server-owned report artifact linked to an analysis run."""
+
+    __tablename__ = "report"
+    __table_args__ = (
+        Index("ix_report_project_created_at", "project_id", "created_at"),
+        Index("ix_report_analysis_run_created_at", "analysis_run_id", "created_at"),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    project_id: uuid.UUID = Field(
+        foreign_key="project.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    analysis_run_id: uuid.UUID = Field(
+        foreign_key="analysis_run.id",
+        index=True,
+        nullable=False,
+        ondelete="CASCADE",
+    )
+    path: str = Field(sa_column=Column(String(1000), nullable=False))
+    created_at: datetime = Field(
+        default_factory=get_datetime_utc,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class ReportPublic(ReportBase):
+    """Public report metadata without exposing server filesystem paths."""
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    analysis_run_id: uuid.UUID
+    created_at: datetime
+    download_url: str
+
+
+class ReportsPublic(SQLModel):
+    """Collection response for reports."""
+
+    data: list[ReportPublic]
+    count: int

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -3,11 +3,13 @@
 from app.repositories.assets import AssetRepository
 from app.repositories.findings import FindingRepository
 from app.repositories.projects import ProjectRepository
+from app.repositories.reports import ReportRepository
 from app.repositories.runs import RunRepository
 
 __all__ = [
     "AssetRepository",
     "FindingRepository",
     "ProjectRepository",
+    "ReportRepository",
     "RunRepository",
 ]

--- a/backend/app/repositories/reports.py
+++ b/backend/app/repositories/reports.py
@@ -1,0 +1,72 @@
+"""Report metadata repository for template Workbench persistence."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlmodel import Session, col, select
+
+from app.models import Report
+
+
+class ReportRepository:
+    """Persistence helpers for generated report artifacts."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create_report(
+        self,
+        *,
+        report_id: uuid.UUID,
+        project_id: uuid.UUID,
+        analysis_run_id: uuid.UUID,
+        kind: str,
+        format: str,
+        filename: str,
+        content_type: str,
+        path: str,
+        sha256: str,
+        size_bytes: int,
+        metadata_json: dict[str, Any] | None = None,
+    ) -> Report:
+        """Create report metadata without committing the transaction."""
+        report = Report(
+            id=report_id,
+            project_id=project_id,
+            analysis_run_id=analysis_run_id,
+            kind=kind,
+            format=format,
+            filename=filename,
+            content_type=content_type,
+            path=path,
+            sha256=sha256,
+            size_bytes=size_bytes,
+            metadata_json=metadata_json or {},
+        )
+        self.session.add(report)
+        self.session.flush()
+        return report
+
+    def get_report(self, report_id: uuid.UUID) -> Report | None:
+        """Return a report by primary key."""
+        return self.session.get(Report, report_id)
+
+    def list_run_reports(self, analysis_run_id: uuid.UUID) -> list[Report]:
+        """Return reports for one run newest first."""
+        statement = (
+            select(Report)
+            .where(Report.analysis_run_id == analysis_run_id)
+            .order_by(col(Report.created_at).desc())
+        )
+        return list(self.session.exec(statement).all())
+
+    def list_project_reports(self, project_id: uuid.UUID) -> list[Report]:
+        """Return reports for one project newest first."""
+        statement = (
+            select(Report)
+            .where(Report.project_id == project_id)
+            .order_by(col(Report.created_at).desc())
+        )
+        return list(self.session.exec(statement).all())

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -7,13 +7,27 @@ from app.services.decisions import (
     build_finding_explanation_payload,
     build_project_summary_payload,
 )
+from app.services.reports import (
+    MarkdownProviderSnapshot,
+    MarkdownReportFinding,
+    MarkdownReportPayload,
+    ReportGenerationError,
+    ReportService,
+    render_markdown_report,
+)
 
 __all__ = [
     "AnalysisService",
     "DecisionDataUnavailableError",
+    "MarkdownProviderSnapshot",
+    "MarkdownReportFinding",
+    "MarkdownReportPayload",
+    "ReportGenerationError",
+    "ReportService",
     "TemplateAnalysisError",
     "TemplateAnalysisResult",
     "build_cvss_only_comparison_payload",
     "build_finding_explanation_payload",
     "build_project_summary_payload",
+    "render_markdown_report",
 ]

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -1,0 +1,488 @@
+"""Template-stack report generation services."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import re
+import uuid
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlmodel import Session, col, select
+
+from app.core.config import Settings
+from app.models import (
+    AnalysisRun,
+    AnalysisRunStatus,
+    Finding,
+    FindingOccurrence,
+    Project,
+    ProviderSnapshot,
+    Report,
+)
+from app.models.base import get_datetime_utc
+from app.repositories import ReportRepository
+
+REPORT_KIND_TECHNICAL_MARKDOWN = "technical-markdown"
+REPORT_FILENAME_TECHNICAL_MARKDOWN = "technical-report.md"
+REPORT_CONTENT_TYPE_MARKDOWN = "text/markdown; charset=utf-8"
+REPORT_SUPPORTED_RUN_STATUSES = {
+    AnalysisRunStatus.COMPLETED,
+    AnalysisRunStatus.COMPLETED_WITH_ERRORS,
+    AnalysisRunStatus.SUCCEEDED,
+}
+PRIORITY_LABELS = ("Critical", "High", "Medium", "Low")
+MARKDOWN_SPECIAL_CHARS = "\\`*_{}[]()!"
+
+
+class ReportGenerationError(RuntimeError):
+    """Raised when a report cannot be generated from the stored run."""
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownProviderSnapshot:
+    """Provider snapshot context shown in generated Markdown reports."""
+
+    id: str | None
+    content_hash: str | None
+    nvd_last_sync: str | None
+    epss_date: str | None
+    kev_catalog_version: str | None
+    source_hashes: dict[str, Any] = field(default_factory=dict)
+    source_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownReportFinding:
+    """Finding context shown in generated Markdown reports."""
+
+    operational_rank: int
+    cve_id: str
+    priority: str
+    status: str
+    risk_score: float | None
+    epss: float | None
+    cvss_base_score: float | None
+    in_kev: bool
+    asset: str | None
+    component: str | None
+    rationale: str | None
+    recommended_action: str | None
+    data_quality_confidence: str | None
+    data_quality_flags: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownReportPayload:
+    """Pure rendering payload for deterministic snapshot tests."""
+
+    generated_at: datetime
+    project_id: str
+    project_name: str
+    run_id: str
+    run_status: str
+    input_type: str
+    filename: str | None
+    summary: dict[str, Any]
+    findings: list[MarkdownReportFinding]
+    provider_snapshot: MarkdownProviderSnapshot | None
+
+
+class ReportService:
+    """Generate and persist report artifacts for template analysis runs."""
+
+    def __init__(self, session: Session, settings: Settings) -> None:
+        self.session = session
+        self.settings = settings
+
+    def create_markdown_report(self, *, run: AnalysisRun, project: Project) -> Report:
+        """Generate a Markdown technical report and persist its metadata."""
+        if run.status not in REPORT_SUPPORTED_RUN_STATUSES:
+            raise ReportGenerationError(
+                f"Analysis run must be completed before reporting; current status is {run.status}."
+            )
+
+        report_id = uuid.uuid4()
+        generated_at = get_datetime_utc()
+        findings = self._run_findings(run)
+        payload = MarkdownReportPayload(
+            generated_at=generated_at,
+            project_id=str(project.id),
+            project_name=project.name,
+            run_id=str(run.id),
+            run_status=str(run.status),
+            input_type=run.input_type,
+            filename=run.filename,
+            summary=dict(run.summary_json or {}),
+            findings=[_finding_payload(finding) for finding in findings],
+            provider_snapshot=_provider_snapshot_payload(run.provider_snapshot),
+        )
+        content = render_markdown_report(payload)
+        report_path = self._report_path(
+            project_id=project.id,
+            run_id=run.id,
+            report_id=report_id,
+        )
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(content, encoding="utf-8")
+        content_bytes = content.encode("utf-8")
+        sha256 = hashlib.sha256(content_bytes).hexdigest()
+        return ReportRepository(self.session).create_report(
+            report_id=report_id,
+            project_id=project.id,
+            analysis_run_id=run.id,
+            kind=REPORT_KIND_TECHNICAL_MARKDOWN,
+            format="markdown",
+            filename=REPORT_FILENAME_TECHNICAL_MARKDOWN,
+            content_type=REPORT_CONTENT_TYPE_MARKDOWN,
+            path=str(report_path),
+            sha256=sha256,
+            size_bytes=len(content_bytes),
+            metadata_json={
+                "generated_at": generated_at.isoformat(),
+                "project_id": str(project.id),
+                "analysis_run_id": str(run.id),
+                "provider_snapshot_id": str(run.provider_snapshot_id)
+                if run.provider_snapshot_id is not None
+                else None,
+                "finding_count": len(findings),
+                "format": "markdown",
+                "kind": REPORT_KIND_TECHNICAL_MARKDOWN,
+                "service": "template-report-service",
+            },
+        )
+
+    def _run_findings(self, run: AnalysisRun) -> list[Finding]:
+        statement = (
+            select(Finding)
+            .join(FindingOccurrence)
+            .where(FindingOccurrence.analysis_run_id == run.id)
+            .order_by(col(Finding.operational_rank), col(Finding.priority_rank), Finding.cve_id)
+        )
+        findings: list[Finding] = []
+        seen_ids: set[uuid.UUID] = set()
+        for finding in self.session.exec(statement).all():
+            if finding.id in seen_ids:
+                continue
+            findings.append(finding)
+            seen_ids.add(finding.id)
+        return findings
+
+    def _report_path(
+        self,
+        *,
+        project_id: uuid.UUID,
+        run_id: uuid.UUID,
+        report_id: uuid.UUID,
+    ) -> Path:
+        return (
+            self.settings.report_dir_path
+            / str(project_id)
+            / str(run_id)
+            / str(report_id)
+            / REPORT_FILENAME_TECHNICAL_MARKDOWN
+        )
+
+
+def render_markdown_report(payload: MarkdownReportPayload) -> str:
+    """Render a deterministic technical Markdown report from stored analysis data."""
+    finding_count = len(payload.findings)
+    counts = _counts_by_priority(payload.findings)
+    lines = [
+        "# Technical Vulnerability Report",
+        "",
+        "## Summary",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Project | {_safe_cell(payload.project_name)} |",
+        f"| Project ID | {_safe_cell(payload.project_id)} |",
+        f"| Analysis Run | {_safe_cell(payload.run_id)} |",
+        f"| Run Status | {_safe_cell(payload.run_status)} |",
+        f"| Input Type | {_safe_cell(payload.input_type)} |",
+        f"| Input File | {_safe_cell(payload.filename)} |",
+        f"| Generated At | {_safe_cell(_iso_datetime(payload.generated_at))} |",
+        f"| Finding Count | {finding_count} |",
+        f"| Critical | {counts['Critical']} |",
+        f"| High | {counts['High']} |",
+        f"| Medium | {counts['Medium']} |",
+        f"| Low | {counts['Low']} |",
+        "",
+        "## Top Findings",
+        "",
+    ]
+    if payload.findings:
+        lines.extend(
+            [
+                (
+                    "| Operational Rank | CVE | Priority | Score | EPSS | CVSS | KEV | Status | "
+                    "Asset | Component | Action |"
+                ),
+                "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for finding in payload.findings:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        str(finding.operational_rank),
+                        _safe_cell(finding.cve_id),
+                        _safe_cell(_priority_label(finding.priority)),
+                        _safe_cell(_format_number(finding.risk_score)),
+                        _safe_cell(_format_number(finding.epss)),
+                        _safe_cell(_format_number(finding.cvss_base_score)),
+                        "Yes" if finding.in_kev else "No",
+                        _safe_cell(finding.status),
+                        _safe_cell(finding.asset),
+                        _safe_cell(finding.component),
+                        _safe_cell(finding.recommended_action),
+                    ]
+                )
+                + " |"
+            )
+    else:
+        lines.append("No findings were recorded for this analysis run.")
+
+    lines.extend(
+        [
+            "",
+            "## Reasons",
+            "",
+        ]
+    )
+    if payload.findings:
+        lines.extend(
+            [
+                "| CVE | Rationale | Recommended Action |",
+                "| --- | --- | --- |",
+            ]
+        )
+        for finding in payload.findings:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _safe_cell(finding.cve_id),
+                        _safe_cell(finding.rationale),
+                        _safe_cell(finding.recommended_action),
+                    ]
+                )
+                + " |"
+            )
+    else:
+        lines.append("No rationale records are available for this analysis run.")
+
+    lines.extend(
+        [
+            "",
+            "## Data Quality",
+            "",
+        ]
+    )
+    if payload.findings:
+        lines.extend(
+            [
+                "| CVE | Confidence | Flags |",
+                "| --- | --- | --- |",
+            ]
+        )
+        for finding in payload.findings:
+            flags = "; ".join(finding.data_quality_flags) if finding.data_quality_flags else "None"
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _safe_cell(finding.cve_id),
+                        _safe_cell(finding.data_quality_confidence or "unknown"),
+                        _safe_cell(flags),
+                    ]
+                )
+                + " |"
+            )
+    else:
+        lines.append("No data quality records are available for this analysis run.")
+
+    lines.extend(
+        [
+            "",
+            "## Provider Snapshot",
+            "",
+        ]
+    )
+    snapshot = payload.provider_snapshot
+    if snapshot is None:
+        lines.append("No provider snapshot was linked to this analysis run.")
+    else:
+        locked_provider_data = _metadata_bool(snapshot.source_metadata, "locked_provider_data")
+        selected_sources = _metadata_list(snapshot.source_metadata, "selected_sources")
+        lines.extend(
+            [
+                "| Field | Value |",
+                "| --- | --- |",
+                f"| Snapshot ID | {_safe_cell(snapshot.id)} |",
+                f"| Content Hash | {_safe_cell(snapshot.content_hash)} |",
+                f"| NVD Last Sync | {_safe_cell(snapshot.nvd_last_sync)} |",
+                f"| EPSS Date | {_safe_cell(snapshot.epss_date)} |",
+                f"| KEV Catalog Version | {_safe_cell(snapshot.kev_catalog_version)} |",
+                f"| Locked Provider Data | {_safe_cell(locked_provider_data)} |",
+                f"| Selected Sources | {_safe_cell(selected_sources)} |",
+            ]
+        )
+        for key, value in sorted(snapshot.source_hashes.items()):
+            lines.append(f"| Source Hash: {_safe_cell(key)} | {_safe_cell(value)} |")
+        for key in ("source_path", "item_count", "missing", "validation_error"):
+            if key in snapshot.source_metadata:
+                lines.append(
+                    f"| Metadata: {_safe_cell(key)} | {_safe_cell(snapshot.source_metadata[key])} |"
+                )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _finding_payload(finding: Finding) -> MarkdownReportFinding:
+    return MarkdownReportFinding(
+        operational_rank=finding.operational_rank,
+        cve_id=finding.cve_id,
+        priority=str(finding.priority),
+        status=str(finding.status),
+        risk_score=finding.risk_score,
+        epss=finding.epss,
+        cvss_base_score=finding.cvss_base_score,
+        in_kev=finding.in_kev,
+        asset=_asset_label(finding),
+        component=_component_label(finding),
+        rationale=finding.rationale,
+        recommended_action=finding.recommended_action,
+        data_quality_confidence=_data_quality_confidence(finding),
+        data_quality_flags=_data_quality_flags(finding),
+    )
+
+
+def _provider_snapshot_payload(
+    snapshot: ProviderSnapshot | None,
+) -> MarkdownProviderSnapshot | None:
+    if snapshot is None:
+        return None
+    return MarkdownProviderSnapshot(
+        id=str(snapshot.id),
+        content_hash=snapshot.content_hash,
+        nvd_last_sync=snapshot.nvd_last_sync,
+        epss_date=snapshot.epss_date,
+        kev_catalog_version=snapshot.kev_catalog_version,
+        source_hashes=dict(snapshot.source_hashes_json or {}),
+        source_metadata=dict(snapshot.source_metadata_json or {}),
+    )
+
+
+def _asset_label(finding: Finding) -> str | None:
+    if finding.asset is None:
+        return None
+    return finding.asset.name or finding.asset.asset_key
+
+
+def _component_label(finding: Finding) -> str | None:
+    if finding.component is None:
+        return None
+    if finding.component.version:
+        return f"{finding.component.name} {finding.component.version}"
+    return finding.component.name
+
+
+def _data_quality_confidence(finding: Finding) -> str | None:
+    explanation_json = _dict_value(finding.explanation_json)
+    data_quality_json = _dict_value(finding.data_quality_json)
+    value = explanation_json.get("data_quality_confidence") or data_quality_json.get("confidence")
+    return str(value) if value else None
+
+
+def _data_quality_flags(finding: Finding) -> list[str]:
+    explanation_json = _dict_value(finding.explanation_json)
+    data_quality_json = _dict_value(finding.data_quality_json)
+    flags = _flag_items(explanation_json.get("data_quality_flags"))
+    flags.extend(_flag_items(data_quality_json.get("flags")))
+    return flags
+
+
+def _flag_items(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    flags: list[str] = []
+    for item in value:
+        if isinstance(item, dict):
+            parts = [
+                str(item[key]) for key in ("code", "label", "message", "detail") if item.get(key)
+            ]
+            if parts:
+                flags.append(" - ".join(parts))
+        elif item:
+            flags.append(str(item))
+    return flags
+
+
+def _counts_by_priority(findings: list[MarkdownReportFinding]) -> dict[str, int]:
+    counts = Counter(_priority_label(finding.priority) for finding in findings)
+    return {priority: counts.get(priority, 0) for priority in PRIORITY_LABELS}
+
+
+def _priority_label(value: str) -> str:
+    normalized = value.split(".", maxsplit=1)[-1].strip().lower()
+    return {
+        "critical": "Critical",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low",
+    }.get(normalized, "Low")
+
+
+def _safe_cell(value: object | None) -> str:
+    return _safe_inline(value).replace("|", "\\|")
+
+
+def _safe_inline(value: object | None) -> str:
+    if value is None:
+        return "N/A"
+    text = str(value).strip()
+    if not text:
+        return "N/A"
+    text = re.sub(r"\s+", " ", text)
+    escaped = html.escape(text, quote=True)
+    return "".join(
+        f"\\{character}" if character in MARKDOWN_SPECIAL_CHARS else character
+        for character in escaped
+    )
+
+
+def _format_number(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    number = float(value)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.3f}".rstrip("0").rstrip(".")
+
+
+def _iso_datetime(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _metadata_bool(metadata: dict[str, Any], key: str) -> str:
+    if key not in metadata:
+        return "N/A"
+    return "Yes" if bool(metadata[key]) else "No"
+
+
+def _metadata_list(metadata: dict[str, Any], key: str) -> str:
+    value = metadata.get(key)
+    if isinstance(value, list):
+        items = [str(item) for item in value if item]
+        return ", ".join(items) if items else "N/A"
+    return str(value) if value else "N/A"
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}

--- a/backend/tests/api/snapshots/vpw_048_technical_report.md
+++ b/backend/tests/api/snapshots/vpw_048_technical_report.md
@@ -1,0 +1,54 @@
+# Technical Vulnerability Report
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Project | Snapshot Project &lt;script&gt;alert\(1\)&lt;/script&gt; |
+| Project ID | 00000000-0000-4000-8000-000000000048 |
+| Analysis Run | 00000000-0000-4000-8000-000000000049 |
+| Run Status | completed |
+| Input Type | cve-list |
+| Input File | known-cves.txt |
+| Generated At | 2026-04-29T12:00:00Z |
+| Finding Count | 2 |
+| Critical | 1 |
+| High | 1 |
+| Medium | 0 |
+| Low | 0 |
+
+## Top Findings
+
+| Operational Rank | CVE | Priority | Score | EPSS | CVSS | KEV | Status | Asset | Component | Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | CVE-2024-3094 | Critical | 100 | 0.846 | 10 | No | open | Payments API | xz 5.6.0-r0 | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| 2 | CVE-2021-44228 | High | 94.2 | 0.944 | 10 | Yes | in\_review | Ops API | log4j-core 2.14.1 | Patch via vendor upgrade. |
+
+## Reasons
+
+| CVE | Rationale | Recommended Action |
+| --- | --- | --- |
+| CVE-2024-3094 | Internet-facing production asset with critical score. | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| CVE-2021-44228 | CISA KEV listing and vulnerable component evidence. | Patch via vendor upgrade. |
+
+## Data Quality
+
+| CVE | Confidence | Flags |
+| --- | --- | --- |
+| CVE-2024-3094 | high | None |
+| CVE-2021-44228 | medium | missing\_asset\_owner - Owner is not set |
+
+## Provider Snapshot
+
+| Field | Value |
+| --- | --- |
+| Snapshot ID | 00000000-0000-4000-8000-000000000050 |
+| Content Hash | sha256:vpw048-snapshot |
+| NVD Last Sync | 2026-04-28T10:15:00Z |
+| EPSS Date | 2026-04-28 |
+| KEV Catalog Version | 2026-04-28 |
+| Locked Provider Data | Yes |
+| Selected Sources | nvd, epss, kev |
+| Source Hash: provider\_snapshot | sha256:vpw048-snapshot |
+| Metadata: source\_path | demo\_provider\_snapshot.json |
+| Metadata: item\_count | 2 |

--- a/backend/tests/api/test_template_reports_api.py
+++ b/backend/tests/api/test_template_reports_api.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+from utils.template_workbench import (
+    DEMO_CVE_LOG4SHELL,
+    DEMO_CVE_XZ,
+    TemplateApiEnv,
+    auth_headers,
+    create_asset,
+    create_component,
+    create_finding,
+    create_project_via_api,
+    create_vulnerability,
+    seed_foreign_project_graph,
+)
+
+from app.main import app
+from app.services import (
+    MarkdownProviderSnapshot,
+    MarkdownReportFinding,
+    MarkdownReportPayload,
+    render_markdown_report,
+)
+
+
+def test_vpw048_openapi_exposes_markdown_report_contract() -> None:
+    response = TestClient(app).get("/api/v1/openapi.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "/api/v1/runs/{run_id}/reports" in payload["paths"]
+    assert "/api/v1/reports/{report_id}/download" in payload["paths"]
+    assert {"ReportCreate", "ReportPublic", "ReportsPublic"}.issubset(
+        payload["components"]["schemas"]
+    )
+
+
+def test_vpw048_markdown_report_create_downloads_for_completed_run(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    report_dir = _configure_report_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    run_id = _seed_reportable_run(template_api_env, uuid.UUID(project["id"]))
+
+    response = template_api_env.client.post(
+        f"/api/v1/runs/{run_id}/reports",
+        headers=headers,
+        json={"format": "markdown"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["format"] == "markdown"
+    assert payload["kind"] == "technical-markdown"
+    assert payload["filename"] == "technical-report.md"
+    assert len(payload["sha256"]) == 64
+    assert payload["download_url"] == f"/api/v1/reports/{payload['id']}/download"
+
+    with Session(template_api_env.engine) as session:
+        report = session.get(template_api_env.app_models.Report, uuid.UUID(payload["id"]))
+        assert report is not None
+        assert Path(report.path).resolve(strict=True).is_relative_to(report_dir)
+        assert report.metadata_json["finding_count"] == 2
+
+    download = template_api_env.client.get(payload["download_url"], headers=headers)
+
+    assert download.status_code == 200
+    assert download.headers["cache-control"] == "no-store"
+    assert "attachment" in download.headers["content-disposition"]
+    assert "technical-report.md" in download.headers["content-disposition"]
+    body = download.text
+    assert hashlib.sha256(download.content).hexdigest() == payload["sha256"]
+    assert "# Technical Vulnerability Report" in body
+    assert "## Summary" in body
+    assert "## Top Findings" in body
+    assert "## Reasons" in body
+    assert "## Data Quality" in body
+    assert "## Provider Snapshot" in body
+    assert body.index(DEMO_CVE_XZ) < body.index(DEMO_CVE_LOG4SHELL)
+    assert "sha256:vpw048-snapshot" in body
+    assert "Yes" in body
+    assert "<script>" not in body
+    assert "<img" not in body
+    assert "[open](" not in body
+    assert "&lt;script&gt;" in body
+
+
+def test_vpw048_report_auth_project_visibility_and_invalid_run_state(
+    restricted_template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_report_dir(restricted_template_api_env, tmp_path)
+    headers = auth_headers(restricted_template_api_env.client)
+    foreign = seed_foreign_project_graph(
+        restricted_template_api_env.engine,
+        restricted_template_api_env.app_models,
+        restricted_template_api_env.repositories,
+    )
+    missing_id = uuid.UUID("00000000-0000-4000-8000-000000000404")
+    pending_run_id = _seed_status_run(restricted_template_api_env, "pending")
+    failed_run_id = _seed_status_run(restricted_template_api_env, "failed")
+    foreign_report_id = _seed_foreign_report(restricted_template_api_env, foreign)
+
+    assert (
+        restricted_template_api_env.client.post(
+            f"/api/v1/runs/{missing_id}/reports",
+            headers=headers,
+            json={"format": "markdown"},
+        ).status_code
+        == 404
+    )
+    assert (
+        restricted_template_api_env.client.post(
+            f"/api/v1/runs/{foreign['run_id']}/reports",
+            headers=headers,
+            json={"format": "markdown"},
+        ).status_code
+        == 403
+    )
+    assert (
+        restricted_template_api_env.client.get(
+            f"/api/v1/reports/{foreign_report_id}/download",
+            headers=headers,
+        ).status_code
+        == 403
+    )
+    for run_id in (pending_run_id, failed_run_id):
+        response = restricted_template_api_env.client.post(
+            f"/api/v1/runs/{run_id}/reports",
+            headers=headers,
+            json={"format": "markdown"},
+        )
+        assert response.status_code == 422
+        assert "completed" in response.json()["detail"]
+
+
+def test_vpw048_download_rejects_path_escape_and_checksum_mismatch(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_report_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    run_id = _seed_reportable_run(template_api_env, uuid.UUID(project["id"]))
+    created = template_api_env.client.post(
+        f"/api/v1/runs/{run_id}/reports",
+        headers=headers,
+        json={"format": "markdown"},
+    ).json()
+    report_id = uuid.UUID(created["id"])
+
+    with Session(template_api_env.engine) as session:
+        report = session.get(template_api_env.app_models.Report, report_id)
+        assert report is not None
+        report_path = Path(report.path)
+    report_path.write_text("tampered report\n", encoding="utf-8")
+
+    tampered = template_api_env.client.get(created["download_url"], headers=headers)
+    assert tampered.status_code == 409
+    assert tampered.json()["detail"] == "Report artifact checksum mismatch"
+
+    outside_path = tmp_path / "outside-report.md"
+    outside_path.write_text("outside root\n", encoding="utf-8")
+    with Session(template_api_env.engine) as session:
+        report = session.get(template_api_env.app_models.Report, report_id)
+        assert report is not None
+        report.path = str(outside_path)
+        session.add(report)
+        session.commit()
+
+    escaped = template_api_env.client.get(created["download_url"], headers=headers)
+    assert escaped.status_code == 404
+    assert escaped.json()["detail"] == "Report artifact not found"
+
+
+def test_vpw048_markdown_report_snapshot_is_stable() -> None:
+    payload = MarkdownReportPayload(
+        generated_at=datetime(2026, 4, 29, 12, 0, tzinfo=UTC),
+        project_id="00000000-0000-4000-8000-000000000048",
+        project_name="Snapshot Project <script>alert(1)</script>",
+        run_id="00000000-0000-4000-8000-000000000049",
+        run_status="completed",
+        input_type="cve-list",
+        filename="known-cves.txt",
+        summary={"finding_count": 2},
+        findings=[
+            MarkdownReportFinding(
+                operational_rank=1,
+                cve_id=DEMO_CVE_XZ,
+                priority="critical",
+                status="open",
+                risk_score=100.0,
+                epss=0.846,
+                cvss_base_score=10.0,
+                in_kev=False,
+                asset="Payments API",
+                component="xz 5.6.0-r0",
+                rationale="Internet-facing production asset with critical score.",
+                recommended_action="Patch [open](javascript:alert(1)) now.",
+                data_quality_confidence="high",
+                data_quality_flags=[],
+            ),
+            MarkdownReportFinding(
+                operational_rank=2,
+                cve_id=DEMO_CVE_LOG4SHELL,
+                priority="high",
+                status="in_review",
+                risk_score=94.2,
+                epss=0.944,
+                cvss_base_score=10.0,
+                in_kev=True,
+                asset="Ops API",
+                component="log4j-core 2.14.1",
+                rationale="CISA KEV listing and vulnerable component evidence.",
+                recommended_action="Patch via vendor upgrade.",
+                data_quality_confidence="medium",
+                data_quality_flags=["missing_asset_owner - Owner is not set"],
+            ),
+        ],
+        provider_snapshot=MarkdownProviderSnapshot(
+            id="00000000-0000-4000-8000-000000000050",
+            content_hash="sha256:vpw048-snapshot",
+            nvd_last_sync="2026-04-28T10:15:00Z",
+            epss_date="2026-04-28",
+            kev_catalog_version="2026-04-28",
+            source_hashes={"provider_snapshot": "sha256:vpw048-snapshot"},
+            source_metadata={
+                "locked_provider_data": True,
+                "selected_sources": ["nvd", "epss", "kev"],
+                "source_path": "demo_provider_snapshot.json",
+                "item_count": 2,
+            },
+        ),
+    )
+    snapshot_path = Path(__file__).resolve().parent / "snapshots" / "vpw_048_technical_report.md"
+
+    assert render_markdown_report(payload) == snapshot_path.read_text(encoding="utf-8")
+
+
+def _configure_report_dir(template_api_env: TemplateApiEnv, tmp_path: Path) -> Path:
+    report_dir = (tmp_path / "template-reports").resolve(strict=False)
+    active_settings = template_api_env.client.app.state.template_settings
+    template_api_env.client.app.state.template_settings = replace(
+        active_settings,
+        REPORT_DIR=str(report_dir),
+    )
+    return report_dir
+
+
+def _seed_reportable_run(template_api_env: TemplateApiEnv, project_id: uuid.UUID) -> uuid.UUID:
+    app_models = template_api_env.app_models
+    repositories = template_api_env.repositories
+    with Session(template_api_env.engine) as session:
+        run_repo = repositories.RunRepository(session)
+        snapshot = run_repo.get_or_create_provider_snapshot(
+            content_hash="sha256:vpw048-snapshot",
+            nvd_last_sync="2026-04-28T10:15:00Z",
+            epss_date="2026-04-28",
+            kev_catalog_version="2026-04-28",
+            source_hashes_json={"provider_snapshot": "sha256:vpw048-snapshot"},
+            source_metadata_json={
+                "locked_provider_data": True,
+                "selected_sources": ["nvd", "epss", "kev"],
+                "source_path": "demo_provider_snapshot.json",
+                "item_count": 2,
+            },
+        )
+        run = run_repo.create_analysis_run(
+            project_id=project_id,
+            provider_snapshot_id=snapshot.id,
+            input_type="cve-list",
+            filename="known-cves.txt",
+            status=app_models.AnalysisRunStatus.COMPLETED,
+            summary_json={
+                "finding_count": 2,
+                "counts_by_priority": {"Critical": 1, "High": 1},
+                "locked_provider_data": True,
+            },
+        )
+        first = _seed_finding(
+            session,
+            app_models,
+            repositories,
+            project_id=project_id,
+            cve_id=DEMO_CVE_LOG4SHELL,
+            asset_key="ops-api",
+            asset_name="Ops <img src=x onerror=alert(1)> API",
+            component_name="log4j-core",
+            component_version="2.14.1",
+            priority=app_models.FindingPriority.HIGH,
+            priority_rank=2,
+            operational_rank=2,
+            risk_score=94.2,
+            epss=0.944,
+            cvss=10.0,
+            in_kev=True,
+            rationale="KEV-listed issue with <script>alert(1)</script> evidence.",
+            action="Patch via vendor upgrade.",
+            confidence="medium",
+            flags=[{"code": "missing_asset_owner", "message": "Owner missing <img>"}],
+        )
+        second = _seed_finding(
+            session,
+            app_models,
+            repositories,
+            project_id=project_id,
+            cve_id=DEMO_CVE_XZ,
+            asset_key="payments-api",
+            asset_name="Payments <script>alert(1)</script> API",
+            component_name="xz",
+            component_version="5.6.0-r0",
+            priority=app_models.FindingPriority.CRITICAL,
+            priority_rank=1,
+            operational_rank=1,
+            risk_score=100.0,
+            epss=0.846,
+            cvss=10.0,
+            in_kev=False,
+            rationale="Internet-facing production asset with critical score.",
+            action="Patch [open](javascript:alert(1)) now.",
+            confidence="high",
+            flags=[],
+        )
+        run_repo.add_finding_occurrence(
+            finding_id=first.id,
+            analysis_run_id=run.id,
+            source="cve-list",
+            raw_reference=DEMO_CVE_LOG4SHELL,
+        )
+        run_repo.add_finding_occurrence(
+            finding_id=second.id,
+            analysis_run_id=run.id,
+            source="cve-list",
+            raw_reference=DEMO_CVE_XZ,
+        )
+        run_id = run.id
+        session.commit()
+        return run_id
+
+
+def _seed_finding(
+    session: Session,
+    app_models: Any,
+    repositories: Any,
+    *,
+    project_id: uuid.UUID,
+    cve_id: str,
+    asset_key: str,
+    asset_name: str,
+    component_name: str,
+    component_version: str,
+    priority: Any,
+    priority_rank: int,
+    operational_rank: int,
+    risk_score: float,
+    epss: float,
+    cvss: float,
+    in_kev: bool,
+    rationale: str,
+    action: str,
+    confidence: str,
+    flags: list[dict[str, str]],
+) -> Any:
+    asset = create_asset(
+        session,
+        app_models,
+        repositories,
+        project_id=project_id,
+        asset_key=asset_key,
+        name=asset_name,
+    )
+    component = create_component(
+        session,
+        repositories,
+        name=component_name,
+        version=component_version,
+    )
+    vulnerability = create_vulnerability(session, repositories, cve_id=cve_id, cvss_score=cvss)
+    finding = create_finding(
+        session,
+        app_models,
+        repositories,
+        project_id=project_id,
+        vulnerability_id=vulnerability.id,
+        component_id=component.id,
+        asset_id=asset.id,
+        cve_id=cve_id,
+        priority=priority,
+        priority_rank=priority_rank,
+        operational_rank=operational_rank,
+    )
+    finding.risk_score = risk_score
+    finding.epss = epss
+    finding.cvss_base_score = cvss
+    finding.in_kev = in_kev
+    finding.rationale = rationale
+    finding.recommended_action = action
+    finding.data_quality_json = {"confidence": confidence, "flags": flags}
+    finding.explanation_json = {"data_quality_confidence": confidence, "data_quality_flags": flags}
+    session.flush()
+    return finding
+
+
+def _seed_status_run(template_api_env: TemplateApiEnv, status: str) -> uuid.UUID:
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    with Session(template_api_env.engine) as session:
+        run = template_api_env.repositories.RunRepository(session).create_analysis_run(
+            project_id=uuid.UUID(project["id"]),
+            input_type="cve-list",
+            filename=f"{status}.txt",
+            status=status,
+        )
+        run_id = run.id
+        session.commit()
+        return run_id
+
+
+def _seed_foreign_report(
+    template_api_env: TemplateApiEnv,
+    foreign: dict[str, uuid.UUID],
+) -> uuid.UUID:
+    report_id = uuid.uuid4()
+    with Session(template_api_env.engine) as session:
+        template_api_env.repositories.ReportRepository(session).create_report(
+            report_id=report_id,
+            project_id=foreign["project_id"],
+            analysis_run_id=foreign["run_id"],
+            kind="technical-markdown",
+            format="markdown",
+            filename="technical-report.md",
+            content_type="text/markdown; charset=utf-8",
+            path="data/template-reports/foreign/technical-report.md",
+            sha256="0" * 64,
+            size_bytes=0,
+            metadata_json={},
+        )
+        session.commit()
+    return report_id

--- a/backend/tests/api/test_template_workbench_api_skeleton.py
+++ b/backend/tests/api/test_template_workbench_api_skeleton.py
@@ -43,6 +43,8 @@ def test_vpw011_openapi_exposes_workbench_domain_routes_without_items() -> None:
         "/api/v1/projects/{project_id}/runs/",
         "/api/v1/runs/{run_id}",
         "/api/v1/runs/{run_id}/summary",
+        "/api/v1/runs/{run_id}/reports",
+        "/api/v1/reports/{report_id}/download",
         "/api/v1/projects/{project_id}/findings/",
         "/api/v1/findings/{finding_id}",
         "/api/v1/findings/{finding_id}/explain",
@@ -70,6 +72,9 @@ def test_vpw011_openapi_exposes_workbench_domain_routes_without_items() -> None:
         "ProviderSnapshotStatusPublic",
         "ProviderSourceStatusPublic",
         "ProviderStatusPublic",
+        "ReportCreate",
+        "ReportPublic",
+        "ReportsPublic",
     }
     assert expected_paths.issubset(paths)
 
@@ -116,6 +121,9 @@ def test_vpw011_domain_routes_require_auth(template_api_env: TemplateApiEnv) -> 
         ("get", "/api/v1/providers/status", {}),
         ("get", f"/api/v1/runs/{run_id}", {}),
         ("get", f"/api/v1/runs/{run_id}/summary", {}),
+        ("get", f"/api/v1/runs/{run_id}/reports", {}),
+        ("post", f"/api/v1/runs/{run_id}/reports", {"json": {"format": "markdown"}}),
+        ("get", f"/api/v1/reports/{run_id}/download", {}),
         (
             "get",
             f"/api/v1/projects/{project_id}/findings/",
@@ -786,6 +794,9 @@ def test_vpw011_404_and_403_are_consistent_for_project_scoped_resources(
         ("patch", f"/api/v1/assets/{missing_id}", {"json": {"name": "Missing Asset"}}),
         ("get", f"/api/v1/runs/{missing_id}", {}),
         ("get", f"/api/v1/runs/{missing_id}/summary", {}),
+        ("get", f"/api/v1/runs/{missing_id}/reports", {}),
+        ("post", f"/api/v1/runs/{missing_id}/reports", {"json": {"format": "markdown"}}),
+        ("get", f"/api/v1/reports/{missing_id}/download", {}),
         ("get", f"/api/v1/findings/{missing_id}", {}),
         ("get", f"/api/v1/findings/{missing_id}/explain", {}),
         ("get", f"/api/v1/projects/{missing_id}/assets/", {}),
@@ -799,6 +810,8 @@ def test_vpw011_404_and_403_are_consistent_for_project_scoped_resources(
         ("patch", f"/api/v1/assets/{foreign['asset_id']}", {"json": {"name": "Foreign Asset"}}),
         ("get", f"/api/v1/runs/{foreign['run_id']}", {}),
         ("get", f"/api/v1/runs/{foreign['run_id']}/summary", {}),
+        ("get", f"/api/v1/runs/{foreign['run_id']}/reports", {}),
+        ("post", f"/api/v1/runs/{foreign['run_id']}/reports", {"json": {"format": "markdown"}}),
         ("get", f"/api/v1/findings/{foreign['finding_id']}", {}),
         ("get", f"/api/v1/findings/{foreign['finding_id']}/explain", {}),
         ("get", f"/api/v1/projects/{foreign['project_id']}/assets/", {}),

--- a/docs/evidence/vpw-048-markdown-report.md
+++ b/docs/evidence/vpw-048-markdown-report.md
@@ -1,0 +1,84 @@
+# VPW-048 Markdown Technical Report Evidence
+
+VPW-048 adds the template-stack Markdown technical report path for stored
+analysis runs. The implementation is separate from the legacy Workbench report
+service and uses the FastAPI/SQLModel template API under `/api/v1`.
+
+## Implemented Scope
+
+- `ReportService` builds Markdown from persisted `AnalysisRun`, run-scoped
+  `FindingOccurrence` rows, linked `Finding` records, data-quality metadata,
+  and the run `ProviderSnapshot`.
+- `POST /api/v1/runs/{run_id}/reports` creates a Markdown report for completed
+  runs.
+- `GET /api/v1/runs/{run_id}/reports` lists generated report metadata.
+- `GET /api/v1/reports/{report_id}/download` validates project visibility,
+  resolves the artifact under `REPORT_DIR`, verifies SHA-256, and returns an
+  attachment with `Cache-Control: no-store`.
+- `report` SQLModel metadata is persisted with project/run links, artifact path,
+  format, kind, filename, content type, SHA-256, size, and generation metadata.
+- Dangerous Markdown/HTML content from project, asset, component, reason, action,
+  data-quality, and provider fields is escaped before writing the report.
+
+## Example Artifact
+
+The checked-in example is:
+
+```text
+docs/evidence/vpw-048/technical-report.md
+```
+
+The example includes the required sections:
+
+- Summary
+- Top Findings
+- Reasons
+- Data Quality
+- Provider Snapshot
+
+## Snapshot Test Excerpt
+
+The snapshot fixture is:
+
+```text
+backend/tests/api/snapshots/vpw_048_technical_report.md
+```
+
+Excerpt:
+
+```markdown
+## Top Findings
+
+| Operational Rank | CVE | Priority | Score | EPSS | CVSS | KEV | Status | Asset | Component | Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | CVE-2024-3094 | Critical | 100 | 0.846 | 10 | No | open | Payments API | xz 5.6.0-r0 | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| 2 | CVE-2021-44228 | High | 94.2 | 0.944 | 10 | Yes | in\_review | Ops API | log4j-core 2.14.1 | Patch via vendor upgrade. |
+```
+
+The order proves top findings are sorted by operational rank. The escaped link
+syntax and escaped `<script>` in the snapshot prove untrusted content is not
+emitted as active Markdown/HTML.
+
+## Local Verification
+
+```bash
+python3 -m pytest -q backend/tests/api/test_template_reports_api.py backend/tests/api/test_template_workbench_api_skeleton.py backend/tests/api/test_template_model_metadata.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_reports_api.py::test_vpw048_markdown_report_snapshot_is_stable --no-cov
+python3 -m ruff check backend/app backend/tests/api/test_template_reports_api.py
+python3 -m ruff format --check backend/app backend/tests/api/test_template_reports_api.py
+python3 -m pytest -q backend/tests/api/test_template_reports_api.py backend/tests/api/test_template_workbench_api_skeleton.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_import_upload_api.py --no-cov
+make check
+make frontend-check
+npm --prefix frontend run test
+python3 -m mkdocs build --clean
+git diff --check
+```
+
+Result: all commands passed locally. `make check` reported 739 passed,
+5 skipped, and total coverage of 90.59%.
+
+## Residual Risk
+
+VPW-048 intentionally enables Markdown only. HTML, JSON, CSV, SARIF, evidence
+bundle packaging, and React report creation controls remain in later
+`v0.7-reports-evidence` issues.

--- a/docs/evidence/vpw-048/technical-report.md
+++ b/docs/evidence/vpw-048/technical-report.md
@@ -1,0 +1,54 @@
+# Technical Vulnerability Report
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Project | Snapshot Project &lt;script&gt;alert\(1\)&lt;/script&gt; |
+| Project ID | 00000000-0000-4000-8000-000000000048 |
+| Analysis Run | 00000000-0000-4000-8000-000000000049 |
+| Run Status | completed |
+| Input Type | cve-list |
+| Input File | known-cves.txt |
+| Generated At | 2026-04-29T12:00:00Z |
+| Finding Count | 2 |
+| Critical | 1 |
+| High | 1 |
+| Medium | 0 |
+| Low | 0 |
+
+## Top Findings
+
+| Operational Rank | CVE | Priority | Score | EPSS | CVSS | KEV | Status | Asset | Component | Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | CVE-2024-3094 | Critical | 100 | 0.846 | 10 | No | open | Payments API | xz 5.6.0-r0 | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| 2 | CVE-2021-44228 | High | 94.2 | 0.944 | 10 | Yes | in\_review | Ops API | log4j-core 2.14.1 | Patch via vendor upgrade. |
+
+## Reasons
+
+| CVE | Rationale | Recommended Action |
+| --- | --- | --- |
+| CVE-2024-3094 | Internet-facing production asset with critical score. | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| CVE-2021-44228 | CISA KEV listing and vulnerable component evidence. | Patch via vendor upgrade. |
+
+## Data Quality
+
+| CVE | Confidence | Flags |
+| --- | --- | --- |
+| CVE-2024-3094 | high | None |
+| CVE-2021-44228 | medium | missing\_asset\_owner - Owner is not set |
+
+## Provider Snapshot
+
+| Field | Value |
+| --- | --- |
+| Snapshot ID | 00000000-0000-4000-8000-000000000050 |
+| Content Hash | sha256:vpw048-snapshot |
+| NVD Last Sync | 2026-04-28T10:15:00Z |
+| EPSS Date | 2026-04-28 |
+| KEV Catalog Version | 2026-04-28 |
+| Locked Provider Data | Yes |
+| Selected Sources | nvd, epss, kev |
+| Source Hash: provider\_snapshot | sha256:vpw048-snapshot |
+| Metadata: source\_path | demo\_provider\_snapshot.json |
+| Metadata: item\_count | 2 |

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2426,6 +2426,108 @@ export const ProviderUpdateJobPublicSchema = {
     type: 'object'
 } as const;
 
+export const ReportCreateSchema = {
+    description: 'Request payload for creating a run report.',
+    properties: {
+        format: {
+            const: 'markdown',
+            default: 'markdown',
+            title: 'Format',
+            type: 'string'
+        }
+    },
+    title: 'ReportCreate',
+    type: 'object'
+} as const;
+
+export const ReportPublicSchema = {
+    description: 'Public report metadata without exposing server filesystem paths.',
+    properties: {
+        analysis_run_id: {
+            format: 'uuid',
+            title: 'Analysis Run Id',
+            type: 'string'
+        },
+        content_type: {
+            maxLength: 120,
+            title: 'Content Type',
+            type: 'string'
+        },
+        created_at: {
+            format: 'date-time',
+            title: 'Created At',
+            type: 'string'
+        },
+        download_url: {
+            title: 'Download Url',
+            type: 'string'
+        },
+        filename: {
+            maxLength: 500,
+            title: 'Filename',
+            type: 'string'
+        },
+        format: {
+            maxLength: 40,
+            title: 'Format',
+            type: 'string'
+        },
+        id: {
+            format: 'uuid',
+            title: 'Id',
+            type: 'string'
+        },
+        kind: {
+            maxLength: 80,
+            title: 'Kind',
+            type: 'string'
+        },
+        metadata_json: {
+            additionalProperties: true,
+            title: 'Metadata Json',
+            type: 'object'
+        },
+        project_id: {
+            format: 'uuid',
+            title: 'Project Id',
+            type: 'string'
+        },
+        sha256: {
+            maxLength: 64,
+            minLength: 64,
+            title: 'Sha256',
+            type: 'string'
+        },
+        size_bytes: {
+            title: 'Size Bytes',
+            type: 'integer'
+        }
+    },
+    required: ['kind', 'format', 'filename', 'content_type', 'sha256', 'size_bytes', 'id', 'project_id', 'analysis_run_id', 'created_at', 'download_url'],
+    title: 'ReportPublic',
+    type: 'object'
+} as const;
+
+export const ReportsPublicSchema = {
+    description: 'Collection response for reports.',
+    properties: {
+        count: {
+            title: 'Count',
+            type: 'integer'
+        },
+        data: {
+            items: {
+                '$ref': '#/components/schemas/ReportPublic'
+            },
+            title: 'Data',
+            type: 'array'
+        }
+    },
+    required: ['data', 'count'],
+    title: 'ReportsPublic',
+    type: 'object'
+} as const;
+
 export const TokenSchema = {
     description: 'OAuth2 bearer token response.',
     properties: {

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { AssetsUpdateAssetData, AssetsUpdateAssetResponse, AssetsReadProjectAssetsData, AssetsReadProjectAssetsResponse, AssetsCreateProjectAssetData, AssetsCreateProjectAssetResponse, FindingsReadFindingData, FindingsReadFindingResponse, FindingsExplainFindingData, FindingsExplainFindingResponse, FindingsReadProjectFindingsData, FindingsReadProjectFindingsResponse, ImportsImportProjectUploadData, ImportsImportProjectUploadResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, ProjectsReadProjectsResponse, ProjectsCreateProjectData, ProjectsCreateProjectResponse, ProjectsDeleteProjectData, ProjectsDeleteProjectResponse, ProjectsReadProjectData, ProjectsReadProjectResponse, ProjectsUpdateProjectData, ProjectsUpdateProjectResponse, ProjectsCompareProjectCvssOnlyData, ProjectsCompareProjectCvssOnlyResponse, ProjectsReadProjectSummaryData, ProjectsReadProjectSummaryResponse, ProvidersReadProviderStatusResponse, RunsReadProjectRunsWithoutTrailingSlashData, RunsReadProjectRunsWithoutTrailingSlashResponse, RunsReadProjectRunsData, RunsReadProjectRunsResponse, RunsReadRunData, RunsReadRunResponse, RunsReadRunSummaryData, RunsReadRunSummaryResponse, UsersReadUserMeResponse, UtilsHealthCheckResponse, WorkbenchTemplateWorkbenchStatusResponse } from './types.gen';
+import type { AssetsUpdateAssetData, AssetsUpdateAssetResponse, AssetsReadProjectAssetsData, AssetsReadProjectAssetsResponse, AssetsCreateProjectAssetData, AssetsCreateProjectAssetResponse, FindingsReadFindingData, FindingsReadFindingResponse, FindingsExplainFindingData, FindingsExplainFindingResponse, FindingsReadProjectFindingsData, FindingsReadProjectFindingsResponse, ImportsImportProjectUploadData, ImportsImportProjectUploadResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, ProjectsReadProjectsResponse, ProjectsCreateProjectData, ProjectsCreateProjectResponse, ProjectsDeleteProjectData, ProjectsDeleteProjectResponse, ProjectsReadProjectData, ProjectsReadProjectResponse, ProjectsUpdateProjectData, ProjectsUpdateProjectResponse, ProjectsCompareProjectCvssOnlyData, ProjectsCompareProjectCvssOnlyResponse, ProjectsReadProjectSummaryData, ProjectsReadProjectSummaryResponse, ProvidersReadProviderStatusResponse, ReportsDownloadReportData, ReportsDownloadReportResponse, ReportsReadRunReportsData, ReportsReadRunReportsResponse, ReportsCreateRunReportData, ReportsCreateRunReportResponse, RunsReadProjectRunsWithoutTrailingSlashData, RunsReadProjectRunsWithoutTrailingSlashResponse, RunsReadProjectRunsData, RunsReadProjectRunsResponse, RunsReadRunData, RunsReadRunResponse, RunsReadRunSummaryData, RunsReadRunSummaryResponse, UsersReadUserMeResponse, UtilsHealthCheckResponse, WorkbenchTemplateWorkbenchStatusResponse } from './types.gen';
 
 export class AssetsService {
     /**
@@ -394,6 +394,74 @@ export class ProvidersService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/providers/status'
+        });
+    }
+}
+
+export class ReportsService {
+    /**
+     * Download Report
+     * Download a visible report after root and checksum validation.
+     * @param data The data for the request.
+     * @param data.reportId
+     * @returns unknown Successful Response
+     * @throws ApiError
+     */
+    public static downloadReport(data: ReportsDownloadReportData): CancelablePromise<ReportsDownloadReportResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/reports/{report_id}/download',
+            path: {
+                report_id: data.reportId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+
+    /**
+     * Read Run Reports
+     * List report metadata for a visible analysis run.
+     * @param data The data for the request.
+     * @param data.runId
+     * @returns ReportsPublic Successful Response
+     * @throws ApiError
+     */
+    public static readRunReports(data: ReportsReadRunReportsData): CancelablePromise<ReportsReadRunReportsResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/runs/{run_id}/reports',
+            path: {
+                run_id: data.runId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+
+    /**
+     * Create Run Report
+     * Create a Markdown technical report for a completed visible analysis run.
+     * @param data The data for the request.
+     * @param data.runId
+     * @param data.requestBody
+     * @returns ReportPublic Successful Response
+     * @throws ApiError
+     */
+    public static createRunReport(data: ReportsCreateRunReportData): CancelablePromise<ReportsCreateRunReportResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/runs/{run_id}/reports',
+            path: {
+                run_id: data.runId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
         });
     }
 }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -523,6 +523,41 @@ export type ProviderUpdateJobPublic = {
 };
 
 /**
+ * Request payload for creating a run report.
+ */
+export type ReportCreate = {
+    format?: "markdown";
+};
+
+/**
+ * Public report metadata without exposing server filesystem paths.
+ */
+export type ReportPublic = {
+    analysis_run_id: string;
+    content_type: string;
+    created_at: string;
+    download_url: string;
+    filename: string;
+    format: string;
+    id: string;
+    kind: string;
+    metadata_json?: {
+        [key: string]: unknown;
+    };
+    project_id: string;
+    sha256: string;
+    size_bytes: number;
+};
+
+/**
+ * Collection response for reports.
+ */
+export type ReportsPublic = {
+    count: number;
+    data: Array<ReportPublic>;
+};
+
+/**
  * OAuth2 bearer token response.
  */
 export type Token = {
@@ -674,6 +709,25 @@ export type ProjectsReadProjectSummaryData = {
 export type ProjectsReadProjectSummaryResponse = (ProjectDecisionSummaryPublic);
 
 export type ProvidersReadProviderStatusResponse = (ProviderStatusPublic);
+
+export type ReportsDownloadReportData = {
+    reportId: string;
+};
+
+export type ReportsDownloadReportResponse = (unknown);
+
+export type ReportsReadRunReportsData = {
+    runId: string;
+};
+
+export type ReportsReadRunReportsResponse = (ReportsPublic);
+
+export type ReportsCreateRunReportData = {
+    requestBody: ReportCreate;
+    runId: string;
+};
+
+export type ReportsCreateRunReportResponse = (ReportPublic);
 
 export type RunsReadProjectRunsWithoutTrailingSlashData = {
     projectId: string;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,8 @@ nav:
       - VPW-045 Provider Status Page: evidence/vpw-045-provider-status.md
       - VPW-046 Reports Page Shell: evidence/vpw-046-reports-page.md
       - VPW-047 Frontend E2E Smoke: evidence/vpw-047-frontend-e2e-smoke.md
+      - VPW-048 Markdown Report: evidence/vpw-048-markdown-report.md
+      - VPW-048 Example Technical Report: evidence/vpw-048/technical-report.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary
- Implements VPW-048 as a template-stack Markdown technical report generator under `/api/v1`.
- Adds SQLModel `report` metadata, Alembic migration, repository/service/router, root-bound checksum-verified downloads, and generated frontend client types/services.
- Adds snapshot/API/security tests plus docs and checked-in example `docs/evidence/vpw-048/technical-report.md`.

## Verification
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py backend/tests/api/test_template_workbench_api_skeleton.py backend/tests/api/test_template_model_metadata.py --no-cov`
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py::test_vpw048_markdown_report_snapshot_is_stable --no-cov`
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py backend/tests/api/test_template_workbench_api_skeleton.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_import_upload_api.py --no-cov`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `cd backend && python3 -m mypy app src`
- `make check` (739 passed, 5 skipped, coverage 90.59%)
- `make frontend-check`
- `npm --prefix frontend run test` (1 passed)
- `python3 -m mkdocs build --clean`
- `git diff --check`

## Evidence
- Snapshot: `backend/tests/api/snapshots/vpw_048_technical_report.md`
- Example report: `docs/evidence/vpw-048/technical-report.md`
- DoD evidence: `docs/evidence/vpw-048-markdown-report.md`

## Residual Risk
- Markdown is enabled here. HTML/JSON/CSV/SARIF, evidence bundles, and active React report controls remain for later `v0.7-reports-evidence` issues.

Closes #154
