### PR TITLE
VPW-056: Implement curated ATT&CK mapping loader

### DIFF
--- a/backend/src/vuln_prioritizer/attack_enrichment.py
+++ b/backend/src/vuln_prioritizer/attack_enrichment.py
@@ -234,10 +234,13 @@ def _determine_attack_relevance(
         return "Unmapped", "No CTID ATT&CK mapping is available for this CVE."
 
     normalized_tactics = {_normalize_tactic_name(tactic) for tactic in attack_tactics}
-    if "exploitation_technique" in mapping_types or "primary_impact" in mapping_types:
+    if any(
+        mapping_type in mapping_types
+        for mapping_type in ("exploitation_technique", "primary_impact", "exploitation", "impact")
+    ):
         return _append_missing_metadata_note(
             "High",
-            "CTID ATT&CK mappings include exploitation or primary impact behavior.",
+            "ATT&CK mappings include reviewed exploitation or impact context.",
             missing_metadata_ids,
         )
     if normalized_tactics.intersection(HIGH_IMPACT_TACTICS):
@@ -246,16 +249,19 @@ def _determine_attack_relevance(
             "Resolved ATT&CK tactics include high-impact adversary behaviors.",
             missing_metadata_ids,
         )
-    if "secondary_impact" in mapping_types:
+    if "secondary_impact" in mapping_types or "post_exploitation" in mapping_types:
         return _append_missing_metadata_note(
             "Medium",
-            "Only secondary impact ATT&CK mappings are available for this CVE.",
+            "Only secondary or post-exploitation ATT&CK mappings are available for this CVE.",
             missing_metadata_ids,
         )
-    if "uncategorized" in mapping_types:
+    if any(
+        mapping_type in mapping_types
+        for mapping_type in ("uncategorized", "mitigation_context", "detection_context")
+    ):
         return _append_missing_metadata_note(
             "Low",
-            "Only uncategorized ATT&CK mappings are available for this CVE.",
+            "Only low-confidence or defensive-context ATT&CK mappings are available for this CVE.",
             missing_metadata_ids,
         )
     return _append_missing_metadata_note(

--- a/backend/src/vuln_prioritizer/attack_sources.py
+++ b/backend/src/vuln_prioritizer/attack_sources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 ATTACK_SOURCE_NONE = "none"
 ATTACK_SOURCE_LOCAL_CSV = "local-csv"
+ATTACK_SOURCE_LOCAL_CURATED = "local-curated"
 ATTACK_SOURCE_CTID_JSON = "ctid-json"
 ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER = "ctid-mappings-explorer"
 

--- a/backend/src/vuln_prioritizer/cli_options.py
+++ b/backend/src/vuln_prioritizer/cli_options.py
@@ -67,6 +67,7 @@ class SortBy(StrEnum):
 class AttackSource(StrEnum):
     none = "none"
     local_csv = "local-csv"
+    local_curated = "local-curated"
     ctid_json = "ctid-json"
 
 

--- a/backend/src/vuln_prioritizer/cli_support/attack_support.py
+++ b/backend/src/vuln_prioritizer/cli_support/attack_support.py
@@ -14,6 +14,7 @@ from vuln_prioritizer.models import AttackData, AttackSummary
 from vuln_prioritizer.providers.attack import AttackProvider
 from vuln_prioritizer.providers.attack_metadata import AttackMetadataProvider
 from vuln_prioritizer.providers.ctid_mappings import CtidMappingsProvider
+from vuln_prioritizer.providers.curated_attack_mappings import CuratedAttackMappingProvider
 
 from .common import AttackSource, exit_input_validation
 
@@ -42,7 +43,10 @@ def validate_attack_inputs(
     attack_technique_metadata_file: Path | None,
 ) -> dict[str, Any]:
     if attack_source == AttackSource.none.value:
-        raise ValueError("ATT&CK utility commands require --attack-source ctid-json or local-csv.")
+        raise ValueError(
+            "ATT&CK utility commands require --attack-source ctid-json, "
+            "local-curated, or local-csv."
+        )
 
     warnings: list[str] = []
     metadata: dict[str, str | None]
@@ -53,6 +57,7 @@ def validate_attack_inputs(
     domain_mismatch = False
     attack_version_mismatch = False
     revoked_or_deprecated_count = 0
+    quality_report: dict[str, Any] | None = None
 
     if attack_source == AttackSource.ctid_json.value:
         mappings_by_cve, mapping_metadata, mapping_warnings = CtidMappingsProvider().load(
@@ -144,6 +149,38 @@ def validate_attack_inputs(
             metadata["metadata_format"] = technique_metadata.get("metadata_format")
             metadata["metadata_source"] = technique_metadata.get("metadata_source")
             metadata["stix_spec_version"] = technique_metadata.get("stix_spec_version")
+    elif attack_source == AttackSource.local_curated.value:
+        bundle = CuratedAttackMappingProvider().load(attack_mapping_file)
+        warnings.extend(bundle.warnings)
+        mapping_count = sum(len(items) for items in bundle.mappings_by_cve.values())
+        unique_cves = len(bundle.mappings_by_cve)
+        technique_count = len(bundle.techniques_by_id)
+        quality_report = bundle.quality_report
+        metadata = {
+            "source": "local-curated",
+            "mapping_file": str(attack_mapping_file),
+            "technique_metadata_file": None,
+            "source_version": bundle.metadata.get("mapping_framework_version")
+            or bundle.metadata.get("mapping_version"),
+            "attack_version": bundle.metadata.get("attack_version"),
+            "domain": bundle.metadata.get("domain"),
+            "mapping_framework": bundle.metadata.get("mapping_framework"),
+            "mapping_framework_version": bundle.metadata.get("mapping_framework_version"),
+            "mapping_file_sha256": bundle.metadata.get("mapping_file_sha256"),
+            "technique_metadata_file_sha256": None,
+            "metadata_format": bundle.metadata.get("metadata_format"),
+            "metadata_source": bundle.metadata.get("metadata_source"),
+            "stix_spec_version": None,
+            "mapping_created_at": bundle.metadata.get("creation_date"),
+            "mapping_updated_at": bundle.metadata.get("last_update"),
+            "mapping_organization": bundle.metadata.get("organization"),
+            "mapping_author": bundle.metadata.get("author"),
+            "mapping_contact": bundle.metadata.get("contact"),
+        }
+        if attack_technique_metadata_file is not None:
+            warnings.append(
+                "ATT&CK technique metadata is ignored when --attack-source local-curated is used."
+            )
     else:
         provider = AttackProvider()
         results, metadata, provider_warnings = provider.inspect_legacy_csv(attack_mapping_file)
@@ -151,7 +188,7 @@ def validate_attack_inputs(
         mapping_count = sum(1 for item in results.values() if item.mapped)
         unique_cves = len(results)
 
-    return {
+    result: dict[str, Any] = {
         "schema_version": "1.2.0",
         "source": metadata["source"],
         "mapping_file": metadata["mapping_file"],
@@ -180,6 +217,13 @@ def validate_attack_inputs(
         "revoked_or_deprecated_count": revoked_or_deprecated_count,
         "warnings": warnings,
     }
+    if quality_report is not None:
+        result["quality_report"] = quality_report
+        result["low_confidence_count"] = quality_report["low_confidence_count"]
+        result["review_status_counts"] = quality_report["review_status_counts"]
+        result["confidence_counts"] = quality_report["confidence_counts"]
+        result["mapping_type_counts"] = quality_report["mapping_type_counts"]
+    return result
 
 
 def render_attack_validation_panel(result: dict[str, Any]) -> Panel:
@@ -202,6 +246,16 @@ def render_attack_validation_panel(result: dict[str, Any]) -> Panel:
         f"ATT&CK version mismatch: {'Yes' if result['attack_version_mismatch'] else 'No'}",
         f"Revoked/deprecated mapped techniques: {result['revoked_or_deprecated_count']}",
     ]
+    if result.get("quality_report") is not None:
+        lines.extend(
+            [
+                f"Low-confidence mappings: {result.get('low_confidence_count', 0)}",
+                "Review status distribution: "
+                + format_distribution(result.get("review_status_counts", {})),
+                "Confidence distribution: "
+                + format_distribution(result.get("confidence_counts", {})),
+            ]
+        )
     return Panel("\n".join(lines), title="ATT&CK Validation")
 
 
@@ -227,9 +281,18 @@ def generate_attack_validation_markdown(result: dict[str, Any]) -> str:
         f"- Domain mismatch: {'Yes' if result['domain_mismatch'] else 'No'}",
         "- ATT&CK version mismatch: " + ("Yes" if result["attack_version_mismatch"] else "No"),
         "- Revoked/deprecated mapped techniques: " + str(result["revoked_or_deprecated_count"]),
-        "",
-        "## Warnings",
     ]
+    if result.get("quality_report") is not None:
+        lines.extend(
+            [
+                f"- Low-confidence mappings: {result.get('low_confidence_count', 0)}",
+                "- Review status distribution: "
+                + format_distribution(result.get("review_status_counts", {})),
+                "- Confidence distribution: "
+                + format_distribution(result.get("confidence_counts", {})),
+            ]
+        )
+    lines.extend(["", "## Warnings"])
     if result["warnings"]:
         lines.extend(f"- {warning}" for warning in result["warnings"])
     else:

--- a/backend/src/vuln_prioritizer/providers/attack.py
+++ b/backend/src/vuln_prioritizer/providers/attack.py
@@ -11,12 +11,14 @@ from vuln_prioritizer.attack_sources import (
     ATTACK_SOURCE_CTID_JSON,
     ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER,
     ATTACK_SOURCE_LOCAL_CSV,
+    ATTACK_SOURCE_LOCAL_CURATED,
     ATTACK_SOURCE_NONE,
     LEGACY_LOCAL_CSV_WARNING,
 )
 from vuln_prioritizer.models import AttackData, AttackTechnique
 from vuln_prioritizer.providers.attack_metadata import AttackMetadataProvider
 from vuln_prioritizer.providers.ctid_mappings import CtidMappingsProvider
+from vuln_prioritizer.providers.curated_attack_mappings import CuratedAttackMappingProvider
 from vuln_prioritizer.utils import normalize_cve_id
 
 SEPARATOR_RE = re.compile(r"[;|]")
@@ -27,6 +29,7 @@ class AttackProvider:
 
     def __init__(self) -> None:
         self.ctid_provider = CtidMappingsProvider()
+        self.curated_provider = CuratedAttackMappingProvider()
         self.metadata_provider = AttackMetadataProvider()
         self.enrichment_service = AttackEnrichmentService()
 
@@ -47,6 +50,8 @@ class AttackProvider:
             candidate = mapping_file or offline_file
             if candidate is not None and candidate.suffix.lower() == ".csv":
                 source = ATTACK_SOURCE_LOCAL_CSV
+            elif candidate is not None and candidate.suffix.lower() in {".yaml", ".yml"}:
+                source = ATTACK_SOURCE_LOCAL_CURATED
             else:
                 source = ATTACK_SOURCE_CTID_JSON
         if source == ATTACK_SOURCE_NONE:
@@ -85,6 +90,9 @@ class AttackProvider:
                 mapping_file=mapping_file,
                 technique_metadata_file=technique_metadata_file,
             )
+
+        if normalized_source == ATTACK_SOURCE_LOCAL_CURATED:
+            return self._load_local_curated(cve_ids, mapping_file=mapping_file)
 
         return (
             {},
@@ -161,6 +169,43 @@ class AttackProvider:
             mapping_contact=mapping_metadata.get("contact"),
         )
         return results, metadata, mapping_warnings + metadata_warnings
+
+    def _load_local_curated(
+        self,
+        cve_ids: list[str],
+        *,
+        mapping_file: Path,
+    ) -> tuple[dict[str, AttackData], dict[str, str | None], list[str]]:
+        bundle = self.curated_provider.load(mapping_file)
+        results = self.enrichment_service.enrich_ctid(
+            cve_ids,
+            mappings_by_cve=bundle.mappings_by_cve,
+            techniques_by_id=bundle.techniques_by_id,
+            source=ATTACK_SOURCE_LOCAL_CURATED,
+            source_version=bundle.metadata.get("mapping_framework_version")
+            or bundle.metadata.get("mapping_version"),
+            attack_version=bundle.metadata.get("attack_version"),
+            domain=bundle.metadata.get("domain"),
+        )
+        metadata = _build_metadata(
+            source=ATTACK_SOURCE_LOCAL_CURATED,
+            mapping_file=mapping_file,
+            source_version=bundle.metadata.get("mapping_framework_version")
+            or bundle.metadata.get("mapping_version"),
+            attack_version=bundle.metadata.get("attack_version"),
+            domain=bundle.metadata.get("domain"),
+            mapping_framework=bundle.metadata.get("mapping_framework"),
+            mapping_framework_version=bundle.metadata.get("mapping_framework_version"),
+            mapping_file_sha256=bundle.metadata.get("mapping_file_sha256"),
+            metadata_format=bundle.metadata.get("metadata_format"),
+            metadata_source=bundle.metadata.get("metadata_source"),
+            mapping_created_at=bundle.metadata.get("creation_date"),
+            mapping_updated_at=bundle.metadata.get("last_update"),
+            mapping_organization=bundle.metadata.get("organization"),
+            mapping_author=bundle.metadata.get("author"),
+            mapping_contact=bundle.metadata.get("contact"),
+        )
+        return results, metadata, bundle.warnings
 
     def _load_legacy_csv(
         self,

--- a/backend/src/vuln_prioritizer/providers/curated_attack_mappings.py
+++ b/backend/src/vuln_prioritizer/providers/curated_attack_mappings.py
@@ -1,0 +1,444 @@
+"""Provider for reviewed local CVE-to-ATT&CK mapping artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from pydantic import ValidationError
+
+from vuln_prioritizer.attack_sources import (
+    ATTACK_SOURCE_LOCAL_CURATED,
+    WORKBENCH_DISALLOWED_MAPPING_SOURCE_PREFIXES,
+    WORKBENCH_DISALLOWED_MAPPING_SOURCES,
+)
+from vuln_prioritizer.models import (
+    AttackMapping,
+    AttackMappingType,
+    AttackReviewStatus,
+    AttackTechnique,
+    CveAttackMapping,
+)
+from vuln_prioritizer.utils import normalize_cve_id
+
+CONFIDENCE_BY_LABEL = {"low": 0.3, "medium": 0.6, "high": 0.9}
+LOW_CONFIDENCE_THRESHOLD = 0.4
+REVIEW_STATUSES_REQUIRING_REVIEWER = {"reviewed", "rejected", "stale"}
+TACTIC_ID_TO_SHORT_NAME = {
+    "TA0001": "initial-access",
+    "TA0002": "execution",
+    "TA0003": "persistence",
+    "TA0004": "privilege-escalation",
+    "TA0005": "defense-evasion",
+    "TA0006": "credential-access",
+    "TA0007": "discovery",
+    "TA0008": "lateral-movement",
+    "TA0009": "collection",
+    "TA0010": "exfiltration",
+    "TA0011": "command-and-control",
+    "TA0040": "impact",
+    "TA0042": "resource-development",
+    "TA0043": "reconnaissance",
+}
+
+
+class CuratedAttackMappingValidationError(ValueError):
+    """Raised when a curated ATT&CK mapping artifact is structurally invalid."""
+
+
+@dataclass(frozen=True)
+class CuratedAttackMappingBundle:
+    mappings_by_cve: dict[str, list[AttackMapping]]
+    techniques_by_id: dict[str, AttackTechnique]
+    metadata: dict[str, str | None]
+    warnings: list[str]
+    quality_report: dict[str, Any]
+
+
+class CuratedAttackMappingProvider:
+    """Load reviewed YAML/JSON CVE-to-ATT&CK mappings from local files."""
+
+    def load(self, mapping_file: Path) -> CuratedAttackMappingBundle:
+        raw_content = _read_mapping_bytes(mapping_file)
+        payload = _decode_payload(mapping_file, raw_content)
+        metadata = _require_object(payload.get("metadata"), "metadata")
+        mapping_objects = _require_array(payload.get("mapping_objects"), "mapping_objects")
+
+        errors: list[str] = []
+        warnings: list[str] = []
+        _validate_metadata(metadata, errors)
+
+        mappings_by_cve: dict[str, list[AttackMapping]] = {}
+        techniques_by_id: dict[str, AttackTechnique] = {}
+        parsed_mappings: list[CveAttackMapping] = []
+        confidence_labels: list[str] = []
+        seen_keys: set[tuple[str, str, str]] = set()
+
+        for index, raw_object in enumerate(mapping_objects, start=1):
+            location = f"mapping_objects[{index - 1}]"
+            if not isinstance(raw_object, dict):
+                errors.append(f"{location} must be an object.")
+                continue
+
+            parsed, confidence_label = _parse_mapping_object(raw_object, location, errors)
+            if parsed is None or confidence_label is None:
+                continue
+
+            dedupe_key = (parsed.cve_id, parsed.technique_id, parsed.mapping_type)
+            if dedupe_key in seen_keys:
+                errors.append(
+                    f"{location} duplicates {parsed.cve_id} / {parsed.technique_id} / "
+                    f"{parsed.mapping_type}."
+                )
+                continue
+            seen_keys.add(dedupe_key)
+            parsed_mappings.append(parsed)
+            confidence_labels.append(confidence_label)
+            if confidence_label == "low" or parsed.confidence <= LOW_CONFIDENCE_THRESHOLD:
+                warnings.append(
+                    "Low-confidence curated ATT&CK mapping marked for review: "
+                    f"{parsed.cve_id} / {parsed.technique_id}."
+                )
+            if parsed.review_status in {"unreviewed", "needs_review"}:
+                warnings.append(
+                    "Curated ATT&CK mapping is not fully reviewed: "
+                    f"{parsed.cve_id} / {parsed.technique_id} has status "
+                    f"{parsed.review_status}."
+                )
+
+            mappings_by_cve.setdefault(parsed.cve_id, []).append(
+                AttackMapping(
+                    capability_id=parsed.cve_id,
+                    attack_object_id=parsed.technique_id,
+                    attack_object_name=parsed.technique_name,
+                    mapping_type=parsed.mapping_type,
+                    capability_group=_optional_string(raw_object.get("capability_group"))
+                    or parsed.mapping_type,
+                    capability_description=parsed.rationale,
+                    comments=_curated_mapping_comment(parsed, confidence_label),
+                    references=parsed.references,
+                )
+            )
+            techniques_by_id.setdefault(
+                parsed.technique_id,
+                AttackTechnique(
+                    attack_object_id=parsed.technique_id,
+                    name=parsed.technique_name or parsed.technique_id,
+                    tactics=_tactic_short_names(parsed.tactic_ids),
+                    url=None,
+                    revoked=False,
+                    deprecated=False,
+                ),
+            )
+
+        if errors:
+            message = "Curated ATT&CK mapping validation failed:\n- " + "\n- ".join(errors)
+            raise CuratedAttackMappingValidationError(message)
+
+        normalized_metadata = _normalize_metadata(metadata, mapping_file, raw_content)
+        quality_report = _build_quality_report(
+            metadata=normalized_metadata,
+            mappings=parsed_mappings,
+            confidence_labels=confidence_labels,
+            warnings=warnings,
+        )
+        return CuratedAttackMappingBundle(
+            mappings_by_cve=mappings_by_cve,
+            techniques_by_id=techniques_by_id,
+            metadata=normalized_metadata,
+            warnings=warnings,
+            quality_report=quality_report,
+        )
+
+
+def _read_mapping_bytes(mapping_file: Path) -> bytes:
+    if not mapping_file.exists() or not mapping_file.is_file():
+        raise FileNotFoundError(f"Curated ATT&CK mapping file not found: {mapping_file}")
+    if mapping_file.suffix.lower() not in {".json", ".yaml", ".yml"}:
+        raise ValueError("Curated ATT&CK mapping file must be JSON, YAML, or YML.")
+    return mapping_file.read_bytes()
+
+
+def _decode_payload(mapping_file: Path, raw_content: bytes) -> dict[str, Any]:
+    try:
+        if mapping_file.suffix.lower() == ".json":
+            payload = json.loads(raw_content.decode("utf-8"))
+        else:
+            payload = yaml.safe_load(raw_content.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Curated ATT&CK mapping JSON is not valid JSON: {exc.msg}.") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Curated ATT&CK mapping YAML is not valid YAML: {exc}.") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Curated ATT&CK mapping file must contain a top-level object.")
+    return payload
+
+
+def _require_object(value: Any, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"Curated ATT&CK mapping file is missing a {field_name} object.")
+    return value
+
+
+def _require_array(value: Any, field_name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"Curated ATT&CK mapping file is missing a {field_name} array.")
+    if not value:
+        raise ValueError(f"Curated ATT&CK mapping {field_name} array must not be empty.")
+    return value
+
+
+def _validate_metadata(metadata: dict[str, Any], errors: list[str]) -> None:
+    for field_name in (
+        "mapping_framework",
+        "mapping_framework_version",
+        "attack_version",
+        "technology_domain",
+        "mapping_types",
+    ):
+        value = metadata.get(field_name)
+        if field_name == "mapping_types":
+            if not isinstance(value, dict) or not value:
+                errors.append("metadata.mapping_types must be a non-empty object.")
+            continue
+        if _optional_string(value) is None:
+            errors.append(f"metadata.{field_name} is required.")
+
+
+def _parse_mapping_object(
+    raw_object: dict[str, Any],
+    location: str,
+    errors: list[str],
+) -> tuple[CveAttackMapping | None, str | None]:
+    confidence, confidence_label = _normalize_confidence(raw_object.get("confidence"))
+    cve_id = normalize_cve_id(_coalesce(raw_object, "cve_id", "capability_id"))
+    technique_id = _optional_string(_coalesce(raw_object, "technique_id", "attack_object_id"))
+    source = _optional_string(raw_object.get("source"))
+    review_status = _optional_string(raw_object.get("review_status")) or "unreviewed"
+    reviewer = _optional_string(raw_object.get("reviewer"))
+    reviewed_at = _optional_string(raw_object.get("reviewed_at"))
+    local_errors: list[str] = []
+
+    if cve_id is None:
+        local_errors.append(f"{location}.cve_id must be a valid CVE identifier.")
+    if technique_id is None:
+        local_errors.append(f"{location}.technique_id is required.")
+    if confidence is None or confidence_label is None:
+        local_errors.append(f"{location}.confidence must be one of low, medium, or high.")
+    elif confidence_label == "high" and review_status != "reviewed":
+        local_errors.append(f"{location}.confidence high requires review_status reviewed.")
+    if source is None:
+        local_errors.append(f"{location}.source is required.")
+    elif _is_disallowed_source(source):
+        local_errors.append(
+            f"{location}.source must not be heuristic or LLM-generated mapping evidence."
+        )
+    if review_status in REVIEW_STATUSES_REQUIRING_REVIEWER and reviewer is None:
+        local_errors.append(
+            f"{location}.reviewer is required when review_status is {review_status}."
+        )
+    if review_status in REVIEW_STATUSES_REQUIRING_REVIEWER and reviewed_at is None:
+        local_errors.append(
+            f"{location}.reviewed_at is required when review_status is {review_status}."
+        )
+
+    if local_errors:
+        errors.extend(local_errors)
+        return None, None
+
+    assert cve_id is not None
+    assert technique_id is not None
+    assert source is not None
+    assert confidence is not None
+    assert confidence_label is not None
+
+    metadata = _string_metadata(
+        {
+            "confidence_label": confidence_label,
+            "reviewer": reviewer,
+            "reviewed_at": reviewed_at,
+            "curated_source": ATTACK_SOURCE_LOCAL_CURATED,
+        }
+    )
+    try:
+        return (
+            CveAttackMapping(
+                cve_id=cve_id,
+                technique_id=technique_id,
+                technique_name=_optional_string(
+                    _coalesce(raw_object, "technique_name", "attack_object_name")
+                ),
+                tactic_ids=_string_list(raw_object.get("tactic_ids")),
+                mapping_type=cast(
+                    AttackMappingType,
+                    _optional_string(raw_object.get("mapping_type")) or "exploitation",
+                ),
+                source=source,
+                source_url=_optional_string(raw_object.get("source_url")),
+                confidence=confidence,
+                rationale=_optional_string(raw_object.get("rationale")) or "",
+                review_status=cast(AttackReviewStatus, review_status),
+                defensive_note=_optional_string(raw_object.get("defensive_note")) or "",
+                references=_string_list(raw_object.get("references")),
+                metadata=metadata,
+            ),
+            confidence_label,
+        )
+    except ValidationError as exc:
+        errors.extend(f"{location}.{error['loc'][0]}: {error['msg']}" for error in exc.errors())
+    return None, None
+
+
+def _normalize_confidence(value: Any) -> tuple[float | None, str | None]:
+    if isinstance(value, str):
+        label = value.strip().lower()
+        if label in CONFIDENCE_BY_LABEL:
+            return CONFIDENCE_BY_LABEL[label], label
+        return None, None
+    if value is None:
+        return None, None
+    return None, None
+
+
+def _confidence_label(confidence: float) -> str:
+    if confidence <= LOW_CONFIDENCE_THRESHOLD:
+        return "low"
+    if confidence <= 0.75:
+        return "medium"
+    return "high"
+
+
+def _is_disallowed_source(source: str) -> bool:
+    normalized = source.strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized in WORKBENCH_DISALLOWED_MAPPING_SOURCES or normalized.startswith(
+        WORKBENCH_DISALLOWED_MAPPING_SOURCE_PREFIXES
+    )
+
+
+def _normalize_metadata(
+    metadata: dict[str, Any],
+    mapping_file: Path,
+    raw_content: bytes,
+) -> dict[str, str | None]:
+    suffix = mapping_file.suffix.lower().lstrip(".")
+    return {
+        "mapping_framework": _optional_string(metadata.get("mapping_framework")),
+        "mapping_framework_version": _optional_string(metadata.get("mapping_framework_version")),
+        "mapping_version": _optional_string(metadata.get("mapping_version")),
+        "attack_version": _optional_string(metadata.get("attack_version")),
+        "domain": _optional_string(metadata.get("technology_domain")),
+        "mapping_file_sha256": hashlib.sha256(raw_content).hexdigest(),
+        "mapping_file": str(mapping_file),
+        "creation_date": _optional_string(metadata.get("creation_date")),
+        "last_update": _optional_string(metadata.get("last_update")),
+        "organization": _optional_string(metadata.get("organization")),
+        "author": _optional_string(metadata.get("author")),
+        "contact": _optional_string(metadata.get("contact")),
+        "metadata_format": f"vuln-prioritizer-curated-{suffix}",
+        "metadata_source": ATTACK_SOURCE_LOCAL_CURATED,
+    }
+
+
+def _build_quality_report(
+    *,
+    metadata: dict[str, str | None],
+    mappings: list[CveAttackMapping],
+    confidence_labels: list[str],
+    warnings: list[str],
+) -> dict[str, Any]:
+    review_status_counts = _count_values(mapping.review_status for mapping in mappings)
+    confidence_counts = _count_values(confidence_labels)
+    mapping_type_counts = _count_values(mapping.mapping_type for mapping in mappings)
+    low_confidence_mappings = [
+        {
+            "cve_id": mapping.cve_id,
+            "technique_id": mapping.technique_id,
+            "review_status": mapping.review_status,
+            "confidence": mapping.metadata.get(
+                "confidence_label", _confidence_label(mapping.confidence)
+            ),
+        }
+        for mapping in mappings
+        if mapping.metadata.get("confidence_label") == "low"
+        or mapping.confidence <= LOW_CONFIDENCE_THRESHOLD
+    ]
+    return {
+        "schema_version": "1.0.0",
+        "source": ATTACK_SOURCE_LOCAL_CURATED,
+        "mapping_file": metadata["mapping_file"],
+        "mapping_file_sha256": metadata["mapping_file_sha256"],
+        "mapping_count": len(mappings),
+        "unique_cves": len({mapping.cve_id for mapping in mappings}),
+        "unique_techniques": len({mapping.technique_id for mapping in mappings}),
+        "review_status_counts": review_status_counts,
+        "confidence_counts": confidence_counts,
+        "mapping_type_counts": mapping_type_counts,
+        "low_confidence_count": len(low_confidence_mappings),
+        "low_confidence_mappings": low_confidence_mappings,
+        "safety_review": {
+            "defensive_notes_required": True,
+            "reviewer_required_for_reviewed_status": True,
+            "heuristic_or_llm_sources_rejected": True,
+            "free_text_requires_human_review": True,
+        },
+        "warnings": warnings,
+    }
+
+
+def _curated_mapping_comment(mapping: CveAttackMapping, confidence_label: str) -> str:
+    suffix = (
+        f" Review status: {mapping.review_status}; confidence: {confidence_label}; "
+        "local curated mapping."
+    )
+    return mapping.defensive_note.rstrip(".") + "." + suffix
+
+
+def _tactic_short_names(tactic_ids: list[str]) -> list[str]:
+    names: list[str] = []
+    for tactic_id in tactic_ids:
+        name = TACTIC_ID_TO_SHORT_NAME.get(tactic_id, tactic_id)
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def _count_values(values: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[str(value)] = counts.get(str(value), 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _coalesce(mapping: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = mapping.get(key)
+        if _optional_string(value) is not None:
+            return value
+    return None
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for item in value:
+        text = _optional_string(item)
+        if text is not None and text not in normalized:
+            normalized.append(text)
+    return normalized
+
+
+def _string_metadata(value: dict[str, str | None]) -> dict[str, str]:
+    return {key: item for key, item in value.items() if item is not None}

--- a/backend/src/vuln_prioritizer/services/analysis_attack.py
+++ b/backend/src/vuln_prioritizer/services/analysis_attack.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from vuln_prioritizer.attack_sources import (
     ATTACK_SOURCE_CTID_JSON,
     ATTACK_SOURCE_LOCAL_CSV,
+    ATTACK_SOURCE_LOCAL_CURATED,
     ATTACK_SOURCE_NONE,
 )
 from vuln_prioritizer.models import (
@@ -35,6 +36,8 @@ def resolve_attack_options(
         if offline_attack_file is not None:
             return True, ATTACK_SOURCE_LOCAL_CSV, offline_attack_file, None
         if attack_mapping_file is not None:
+            if attack_mapping_file.suffix.lower() in {".yaml", ".yml"}:
+                return True, ATTACK_SOURCE_LOCAL_CURATED, attack_mapping_file, None
             return (
                 True,
                 ATTACK_SOURCE_CTID_JSON,

--- a/backend/src/vuln_prioritizer/services/workbench_attack.py
+++ b/backend/src/vuln_prioritizer/services/workbench_attack.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from vuln_prioritizer.attack_sources import (
     ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER,
+    ATTACK_SOURCE_LOCAL_CURATED,
     ATTACK_SOURCE_NONE,
     WORKBENCH_ALLOWED_MAPPING_SOURCES,
     WORKBENCH_ATTACK_SOURCE_CTID,
@@ -39,6 +40,8 @@ def validate_workbench_attack_source(source: str) -> None:
 def workbench_mapping_source(analysis_attack_source: str) -> str:
     if analysis_attack_source == ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER:
         return WORKBENCH_ATTACK_SOURCE_CTID
+    if analysis_attack_source == ATTACK_SOURCE_LOCAL_CURATED:
+        return WORKBENCH_ATTACK_SOURCE_LOCAL_CURATED
     if analysis_attack_source in {
         WORKBENCH_ATTACK_SOURCE_LOCAL_CURATED,
         WORKBENCH_ATTACK_SOURCE_MANUAL,

--- a/backend/tests/test_analysis_refactor.py
+++ b/backend/tests/test_analysis_refactor.py
@@ -33,6 +33,7 @@ def test_analysis_service_rejects_invalid_policy_thresholds() -> None:
 def test_analysis_service_resolves_attack_option_modes(tmp_path: Path) -> None:
     csv_file = tmp_path / "attack.csv"
     json_file = tmp_path / "attack.json"
+    yaml_file = tmp_path / "attack.yml"
 
     assert service_analysis.resolve_attack_options(
         no_attack=True,
@@ -55,6 +56,13 @@ def test_analysis_service_resolves_attack_option_modes(tmp_path: Path) -> None:
         attack_technique_metadata_file=None,
         offline_attack_file=None,
     ) == (True, "ctid-json", json_file, None)
+    assert service_analysis.resolve_attack_options(
+        no_attack=False,
+        attack_source="none",
+        attack_mapping_file=yaml_file,
+        attack_technique_metadata_file=json_file,
+        offline_attack_file=None,
+    ) == (True, "local-curated", yaml_file, None)
 
 
 def test_analysis_service_filter_helpers_accept_enum_and_string_values() -> None:

--- a/backend/tests/test_attack_enrichment.py
+++ b/backend/tests/test_attack_enrichment.py
@@ -69,6 +69,40 @@ def test_attack_enrichment_summary_counts_mapped_and_unmapped_items() -> None:
     assert summary.tactic_distribution == {"initial-access": 1}
 
 
+def test_attack_enrichment_service_marks_curated_context_relevance() -> None:
+    service = AttackEnrichmentService()
+
+    results = service.enrich_ctid(
+        ["CVE-2024-0001", "CVE-2024-0002"],
+        mappings_by_cve={
+            "CVE-2024-0001": [
+                AttackMapping(
+                    capability_id="CVE-2024-0001",
+                    attack_object_id="T1190",
+                    attack_object_name="Exploit Public-Facing Application",
+                    mapping_type="exploitation",
+                )
+            ],
+            "CVE-2024-0002": [
+                AttackMapping(
+                    capability_id="CVE-2024-0002",
+                    attack_object_id="T1046",
+                    attack_object_name="Network Service Discovery",
+                    mapping_type="detection_context",
+                )
+            ],
+        },
+        techniques_by_id={},
+        source="local-curated",
+        source_version="1.0",
+        attack_version="16.1",
+        domain="enterprise-attack",
+    )
+
+    assert results["CVE-2024-0001"].attack_relevance == "High"
+    assert results["CVE-2024-0002"].attack_relevance == "Low"
+
+
 def test_attack_enrichment_surfaces_missing_metadata_in_note_and_rationale() -> None:
     service = AttackEnrichmentService()
 

--- a/backend/tests/test_cli_attack.py
+++ b/backend/tests/test_cli_attack.py
@@ -23,6 +23,7 @@ ATTACK_STIX_FILE = DATA_ROOT / "attack" / "attack_stix_enterprise_16.1_subset.js
 SAMPLE_CVES_MIXED = DATA_ROOT / "sample_cves_mixed.txt"
 SAMPLE_CVES_ATTACK = DATA_ROOT / "sample_cves_attack.txt"
 OPTIONAL_ATTACK_TO_CVE = DATA_ROOT / "optional_attack_to_cve.csv"
+CURATED_ATTACK_MAPPING_FILE = DATA_ROOT / "cve_attack_mappings.yml"
 
 
 def test_cli_analyze_supports_ctid_attack_source(monkeypatch, tmp_path: Path) -> None:
@@ -373,6 +374,105 @@ def test_cli_attack_validate_local_csv_counts_rows_and_marks_legacy_mode(tmp_pat
     assert payload["unique_cves"] == 2
     assert payload["mapping_count"] == 2
     assert any("legacy compatibility mode" in warning for warning in payload["warnings"])
+
+
+def test_cli_attack_validate_local_curated_reports_quality(tmp_path: Path) -> None:
+    output_file = tmp_path / "attack-validate-curated.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "attack",
+            "validate",
+            "--attack-source",
+            "local-curated",
+            "--attack-mapping-file",
+            str(CURATED_ATTACK_MAPPING_FILE),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["source"] == "local-curated"
+    assert payload["mapping_count"] == 6
+    assert payload["unique_cves"] == 6
+    assert payload["quality_report"]["low_confidence_count"] == 1
+    assert payload["confidence_counts"] == {"high": 3, "low": 1, "medium": 2}
+    assert any("Low-confidence curated" in warning for warning in payload["warnings"])
+
+
+def test_cli_attack_validate_local_curated_invalid_file_exits_cleanly(tmp_path: Path) -> None:
+    mapping_file = tmp_path / "curated.yml"
+    mapping_file.write_text(
+        """
+metadata:
+  mapping_framework: vuln-prioritizer-curated-attack
+  mapping_framework_version: "1.0"
+  attack_version: "16.1"
+  technology_domain: enterprise-attack
+  mapping_types:
+    exploitation: reviewed defensive context
+mapping_objects:
+  - cve_id: CVE-2024-0001
+    technique_id: T1190
+    mapping_type: exploitation
+    source: reviewed source
+    confidence: high
+    rationale: defensive rationale
+    review_status: reviewed
+    defensive_note: defensive note only
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "attack",
+            "validate",
+            "--attack-source",
+            "local-curated",
+            "--attack-mapping-file",
+            str(mapping_file),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Curated ATT&CK mapping validation failed" in result.stdout
+    assert "reviewer is required" in result.stdout
+
+
+def test_cli_attack_coverage_local_curated_works_offline(tmp_path: Path) -> None:
+    output_file = tmp_path / "coverage-curated.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "attack",
+            "coverage",
+            "--input",
+            str(SAMPLE_CVES_MIXED),
+            "--attack-source",
+            "local-curated",
+            "--attack-mapping-file",
+            str(CURATED_ATTACK_MAPPING_FILE),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["metadata"]["source"] == "local-curated"
+    assert payload["summary"]["mapped_cves"] == 2
+    assert payload["summary"]["unmapped_cves"] == 3
+    assert any("Low-confidence curated" in warning for warning in payload["warnings"])
 
 
 def test_cli_attack_coverage_missing_mapping_file_exits_cleanly(tmp_path: Path) -> None:

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -149,8 +149,18 @@ def test_attack_curated_mapping_example_matches_schema() -> None:
     jsonschema.validate(payload, schema)
     jsonschema.validate(yaml_payload, schema)
     assert payload["mapping_objects"][0]["technique_id"] == "T1190"
-    assert payload["mapping_objects"][0]["confidence"] == 0.9
-    assert "commands" in payload["mapping_objects"][0]["comments"]
+    assert payload["mapping_objects"][0]["confidence"] == "high"
+    assert payload["mapping_objects"][0]["reviewer"] == "security-review"
+    assert "not exploit proof" in payload["mapping_objects"][0]["defensive_note"]
+
+
+def test_attack_curated_mapping_demo_yaml_matches_schema() -> None:
+    schema = _load_schema("attack-curated-mapping.schema.json")
+    payload = yaml.safe_load((DATA_ROOT / "cve_attack_mappings.yml").read_text(encoding="utf-8"))
+
+    jsonschema.validate(payload, schema)
+    assert len(payload["mapping_objects"]) == 6
+    assert any(item["confidence"] == "low" for item in payload["mapping_objects"])
 
 
 def test_attack_curated_mapping_schema_rejects_unreviewable_mappings() -> None:
@@ -169,6 +179,16 @@ def test_attack_curated_mapping_schema_rejects_unreviewable_mappings() -> None:
     invalid_technique["mapping_objects"][0]["technique_id"] = "TA0001"
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(invalid_technique, schema)
+
+    numeric_confidence = json.loads(json.dumps(payload))
+    numeric_confidence["mapping_objects"][0]["confidence"] = 0.9
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(numeric_confidence, schema)
+
+    missing_reviewer = json.loads(json.dumps(payload))
+    missing_reviewer["mapping_objects"][0].pop("reviewer")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(missing_reviewer, schema)
 
 
 def test_example_score_json_documents_vpw_030_operational_score() -> None:
@@ -555,6 +575,31 @@ def test_attack_validation_json_matches_published_schema(tmp_path: Path) -> None
     assert result.exit_code == 0
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     jsonschema.validate(payload, _load_schema("attack-validation-report.schema.json"))
+
+
+def test_attack_validation_local_curated_json_matches_published_schema(tmp_path: Path) -> None:
+    output_file = tmp_path / "attack-validation-curated.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "attack",
+            "validate",
+            "--attack-source",
+            "local-curated",
+            "--attack-mapping-file",
+            str(DATA_ROOT / "cve_attack_mappings.yml"),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    jsonschema.validate(payload, _load_schema("attack-validation-report.schema.json"))
+    assert payload["quality_report"]["low_confidence_count"] == 1
 
 
 def test_attack_coverage_json_matches_published_schema(tmp_path: Path) -> None:

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -23,6 +23,10 @@ from vuln_prioritizer.models import (
 from vuln_prioritizer.providers.attack import AttackProvider
 from vuln_prioritizer.providers.attack_metadata import AttackMetadataProvider
 from vuln_prioritizer.providers.ctid_mappings import CtidMappingsProvider
+from vuln_prioritizer.providers.curated_attack_mappings import (
+    CuratedAttackMappingProvider,
+    CuratedAttackMappingValidationError,
+)
 from vuln_prioritizer.providers.epss import EpssProvider
 from vuln_prioritizer.providers.kev import KevProvider
 from vuln_prioritizer.providers.nvd import NvdFetchDiagnostics, NvdProvider
@@ -1425,6 +1429,143 @@ def test_attack_provider_ctid_json_enriches_structured_attack_data() -> None:
     assert results["CVE-2023-34362"].techniques[0].name == "Exploit Public-Facing Application"
     assert results["CVE-2024-3094"].mapped is False
     assert results["CVE-2024-3094"].attack_relevance == "Unmapped"
+
+
+def test_curated_attack_mapping_provider_loads_yaml_fixture() -> None:
+    provider = CuratedAttackMappingProvider()
+
+    bundle = provider.load(DATA_ROOT / "cve_attack_mappings.yml")
+
+    assert bundle.quality_report["mapping_count"] == 6
+    assert bundle.quality_report["unique_cves"] == 6
+    assert bundle.quality_report["confidence_counts"] == {"high": 3, "low": 1, "medium": 2}
+    assert bundle.quality_report["low_confidence_count"] == 1
+    assert bundle.mappings_by_cve["CVE-2021-44228"][0].attack_object_id == "T1190"
+    assert bundle.techniques_by_id["T1195.002"].tactics == ["initial-access"]
+    assert any("Low-confidence curated" in warning for warning in bundle.warnings)
+
+
+def test_curated_attack_mapping_provider_rejects_missing_reviewer_for_reviewed(
+    tmp_path: Path,
+) -> None:
+    mapping_file = tmp_path / "curated.yml"
+    mapping_file.write_text(
+        """
+metadata:
+  mapping_framework: vuln-prioritizer-curated-attack
+  mapping_framework_version: "1.0"
+  attack_version: "16.1"
+  technology_domain: enterprise-attack
+  mapping_types:
+    exploitation: reviewed defensive context
+mapping_objects:
+  - cve_id: CVE-2024-0001
+    technique_id: T1190
+    mapping_type: exploitation
+    source: reviewed source
+    confidence: high
+    rationale: defensive rationale
+    review_status: reviewed
+    defensive_note: defensive note only
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CuratedAttackMappingValidationError, match="reviewer is required"):
+        CuratedAttackMappingProvider().load(mapping_file)
+
+
+def test_curated_attack_mapping_provider_rejects_numeric_confidence(tmp_path: Path) -> None:
+    mapping_file = tmp_path / "curated.yml"
+    mapping_file.write_text(
+        """
+metadata:
+  mapping_framework: vuln-prioritizer-curated-attack
+  mapping_framework_version: "1.0"
+  attack_version: "16.1"
+  technology_domain: enterprise-attack
+  mapping_types:
+    exploitation: reviewed defensive context
+mapping_objects:
+  - cve_id: CVE-2024-0001
+    technique_id: T1190
+    mapping_type: exploitation
+    source: reviewed source
+    confidence: 0.9
+    rationale: defensive rationale
+    review_status: reviewed
+    reviewer: security-review
+    reviewed_at: "2026-04-29"
+    defensive_note: defensive note only
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CuratedAttackMappingValidationError, match="confidence must be one"):
+        CuratedAttackMappingProvider().load(mapping_file)
+
+
+def test_curated_attack_mapping_provider_rejects_invalid_cve_and_attack_ids(
+    tmp_path: Path,
+) -> None:
+    mapping_file = tmp_path / "curated.yml"
+    mapping_file.write_text(
+        """
+metadata:
+  mapping_framework: vuln-prioritizer-curated-attack
+  mapping_framework_version: "1.0"
+  attack_version: "16.1"
+  technology_domain: enterprise-attack
+  mapping_types:
+    exploitation: reviewed defensive context
+mapping_objects:
+  - cve_id: NOT-A-CVE
+    technique_id: T1190
+    mapping_type: exploitation
+    source: reviewed source
+    confidence: medium
+    rationale: defensive rationale
+    review_status: needs_review
+    defensive_note: defensive note only
+  - cve_id: CVE-2024-0001
+    technique_id: TA0001
+    mapping_type: exploitation
+    source: reviewed source
+    confidence: medium
+    rationale: defensive rationale
+    review_status: needs_review
+    defensive_note: defensive note only
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CuratedAttackMappingValidationError) as exc_info:
+        CuratedAttackMappingProvider().load(mapping_file)
+
+    message = str(exc_info.value)
+    assert "cve_id must be a valid CVE identifier" in message
+    assert "ATT&CK technique IDs must match" in message
+
+
+def test_attack_provider_local_curated_enriches_structured_attack_data() -> None:
+    provider = AttackProvider()
+
+    results, metadata, warnings = provider.fetch_many(
+        ["CVE-2023-34362", "CVE-2024-3094", "CVE-2024-9999"],
+        enabled=True,
+        source="local-curated",
+        mapping_file=DATA_ROOT / "cve_attack_mappings.yml",
+    )
+
+    assert metadata["source"] == "local-curated"
+    assert metadata["metadata_format"] == "vuln-prioritizer-curated-yml"
+    assert len(metadata["mapping_file_sha256"] or "") == 64
+    assert any("Low-confidence curated" in warning for warning in warnings)
+    assert results["CVE-2023-34362"].mapped is True
+    assert results["CVE-2023-34362"].attack_relevance == "High"
+    assert results["CVE-2023-34362"].attack_techniques == ["T1190"]
+    assert results["CVE-2024-3094"].attack_techniques == ["T1195.002"]
+    assert results["CVE-2024-9999"].mapped is False
 
 
 def test_ctid_provider_rejects_invalid_json(tmp_path: Path) -> None:

--- a/backend/tests/test_workbench_guardrail_helpers.py
+++ b/backend/tests/test_workbench_guardrail_helpers.py
@@ -51,6 +51,7 @@ def test_workbench_attack_source_guardrails_allow_only_reviewable_sources() -> N
         validate_workbench_attack_source("blog")
 
     assert workbench_mapping_source("ctid-mappings-explorer") == "ctid"
+    assert workbench_mapping_source("local-curated") == "local_curated"
     assert workbench_mapping_source("local_curated") == "local_curated"
     assert workbench_mapping_source("manual") == "manual"
     assert workbench_mapping_source("none") == "none"

--- a/data/cve_attack_mappings.yml
+++ b/data/cve_attack_mappings.yml
@@ -1,0 +1,123 @@
+metadata:
+  mapping_framework: vuln-prioritizer-curated-attack
+  mapping_framework_version: "1.0"
+  mapping_version: "2026-04-29"
+  attack_version: "16.1"
+  technology_domain: enterprise-attack
+  creation_date: "2026-04-29"
+  last_update: "2026-04-29"
+  organization: Noetheon demo
+  author: reviewed-demo
+  contact: security@example.invalid
+  mapping_types:
+    exploitation: Reviewed defensive mapping from a CVE to initial-access context.
+    impact: Reviewed defensive mapping from a CVE to likely business-impact context.
+    post_exploitation: Reviewed defensive mapping for post-exploitation triage context.
+    mitigation_context: Reviewed mapping used only to guide mitigation review.
+    detection_context: Reviewed mapping used only to guide detection coverage review.
+mapping_objects:
+  - cve_id: CVE-2021-44228
+    technique_id: T1190
+    technique_name: Exploit Public-Facing Application
+    tactic_ids:
+      - TA0001
+    mapping_type: exploitation
+    capability_group: public-facing-application-risk
+    source: CTID Mappings Explorer review
+    source_url: https://ctid.mitre.org/projects/mappings-explorer
+    confidence: high
+    rationale: Reviewed defensive context links public-facing vulnerable application exposure to initial-access triage.
+    review_status: reviewed
+    reviewer: security-review
+    reviewed_at: "2026-04-29"
+    defensive_note: Use this mapping to prioritize patching, exposure review, and detection coverage. It is not exploit proof or procedure guidance.
+    comments: Safe demo entry for defensive triage only.
+    references:
+      - https://ctid.mitre.org/projects/mappings-explorer
+  - cve_id: CVE-2023-34362
+    technique_id: T1190
+    technique_name: Exploit Public-Facing Application
+    tactic_ids:
+      - TA0001
+    mapping_type: exploitation
+    capability_group: managed-file-transfer-risk
+    source: CTID Mappings Explorer review
+    source_url: https://ctid.mitre.org/projects/mappings-explorer
+    confidence: high
+    rationale: Reviewed defensive context links exposed managed file transfer systems to initial-access triage.
+    review_status: reviewed
+    reviewer: security-review
+    reviewed_at: "2026-04-29"
+    defensive_note: Use this mapping for exposure review and remediation sequencing only.
+    comments: Defensive mapping summary without payloads or procedure steps.
+    references:
+      - https://ctid.mitre.org/projects/mappings-explorer
+  - cve_id: CVE-2024-3094
+    technique_id: T1195.002
+    technique_name: Compromise Software Supply Chain
+    tactic_ids:
+      - TA0001
+    mapping_type: exploitation
+    capability_group: supply-chain-risk
+    source: Maintainer review of public advisory context
+    source_url: https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094
+    confidence: medium
+    rationale: Reviewed defensive context links the CVE to supply-chain exposure review and affected package inventory triage.
+    review_status: reviewed
+    reviewer: security-review
+    reviewed_at: "2026-04-29"
+    defensive_note: Use this mapping to guide inventory review, package remediation, and detection coverage checks only.
+    comments: Defensive context only; no reproduction, payload, or command guidance.
+    references:
+      - https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094
+  - cve_id: CVE-2022-22965
+    technique_id: T1190
+    technique_name: Exploit Public-Facing Application
+    tactic_ids:
+      - TA0001
+    mapping_type: exploitation
+    capability_group: java-web-application-risk
+    source: CTID Mappings Explorer review
+    source_url: https://ctid.mitre.org/projects/mappings-explorer
+    confidence: high
+    rationale: Reviewed defensive context links vulnerable internet-facing Java application exposure to initial-access triage.
+    review_status: reviewed
+    reviewer: security-review
+    reviewed_at: "2026-04-29"
+    defensive_note: Use this mapping to prioritize remediation and exposure reduction only.
+    comments: Defensive prioritization note with no exploit procedure detail.
+    references:
+      - https://ctid.mitre.org/projects/mappings-explorer
+  - cve_id: CVE-2023-3519
+    technique_id: T1190
+    technique_name: Exploit Public-Facing Application
+    tactic_ids:
+      - TA0001
+    mapping_type: exploitation
+    capability_group: edge-appliance-risk
+    source: CTID Mappings Explorer review
+    source_url: https://ctid.mitre.org/projects/mappings-explorer
+    confidence: medium
+    rationale: Reviewed defensive context links exposed edge appliance findings to initial-access triage and patch sequencing.
+    review_status: reviewed
+    reviewer: security-review
+    reviewed_at: "2026-04-29"
+    defensive_note: Use this mapping for remediation prioritization and monitoring coverage only.
+    comments: Defensive mapping summary without operational attack steps.
+    references:
+      - https://ctid.mitre.org/projects/mappings-explorer
+  - cve_id: CVE-2021-26855
+    technique_id: T1046
+    technique_name: Network Service Discovery
+    tactic_ids:
+      - TA0007
+    mapping_type: detection_context
+    capability_group: exchange-server-review
+    source: Maintainer defensive coverage review
+    confidence: low
+    rationale: Low-confidence defensive context used only to flag related service inventory and monitoring review.
+    review_status: needs_review
+    defensive_note: Treat this mapping as a review queue hint, not as confirmed exploitation behavior.
+    comments: Low-confidence entry intentionally retained to prove quality-report flagging.
+    references:
+      - https://www.cisa.gov/news-events/alerts/2021/03/03/mitigate-microsoft-exchange-server-vulnerabilities

--- a/docs/attack-ttp-methodology.md
+++ b/docs/attack-ttp-methodology.md
@@ -21,11 +21,11 @@ Every curated mapping object must include:
 
 | Field | Requirement |
 | --- | --- |
-| `capability_id` | CVE identifier such as `CVE-2021-44228`. |
-| `attack_object_id` | ATT&CK technique or sub-technique ID, matching `T####` or `T####.###`. |
+| `cve_id` | CVE identifier such as `CVE-2021-44228`. `capability_id` may be supplied only as a CTID-compatible alias. |
+| `technique_id` | ATT&CK technique or sub-technique ID, matching `T####` or `T####.###`. `attack_object_id` may be supplied only as a CTID-compatible alias. |
 | `mapping_type` | One of `exploitation`, `impact`, `post_exploitation`, `mitigation_context`, or `detection_context`. |
 | `source` | Human-readable source for the mapping. |
-| `confidence` | Numeric value from `0.0` through `1.0`. |
+| `confidence` | Enum bucket: `low`, `medium`, or `high`. Numeric confidence values are rejected by the curated artifact validator. |
 | `rationale` | Defensive reason for the mapping. |
 | `review_status` | One of `unreviewed`, `needs_review`, `reviewed`, `rejected`, or `stale`. |
 | `defensive_note` | Required safety note that frames the mapping as defensive context only. |
@@ -34,13 +34,23 @@ Optional fields such as `capability_description`, `comments`, and `references`
 must remain high-level defensive context. They must not contain exploit payloads,
 reproduction steps, credential-testing guidance, or command sequences.
 
+Reviewer rules are enforced by the loader and schema:
+
+- `review_status=reviewed`, `rejected`, or `stale` requires `reviewer` and
+  `reviewed_at`.
+- `confidence=high` requires `review_status=reviewed`.
+- `confidence=low` remains valid but is highlighted in the mapping quality
+  report.
+
 ## Schema And Example
 
 - Schema: [`docs/schemas/attack-curated-mapping.schema.json`](schemas/attack-curated-mapping.schema.json)
 - Example: [`docs/examples/example_attack_curated_mapping.json`](examples/example_attack_curated_mapping.json)
 
-The schema accepts JSON and YAML-compatible object shapes after parsing. YAML
-files should use the same keys as the JSON example.
+The canonical demo file for the duplicate VPW execution track is
+`data/cve_attack_mappings.yml`. The schema accepts JSON and YAML-compatible
+object shapes after parsing. YAML files should use the same keys as the JSON
+example.
 
 ## Validation
 
@@ -48,9 +58,10 @@ Use the published schema for local artifact checks:
 
 ```bash
 python3 -m pytest -q backend/tests/test_output_schemas.py::test_attack_curated_mapping_example_matches_schema --no-cov
+python3 -m vuln_prioritizer.cli attack validate --attack-source local-curated --attack-mapping-file data/cve_attack_mappings.yml --format json
 ```
 
-The schema rejects missing `source`, `rationale`, or `confidence` fields and
-rejects malformed ATT&CK technique IDs. Free-text safety still requires human
-review; JSON Schema cannot reliably prove that prose contains no offensive
-procedure guidance.
+The schema and loader reject missing `source`, `rationale`, `confidence`,
+reviewer metadata, and malformed ATT&CK technique IDs. Free-text safety still
+requires human review; JSON Schema cannot reliably prove that prose contains no
+offensive procedure guidance.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -79,7 +79,9 @@ Published JSON schemas in `docs/schemas/` cover:
 the `input normalize --format json` compatibility alias.
 `attack-curated-mapping.schema.json` is a local ATT&CK mapping artifact schema
 for reviewed JSON or YAML-compatible curated mapping files. It is an input
-contract, not a command output report.
+contract, not a command output report. Its `confidence` field is a `low`,
+`medium`, or `high` enum; the loader emits numeric confidence only internally
+for compatibility with existing enrichment models.
 
 `report html` is a secondary renderer over the analysis JSON contract. It does not define its own independent source model.
 `report evidence-bundle` is a ZIP transport over the analysis JSON contract. Its published machine contract is the `manifest.json` stored inside the bundle.
@@ -211,7 +213,8 @@ ATT&CK fields are optional enrichment.
 
 Current guarantees:
 
-- ATT&CK is local-file sourced only
+- ATT&CK is local-file sourced only through `ctid-json`, reviewed
+  `local-curated`, or legacy `local-csv`
 - no heuristic or LLM-generated CVE-to-ATT&CK mapping is performed
 - `attack_relevance` is a contextual, explainable helper label produced locally by this CLI
 - absence of ATT&CK data is represented as unmapped context, not guessed context

--- a/docs/evidence/vpw-056-curated-attack-loader.md
+++ b/docs/evidence/vpw-056-curated-attack-loader.md
@@ -1,0 +1,61 @@
+# VPW-056 Curated ATT&CK Mapping Loader Evidence
+
+## Scope
+
+VPW-056 adds a reviewed local CVE-to-ATT&CK mapping path for
+`data/cve_attack_mappings.yml`.
+
+Implemented scope:
+
+- `local-curated` ATT&CK source for CLI validation, coverage, navigator, and
+  analysis option resolution.
+- YAML/JSON curated mapping loader with CVE ID, ATT&CK technique ID, confidence
+  enum, source, rationale, reviewer, and defensive-note validation.
+- Versioned demo mapping file with six defensive mappings.
+- Mapping quality report with low-confidence and review-status counts.
+
+## Evidence Artifacts
+
+- Demo mapping file: `data/cve_attack_mappings.yml`
+- Mapping quality report: `docs/evidence/vpw-056-mapping-quality-report.json`
+- Curated mapping schema: `docs/schemas/attack-curated-mapping.schema.json`
+- Methodology: `docs/attack-ttp-methodology.md`
+
+## Mapping Quality Summary
+
+- Mapping count: 6
+- Unique CVEs: 6
+- Unique techniques: 3
+- Confidence distribution: `high=3`, `medium=2`, `low=1`
+- Review status distribution: `reviewed=5`, `needs_review=1`
+- Low-confidence mappings: 1
+
+The low-confidence entry is intentionally retained to prove validator/report
+flagging:
+
+- `CVE-2021-26855` / `T1046`, `review_status=needs_review`
+
+## Safety Review
+
+- Heuristic and LLM-generated sources are rejected by the loader.
+- `review_status=reviewed`, `rejected`, or `stale` requires `reviewer` and
+  `reviewed_at`.
+- `confidence=high` requires `review_status=reviewed`.
+- Free-text `rationale`, `comments`, and `defensive_note` remain defensive
+  triage context only. The validator enforces required fields, but human review
+  remains responsible for prose safety.
+
+## Commands
+
+```bash
+python3 -m pytest -q backend/tests/test_providers.py::test_curated_attack_mapping_provider_loads_yaml_fixture backend/tests/test_providers.py::test_curated_attack_mapping_provider_rejects_missing_reviewer_for_reviewed backend/tests/test_providers.py::test_curated_attack_mapping_provider_rejects_numeric_confidence backend/tests/test_providers.py::test_curated_attack_mapping_provider_rejects_invalid_cve_and_attack_ids backend/tests/test_providers.py::test_attack_provider_local_curated_enriches_structured_attack_data --no-cov
+python3 -m pytest -q backend/tests/test_output_schemas.py::test_published_schema_documents_are_valid_json_schema backend/tests/test_output_schemas.py::test_attack_curated_mapping_example_matches_schema backend/tests/test_output_schemas.py::test_attack_curated_mapping_demo_yaml_matches_schema backend/tests/test_output_schemas.py::test_attack_curated_mapping_schema_rejects_unreviewable_mappings backend/tests/test_output_schemas.py::test_attack_validation_local_curated_json_matches_published_schema --no-cov
+python3 -m pytest -q backend/tests/test_cli_attack.py::test_cli_attack_validate_local_curated_reports_quality backend/tests/test_cli_attack.py::test_cli_attack_validate_local_curated_invalid_file_exits_cleanly backend/tests/test_cli_attack.py::test_cli_attack_coverage_local_curated_works_offline --no-cov
+python3 -m pytest -q backend/tests/test_attack_enrichment.py::test_attack_enrichment_service_marks_curated_context_relevance backend/tests/test_analysis_refactor.py::test_analysis_service_resolves_attack_option_modes backend/tests/test_workbench_guardrail_helpers.py::test_workbench_attack_source_guardrails_allow_only_reviewable_sources --no-cov
+python3 -m vuln_prioritizer.cli attack validate --attack-source local-curated --attack-mapping-file data/cve_attack_mappings.yml --output docs/evidence/vpw-056-mapping-quality-report.json --format json
+make docs-check
+make check
+```
+
+Targeted test result: 16 passed.
+Full gate result: 780 passed, 5 skipped, coverage 90.61%.

--- a/docs/evidence/vpw-056-mapping-quality-report.json
+++ b/docs/evidence/vpw-056-mapping-quality-report.json
@@ -1,0 +1,87 @@
+{
+  "attack_version": "16.1",
+  "attack_version_mismatch": false,
+  "confidence_counts": {
+    "high": 3,
+    "low": 1,
+    "medium": 2
+  },
+  "domain": "enterprise-attack",
+  "domain_mismatch": false,
+  "low_confidence_count": 1,
+  "mapping_author": "reviewed-demo",
+  "mapping_contact": "security@example.invalid",
+  "mapping_count": 6,
+  "mapping_created_at": "2026-04-29",
+  "mapping_file": "data/cve_attack_mappings.yml",
+  "mapping_file_sha256": "fe4918329b0efeb01f53fec495d784b2a148f28b265dae497740f835d2968436",
+  "mapping_framework": "vuln-prioritizer-curated-attack",
+  "mapping_framework_version": "1.0",
+  "mapping_organization": "Noetheon demo",
+  "mapping_type_counts": {
+    "detection_context": 1,
+    "exploitation": 5
+  },
+  "mapping_updated_at": "2026-04-29",
+  "metadata_format": "vuln-prioritizer-curated-yml",
+  "metadata_source": "local-curated",
+  "missing_metadata_ids": [],
+  "quality_report": {
+    "confidence_counts": {
+      "high": 3,
+      "low": 1,
+      "medium": 2
+    },
+    "low_confidence_count": 1,
+    "low_confidence_mappings": [
+      {
+        "confidence": "low",
+        "cve_id": "CVE-2021-26855",
+        "review_status": "needs_review",
+        "technique_id": "T1046"
+      }
+    ],
+    "mapping_count": 6,
+    "mapping_file": "data/cve_attack_mappings.yml",
+    "mapping_file_sha256": "fe4918329b0efeb01f53fec495d784b2a148f28b265dae497740f835d2968436",
+    "mapping_type_counts": {
+      "detection_context": 1,
+      "exploitation": 5
+    },
+    "review_status_counts": {
+      "needs_review": 1,
+      "reviewed": 5
+    },
+    "safety_review": {
+      "defensive_notes_required": true,
+      "free_text_requires_human_review": true,
+      "heuristic_or_llm_sources_rejected": true,
+      "reviewer_required_for_reviewed_status": true
+    },
+    "schema_version": "1.0.0",
+    "source": "local-curated",
+    "unique_cves": 6,
+    "unique_techniques": 3,
+    "warnings": [
+      "Low-confidence curated ATT&CK mapping marked for review: CVE-2021-26855 / T1046.",
+      "Curated ATT&CK mapping is not fully reviewed: CVE-2021-26855 / T1046 has status needs_review."
+    ]
+  },
+  "review_status_counts": {
+    "needs_review": 1,
+    "reviewed": 5
+  },
+  "revoked_or_deprecated_count": 0,
+  "schema_version": "1.2.0",
+  "source": "local-curated",
+  "source_version": "1.0",
+  "stix_spec_version": null,
+  "technique_count": 3,
+  "technique_metadata_file": null,
+  "technique_metadata_file_sha256": null,
+  "unique_cves": 6,
+  "warnings": [
+    "Low-confidence curated ATT&CK mapping marked for review: CVE-2021-26855 / T1046.",
+    "Curated ATT&CK mapping is not fully reviewed: CVE-2021-26855 / T1046 has status needs_review."
+  ]
+}

--- a/docs/examples/example_attack_curated_mapping.json
+++ b/docs/examples/example_attack_curated_mapping.json
@@ -31,9 +31,11 @@
       "capability_description": "Public-facing application exposure can raise defensive triage urgency when the CVE is present.",
       "source": "CTID Mappings Explorer review",
       "source_url": "https://ctid.mitre.org/projects/mappings-explorer",
-      "confidence": 0.9,
+      "confidence": "high",
       "rationale": "Reviewed mapping links the CVE to defensive initial-access context for exposure and detection review.",
       "review_status": "reviewed",
+      "reviewer": "security-review",
+      "reviewed_at": "2026-04-29",
       "defensive_note": "Use this mapping to prioritize remediation, exposure review, and detection coverage. It is not exploit proof or procedure guidance.",
       "comments": "Safe demo entry with no commands, payloads, or step-by-step procedure content.",
       "references": [

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -40,9 +40,11 @@ For XML ingest, the parser rejects `DOCTYPE` and `ENTITY` declarations before pa
 
 ### ATT&CK
 
-Two local ATT&CK modes exist:
+Three local ATT&CK modes exist:
 
 - `local-csv`: legacy compatibility mode for small hand-authored CSV mappings
+- `local-curated`: reviewed YAML/JSON curated mappings with confidence enum,
+  source, rationale, reviewer metadata, and defensive notes
 - `ctid-json`: structured CTID Mappings Explorer JSON plus local ATT&CK technique metadata
 
 The `ctid-json` workflow is the preferred current ATT&CK path.
@@ -57,6 +59,8 @@ ATT&CK rules:
 - curated local mappings require source, confidence, rationale, review status,
   and a defensive note; they must not include exploit payloads, commands, or
   step-by-step procedure guidance
+- curated local mapping confidence is one of `low`, `medium`, or `high`;
+  low-confidence entries are preserved but highlighted in the quality report
 
 ## ATT&CK Data Model
 
@@ -78,9 +82,9 @@ Compatibility projections remain available:
 
 `attack_relevance` is deterministic, local to this tool, and separate from the main priority label. It is not an official CTID field and it does not override the primary `CVSS + EPSS + KEV` priority:
 
-- `High`: at least one `exploitation_technique` or `primary_impact`, or tactics in the high-impact set
-- `Medium`: only `secondary_impact`, or mapped but incomplete metadata
-- `Low`: only `uncategorized`
+- `High`: at least one `exploitation_technique`, `primary_impact`, `exploitation`, or `impact`, or tactics in the high-impact set
+- `Medium`: only `secondary_impact` or `post_exploitation`, or mapped but incomplete metadata
+- `Low`: only `uncategorized`, `mitigation_context`, or `detection_context`
 - `Unmapped`: no CTID mapping found
 
 High-impact tactics are:

--- a/docs/schemas/attack-curated-mapping.schema.json
+++ b/docs/schemas/attack-curated-mapping.schema.json
@@ -141,9 +141,13 @@
           "type": "string"
         },
         "confidence": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Reviewer confidence bucket. The loader normalizes this enum internally; numeric confidence values are not accepted by the curated artifact contract."
         },
         "rationale": {
           "type": "string",
@@ -158,6 +162,14 @@
             "rejected",
             "stale"
           ]
+        },
+        "reviewer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewed_at": {
+          "type": "string",
+          "minLength": 1
         },
         "defensive_note": {
           "type": "string",
@@ -175,7 +187,50 @@
           },
           "uniqueItems": true
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "review_status": {
+                "enum": [
+                  "reviewed",
+                  "rejected",
+                  "stale"
+                ]
+              }
+            },
+            "required": [
+              "review_status"
+            ]
+          },
+          "then": {
+            "required": [
+              "reviewer",
+              "reviewed_at"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "confidence": {
+                "const": "high"
+              }
+            },
+            "required": [
+              "confidence"
+            ]
+          },
+          "then": {
+            "properties": {
+              "review_status": {
+                "const": "reviewed"
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/docs/schemas/attack-validation-report.schema.json
+++ b/docs/schemas/attack-validation-report.schema.json
@@ -113,6 +113,24 @@
       "type": "integer",
       "minimum": 0
     },
+    "quality_report": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Present for --attack-source local-curated. Contains mapping quality, review status, confidence, and safety-review counts."
+    },
+    "low_confidence_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "review_status_counts": {
+      "$ref": "#/$defs/countMap"
+    },
+    "confidence_counts": {
+      "$ref": "#/$defs/countMap"
+    },
+    "mapping_type_counts": {
+      "$ref": "#/$defs/countMap"
+    },
     "warnings": {
       "$ref": "#/$defs/stringArray"
     }
@@ -128,6 +146,13 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "countMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
       }
     }
   }

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -56,7 +56,7 @@ Maintainer-facing parser fixture regression coverage is documented in
 
 | Feature | `analyze` | `compare` | `explain` | Notes |
 | --- | --- | --- | --- | --- |
-| ATT&CK enrichment | yes | yes | yes | Sources: `none`, `local-csv`, `ctid-json`. Prefer `ctid-json`; `local-csv` remains legacy compatibility only. Technique metadata can use the simplified local JSON or a pinned ATT&CK STIX bundle. No remote ATT&CK dependency. |
+| ATT&CK enrichment | yes | yes | yes | Sources: `none`, `local-csv`, `local-curated`, `ctid-json`. Prefer `ctid-json`; `local-curated` is for reviewed YAML/JSON CVE-to-ATT&CK mappings; `local-csv` remains legacy compatibility only. Technique metadata can use the simplified local JSON or a pinned ATT&CK STIX bundle. No remote ATT&CK dependency. |
 | Defensive context file | yes | yes | yes | `--defensive-context-file` reads a local/offline JSON overlay for OSV, GHSA, Vulnrichment, or SSVC evidence you already have. It is contextual evidence only; it does not fetch advisory data and does not change base priority scoring from CVSS, EPSS, and KEV. |
 | Asset context CSV | yes | yes | yes | `target_kind` stays exact; `target_ref` supports deterministic `exact` and `glob` rules with optional `rule_id`, `match_mode`, `precedence`, and aggregated conflict reporting. |
 | VEX files | yes | yes | yes | Supports OpenVEX JSON and CycloneDX VEX JSON with deterministic ranked matching, occurrence-level match provenance, aggregated conflict reporting, and visible `under_investigation` status. |

--- a/docs/workbench-attack-methodology.md
+++ b/docs/workbench-attack-methodology.md
@@ -26,6 +26,9 @@ Workbench ATT&CK enrichment is evidence-based and deterministic.
   and a defensive note. Free-text comments must stay at defensive triage or
   detection-context level and must not include exploit payloads, commands, or
   step-by-step procedure guidance.
+- Curated local mapping confidence is a `low`, `medium`, or `high` enum. High
+  confidence requires `review_status=reviewed`; reviewed, rejected, and stale
+  entries require `reviewer` and `reviewed_at` metadata.
 
 Analyst annotations are outside the current Workbench contract. If added later, they need separate storage and display from CTID mappings.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - VPW-053 Report Downloads: evidence/vpw-053-report-downloads.md
       - VPW-054 Report Snapshots: evidence/vpw-054-report-snapshots.md
       - VPW-055 ATT&CK Models And Schema: evidence/vpw-055-attack-models-schema.md
+      - VPW-056 Curated ATT&CK Loader: evidence/vpw-056-curated-attack-loader.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary

Implements VPW-056 for the duplicate VPW roadmap execution track.

- adds `local-curated` ATT&CK source support for reviewed YAML/JSON CVE-to-ATT&CK mappings
- adds `data/cve_attack_mappings.yml` with 6 defensive demo mappings
- validates CVE IDs, ATT&CK technique IDs, confidence enum, source/rationale, reviewer rules, and defensive notes
- emits a mapping quality report with low-confidence and review-status counts
- updates schema, contracts, methodology docs, evidence, and tests

Closes #162.

## Evidence

- `docs/evidence/vpw-056-curated-attack-loader.md`
- `docs/evidence/vpw-056-mapping-quality-report.json`

## Validation

- `python3 -m pytest -q ... --no-cov` targeted VPW-056 tests: 16 passed
- `python3 -m vuln_prioritizer.cli attack validate --attack-source local-curated --attack-mapping-file data/cve_attack_mappings.yml --output docs/evidence/vpw-056-mapping-quality-report.json --format json`
- `make docs-check` passed; existing mkdocs info only for `architecture/vpw-011-api-skeleton.md`
- `make check` passed: 780 passed, 5 skipped, coverage 90.61%

## Residual Risk

Free-text safety in curated rationale/comments still requires human review; the loader enforces required metadata and rejects heuristic/LLM sources, but it cannot prove all prose is safe by itself.
