### PR TITLE
VPW-057: Enrich findings with ATT&CK context

### DIFF
--- a/backend/src/vuln_prioritizer/api/schemas.py
+++ b/backend/src/vuln_prioritizer/api/schemas.py
@@ -432,8 +432,32 @@ class FindingResponse(StrictModel):
     status_history: list[FindingStatusHistoryResponse] | None = None
 
 
+class FindingAttackContextResponse(StrictModel):
+    finding_id: str
+    cve_id: str
+    mapped: bool
+    source: str
+    source_version: str | None = None
+    source_hash: str | None = None
+    source_path: str | None = None
+    attack_version: str | None = None
+    domain: str | None = None
+    metadata_hash: str | None = None
+    metadata_path: str | None = None
+    attack_relevance: str
+    threat_context_rank: int
+    rationale: str | None = None
+    confidence: str | None = None
+    low_confidence: bool = False
+    review_status: str
+    techniques: list[dict[str, Any]] = Field(default_factory=list)
+    tactics: list[str] = Field(default_factory=list)
+    mappings: list[dict[str, Any]] = Field(default_factory=list)
+
+
 class FindingDetailResponse(FindingResponse):
     kev_detail: KevDetailResponse | None = None
+    attack_context: FindingAttackContextResponse | None = None
 
 
 class FindingsListResponse(StrictModel):
@@ -524,27 +548,6 @@ class AttackTechniqueSummary(StrictModel):
     url: str | None = None
     count: int
     cves: list[str] = Field(default_factory=list)
-
-
-class FindingAttackContextResponse(StrictModel):
-    finding_id: str
-    cve_id: str
-    mapped: bool
-    source: str
-    source_version: str | None = None
-    source_hash: str | None = None
-    source_path: str | None = None
-    attack_version: str | None = None
-    domain: str | None = None
-    metadata_hash: str | None = None
-    metadata_path: str | None = None
-    attack_relevance: str
-    threat_context_rank: int
-    rationale: str | None = None
-    review_status: str
-    techniques: list[dict[str, Any]] = Field(default_factory=list)
-    tactics: list[str] = Field(default_factory=list)
-    mappings: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class TopTechniquesResponse(StrictModel):

--- a/backend/src/vuln_prioritizer/api/workbench_payloads.py
+++ b/backend/src/vuln_prioritizer/api/workbench_payloads.py
@@ -120,6 +120,7 @@ def _finding_payload(finding: Any, *, include_detail: bool = False) -> dict[str,
     if include_detail:
         payload["finding"] = finding.finding_json
         payload["kev_detail"] = _finding_kev_detail(finding)
+        payload["attack_context"] = _finding_attack_context(finding)
         payload["occurrences"] = [item.evidence_json for item in finding.occurrences]
         payload["status_history"] = [
             _finding_status_history_payload(item) for item in getattr(finding, "status_history", [])
@@ -275,7 +276,22 @@ def _latest_threat_context_rank(finding: Any) -> int | None:
     return min(int(context.threat_context_rank) for context in contexts)
 
 
+def _finding_attack_context(finding: Any) -> dict[str, Any] | None:
+    contexts = getattr(finding, "attack_contexts", None) or []
+    if not contexts:
+        return None
+    context = sorted(
+        contexts,
+        key=lambda item: (
+            int(getattr(item, "threat_context_rank", 99)),
+            str(getattr(item, "created_at", "")),
+        ),
+    )[0]
+    return _attack_context_payload(context, finding_id=finding.id)
+
+
 def _attack_context_payload(context: Any, *, finding_id: str) -> dict[str, Any]:
+    confidence = _attack_context_confidence(context)
     return {
         "finding_id": finding_id,
         "cve_id": context.cve_id,
@@ -291,11 +307,35 @@ def _attack_context_payload(context: Any, *, finding_id: str) -> dict[str, Any]:
         "attack_relevance": context.attack_relevance,
         "threat_context_rank": context.threat_context_rank,
         "rationale": context.rationale,
+        "confidence": confidence,
+        "low_confidence": confidence == "low",
         "review_status": context.review_status,
         "techniques": context.techniques_json or [],
         "tactics": context.tactics_json or [],
         "mappings": context.mappings_json or [],
     }
+
+
+def _attack_context_confidence(context: Any) -> str | None:
+    mappings = [item for item in (context.mappings_json or []) if isinstance(item, dict)]
+    labels = {
+        str(item["confidence"]).strip().lower()
+        for item in mappings
+        if str(item.get("confidence") or "").strip().lower() in {"low", "medium", "high"}
+    }
+    if "low" in labels:
+        return "low"
+    if "medium" in labels:
+        return "medium"
+    if "high" in labels:
+        return "high"
+    if not context.mapped:
+        return None
+    if context.source == "ctid":
+        return "high"
+    if context.source in {"local_curated", "manual"}:
+        return "medium"
+    return None
 
 
 def _attack_review_queue_item_payload(context: Any) -> dict[str, Any]:

--- a/backend/src/vuln_prioritizer/explanations.py
+++ b/backend/src/vuln_prioritizer/explanations.py
@@ -205,6 +205,29 @@ def _explanation_notes(finding: PrioritizedFinding) -> list[ExplanationNote]:
                 message="An active or review-due waiver records accepted risk for this finding.",
             )
         )
