### PR TITLE
VPW-054: Add report snapshot artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ That command starts the template backend and React shell, verifies
 `/api/v1/workbench/status`, checks the frontend and login route, then tears down
 the stack.
 
+Committed template report demo artifacts are available for review without
+running the Workbench:
+
+- [docs/examples/vpw-054-template-technical-report.md](docs/examples/vpw-054-template-technical-report.md)
+- [docs/examples/vpw-054-template-executive-report.html](docs/examples/vpw-054-template-executive-report.html)
+- [docs/examples/vpw-054-template-analysis-result.v1.json](docs/examples/vpw-054-template-analysis-result.v1.json)
+
 ## Quickstart
 
 ### 1. Fastest Public-Install Analyze Run

--- a/backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
+++ b/backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Executive Vulnerability Report</title>
+  <style>
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #18202f;
+  --muted: #5d6a7d;
+  --border: #d8dee8;
+  --accent: #1665d8;
+  --accent-soft: #e8f1ff;
+  --critical: #b42318;
+  --high: #b54708;
+  --medium: #8a6116;
+  --low: #186a3b;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+}
+.report-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+header,
+section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 18px;
+  padding: 24px;
+}
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+h1 {
+  margin-bottom: 10px;
+  font-size: 32px;
+  line-height: 1.15;
+}
+h2 {
+  margin-bottom: 12px;
+  font-size: 22px;
+  line-height: 1.25;
+}
+.eyebrow {
+  margin-bottom: 6px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.lede {
+  max-width: 840px;
+  color: var(--muted);
+}
+.section-heading {
+  margin-bottom: 14px;
+}
+.meta-grid,
+.metric-grid,
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+.meta-grid {
+  margin: 18px 0 0;
+}
+.meta-grid div,
+.metric,
+.provider-grid div {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  background: #fbfcfe;
+}
+dt,
+.metric span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+.metric strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 26px;
+  line-height: 1.1;
+}
+.table-wrap {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: collapse;
+}
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+td {
+  overflow-wrap: anywhere;
+}
+.badge {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+tbody td:nth-child(-n + 7),
+thead th:nth-child(-n + 7) {
+  white-space: nowrap;
+}
+.badge-critical {
+  background: #fee4e2;
+  color: var(--critical);
+}
+.badge-high {
+  background: #ffead5;
+  color: var(--high);
+}
+.badge-medium {
+  background: #fef3c7;
+  color: var(--medium);
+}
+.badge-low {
+  background: #dcfae6;
+  color: var(--low);
+}
+.recommendation-list {
+  margin: 0;
+  padding-left: 24px;
+}
+.recommendation-list li + li {
+  margin-top: 12px;
+}
+.recommendation-list strong {
+  display: block;
+}
+.empty-state {
+  color: var(--muted);
+}
+@media (max-width: 820px) {
+  .report-shell {
+    width: min(100% - 20px, 1160px);
+    padding-top: 16px;
+  }
+  header,
+  section {
+    padding: 16px;
+  }
+  h1 {
+    font-size: 26px;
+  }
+  .meta-grid,
+  .metric-grid,
+  .provider-grid {
+    grid-template-columns: 1fr;
+  }
+}
+@media print {
+  body {
+    background: #ffffff;
+    color: #000000;
+  }
+  .report-shell {
+    width: 100%;
+    padding: 0;
+  }
+  header,
+  section {
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  .table-wrap {
+    overflow: visible;
+  }
+  table {
+    min-width: 0;
+  }
+}
+  </style>
+</head>
+<body>
+  <main class="report-shell">
+    <header>
+      <p class="eyebrow">Executive Vulnerability Report</p>
+      <h1>VPW-054 Demo Reports</h1>
+      <p class="lede">Decision-ready vulnerability prioritization summary for analysis run 00000000-0000-4000-8000-000000000540 generated at 2026-04-29T12:00:00Z.</p>
+      <dl class="meta-grid">
+        <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000054</dd></div>
+        <div><dt>Run Status</dt><dd>completed</dd></div>
+        <div><dt>Input Type</dt><dd>cve-list</dd></div>
+        <div><dt>Input File</dt><dd>vpw-054-known-cves.txt</dd></div>
+      </dl>
+    </header>
+    <section aria-labelledby="executive-summary">
+      <div class="section-heading">
+        <p class="eyebrow">Summary</p>
+        <h2 id="executive-summary">Executive Summary</h2>
+      </div>
+      <div class="metric-grid">
+        <div class="metric"><span>Findings</span><strong>2</strong></div>
+        <div class="metric"><span>Critical</span><strong>1</strong></div>
+        <div class="metric"><span>High</span><strong>1</strong></div>
+        <div class="metric"><span>Critical or High</span><strong>2</strong></div>
+      </div>
+      <p>The run contains 2 finding(s), including 2 critical or high priority item(s). Prioritize the listed top risks first and validate execution against provider freshness. Locked provider data: Yes.</p>
+    </section>
+    <section aria-labelledby="business-impact">
+      <div class="section-heading">
+        <p class="eyebrow">Impact</p>
+        <h2 id="business-impact">Business Impact</h2>
+      </div>
+      <p>Checkout traffic depends on the affected service.</p>
+    </section>
+    <section aria-labelledby="top-risks">
+      <div class="section-heading">
+        <p class="eyebrow">Priorities</p>
+        <h2 id="top-risks">Top Risks</h2>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Rank</th><th>CVE</th><th>Priority</th><th>Score</th><th>EPSS</th><th>CVSS</th><th>KEV</th><th>Asset</th><th>Decision Statement</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>CVE-2024-3094</td><td><span class="badge badge-critical">Critical</span></td><td>100</td><td>0.846</td><td>10</td><td>No</td><td>Payments API</td><td>Decision Statement: patch CVE-2024-3094 on Payments API within the emergency SLA.</td></tr>
+            <tr><td>2</td><td>CVE-2021-44228</td><td><span class="badge badge-high">High</span></td><td>94.2</td><td>0.944</td><td>10</td><td>Yes</td><td>Ops API</td><td>Decision Statement: patch after owner validation.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section aria-labelledby="recommendations">
+      <div class="section-heading">
+        <p class="eyebrow">Actions</p>
+        <h2 id="recommendations">Recommendations</h2>
+      </div>
+      <ol class="recommendation-list">
+        <li><strong>CVE-2024-3094 - Critical</strong><span>Patch [open](javascript:alert(1)) now. SLA: Emergency / 24h</span></li>
+        <li><strong>CVE-2021-44228 - High</strong><span>Patch via vendor upgrade. SLA: Emergency / 24h</span></li>
+      </ol>
+    </section>
+    <section aria-labelledby="provider-freshness">
+      <div class="section-heading">
+        <p class="eyebrow">Evidence</p>
+        <h2 id="provider-freshness">Provider Freshness</h2>
+      </div>
+      <dl class="provider-grid">
+        <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
+        <div><dt>Content Hash</dt><dd>sha256:vpw050-snapshot</dd></div>
+        <div><dt>NVD Last Sync</dt><dd>2026-04-28T10:15:00Z</dd></div>
+        <div><dt>EPSS Date</dt><dd>2026-04-28</dd></div>
+        <div><dt>KEV Catalog Version</dt><dd>2026-04-28</dd></div>
+        <div><dt>Locked Provider Data</dt><dd>Yes</dd></div>
+        <div><dt>Selected Sources</dt><dd>nvd, epss, kev</dd></div>
+        <div><dt>Source Hash: provider_snapshot</dt><dd>sha256:vpw050-snapshot</dd></div>
+      </dl>
+    </section>
+  </main>
+</body>
+</html>

--- a/backend/tests/api/test_template_reports_api.py
+++ b/backend/tests/api/test_template_reports_api.py
@@ -71,6 +71,23 @@ CSV_FINDINGS_COLUMNS = [
     "recommended_action",
 ]
 
+VPW054_DEMO_ARTIFACTS = {
+    "markdown": Path("docs/examples/vpw-054-template-technical-report.md"),
+    "html": Path("docs/examples/vpw-054-template-executive-report.html"),
+    "json": Path("docs/examples/vpw-054-template-analysis-result.v1.json"),
+}
+VPW054_HTML_SNAPSHOT = Path("backend/tests/api/snapshots/vpw_054_executive_report.normalized.html")
+VPW054_SECRET_MARKERS = (
+    "super-secret-token",
+    "provider-secret-key",
+    "bearer ",
+    "api_key",
+    "authorization",
+    "/users/",
+    "/tmp/",
+    ".env",
+)
+
 
 def test_vpw049_openapi_exposes_report_format_contract() -> None:
     response = TestClient(app).get("/api/v1/openapi.json")
@@ -868,6 +885,53 @@ def test_vpw050_findings_csv_export_snapshot_is_stable() -> None:
     assert render_findings_csv(payload) == snapshot_path.read_text(encoding="utf-8")
 
 
+def test_vpw054_demo_report_artifacts_match_current_renderers() -> None:
+    payload = _vpw054_demo_payload()
+    repo_root = _repo_root()
+    rendered = {
+        "markdown": render_markdown_report(payload),
+        "html": render_html_executive_report(payload),
+        "json": render_analysis_result_json(payload),
+    }
+
+    for artifact_type, relative_path in VPW054_DEMO_ARTIFACTS.items():
+        artifact_path = repo_root / relative_path
+        assert artifact_path.read_text(encoding="utf-8") == rendered[artifact_type]
+
+    jsonschema.validate(
+        json.loads(rendered["json"]),
+        _load_schema("analysis-result.v1.schema.json"),
+    )
+
+
+def test_vpw054_normalized_html_report_snapshot_is_stable() -> None:
+    payload = _vpw054_demo_payload()
+    snapshot_path = _repo_root() / VPW054_HTML_SNAPSHOT
+
+    assert _normalize_html_snapshot(
+        render_html_executive_report(payload)
+    ) == snapshot_path.read_text(encoding="utf-8")
+
+
+def test_vpw054_demo_report_artifacts_are_linked_and_secret_free() -> None:
+    repo_root = _repo_root()
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+    evidence = (repo_root / "docs" / "evidence" / "vpw-054-report-snapshots.md").read_text(
+        encoding="utf-8"
+    )
+    combined_artifacts: list[str] = []
+
+    for relative_path in VPW054_DEMO_ARTIFACTS.values():
+        artifact_link = relative_path.as_posix()
+        assert artifact_link in readme
+        assert artifact_link in evidence
+        combined_artifacts.append((repo_root / relative_path).read_text(encoding="utf-8"))
+
+    combined_text = "\n".join(combined_artifacts).lower()
+    for marker in VPW054_SECRET_MARKERS:
+        assert marker not in combined_text
+
+
 def _configure_report_dir(template_api_env: TemplateApiEnv, tmp_path: Path) -> Path:
     report_dir = (tmp_path / "template-reports").resolve(strict=False)
     active_settings = template_api_env.client.app.state.template_settings
@@ -885,6 +949,11 @@ def _repo_root() -> Path:
 def _load_schema(filename: str) -> dict[str, Any]:
     schema_path = _repo_root() / "docs" / "schemas" / filename
     return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def _normalize_html_snapshot(value: str) -> str:
+    lines = [line.rstrip() for line in value.replace("\r\n", "\n").splitlines() if line.strip()]
+    return "\n".join(lines) + "\n"
 
 
 def _replace_zip_member(bundle: bytes, member_path: str, replacement: bytes) -> bytes:
@@ -1054,6 +1123,18 @@ def _vpw050_snapshot_payload() -> MarkdownReportPayload:
         run_started_at=datetime(2026, 4, 29, 11, 0, tzinfo=UTC),
         run_finished_at=datetime(2026, 4, 29, 11, 45, tzinfo=UTC),
         run_errors={},
+    )
+
+
+def _vpw054_demo_payload() -> MarkdownReportPayload:
+    payload = _vpw050_snapshot_payload()
+    return replace(
+        payload,
+        project_id="00000000-0000-4000-8000-000000000054",
+        project_name="VPW-054 Demo Reports",
+        project_description="Committed demo artifacts for VPW-054 report snapshot coverage.",
+        run_id="00000000-0000-4000-8000-000000000540",
+        filename="vpw-054-known-cves.txt",
     )
 
 

--- a/docs/evidence/vpw-054-report-snapshots.md
+++ b/docs/evidence/vpw-054-report-snapshots.md
@@ -1,0 +1,63 @@
+# VPW-054 Report Snapshots
+
+VPW-054 makes the template report demo artifacts part of the tested repository
+contract. The current demo set is rendered from the deterministic VPW-054
+payload in `backend/tests/api/test_template_reports_api.py`.
+
+## Demo Artifacts
+
+- [docs/examples/vpw-054-template-technical-report.md](../examples/vpw-054-template-technical-report.md)
+- [docs/examples/vpw-054-template-executive-report.html](../examples/vpw-054-template-executive-report.html)
+- [docs/examples/vpw-054-template-analysis-result.v1.json](../examples/vpw-054-template-analysis-result.v1.json)
+
+## Snapshot Coverage
+
+- Markdown demo artifact must match `render_markdown_report`.
+- HTML demo artifact must match `render_html_executive_report`.
+- Normalized HTML must match
+  `backend/tests/api/snapshots/vpw_054_executive_report.normalized.html`.
+- JSON demo artifact must match `render_analysis_result_json` and validate
+  against `docs/schemas/analysis-result.v1.schema.json`.
+- README and this evidence page must link every committed demo artifact.
+- Demo artifacts must not contain API keys, bearer tokens, `.env` content, or
+  machine-local absolute paths.
+
+## Artifact Hashes
+
+```text
+bc8dc6af67958a6d5ef5c48dc487af7a9aaffa356db2a883f4294ff9b560033e  docs/examples/vpw-054-template-technical-report.md
+a96ded8d66ab40667badd38319d30fd9b7ebf9e85fc71fb3d06a54b71addbfd5  docs/examples/vpw-054-template-executive-report.html
+dd9210c755d9df913f7a2de94baa293debaca38736037dbf887dcfecd5cbf206  docs/examples/vpw-054-template-analysis-result.v1.json
+3795823e05b422db9e09d9b70af98015aadf751928830f98fe7d88b27319f3ed  backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
+```
+
+## Update Process
+
+Only update these artifacts when a report contract change is intentional.
+
+1. Change the report renderer, schema, or deterministic VPW-054 payload.
+2. Regenerate the three `docs/examples/vpw-054-template-*` artifacts and the
+   normalized HTML snapshot from the renderer output.
+3. Review the diff for contract changes and secret/path leakage.
+4. Run the targeted snapshot gate:
+
+```bash
+python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov
+```
+
+5. Run the docs gate:
+
+```bash
+python3 -m mkdocs build --clean
+```
+
+6. Record the exact commands and changed artifact paths in the issue closing
+   evidence.
+
+## Definition Of Done
+
+- Snapshot tests pass for Markdown, normalized HTML, and JSON report output.
+- Demo artifacts are committed under `docs/examples/`.
+- README links the demo report artifacts.
+- The update process is documented here.
+- Local validation confirms the artifacts are schema-valid and secret-free.

--- a/docs/examples/vpw-054-template-analysis-result.v1.json
+++ b/docs/examples/vpw-054-template-analysis-result.v1.json
@@ -1,0 +1,239 @@
+{
+  "analysis_run": {
+    "error_message": null,
+    "errors": {},
+    "filename": "vpw-054-known-cves.txt",
+    "finished_at": "2026-04-29T11:45:00Z",
+    "id": "00000000-0000-4000-8000-000000000540",
+    "input_type": "cve-list",
+    "project_id": "00000000-0000-4000-8000-000000000054",
+    "started_at": "2026-04-29T11:00:00Z",
+    "status": "completed",
+    "summary": {
+      "counts_by_priority": {
+        "Critical": 1,
+        "High": 1
+      },
+      "finding_count": 2
+    }
+  },
+  "explanations": {
+    "CVE-2021-44228": {
+      "attack_techniques": [
+        "T1190"
+      ],
+      "decision_guidance": {
+        "decision_statement": "Decision Statement: patch after owner validation.",
+        "template_label": "Patch"
+      }
+    },
+    "CVE-2024-3094": {
+      "decision_guidance": {
+        "decision_statement": "Decision Statement: patch CVE-2024-3094 on Payments API within the emergency SLA.",
+        "template_label": "Patch"
+      }
+    }
+  },
+  "findings": [
+    {
+      "asset": {
+        "asset_key": "payments-api",
+        "business_service": "checkout",
+        "criticality": "critical",
+        "environment": "prod",
+        "exposure": "internet-facing",
+        "label": "Payments API",
+        "owner": "platform-team"
+      },
+      "attack_mapped": false,
+      "component": {
+        "label": "xz 5.6.0-r0",
+        "purl": "pkg:apk/alpine/xz@5.6.0-r0"
+      },
+      "created_at": "2026-04-29T11:00:00Z",
+      "cve_id": "CVE-2024-3094",
+      "cvss_base_score": 10.0,
+      "data_quality": {
+        "confidence": "high",
+        "flags": [],
+        "raw": {
+          "confidence": "high",
+          "flags": []
+        }
+      },
+      "dedup_key": "vpw050-xz",
+      "epss": 0.846,
+      "evidence": {
+        "source": "snapshot"
+      },
+      "explanation": {
+        "decision_guidance": {
+          "decision_statement": "Decision Statement: patch CVE-2024-3094 on Payments API within the emergency SLA.",
+          "template_label": "Patch"
+        }
+      },
+      "first_seen_at": "2026-04-29T11:00:00Z",
+      "id": "00000000-0000-4000-8000-000000000501",
+      "in_kev": false,
+      "last_seen_at": "2026-04-29T11:30:00Z",
+      "occurrences": [
+        {
+          "analysis_run_id": "00000000-0000-4000-8000-000000000050",
+          "evidence": {
+            "line": 1
+          },
+          "id": "00000000-0000-4000-8000-000000000601",
+          "raw_reference": "CVE-2024-3094",
+          "source": "cve-list"
+        }
+      ],
+      "operational_rank": 1,
+      "priority": "Critical",
+      "priority_rank": 1,
+      "priority_raw": "critical",
+      "recommendation": {
+        "business_impact": "Checkout traffic depends on the affected service.",
+        "decision_guidance": {
+          "decision_statement": "Decision Statement: patch CVE-2024-3094 on Payments API within the emergency SLA.",
+          "template_label": "Patch"
+        },
+        "decision_sla": "Emergency / 24h",
+        "decision_statement": "Decision Statement: patch CVE-2024-3094 on Payments API within the emergency SLA.",
+        "rationale": "Internet-facing production asset with critical score.",
+        "recommended_action": "Patch [open](javascript:alert(1)) now."
+      },
+      "risk_score": 100.0,
+      "status": "open",
+      "suppressed_by_vex": false,
+      "under_investigation": false,
+      "updated_at": "2026-04-29T11:30:00Z",
+      "vulnerability": {
+        "provider": {
+          "nvd": "locked"
+        },
+        "severity": "CRITICAL"
+      },
+      "waived": false
+    },
+    {
+      "asset": {
+        "asset_key": "ops-api",
+        "business_service": "operations",
+        "criticality": "high",
+        "environment": "prod",
+        "exposure": "internal",
+        "label": "Ops API",
+        "owner": "secops"
+      },
+      "attack_mapped": true,
+      "component": {
+        "label": "log4j-core 2.14.1",
+        "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"
+      },
+      "created_at": "2026-04-29T11:00:00Z",
+      "cve_id": "CVE-2021-44228",
+      "cvss_base_score": 10.0,
+      "data_quality": {
+        "confidence": "medium",
+        "flags": [
+          "missing_asset_owner - Owner is not set"
+        ],
+        "raw": {
+          "confidence": "medium",
+          "flags": [
+            {
+              "code": "missing_asset_owner",
+              "message": "Owner is not set"
+            }
+          ]
+        }
+      },
+      "dedup_key": "vpw050-log4shell",
+      "epss": 0.944,
+      "evidence": {
+        "source": "snapshot"
+      },
+      "explanation": {
+        "attack_techniques": [
+          "T1190"
+        ],
+        "decision_guidance": {
+          "decision_statement": "Decision Statement: patch after owner validation.",
+          "template_label": "Patch"
+        }
+      },
+      "first_seen_at": "2026-04-29T11:00:00Z",
+      "id": "00000000-0000-4000-8000-000000000502",
+      "in_kev": true,
+      "last_seen_at": "2026-04-29T11:30:00Z",
+      "occurrences": [
+        {
+          "analysis_run_id": "00000000-0000-4000-8000-000000000050",
+          "evidence": {
+            "line": 2
+          },
+          "id": "00000000-0000-4000-8000-000000000602",
+          "raw_reference": "CVE-2021-44228",
+          "source": "cve-list"
+        }
+      ],
+      "operational_rank": 2,
+      "priority": "High",
+      "priority_rank": 2,
+      "priority_raw": "high",
+      "recommendation": {
+        "business_impact": "Operational tooling exposure requires management visibility.",
+        "decision_guidance": {
+          "decision_statement": "Decision Statement: patch after owner validation.",
+          "template_label": "Patch"
+        },
+        "decision_sla": "Emergency / 24h",
+        "decision_statement": "Decision Statement: patch after owner validation.",
+        "rationale": "CISA KEV listing and vulnerable component evidence.",
+        "recommended_action": "Patch via vendor upgrade."
+      },
+      "risk_score": 94.2,
+      "status": "in_review",
+      "suppressed_by_vex": false,
+      "under_investigation": false,
+      "updated_at": "2026-04-29T11:30:00Z",
+      "vulnerability": {
+        "provider": {
+          "kev": true
+        },
+        "severity": "CRITICAL"
+      },
+      "waived": false
+    }
+  ],
+  "generated_at": "2026-04-29T12:00:00Z",
+  "project": {
+    "created_at": "2026-04-29T10:00:00Z",
+    "description": "Committed demo artifacts for VPW-054 report snapshot coverage.",
+    "id": "00000000-0000-4000-8000-000000000054",
+    "name": "VPW-054 Demo Reports",
+    "owner_id": "00000000-0000-4000-8000-000000000011",
+    "updated_at": "2026-04-29T10:30:00Z"
+  },
+  "provider_snapshot": {
+    "content_hash": "sha256:vpw050-snapshot",
+    "created_at": "2026-04-28T10:20:00Z",
+    "epss_date": "2026-04-28",
+    "id": "00000000-0000-4000-8000-000000000650",
+    "kev_catalog_version": "2026-04-28",
+    "nvd_last_sync": "2026-04-28T10:15:00Z",
+    "source_hashes": {
+      "provider_snapshot": "sha256:vpw050-snapshot"
+    },
+    "source_metadata": {
+      "locked_provider_data": true,
+      "selected_sources": [
+        "nvd",
+        "epss",
+        "kev"
+      ]
+    }
+  },
+  "schema": "analysis-result.v1",
+  "schema_version": "1.0.0"
+}

--- a/docs/examples/vpw-054-template-executive-report.html
+++ b/docs/examples/vpw-054-template-executive-report.html
@@ -1,0 +1,305 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Executive Vulnerability Report</title>
+  <style>
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #18202f;
+  --muted: #5d6a7d;
+  --border: #d8dee8;
+  --accent: #1665d8;
+  --accent-soft: #e8f1ff;
+  --critical: #b42318;
+  --high: #b54708;
+  --medium: #8a6116;
+  --low: #186a3b;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+}
+.report-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+header,
+section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 18px;
+  padding: 24px;
+}
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+h1 {
+  margin-bottom: 10px;
+  font-size: 32px;
+  line-height: 1.15;
+}
+h2 {
+  margin-bottom: 12px;
+  font-size: 22px;
+  line-height: 1.25;
+}
+.eyebrow {
+  margin-bottom: 6px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.lede {
+  max-width: 840px;
+  color: var(--muted);
+}
+.section-heading {
+  margin-bottom: 14px;
+}
+.meta-grid,
+.metric-grid,
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+.meta-grid {
+  margin: 18px 0 0;
+}
+.meta-grid div,
+.metric,
+.provider-grid div {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  background: #fbfcfe;
+}
+dt,
+.metric span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+.metric strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 26px;
+  line-height: 1.1;
+}
+.table-wrap {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: collapse;
+}
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+td {
+  overflow-wrap: anywhere;
+}
+.badge {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+tbody td:nth-child(-n + 7),
+thead th:nth-child(-n + 7) {
+  white-space: nowrap;
+}
+.badge-critical {
+  background: #fee4e2;
+  color: var(--critical);
+}
+.badge-high {
+  background: #ffead5;
+  color: var(--high);
+}
+.badge-medium {
+  background: #fef3c7;
+  color: var(--medium);
+}
+.badge-low {
+  background: #dcfae6;
+  color: var(--low);
+}
+.recommendation-list {
+  margin: 0;
+  padding-left: 24px;
+}
+.recommendation-list li + li {
+  margin-top: 12px;
+}
+.recommendation-list strong {
+  display: block;
+}
+.empty-state {
+  color: var(--muted);
+}
+@media (max-width: 820px) {
+  .report-shell {
+    width: min(100% - 20px, 1160px);
+    padding-top: 16px;
+  }
+  header,
+  section {
+    padding: 16px;
+  }
+  h1 {
+    font-size: 26px;
+  }
+  .meta-grid,
+  .metric-grid,
+  .provider-grid {
+    grid-template-columns: 1fr;
+  }
+}
+@media print {
+  body {
+    background: #ffffff;
+    color: #000000;
+  }
+  .report-shell {
+    width: 100%;
+    padding: 0;
+  }
+  header,
+  section {
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  .table-wrap {
+    overflow: visible;
+  }
+  table {
+    min-width: 0;
+  }
+}
+  </style>
+</head>
+<body>
+  <main class="report-shell">
+    <header>
+      <p class="eyebrow">Executive Vulnerability Report</p>
+      <h1>VPW-054 Demo Reports</h1>
+      <p class="lede">Decision-ready vulnerability prioritization summary for analysis run 00000000-0000-4000-8000-000000000540 generated at 2026-04-29T12:00:00Z.</p>
+      <dl class="meta-grid">
+        <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000054</dd></div>
+        <div><dt>Run Status</dt><dd>completed</dd></div>
+        <div><dt>Input Type</dt><dd>cve-list</dd></div>
+        <div><dt>Input File</dt><dd>vpw-054-known-cves.txt</dd></div>
+      </dl>
+    </header>
+
+    <section aria-labelledby="executive-summary">
+      <div class="section-heading">
+        <p class="eyebrow">Summary</p>
+        <h2 id="executive-summary">Executive Summary</h2>
+      </div>
+      <div class="metric-grid">
+        <div class="metric"><span>Findings</span><strong>2</strong></div>
+        <div class="metric"><span>Critical</span><strong>1</strong></div>
+        <div class="metric"><span>High</span><strong>1</strong></div>
+        <div class="metric"><span>Critical or High</span><strong>2</strong></div>
+      </div>
+      <p>The run contains 2 finding(s), including 2 critical or high priority item(s). Prioritize the listed top risks first and validate execution against provider freshness. Locked provider data: Yes.</p>
+    </section>
+
+    <section aria-labelledby="business-impact">
+      <div class="section-heading">
+        <p class="eyebrow">Impact</p>
+        <h2 id="business-impact">Business Impact</h2>
+      </div>
+      <p>Checkout traffic depends on the affected service.</p>
+    </section>
+
+    <section aria-labelledby="top-risks">
+      <div class="section-heading">
+        <p class="eyebrow">Priorities</p>
+        <h2 id="top-risks">Top Risks</h2>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Rank</th><th>CVE</th><th>Priority</th><th>Score</th><th>EPSS</th><th>CVSS</th><th>KEV</th><th>Asset</th><th>Decision Statement</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>CVE-2024-3094</td><td><span class="badge badge-critical">Critical</span></td><td>100</td><td>0.846</td><td>10</td><td>No</td><td>Payments API</td><td>Decision Statement: patch CVE-2024-3094 on Payments API within the emergency SLA.</td></tr>
+            <tr><td>2</td><td>CVE-2021-44228</td><td><span class="badge badge-high">High</span></td><td>94.2</td><td>0.944</td><td>10</td><td>Yes</td><td>Ops API</td><td>Decision Statement: patch after owner validation.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section aria-labelledby="recommendations">
+      <div class="section-heading">
+        <p class="eyebrow">Actions</p>
+        <h2 id="recommendations">Recommendations</h2>
+      </div>
+      <ol class="recommendation-list">
+        <li><strong>CVE-2024-3094 - Critical</strong><span>Patch [open](javascript:alert(1)) now. SLA: Emergency / 24h</span></li>
+        <li><strong>CVE-2021-44228 - High</strong><span>Patch via vendor upgrade. SLA: Emergency / 24h</span></li>
+      </ol>
+    </section>
+
+    <section aria-labelledby="provider-freshness">
+      <div class="section-heading">
+        <p class="eyebrow">Evidence</p>
+        <h2 id="provider-freshness">Provider Freshness</h2>
+      </div>
+      <dl class="provider-grid">
+        <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
+        <div><dt>Content Hash</dt><dd>sha256:vpw050-snapshot</dd></div>
+        <div><dt>NVD Last Sync</dt><dd>2026-04-28T10:15:00Z</dd></div>
+        <div><dt>EPSS Date</dt><dd>2026-04-28</dd></div>
+        <div><dt>KEV Catalog Version</dt><dd>2026-04-28</dd></div>
+        <div><dt>Locked Provider Data</dt><dd>Yes</dd></div>
+        <div><dt>Selected Sources</dt><dd>nvd, epss, kev</dd></div>
+        <div><dt>Source Hash: provider_snapshot</dt><dd>sha256:vpw050-snapshot</dd></div>
+      </dl>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/examples/vpw-054-template-technical-report.md
+++ b/docs/examples/vpw-054-template-technical-report.md
@@ -1,0 +1,52 @@
+# Technical Vulnerability Report
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Project | VPW-054 Demo Reports |
+| Project ID | 00000000-0000-4000-8000-000000000054 |
+| Analysis Run | 00000000-0000-4000-8000-000000000540 |
+| Run Status | completed |
+| Input Type | cve-list |
+| Input File | vpw-054-known-cves.txt |
+| Generated At | 2026-04-29T12:00:00Z |
+| Finding Count | 2 |
+| Critical | 1 |
+| High | 1 |
+| Medium | 0 |
+| Low | 0 |
+
+## Top Findings
+
+| Operational Rank | CVE | Priority | Score | EPSS | CVSS | KEV | Status | Asset | Component | Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | CVE-2024-3094 | Critical | 100 | 0.846 | 10 | No | open | Payments API | xz 5.6.0-r0 | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| 2 | CVE-2021-44228 | High | 94.2 | 0.944 | 10 | Yes | in\_review | Ops API | log4j-core 2.14.1 | Patch via vendor upgrade. |
+
+## Reasons
+
+| CVE | Rationale | Recommended Action |
+| --- | --- | --- |
+| CVE-2024-3094 | Internet-facing production asset with critical score. | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| CVE-2021-44228 | CISA KEV listing and vulnerable component evidence. | Patch via vendor upgrade. |
+
+## Data Quality
+
+| CVE | Confidence | Flags |
+| --- | --- | --- |
+| CVE-2024-3094 | high | None |
+| CVE-2021-44228 | medium | missing\_asset\_owner - Owner is not set |
+
+## Provider Snapshot
+
+| Field | Value |
+| --- | --- |
+| Snapshot ID | 00000000-0000-4000-8000-000000000650 |
+| Content Hash | sha256:vpw050-snapshot |
+| NVD Last Sync | 2026-04-28T10:15:00Z |
+| EPSS Date | 2026-04-28 |
+| KEV Catalog Version | 2026-04-28 |
+| Locked Provider Data | Yes |
+| Selected Sources | nvd, epss, kev |
+| Source Hash: provider\_snapshot | sha256:vpw050-snapshot |

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ The site includes the `v1.1.0` release notes, Workbench milestone evidence, and 
 - [Release notes: Workbench v1.0.0](releases/workbench-v1.0.0.md)
 - [Workbench v1.0 release checklist](workbench-v1-release-checklist.md)
 - [Example HTML report](examples/example_report.html)
+- [Template report demo artifacts](evidence/vpw-054-report-snapshots.md)
 - [Operational use cases](use_cases.md)
 - [Operator playbooks](playbooks.md)
 

--- a/docs/workbench-offline-demo.md
+++ b/docs/workbench-offline-demo.md
@@ -121,6 +121,9 @@ If the browser demo cannot be shown, use these checked-in or generated artifacts
 - `docs/example_compare.md`
 - `docs/example_attack_report.md`
 - `docs/examples/example_report.html`
+- `docs/examples/vpw-054-template-technical-report.md`
+- `docs/examples/vpw-054-template-executive-report.html`
+- `docs/examples/vpw-054-template-analysis-result.v1.json`
 - `docs/examples/example_pr_comment.md`
 - `docs/examples/example_results.sarif`
 - `data/demo_provider_snapshot.json`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - ATT&CK Report: example_attack_report.md
       - ATT&CK Compare: example_attack_compare.md
       - ATT&CK Coverage: example_attack_coverage.md
+      - VPW-054 Template Technical Report: examples/vpw-054-template-technical-report.md
       - PR Comment Body: examples/example_pr_comment.md
       - GitHub Summary Templates: examples/github_action_summary_templates.md
   - Historical Appendix:
@@ -88,6 +89,7 @@ nav:
       - VPW-051 Evidence Bundle: evidence/vpw-051-evidence-bundle.md
       - VPW-052 Evidence Bundle Verification: evidence/vpw-052-evidence-bundle-verification.md
       - VPW-053 Report Downloads: evidence/vpw-053-report-downloads.md
+      - VPW-054 Report Snapshots: evidence/vpw-054-report-snapshots.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary

Closes #160.

- Add deterministic VPW-054 demo report artifacts for Markdown, HTML, and JSON under `docs/examples/`.
- Add a normalized HTML snapshot and tests that compare committed artifacts to the current report renderers.
- Validate the JSON demo artifact against `analysis-result.v1.schema.json` and assert README/evidence links plus no secret/private-path leakage.
- Document the VPW-054 Definition of Done, artifact hashes, and update process.

## Validation

- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov` -> 23 passed
- `make docs-check` -> passed; pre-existing unnav warning remains for `architecture/vpw-011-api-skeleton.md`
- `python3 -m ruff format --check backend/tests/api/test_template_reports_api.py && python3 -m ruff check backend/tests/api/test_template_reports_api.py` -> passed
- `git diff --check` -> passed
- `make check` -> 757 passed, 5 skipped, coverage 90.60%

## Notes

VPW-054 artifacts are intentionally enforced by the pytest report snapshot gate instead of `demo-sync-check`, because they are template-report renderer artifacts rather than CLI demo-sync outputs.