+    if finding.attack_mapped:
+        notes.append(
+            ExplanationNote(
+                code="attack.context",
+                source="MITRE ATT&CK",
+                message=(
+                    "ATT&CK context is reported separately from base priority and does not "
+                    "change the hard priority label."
+                ),
+            )
+        )
+    if finding.attack_context.low_confidence:
+        notes.append(
+            ExplanationNote(
+                code="attack.low_confidence",
+                source="MITRE ATT&CK",
+                severity="warning",
+                message=(
+                    "Low-confidence ATT&CK context is retained for review and does not change "
+                    "base priority."
+                ),
+            )
+        )
     if _asset_context_unknown(finding):
         notes.append(
             ExplanationNote(

--- a/backend/src/vuln_prioritizer/models.py
+++ b/backend/src/vuln_prioritizer/models.py
@@ -17,6 +17,7 @@ import vuln_prioritizer.models_waivers as _models_waivers
 from vuln_prioritizer.model_base import StrictModel
 
 AttackData = _models_attack.AttackData
+AttackConfidence = _models_attack.AttackConfidence
 AttackTactic = _models_attack.AttackTactic
 AttackMapping = _models_attack.AttackMapping
 AttackMappingType = _models_attack.AttackMappingType
@@ -25,6 +26,7 @@ AttackSummary = _models_attack.AttackSummary
 AttackTechnique = _models_attack.AttackTechnique
 CveAttackMapping = _models_attack.CveAttackMapping
 FindingAttackContext = _models_attack.FindingAttackContext
+FindingAttackContextSummary = _models_attack.FindingAttackContextSummary
 AssetContextRecord = _models_input.AssetContextRecord
 BusinessImpactBlock = _models_decision.BusinessImpactBlock
 ContextPolicyProfile = _models_input.ContextPolicyProfile
@@ -230,6 +232,7 @@ class PrioritizedFinding(StrictModel):
     attack_note: str | None = None
     attack_mappings: list[AttackMapping] = Field(default_factory=list)
     attack_technique_details: list[AttackTechnique] = Field(default_factory=list)
+    attack_context: FindingAttackContextSummary = Field(default_factory=FindingAttackContextSummary)
     provenance: FindingProvenance = Field(default_factory=FindingProvenance)
     context_summary: str | None = None
     context_recommendation: str | None = None

--- a/backend/src/vuln_prioritizer/models_attack.py
+++ b/backend/src/vuln_prioritizer/models_attack.py
@@ -12,6 +12,7 @@ from vuln_prioritizer.model_base import StrictModel
 ATTACK_TECHNIQUE_ID_PATTERN = r"^T\d{4}(?:\.\d{3})?$"
 ATTACK_TACTIC_ID_PATTERN = r"^TA\d{4}$"
 ATTACK_REVIEW_STATUSES = ("unreviewed", "needs_review", "reviewed", "rejected", "stale")
+ATTACK_CONFIDENCE_LEVELS = ("low", "medium", "high")
 ATTACK_MAPPING_TYPES = (
     "exploitation",
     "impact",
@@ -24,6 +25,7 @@ _TECHNIQUE_ID_RE = re.compile(ATTACK_TECHNIQUE_ID_PATTERN)
 _TACTIC_ID_RE = re.compile(ATTACK_TACTIC_ID_PATTERN)
 
 AttackReviewStatus = Literal["unreviewed", "needs_review", "reviewed", "rejected", "stale"]
+AttackConfidence = Literal["low", "medium", "high"]
 AttackMappingType = Literal[
     "exploitation",
     "impact",
@@ -81,6 +83,12 @@ class AttackMapping(StrictModel):
     capability_group: str | None = None
     capability_description: str | None = None
     comments: str | None = None
+    source: str | None = None
+    confidence: AttackConfidence | None = None
+    review_status: AttackReviewStatus | None = None
+    defensive_note: str | None = None
+    reviewer: str | None = None
+    reviewed_at: str | None = None
     references: list[str] = Field(default_factory=list)
 
 
@@ -151,6 +159,22 @@ class FindingAttackContext(StrictModel):
         if self.mapped and not self.mappings:
             raise ValueError("mapped finding ATT&CK context requires at least one mapping.")
         return self
+
+
+class FindingAttackContextSummary(StrictModel):
+    cve_id: str = ""
+    mapped: bool = False
+    source: str = "none"
+    source_version: str | None = None
+    attack_version: str | None = None
+    domain: str | None = None
+    attack_relevance: str = "Unmapped"
+    rationale: str | None = None
+    confidence: AttackConfidence | None = None
+    low_confidence: bool = False
+    techniques: list[AttackTechnique] = Field(default_factory=list)
+    tactics: list[str] = Field(default_factory=list)
+    mappings: list[AttackMapping] = Field(default_factory=list)
 
 
 class AttackSummary(StrictModel):

--- a/backend/src/vuln_prioritizer/providers/curated_attack_mappings.py
+++ b/backend/src/vuln_prioritizer/providers/curated_attack_mappings.py
@@ -17,6 +17,7 @@ from vuln_prioritizer.attack_sources import (
     WORKBENCH_DISALLOWED_MAPPING_SOURCES,
 )
 from vuln_prioritizer.models import (
+    AttackConfidence,
     AttackMapping,
     AttackMappingType,
     AttackReviewStatus,
@@ -120,6 +121,12 @@ class CuratedAttackMappingProvider:
                     or parsed.mapping_type,
                     capability_description=parsed.rationale,
                     comments=_curated_mapping_comment(parsed, confidence_label),
+                    source=ATTACK_SOURCE_LOCAL_CURATED,
+                    confidence=cast(AttackConfidence, confidence_label),
+                    review_status=parsed.review_status,
+                    defensive_note=parsed.defensive_note,
+                    reviewer=parsed.metadata.get("reviewer"),
+                    reviewed_at=parsed.metadata.get("reviewed_at"),
                     references=parsed.references,
                 )
             )

--- a/backend/src/vuln_prioritizer/services/prioritization.py
+++ b/backend/src/vuln_prioritizer/services/prioritization.py
@@ -8,10 +8,12 @@ from typing import Literal
 
 from vuln_prioritizer.explanations import build_priority_explanation
 from vuln_prioritizer.models import (
+    AttackConfidence,
     AttackData,
     ComparisonFinding,
     ContextPolicyProfile,
     EpssData,
+    FindingAttackContextSummary,
     FindingProvenance,
     KevData,
     NvdData,
@@ -92,6 +94,7 @@ class PrioritizationService:
                     attack_note=attack.attack_note,
                     attack_mappings=attack.mappings,
                     attack_technique_details=attack.techniques,
+                    attack_context=_attack_context_summary(cve_id, attack),
                     provenance=provenance,
                     context_summary=context_summary,
                     context_recommendation=context_recommendation,
@@ -278,6 +281,36 @@ class PrioritizationService:
         """Count findings by enriched priority label."""
         counts = Counter(finding.priority_label for finding in findings)
         return dict(counts)
+
+
+def _attack_context_summary(cve_id: str, attack: AttackData) -> FindingAttackContextSummary:
+    confidence = _aggregate_mapping_confidence(attack)
+    return FindingAttackContextSummary(
+        cve_id=cve_id,
+        mapped=attack.mapped,
+        source=attack.source,
+        source_version=attack.source_version,
+        attack_version=attack.attack_version,
+        domain=attack.domain,
+        attack_relevance=attack.attack_relevance,
+        rationale=attack.attack_rationale,
+        confidence=confidence,
+        low_confidence=confidence == "low",
+        techniques=attack.techniques if attack.mapped else [],
+        tactics=attack.attack_tactics if attack.mapped else [],
+        mappings=attack.mappings if attack.mapped else [],
+    )
+
+
+def _aggregate_mapping_confidence(attack: AttackData) -> AttackConfidence | None:
+    labels = [mapping.confidence for mapping in attack.mappings if mapping.confidence is not None]
+    if not labels:
+        return None
+    if "low" in labels:
+        return "low"
+    if "medium" in labels:
+        return "medium"
+    return "high"
 
 
 def _finding_sort_key(finding: PrioritizedFinding, sort_by: SortField) -> tuple:

--- a/backend/src/vuln_prioritizer/services/workbench_analysis.py
+++ b/backend/src/vuln_prioritizer/services/workbench_analysis.py
@@ -32,7 +32,7 @@ from vuln_prioritizer.services.analysis import (
 from vuln_prioritizer.services.workbench_attack import (
     attack_mapping_payload,
     attack_technique_payload,
-    confidence_for_source,
+    confidence_for_mapping,
     mapping_rationale,
     review_status_for_source,
     threat_context_rank,
@@ -564,7 +564,7 @@ def _persist_attack_context(
             domain=context.attack_domain,
             metadata_hash=context.attack_technique_metadata_file_sha256,
             metadata_path=context.attack_technique_metadata_file,
-            confidence=confidence_for_source(source),
+            confidence=confidence_for_mapping(mapping, source),
             review_status=review_status,
             rationale=mapping_rationale(mapping, attack),
             references_json=mapping.references,

--- a/backend/src/vuln_prioritizer/services/workbench_attack.py
+++ b/backend/src/vuln_prioritizer/services/workbench_attack.py
@@ -18,6 +18,8 @@ from vuln_prioritizer.attack_sources import (
 )
 from vuln_prioritizer.models import AttackData, AttackMapping, AttackTechnique
 
+CONFIDENCE_SCORE_BY_LABEL = {"low": 0.3, "medium": 0.6, "high": 0.9}
+
 
 class WorkbenchAttackValidationError(ValueError):
     """Raised when Workbench ATT&CK inputs violate source guardrails."""
@@ -80,6 +82,12 @@ def confidence_for_source(source: str) -> float | None:
     if source == WORKBENCH_ATTACK_SOURCE_LOCAL_CURATED:
         return 0.7
     return None
+
+
+def confidence_for_mapping(mapping: AttackMapping, source: str) -> float | None:
+    if mapping.confidence is not None:
+        return CONFIDENCE_SCORE_BY_LABEL[mapping.confidence]
+    return confidence_for_source(source)
 
 
 def mapping_rationale(mapping: AttackMapping, attack: AttackData) -> str:

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -1027,17 +1027,41 @@ def test_workbench_attack_import_exposes_ttp_context_and_navigator(tmp_path: Pat
 
     findings = client.get(f"/api/projects/{project['id']}/findings", params={"sort": "cve"})
     assert findings.status_code == 200
-    mapped = [item for item in findings.json()["items"] if item["attack_mapped"]]
+    finding_items = findings.json()["items"]
+    mapped = [item for item in finding_items if item["attack_mapped"]]
     assert mapped
     assert all(item["threat_context_rank"] is not None for item in mapped)
 
     moveit = next(item for item in mapped if item["cve_id"] == "CVE-2023-34362")
+    detail = client.get(f"/api/findings/{moveit['id']}")
+    assert detail.status_code == 200
+    detail_context = detail.json()["attack_context"]
+    assert detail_context["mapped"] is True
+    assert detail_context["confidence"] == "high"
+    assert detail_context["low_confidence"] is False
+    assert {technique["attack_object_id"] for technique in detail_context["techniques"]} >= {
+        "T1190"
+    }
+    assert detail_context["mappings"]
+
+    unmapped = next(item for item in finding_items if not item["attack_mapped"])
+    unmapped_detail = client.get(f"/api/findings/{unmapped['id']}")
+    assert unmapped_detail.status_code == 200
+    empty_context = unmapped_detail.json()["attack_context"]
+    assert empty_context["mapped"] is False
+    assert empty_context["source"] == "none"
+    assert empty_context["confidence"] is None
+    assert empty_context["techniques"] == []
+    assert empty_context["mappings"] == []
+
     ttps = client.get(f"/api/findings/{moveit['id']}/ttps")
     assert ttps.status_code == 200
     ttp_payload = ttps.json()
     assert ttp_payload["source"] == "ctid"
     assert ttp_payload["review_status"] == "source_reviewed"
     assert ttp_payload["mapped"] is True
+    assert ttp_payload["confidence"] == "high"
+    assert ttp_payload["low_confidence"] is False
     assert ttp_payload["source_hash"] == hashlib.sha256(ATTACK_MAPPING.read_bytes()).hexdigest()
     assert ttp_payload["metadata_hash"] == hashlib.sha256(ATTACK_METADATA.read_bytes()).hexdigest()
     assert ttp_payload["source_path"].endswith(ATTACK_MAPPING.name)

--- a/backend/tests/cli/test_analyze.py
+++ b/backend/tests/cli/test_analyze.py
@@ -8,6 +8,7 @@ from vuln_prioritizer.cli import _build_attack_summary_from_findings, app
 from vuln_prioritizer.models import (
     AttackData,
     AttackMapping,
+    AttackTechnique,
     EpssData,
     KevData,
     NvdData,
@@ -237,6 +238,121 @@ def test_cli_analyze_supports_custom_policy_thresholds(
     finding = next(item for item in payload["findings"] if item["cve_id"] == "CVE-2024-0004")
     assert finding["priority_label"] == "High"
     assert payload["metadata"]["policy_overrides"] == ["high-epss=0.300"]
+
+
+def test_cli_analyze_emits_attack_context_with_confidence_and_empty_state(
+    install_fake_providers,
+    monkeypatch,
+    runner,
+    tmp_path: Path,
+    write_input_file,
+) -> None:
+    input_file = write_input_file(tmp_path)
+    output_file = tmp_path / "attack-context.json"
+    mapping_file = tmp_path / "curated.yml"
+    mapping_file.write_text("metadata: {}\nmapping_objects: []\n", encoding="utf-8")
+    install_fake_providers()
+
+    def fake_attack_fetch_many(  # noqa: ANN001
+        self,
+        cve_ids,
+        *,
+        enabled,
+        source="none",
+        mapping_file=None,
+        technique_metadata_file=None,
+        offline_file=None,
+    ):
+        metadata = {
+            "source": "local-curated" if enabled else source,
+            "mapping_file": str(mapping_file) if mapping_file else None,
+            "technique_metadata_file": (
+                str(technique_metadata_file) if technique_metadata_file is not None else None
+            ),
+            "source_version": "fixture",
+            "attack_version": "16.1",
+            "domain": "enterprise-attack",
+            "mapping_framework": "vuln-prioritizer-curated-attack",
+            "mapping_framework_version": "1.0",
+        }
+        if not enabled:
+            return {}, metadata, []
+        return (
+            {
+                "CVE-2021-44228": AttackData(
+                    cve_id="CVE-2021-44228",
+                    mapped=True,
+                    source="local-curated",
+                    source_version="fixture",
+                    attack_version="16.1",
+                    domain="enterprise-attack",
+                    mappings=[
+                        AttackMapping(
+                            capability_id="CVE-2021-44228",
+                            attack_object_id="T1190",
+                            attack_object_name="Exploit Public-Facing Application",
+                            mapping_type="exploitation",
+                            confidence="low",
+                            review_status="needs_review",
+                            defensive_note="Review-only defensive context.",
+                        )
+                    ],
+                    techniques=[
+                        AttackTechnique(
+                            attack_object_id="T1190",
+                            name="Exploit Public-Facing Application",
+                            tactics=["initial-access"],
+                        )
+                    ],
+                    attack_relevance="High",
+                    attack_rationale="Curated defensive mapping requires analyst review.",
+                    attack_techniques=["T1190"],
+                    attack_tactics=["Initial Access"],
+                )
+            },
+            metadata,
+            [],
+        )
+
+    monkeypatch.setattr(AttackProvider, "fetch_many", fake_attack_fetch_many)
+
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+            "--attack-source",
+            "local-curated",
+            "--attack-mapping-file",
+            str(mapping_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    mapped = next(item for item in payload["findings"] if item["cve_id"] == "CVE-2021-44228")
+    context = mapped["attack_context"]
+    assert context["mapped"] is True
+    assert context["confidence"] == "low"
+    assert context["low_confidence"] is True
+    assert context["mappings"][0]["confidence"] == "low"
+    assert context["techniques"][0]["attack_object_id"] == "T1190"
+    assert context["tactics"] == ["Initial Access"]
+    assert mapped["priority_label"] == "Critical"
+    assert "attack.low_confidence" in {note["code"] for note in mapped["explanation"]["notes"]}
+
+    unmapped = next(item for item in payload["findings"] if item["cve_id"] == "CVE-2023-44487")
+    empty_context = unmapped["attack_context"]
+    assert empty_context["mapped"] is False
+    assert empty_context["source"] == "none"
+    assert empty_context["confidence"] is None
+    assert empty_context["techniques"] == []
+    assert empty_context["mappings"] == []
 
 
 def test_cli_analyze_attaches_defensive_context_without_changing_priority(

--- a/backend/tests/cli/test_explain.py
+++ b/backend/tests/cli/test_explain.py
@@ -109,6 +109,9 @@ def test_cli_explain_end_to_end_with_mocked_providers(
     assert payload["comparison"]["cvss_only_label"] == "Critical"
     assert payload["attack"]["attack_note"] == "Representative demo mapping note."
     assert payload["metadata"]["attack_source"] == "local-csv"
+    assert payload["finding"]["attack_context"]["mapped"] is True
+    assert payload["finding"]["attack_context"]["source"] == payload["attack"]["source"]
+    assert payload["finding"]["attack_context"]["tactics"] == payload["attack"]["attack_tactics"]
     assert payload["finding"]["remediation"]["strategy"] in {
         "generic-priority-guidance",
         "review-upgrade-options",

--- a/backend/tests/db/test_workbench_db.py
+++ b/backend/tests/db/test_workbench_db.py
@@ -102,7 +102,7 @@ def test_repository_round_trip_persists_workbench_finding() -> None:
             review_status="source_reviewed",
             rationale="Imported from CTID mapping fixture.",
             references_json=["https://example.invalid/advisory"],
-            mapping_json={"attack_object_id": "T1190"},
+            mapping_json={"attack_object_id": "T1190", "confidence": "high"},
         )
         repo.create_or_update_finding_attack_context(
             finding_id=finding.id,
@@ -125,7 +125,7 @@ def test_repository_round_trip_persists_workbench_finding() -> None:
                 }
             ],
             tactics_json=["initial-access"],
-            mappings_json=[{"attack_object_id": "T1190"}],
+            mappings_json=[{"attack_object_id": "T1190", "confidence": "high"}],
         )
         repo.add_finding_occurrence(
             finding_id=finding.id,
@@ -154,6 +154,7 @@ def test_repository_round_trip_persists_workbench_finding() -> None:
         assert findings[0].attack_contexts[0].source_hash == "f" * 64
         assert findings[0].attack_contexts[0].metadata_hash == "e" * 64
         assert findings[0].attack_contexts[0].threat_context_rank == 1
+        assert findings[0].attack_contexts[0].mappings_json[0]["confidence"] == "high"
         assert findings[0].explanation_json["drivers"] == ["KEV", "internet-facing asset"]
         top_contexts = repo.list_project_attack_contexts(project.id)
         assert top_contexts[0].techniques_json[0]["attack_object_id"] == "T1190"

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -346,6 +346,32 @@ def test_vpw_031_explanation_field_remains_schema_optional() -> None:
         assert "explanation" not in definition.get("required", [])
 
 
+def test_vpw_057_attack_context_schema_fields_remain_optional() -> None:
+    for schema_name in (
+        "analysis-report.schema.json",
+        "explain-report.schema.json",
+        "snapshot-report.schema.json",
+    ):
+        schema = _load_schema(schema_name)
+        finding = schema["$defs"]["prioritizedFinding"]
+        attack_mapping = schema["$defs"]["attackMapping"]
+        attack_context = schema["$defs"]["findingAttackContextSummary"]
+
+        assert "attack_context" in finding["properties"]
+        assert "attack_context" not in finding.get("required", [])
+        assert "confidence" in attack_mapping["properties"]
+        assert "review_status" in attack_mapping["properties"]
+        assert {
+            "mapped",
+            "source",
+            "confidence",
+            "low_confidence",
+            "techniques",
+            "tactics",
+            "mappings",
+        } <= set(attack_context["properties"])
+
+
 def test_vpw_032_baseline_comparison_schema_and_example() -> None:
     schema = _load_schema("analysis-report.schema.json")
     payload = json.loads(

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1441,6 +1441,12 @@ def test_curated_attack_mapping_provider_loads_yaml_fixture() -> None:
     assert bundle.quality_report["confidence_counts"] == {"high": 3, "low": 1, "medium": 2}
     assert bundle.quality_report["low_confidence_count"] == 1
     assert bundle.mappings_by_cve["CVE-2021-44228"][0].attack_object_id == "T1190"
+    assert bundle.mappings_by_cve["CVE-2021-44228"][0].confidence == "high"
+    assert bundle.mappings_by_cve["CVE-2021-44228"][0].review_status == "reviewed"
+    assert bundle.mappings_by_cve["CVE-2021-44228"][0].source == "local-curated"
+    low_confidence = bundle.mappings_by_cve["CVE-2021-26855"][0]
+    assert low_confidence.confidence == "low"
+    assert low_confidence.review_status == "needs_review"
     assert bundle.techniques_by_id["T1195.002"].tactics == ["initial-access"]
     assert any("Low-confidence curated" in warning for warning in bundle.warnings)
 

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -5,6 +5,8 @@ import pytest
 from vuln_prioritizer.explanations import build_priority_explanation
 from vuln_prioritizer.models import (
     AttackData,
+    AttackMapping,
+    AttackTechnique,
     EpssData,
     FindingProvenance,
     InputOccurrence,
@@ -443,6 +445,26 @@ def test_attack_context_does_not_change_priority() -> None:
         attack_data={
             cve_id: AttackData(
                 cve_id=cve_id,
+                mapped=True,
+                source="local-curated",
+                mappings=[
+                    AttackMapping(
+                        capability_id=cve_id,
+                        attack_object_id="T1190",
+                        attack_object_name="Exploit Public-Facing Application",
+                        mapping_type="exploitation",
+                        confidence="low",
+                        review_status="needs_review",
+                    )
+                ],
+                techniques=[
+                    AttackTechnique(
+                        attack_object_id="T1190",
+                        name="Exploit Public-Facing Application",
+                        tactics=["initial-access"],
+                    )
+                ],
+                attack_relevance="High",
                 attack_techniques=["T1190"],
                 attack_tactics=["Initial Access"],
             )
@@ -451,7 +473,14 @@ def test_attack_context_does_not_change_priority() -> None:
 
     assert findings_without_attack[0].priority_label == "High"
     assert findings_with_attack[0].priority_label == "High"
+    assert findings_with_attack[0].priority_rank == findings_without_attack[0].priority_rank
+    assert findings_with_attack[0].priority_drivers == findings_without_attack[0].priority_drivers
     assert findings_with_attack[0].attack_techniques == ["T1190"]
+    assert findings_with_attack[0].attack_context.confidence == "low"
+    assert findings_with_attack[0].attack_context.low_confidence is True
+    assert "attack.low_confidence" in {
+        note.code for note in findings_with_attack[0].explanation.notes
+    }
 
 
 def test_priority_policy_override_descriptions_only_include_changes() -> None:

--- a/backend/tests/test_workbench_guardrail_helpers.py
+++ b/backend/tests/test_workbench_guardrail_helpers.py
@@ -13,6 +13,7 @@ from vuln_prioritizer.services.workbench_attack import (
     WorkbenchAttackValidationError,
     attack_mapping_payload,
     attack_technique_payload,
+    confidence_for_mapping,
     confidence_for_source,
     mapping_rationale,
     navigator_layer_from_contexts,
@@ -82,6 +83,15 @@ def test_workbench_attack_review_confidence_and_payload_helpers() -> None:
     assert confidence_for_source("manual") == 0.8
     assert confidence_for_source("local_curated") == 0.7
     assert confidence_for_source("unknown") is None
+    assert confidence_for_mapping(mapping.model_copy(update={"confidence": "low"}), "ctid") == 0.3
+    assert (
+        confidence_for_mapping(mapping.model_copy(update={"confidence": "medium"}), "local_curated")
+        == 0.6
+    )
+    assert (
+        confidence_for_mapping(mapping.model_copy(update={"confidence": "high"}), "manual") == 0.9
+    )
+    assert confidence_for_mapping(mapping, "ctid") == 1.0
     assert mapping_rationale(mapping, mapped_attack) == "Exploit exposed app"
     assert (
         mapping_rationale(

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -218,6 +218,14 @@ Current guarantees:
 - no heuristic or LLM-generated CVE-to-ATT&CK mapping is performed
 - `attack_relevance` is a contextual, explainable helper label produced locally by this CLI
 - absence of ATT&CK data is represented as unmapped context, not guessed context
+- JSON findings include an additive `attack_context` object with mapped state,
+  source/version metadata, techniques, tactics, mappings, and curated
+  `confidence` when available
+- unmapped findings use `mapped=false`, `source=none`, `confidence=null`, and
+  empty `techniques`, `tactics`, and `mappings` arrays
+- low-confidence ATT&CK context is retained for review and surfaced in
+  explanations as `attack.low_confidence`; it does not change the hard base
+  priority label, rank, or priority drivers
 
 ### Remediation guidance
 
@@ -376,7 +384,7 @@ Workbench API changes are additive:
 - `DELETE /api/reports/{id}` and `DELETE /api/evidence-bundles/{id}` remove managed artifacts after checksum validation
 - `GET/PATCH /api/projects/{project_id}/artifacts/retention` and `POST /api/projects/{project_id}/artifacts/cleanup` manage report/evidence retention and cleanup
 - detection controls support API CRUD, review status, history, and bounded evidence attachments in addition to CSV/YAML import
-- `GET /api/projects/{project_id}/attack/review-queue` and `PATCH /api/findings/{finding_id}/ttps/review` expose review workflow for existing local/CTID ATT&CK context only
+- `GET /api/findings/{finding_id}` includes the latest stored `attack_context`; `GET /api/findings/{finding_id}/ttps`, `GET /api/projects/{project_id}/attack/review-queue`, and `PATCH /api/findings/{finding_id}/ttps/review` expose review workflow for existing local/CTID ATT&CK context only
 - Workbench import summaries may include `defensive_context_sources` and `defensive_context_hits`, and finding/detail/report payloads may include per-finding `defensive_contexts` copied from local defensive context uploads
 - `POST /api/projects/{project_id}/tickets/preview` and `POST /api/projects/{project_id}/tickets/export` support Jira and ServiceNow ticket previews, dry-runs, explicit token environment variables, and idempotency keys without making either system a required dependency
 - project config snapshots can be listed, recursively diffed, exported, and rolled back through settings endpoints

--- a/docs/evidence/vpw-057-attack-context-enrichment.md
+++ b/docs/evidence/vpw-057-attack-context-enrichment.md
@@ -1,0 +1,50 @@
+# VPW-057 ATT&CK Finding Context Evidence
+
+## Scope
+
+VPW-057 adds explicit finding-level ATT&CK context for analysis and Workbench
+detail payloads.
+
+Implemented scope:
+
+- `PrioritizedFinding.attack_context` with mapped/unmapped state, source
+  metadata, tactic/technique arrays, mappings, and confidence.
+- Curated mapping confidence and review metadata preserved on `AttackMapping`.
+- Workbench finding detail response includes the latest stored
+  `attack_context`.
+- Low-confidence ATT&CK context appears as review-only explanation note and does
+  not change hard priority label, rank, or priority drivers.
+
+## Evidence Artifacts
+
+- Example mapped/unmapped context JSON:
+  `docs/evidence/vpw-057-finding-attack-context.json`
+- Published schema updates:
+  `docs/schemas/analysis-report.schema.json`,
+  `docs/schemas/explain-report.schema.json`,
+  `docs/schemas/snapshot-report.schema.json`
+- Contract documentation: `docs/contracts.md`
+
+## Expected Context Semantics
+
+- Mapped finding: `mapped=true`, ATT&CK technique/tactic rows present, and
+  `confidence` is populated when the source supplies curated confidence.
+- Unmapped finding: `mapped=false`, `source=none`, `confidence=null`, and empty
+  `techniques`, `tactics`, and `mappings` arrays.
+- Low-confidence finding: explanation includes `attack.low_confidence`; base
+  priority remains driven by CVSS, EPSS, and KEV only.
+
+## Commands
+
+```bash
+python3 -m pytest -q backend/tests/test_providers.py::test_curated_attack_mapping_provider_loads_yaml_fixture backend/tests/test_scoring.py::test_attack_context_does_not_change_priority backend/tests/test_workbench_guardrail_helpers.py::test_workbench_attack_review_confidence_and_payload_helpers backend/tests/cli/test_analyze.py::test_cli_analyze_emits_attack_context_with_confidence_and_empty_state backend/tests/cli/test_explain.py::test_cli_explain_end_to_end_with_mocked_providers backend/tests/api/test_workbench_api.py::test_workbench_attack_import_exposes_ttp_context_and_navigator backend/tests/db/test_workbench_db.py::test_repository_round_trip_persists_workbench_finding backend/tests/test_output_schemas.py::test_vpw_057_attack_context_schema_fields_remain_optional --no-cov
+python3 -m pytest -q backend/tests/test_output_schemas.py::test_published_schema_documents_are_valid_json_schema backend/tests/test_output_schemas.py::test_analysis_json_matches_published_schema backend/tests/test_output_schemas.py::test_explain_json_matches_published_schema backend/tests/test_output_schemas.py::test_attack_validation_local_curated_json_matches_published_schema backend/tests/test_output_schemas.py::test_vpw_057_attack_context_schema_fields_remain_optional --no-cov
+make docs-check
+make check
+```
+
+Targeted VPW-057 test result: 8 passed.
+Published-schema validation result: 5 passed.
+Documentation build result: passed; existing informational mkdocs note remains
+for `architecture/vpw-011-api-skeleton.md`.
+Full gate result: 782 passed, 5 skipped, coverage 90.59%.

--- a/docs/evidence/vpw-057-finding-attack-context.json
+++ b/docs/evidence/vpw-057-finding-attack-context.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "1.0.0",
+  "issue": "VPW-057",
+  "examples": [
+    {
+      "cve_id": "CVE-2021-44228",
+      "attack_context": {
+        "cve_id": "CVE-2021-44228",
+        "mapped": true,
+        "source": "local-curated",
+        "source_version": "fixture",
+        "attack_version": "16.1",
+        "domain": "enterprise-attack",
+        "attack_relevance": "High",
+        "rationale": "Curated defensive mapping requires analyst review.",
+        "confidence": "low",
+        "low_confidence": true,
+        "techniques": [
+          {
+            "attack_object_id": "T1190",
+            "name": "Exploit Public-Facing Application",
+            "tactics": [
+              "initial-access"
+            ],
+            "url": null,
+            "revoked": false,
+            "deprecated": false
+          }
+        ],
+        "tactics": [
+          "Initial Access"
+        ],
+        "mappings": [
+          {
+            "capability_id": "CVE-2021-44228",
+            "attack_object_id": "T1190",
+            "attack_object_name": "Exploit Public-Facing Application",
+            "mapping_type": "exploitation",
+            "capability_group": null,
+            "capability_description": null,
+            "comments": null,
+            "source": "local-curated",
+            "confidence": "low",
+            "review_status": "needs_review",
+            "defensive_note": "Review-only defensive context.",
+            "reviewer": null,
+            "reviewed_at": null,
+            "references": []
+          }
+        ]
+      }
+    },
+    {
+      "cve_id": "CVE-2023-44487",
+      "attack_context": {
+        "cve_id": "CVE-2023-44487",
+        "mapped": false,
+        "source": "none",
+        "source_version": null,
+        "attack_version": null,
+        "domain": null,
+        "attack_relevance": "Unmapped",
+        "rationale": null,
+        "confidence": null,
+        "low_confidence": false,
+        "techniques": [],
+        "tactics": [],
+        "mappings": []
+      }
+    }
+  ]
+}

--- a/docs/schemas/analysis-report.schema.json
+++ b/docs/schemas/analysis-report.schema.json
@@ -597,6 +597,35 @@
         "comments": {
           "$ref": "#/$defs/nullableString"
         },
+        "source": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "review_status": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "defensive_note": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "reviewer": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "reviewed_at": {
+          "$ref": "#/$defs/nullableString"
+        },
         "references": {
           "$ref": "#/$defs/stringArray"
         }
@@ -627,6 +656,68 @@
         },
         "deprecated": {
           "type": "boolean"
+        }
+      }
+    },
+    "findingAttackContextSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "cve_id": {
+          "type": "string"
+        },
+        "mapped": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "source_version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "attack_version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "domain": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "attack_relevance": {
+          "type": "string"
+        },
+        "rationale": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "low_confidence": {
+          "type": "boolean"
+        },
+        "techniques": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attackTechnique"
+          }
+        },
+        "tactics": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attackMapping"
+          }
         }
       }
     },
@@ -868,6 +959,9 @@
           "items": {
             "$ref": "#/$defs/attackTechnique"
           }
+        },
+        "attack_context": {
+          "$ref": "#/$defs/findingAttackContextSummary"
         },
         "provider_evidence": {
           "anyOf": [

--- a/docs/schemas/explain-report.schema.json
+++ b/docs/schemas/explain-report.schema.json
@@ -510,6 +510,35 @@
         "comments": {
           "$ref": "#/$defs/nullableString"
         },
+        "source": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "review_status": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "defensive_note": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "reviewer": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "reviewed_at": {
+          "$ref": "#/$defs/nullableString"
+        },
         "references": {
           "$ref": "#/$defs/stringArray"
         }
@@ -540,6 +569,68 @@
         },
         "deprecated": {
           "type": "boolean"
+        }
+      }
+    },
+    "findingAttackContextSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "cve_id": {
+          "type": "string"
+        },
+        "mapped": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "source_version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "attack_version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "domain": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "attack_relevance": {
+          "type": "string"
+        },
+        "rationale": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "low_confidence": {
+          "type": "boolean"
+        },
+        "techniques": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attackTechnique"
+          }
+        },
+        "tactics": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attackMapping"
+          }
         }
       }
     },
@@ -781,6 +872,9 @@
           "items": {
             "$ref": "#/$defs/attackTechnique"
           }
+        },
+        "attack_context": {
+          "$ref": "#/$defs/findingAttackContextSummary"
         },
         "provider_evidence": {
           "anyOf": [

--- a/docs/schemas/snapshot-report.schema.json
+++ b/docs/schemas/snapshot-report.schema.json
@@ -741,6 +741,35 @@
         "comments": {
           "$ref": "#/$defs/nullableString"
         },
+        "source": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "review_status": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "defensive_note": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "reviewer": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "reviewed_at": {
+          "$ref": "#/$defs/nullableString"
+        },
         "references": {
           "$ref": "#/$defs/stringArray"
         }
@@ -771,6 +800,68 @@
         },
         "deprecated": {
           "type": "boolean"
+        }
+      }
+    },
+    "findingAttackContextSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "cve_id": {
+          "type": "string"
+        },
+        "mapped": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "source_version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "attack_version": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "domain": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "attack_relevance": {
+          "type": "string"
+        },
+        "rationale": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "low_confidence": {
+          "type": "boolean"
+        },
+        "techniques": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attackTechnique"
+          }
+        },
+        "tactics": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attackMapping"
+          }
         }
       }
     },
@@ -1012,6 +1103,9 @@
           "items": {
             "$ref": "#/$defs/attackTechnique"
           }
+        },
+        "attack_context": {
+          "$ref": "#/$defs/findingAttackContextSummary"
         },
         "provider_evidence": {
           "anyOf": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - VPW-054 Report Snapshots: evidence/vpw-054-report-snapshots.md
       - VPW-055 ATT&CK Models And Schema: evidence/vpw-055-attack-models-schema.md
       - VPW-056 Curated ATT&CK Loader: evidence/vpw-056-curated-attack-loader.md
+      - VPW-057 ATT&CK Finding Context: evidence/vpw-057-attack-context-enrichment.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary
- Adds explicit `attack_context` to prioritized findings with mapped/unmapped state, source metadata, tactics, techniques, mappings, confidence, and low-confidence flag.
- Preserves curated ATT&CK confidence/review metadata on mappings and persists that metadata into Workbench context payloads without a DB migration.
- Exposes inline Workbench finding-detail `attack_context`, updates published schemas/contracts, and adds VPW-057 evidence artifacts.

## Verification
- `python3 -m pytest -q backend/tests/test_providers.py::test_curated_attack_mapping_provider_loads_yaml_fixture backend/tests/test_scoring.py::test_attack_context_does_not_change_priority backend/tests/test_workbench_guardrail_helpers.py::test_workbench_attack_review_confidence_and_payload_helpers backend/tests/cli/test_analyze.py::test_cli_analyze_emits_attack_context_with_confidence_and_empty_state backend/tests/cli/test_explain.py::test_cli_explain_end_to_end_with_mocked_providers backend/tests/api/test_workbench_api.py::test_workbench_attack_import_exposes_ttp_context_and_navigator backend/tests/db/test_workbench_db.py::test_repository_round_trip_persists_workbench_finding backend/tests/test_output_schemas.py::test_vpw_057_attack_context_schema_fields_remain_optional --no-cov` -> 8 passed
- `python3 -m pytest -q backend/tests/test_output_schemas.py::test_published_schema_documents_are_valid_json_schema backend/tests/test_output_schemas.py::test_analysis_json_matches_published_schema backend/tests/test_output_schemas.py::test_explain_json_matches_published_schema backend/tests/test_output_schemas.py::test_attack_validation_local_curated_json_matches_published_schema backend/tests/test_output_schemas.py::test_vpw_057_attack_context_schema_fields_remain_optional --no-cov` -> 5 passed
- `make docs-check` -> passed; existing mkdocs info note for `architecture/vpw-011-api-skeleton.md`
- `make check` -> 782 passed, 5 skipped, coverage 90.59%

## Evidence
- `docs/evidence/vpw-057-attack-context-enrichment.md`
- `docs/evidence/vpw-057-finding-attack-context.json`

Closes #163
