### PR TITLE
VPW-062 asset context matching

### DIFF
--- a/backend/src/vuln_prioritizer/commands/input.py
+++ b/backend/src/vuln_prioritizer/commands/input.py
@@ -350,6 +350,8 @@ def build_input_validation_report(
             "loaded_rows": asset_diagnostics.loaded_rows,
             "skipped_rows": asset_diagnostics.skipped_rows,
             "exact_rules": asset_diagnostics.exact_rules,
+            "contains_rules": asset_diagnostics.contains_rules,
+            "regex_rules": asset_diagnostics.regex_rules,
             "glob_rules": asset_diagnostics.glob_rules,
             "legacy_schema": asset_diagnostics.legacy_schema,
             "warnings": list(asset_diagnostics.warnings),

--- a/backend/src/vuln_prioritizer/inputs/_occurrence_support.py
+++ b/backend/src/vuln_prioritizer/inputs/_occurrence_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -21,6 +22,8 @@ class AssetContextMatchDiagnostics:
     matched_occurrences: int
     unmatched_occurrences: int
     exact_matches: int
+    contains_matches: int
+    regex_matches: int
     glob_matches: int
     ambiguous_occurrences: int
     warnings: tuple[str, ...] = ()
@@ -78,6 +81,8 @@ def apply_asset_context(
             matched_occurrences=0,
             unmatched_occurrences=len(occurrences),
             exact_matches=0,
+            contains_matches=0,
+            regex_matches=0,
             glob_matches=0,
             ambiguous_occurrences=0,
         )
@@ -88,6 +93,8 @@ def apply_asset_context(
         matched_occurrences = 0
         unmatched_occurrences = 0
         exact_matches = 0
+        contains_matches = 0
+        regex_matches = 0
         glob_matches = 0
         ambiguous_occurrences = 0
 
@@ -102,6 +109,10 @@ def apply_asset_context(
                 ambiguous_occurrences += 1
             if matched_rule.match_mode == "glob":
                 glob_matches += 1
+            elif matched_rule.match_mode == "regex":
+                regex_matches += 1
+            elif matched_rule.match_mode == "contains":
+                contains_matches += 1
             else:
                 exact_matches += 1
             enriched.append(
@@ -124,6 +135,8 @@ def apply_asset_context(
             matched_occurrences=matched_occurrences,
             unmatched_occurrences=unmatched_occurrences,
             exact_matches=exact_matches,
+            contains_matches=contains_matches,
+            regex_matches=regex_matches,
             glob_matches=glob_matches,
             ambiguous_occurrences=ambiguous_occurrences,
             warnings=tuple(warning_messages),
@@ -150,6 +163,8 @@ def apply_asset_context(
         matched_occurrences=matched_occurrences,
         unmatched_occurrences=unmatched_occurrences,
         exact_matches=matched_occurrences,
+        contains_matches=0,
+        regex_matches=0,
         glob_matches=0,
         ambiguous_occurrences=0,
     )
@@ -196,7 +211,12 @@ def _resolve_asset_context_rule(
 
 def _asset_context_rule_score(rule: Any) -> tuple[int, int, int, int, int]:
     precedence = int(getattr(rule, "precedence", 0) or 0)
-    specificity = 1 if getattr(rule, "match_mode", "exact") == "exact" else 0
+    specificity = {
+        "exact": 3,
+        "regex": 2,
+        "contains": 1,
+        "glob": 0,
+    }.get(getattr(rule, "match_mode", "exact"), 0)
     order = int(getattr(rule, "order", 0) or 0)
     pattern = str(getattr(rule, "target_ref", "") or "")
     return (
@@ -222,6 +242,13 @@ def _asset_context_rule_matches(
         return False
     if match_mode == "glob":
         return fnmatchcase(occurrence.target_ref, rule_ref)
+    if match_mode == "contains":
+        return rule_ref in occurrence.target_ref
+    if match_mode == "regex":
+        try:
+            return re.search(rule_ref, occurrence.target_ref) is not None
+        except re.error:
+            return False
     return occurrence.target_ref == rule_ref
 
 

--- a/backend/src/vuln_prioritizer/inputs/loader.py
+++ b/backend/src/vuln_prioritizer/inputs/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -86,6 +87,8 @@ class AssetContextLoadDiagnostics:
     loaded_rows: int
     skipped_rows: int
     exact_rules: int
+    contains_rules: int
+    regex_rules: int
     glob_rules: int
     legacy_schema: bool
     warnings: tuple[str, ...] = ()
@@ -403,6 +406,8 @@ def load_asset_context_file(
                 loaded_rows=0,
                 skipped_rows=0,
                 exact_rules=0,
+                contains_rules=0,
+                regex_rules=0,
                 glob_rules=0,
                 legacy_schema=True,
             ),
@@ -413,11 +418,13 @@ def load_asset_context_file(
         if not reader.fieldnames:
             raise ValueError("Asset context CSV is missing a header row.")
         fieldnames = {field.strip() for field in reader.fieldnames if field}
-        required = {"target_kind", "target_ref", "asset_id"}
+        required = {"target_kind", "asset_id"}
         missing = required - fieldnames
-        if missing:
+        has_target_ref = "target_ref" in fieldnames or "asset_ref" in fieldnames
+        if missing or not has_target_ref:
             raise ValueError(
-                "Asset context CSV must contain columns: target_kind, target_ref, asset_id."
+                "Asset context CSV must contain columns: target_kind, "
+                "target_ref or asset_ref, asset_id."
             )
 
         optional_schema_fields = {"rule_id", "match_mode", "precedence"}
@@ -425,6 +432,8 @@ def load_asset_context_file(
         records: dict[tuple[str, str], AssetContextRecord] = {}
         rules: list[AssetContextRule] = []
         exact_rule_count = 0
+        contains_rule_count = 0
+        regex_rule_count = 0
         glob_rule_count = 0
         loaded_rows = 0
         total_rows = 0
@@ -437,15 +446,24 @@ def load_asset_context_file(
         for order, row in enumerate(reader, start=1):
             total_rows += 1
             target_kind = (row.get("target_kind") or "").strip().lower()
-            target_ref = (row.get("target_ref") or "").strip()
+            target_ref = (row.get("target_ref") or row.get("asset_ref") or "").strip()
             asset_id = (row.get("asset_id") or "").strip()
             if not target_kind or not target_ref or not asset_id:
                 skipped_rows += 1
                 continue
             loaded_rows += 1
             match_mode = (row.get("match_mode") or "exact").strip().lower()
-            if match_mode not in {"exact", "glob"}:
-                raise ValueError("Asset context CSV match_mode must be either exact or glob.")
+            if match_mode not in {"exact", "contains", "regex", "glob"}:
+                raise ValueError(
+                    "Asset context CSV match_mode must be exact, contains, regex, or glob."
+                )
+            if match_mode == "regex":
+                try:
+                    re.compile(target_ref)
+                except re.error as exc:
+                    raise ValueError(
+                        f"Asset context CSV regex at row {order} is invalid: {exc}."
+                    ) from exc
             precedence_raw = (row.get("precedence") or "").strip()
             if precedence_raw:
                 try:
@@ -503,6 +521,10 @@ def load_asset_context_file(
             )
             if match_mode == "glob":
                 glob_rule_count += 1
+            elif match_mode == "regex":
+                regex_rule_count += 1
+            elif match_mode == "contains":
+                contains_rule_count += 1
             else:
                 exact_rule_count += 1
 
@@ -527,6 +549,8 @@ def load_asset_context_file(
             loaded_rows=loaded_rows,
             skipped_rows=skipped_rows,
             exact_rules=exact_rule_count,
+            contains_rules=contains_rule_count,
+            regex_rules=regex_rule_count,
             glob_rules=glob_rule_count,
             legacy_schema=legacy_schema,
             warnings=tuple(warning_messages),

--- a/backend/tests/cli/test_input_validate.py
+++ b/backend/tests/cli/test_input_validate.py
@@ -66,6 +66,10 @@ def test_cli_input_validate_json_reports_local_inputs_and_context(
     assert payload["summary"]["total_rows"] == 2
     assert payload["summary"]["unique_cves"] == 1
     assert payload["summary"]["asset_context_rules"] == 1
+    assert payload["asset_context"]["exact_rules"] == 1
+    assert payload["asset_context"]["contains_rules"] == 0
+    assert payload["asset_context"]["regex_rules"] == 0
+    assert payload["asset_context"]["glob_rules"] == 0
     assert payload["summary"]["vex_statement_count"] == 1
     assert payload["vex"]["statuses"] == {"under_investigation": 1}
     assert any("Ignored invalid CVE identifier" in warning for warning in payload["warnings"])

--- a/backend/tests/test_asset_context_rules.py
+++ b/backend/tests/test_asset_context_rules.py
@@ -107,10 +107,36 @@ def test_asset_context_contains_rule_matches_asset_ref_alias_and_reports_invalid
     asset_context_file.write_text(
         "\n".join(
             [
-                "rule_id,target_kind,asset_ref,asset_id,match_mode,precedence,"
-                "criticality,exposure,environment,owner,business_service",
-                "contains-rule,host,app-,asset-contains,contains,10,"
-                "tier-0,publicly,productionish,platform-team,checkout",
+                ",".join(
+                    [
+                        "rule_id",
+                        "target_kind",
+                        "asset_ref",
+                        "asset_id",
+                        "match_mode",
+                        "precedence",
+                        "criticality",
+                        "exposure",
+                        "environment",
+                        "owner",
+                        "business_service",
+                    ]
+                ),
+                ",".join(
+                    [
+                        "contains-rule",
+                        "host",
+                        "app-",
+                        "asset-contains",
+                        "contains",
+                        "10",
+                        "tier-0",
+                        "publicly",
+                        "productionish",
+                        "platform-team",
+                        "checkout",
+                    ]
+                ),
             ]
         )
         + "\n",
@@ -205,10 +231,36 @@ def test_asset_context_application_recomputes_operational_score(
     asset_context_file.write_text(
         "\n".join(
             [
-                "rule_id,target_kind,target_ref,asset_id,match_mode,precedence,"
-                "criticality,exposure,environment,owner,business_service",
-                "prod-api,host,app-01,asset-prod-api,exact,10,"
-                "critical,internet-facing,prod,platform-team,checkout",
+                ",".join(
+                    [
+                        "rule_id",
+                        "target_kind",
+                        "target_ref",
+                        "asset_id",
+                        "match_mode",
+                        "precedence",
+                        "criticality",
+                        "exposure",
+                        "environment",
+                        "owner",
+                        "business_service",
+                    ]
+                ),
+                ",".join(
+                    [
+                        "prod-api",
+                        "host",
+                        "app-01",
+                        "asset-prod-api",
+                        "exact",
+                        "10",
+                        "critical",
+                        "internet-facing",
+                        "prod",
+                        "platform-team",
+                        "checkout",
+                    ]
+                ),
             ]
         )
         + "\n",

--- a/backend/tests/test_asset_context_rules.py
+++ b/backend/tests/test_asset_context_rules.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 from vuln_prioritizer.inputs._occurrence_support import apply_asset_context
 from vuln_prioritizer.inputs.loader import load_asset_context_file
-from vuln_prioritizer.models import InputOccurrence
+from vuln_prioritizer.models import InputOccurrence, PrioritizedFinding
+from vuln_prioritizer.services.contextualization import aggregate_provenance
+from vuln_prioritizer.services.prioritization import PrioritizationService
 
 
 def _occurrence() -> InputOccurrence:
@@ -92,5 +94,150 @@ def test_asset_context_higher_precedence_wins_and_returns_load_diagnostics(
     assert diagnostics.total_rows == 2
     assert diagnostics.loaded_rows == 2
     assert diagnostics.exact_rules == 2
+    assert diagnostics.contains_rules == 0
+    assert diagnostics.regex_rules == 0
     assert diagnostics.glob_rules == 0
     assert diagnostics.legacy_schema is False
+
+
+def test_asset_context_contains_rule_matches_asset_ref_alias_and_reports_invalid_enums(
+    tmp_path: Path,
+) -> None:
+    asset_context_file = tmp_path / "assets.csv"
+    asset_context_file.write_text(
+        "\n".join(
+            [
+                "rule_id,target_kind,asset_ref,asset_id,match_mode,precedence,"
+                "criticality,exposure,environment,owner,business_service",
+                "contains-rule,host,app-,asset-contains,contains,10,"
+                "tier-0,publicly,productionish,platform-team,checkout",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    catalog, diagnostics = load_asset_context_file(asset_context_file, return_diagnostics=True)
+    resolved, match_diagnostics = apply_asset_context(
+        [_occurrence()],
+        catalog,
+        return_diagnostics=True,
+    )
+
+    assert resolved[0].asset_id == "asset-contains"
+    assert resolved[0].asset_match_mode == "contains"
+    assert resolved[0].asset_owner == "platform-team"
+    assert resolved[0].asset_business_service == "checkout"
+    assert resolved[0].asset_criticality is None
+    assert resolved[0].asset_exposure is None
+    assert resolved[0].asset_environment is None
+    assert diagnostics.loaded_rows == 1
+    assert diagnostics.contains_rules == 1
+    assert diagnostics.regex_rules == 0
+    assert diagnostics.exact_rules == 0
+    assert diagnostics.glob_rules == 0
+    assert any("unknown asset criticality" in warning for warning in diagnostics.warnings)
+    assert any("unknown asset exposure" in warning for warning in diagnostics.warnings)
+    assert any("unknown asset environment" in warning for warning in diagnostics.warnings)
+    assert match_diagnostics.contains_matches == 1
+    assert match_diagnostics.regex_matches == 0
+    assert match_diagnostics.exact_matches == 0
+
+
+def test_asset_context_regex_rule_matches_and_loses_to_exact_on_tied_precedence(
+    tmp_path: Path,
+) -> None:
+    asset_context_file = tmp_path / "assets.csv"
+    asset_context_file.write_text(
+        "\n".join(
+            [
+                "rule_id,target_kind,target_ref,asset_id,match_mode,precedence",
+                "regex-rule,host,^app-[0-9]{2}$,asset-regex,regex,20",
+                "exact-rule,host,app-01,asset-exact,exact,20",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    catalog, diagnostics = load_asset_context_file(asset_context_file, return_diagnostics=True)
+    resolved, match_diagnostics = apply_asset_context(
+        [_occurrence()],
+        catalog,
+        return_diagnostics=True,
+    )
+
+    assert resolved[0].asset_id == "asset-exact"
+    assert resolved[0].asset_match_rule_id == "exact-rule"
+    assert resolved[0].asset_match_candidate_count == 2
+    assert diagnostics.regex_rules == 1
+    assert diagnostics.exact_rules == 1
+    assert match_diagnostics.exact_matches == 1
+    assert match_diagnostics.regex_matches == 0
+    assert match_diagnostics.ambiguous_occurrences == 1
+
+
+def test_asset_context_invalid_regex_reports_row_number(tmp_path: Path) -> None:
+    asset_context_file = tmp_path / "assets.csv"
+    asset_context_file.write_text(
+        "\n".join(
+            [
+                "rule_id,target_kind,target_ref,asset_id,match_mode,precedence",
+                "broken-regex,host,[app,asset-regex,regex,20",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        load_asset_context_file(asset_context_file)
+    except ValueError as exc:
+        assert "regex at row 1 is invalid" in str(exc)
+    else:  # pragma: no cover - defensive assertion for clearer failure output
+        raise AssertionError("invalid regex should raise ValueError")
+
+
+def test_asset_context_application_recomputes_operational_score(
+    tmp_path: Path,
+) -> None:
+    asset_context_file = tmp_path / "assets.csv"
+    asset_context_file.write_text(
+        "\n".join(
+            [
+                "rule_id,target_kind,target_ref,asset_id,match_mode,precedence,"
+                "criticality,exposure,environment,owner,business_service",
+                "prod-api,host,app-01,asset-prod-api,exact,10,"
+                "critical,internet-facing,prod,platform-team,checkout",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    catalog = load_asset_context_file(asset_context_file)
+    enriched_occurrences = apply_asset_context([_occurrence()], catalog)
+    provenance = aggregate_provenance(["CVE-2024-9999"], enriched_occurrences)["CVE-2024-9999"]
+    finding = PrioritizedFinding(
+        cve_id="CVE-2024-9999",
+        priority_label="High",
+        priority_rank=2,
+        priority_drivers=["medium-cvss"],
+        cvss_base_score=8.0,
+        epss=0.05,
+        rationale="fixture finding",
+        recommended_action="patch",
+        provenance=provenance,
+        highest_asset_criticality=provenance.highest_asset_criticality,
+        asset_count=provenance.asset_count,
+    )
+
+    scored = PrioritizationService().assign_operational_ranks([finding])[0]
+
+    assert scored.priority_label == "High"
+    assert scored.operational_score == 72
+    assert "internet-facing asset context: +8" in scored.operational_score_reasons
+    assert "production asset context: +5" in scored.operational_score_reasons
+    assert "critical asset criticality: +7" in scored.operational_score_reasons
+    assert "business service checkout routing context: +0" in scored.operational_score_reasons
+    assert "owner platform-team routing context: +0" in scored.operational_score_reasons

--- a/backend/tests/test_output_schemas.py
+++ b/backend/tests/test_output_schemas.py
@@ -656,8 +656,22 @@ def test_attack_coverage_json_matches_published_schema(tmp_path: Path) -> None:
 
 def test_input_validation_json_matches_published_schema(tmp_path: Path) -> None:
     input_file = tmp_path / "cves.txt"
+    asset_context_file = tmp_path / "asset-context.csv"
     output_file = tmp_path / "input-validation.json"
     input_file.write_text("CVE-2021-44228\n", encoding="utf-8")
+    asset_context_file.write_text(
+        "\n".join(
+            [
+                "rule_id,target_kind,target_ref,asset_ref,asset_id,match_mode,precedence",
+                "exact-rule,generic,service-a,,asset-a,exact,30",
+                "contains-rule,generic,service,,asset-service,contains,20",
+                "regex-rule,generic,^svc-[0-9]+$,,asset-regex,regex,10",
+                "glob-rule,generic,svc-*,,asset-glob,glob,5",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     result = runner.invoke(
         app,
@@ -666,6 +680,8 @@ def test_input_validation_json_matches_published_schema(tmp_path: Path) -> None:
             "validate",
             "--input",
             str(input_file),
+            "--asset-context",
+            str(asset_context_file),
             "--output",
             str(output_file),
             "--format",
@@ -676,6 +692,10 @@ def test_input_validation_json_matches_published_schema(tmp_path: Path) -> None:
     assert result.exit_code == 0
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     jsonschema.validate(payload, _load_schema("input-validation-report.schema.json"))
+    assert payload["asset_context"]["exact_rules"] == 1
+    assert payload["asset_context"]["contains_rules"] == 1
+    assert payload["asset_context"]["regex_rules"] == 1
+    assert payload["asset_context"]["glob_rules"] == 1
 
 
 def test_input_inspect_json_matches_published_schema(tmp_path: Path) -> None:

--- a/data/input_fixtures/example_asset_context_rules.csv
+++ b/data/input_fixtures/example_asset_context_rules.csv
@@ -1,0 +1,7 @@
+rule_id,target_kind,target_ref,asset_ref,asset_id,match_mode,precedence,criticality,exposure,environment,owner,business_service
+host-prod-01,host,app-01.example.internal,,app-01,exact,100,critical,internet-facing,prod,platform-team,customer-login
+host-prod-fleet,host,web-*.example.internal,,web-fleet,glob,40,high,dmz,prod,edge-team,public-web
+repo-payments,repository,,github.com/acme/payments,payments-repo,exact,80,high,internal,prod,payments-team,payments
+image-demo,image,ghcr.io/acme/demo-app:1.0.0 (alpine 3.19),,api-gateway,exact,90,critical,internet-facing,prod,platform-team,customer-login
+svc-regex,host,^svc-[0-9]+\.corp\.example$,,service-fleet,regex,50,medium,internal,staging,service-team,shared-services
+contains-batch,host,batch,,batch-fleet,contains,20,medium,internal,prod,data-team,batch-processing

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -104,7 +104,8 @@ Supported input families currently normalize into the same occurrence model:
 Important current rules:
 
 - asset context is occurrence-based, keeps `target_kind` exact, and supports deterministic
-  `target_ref` exact/glob rules with precedence
+  `target_ref`/`asset_ref` `exact`, `contains`, `regex`, and compatibility `glob`
+  rules with precedence; see [Asset Context CSV](../asset-context-csv.md)
 - VEX suppression is evaluated at occurrence level with deterministic specificity-based matching
 - `suppressed_by_vex` is true only when all known occurrences are suppressed
 - `under_investigation` stays visible and is not silently removed

--- a/docs/asset-context-csv.md
+++ b/docs/asset-context-csv.md
@@ -1,0 +1,103 @@
+# Asset Context CSV
+
+Asset context CSV files attach local ownership and operational context to normalized
+input occurrences. The file is read only from local paths supplied by the operator;
+it does not discover assets or scan networks.
+
+Use the fixture at `data/input_fixtures/example_asset_context_rules.csv` as a
+rule-oriented starting point. The older minimal fixture at
+`data/input_fixtures/example_asset_context.csv` remains valid for exact matches.
+
+## Required Columns
+
+| Column | Required | Description |
+| --- | --- | --- |
+| `target_kind` | yes | Normalized occurrence target kind, such as `host`, `image`, `repository`, `package`, or `generic`. Matching requires the rule and occurrence `target_kind` to be equal after lowercasing. |
+| `target_ref` | conditionally | Pattern or exact reference matched against the occurrence `target_ref`. Required unless `asset_ref` is present. |
+| `asset_ref` | alias | Backward-compatible alias for `target_ref`. Use it when exporting from older spreadsheets or CVE-list files. If both `target_ref` and `asset_ref` are present, `target_ref` wins. |
+| `asset_id` | yes | Stable local asset identifier surfaced in explanations, reports, and Workbench findings. |
+
+Rows missing `target_kind`, a target reference, or `asset_id` are skipped. A file
+missing the required header columns fails validation.
+
+## Optional Columns
+
+| Column | Description |
+| --- | --- |
+| `rule_id` | Stable rule identifier. If omitted, the loader assigns `asset-rule:<row_number>`. |
+| `match_mode` | One of `exact`, `contains`, `regex`, or `glob`. Defaults to `exact`. |
+| `precedence` | Integer rule priority. Higher values win. If omitted, the CSV row number is used. |
+| `criticality` | One of `low`, `medium`, `high`, or `critical`. Aliases: `med`, `crit`. |
+| `exposure` | One of `internal`, `dmz`, or `internet-facing`. Aliases: `private`, `internet`, `external`, `public`. |
+| `environment` | One of `prod`, `staging`, `test`, or `dev`. Aliases: `production`, `stage`, `qa`, `development`. |
+| `owner` | Owning team, group, or contact name for routing. |
+| `business_service` | Business service or product surface for routing and reporting. |
+
+Unknown `criticality`, `exposure`, or `environment` values are ignored for that
+field and emitted as diagnostics warnings. They do not invalidate the whole CSV.
+Invalid `match_mode`, invalid regex syntax, and non-integer `precedence` values
+are validation errors because they make matching ambiguous.
+
+## Match Modes
+
+| Mode | Behavior | Example |
+| --- | --- | --- |
+| `exact` | `target_ref` must equal the occurrence `target_ref`. | `app-01.example.internal` |
+| `contains` | Rule `target_ref` must appear as a substring of the occurrence `target_ref`. | `payments` |
+| `regex` | Rule `target_ref` is evaluated as a Python regular expression. | `^svc-[0-9]+\.corp\.example$` |
+| `glob` | Compatibility mode using shell-style wildcards. | `web-*.corp.example` |
+
+All modes are case-sensitive. Normalize exported asset references before
+depending on `contains`, `regex`, or `glob` rules.
+
+Use `exact` for stable IDs and `glob` for compatibility with existing
+wildcard-based rule files. Prefer `contains` or `regex` only when occurrence
+targets are known to be consistently normalized.
+
+## Precedence And Tie-Breaks
+
+Asset context is evaluated per occurrence, not per CVE aggregate. If multiple
+rules match one occurrence, the winner is deterministic:
+
+1. Highest numeric `precedence`.
+2. Most specific match mode: `exact`, then `regex`, then `contains`, then `glob`.
+3. More literal characters in the pattern.
+4. Fewer wildcard characters.
+5. Earlier CSV row.
+
+The matched occurrence records the winning `asset_match_rule_id`,
+`asset_match_mode`, `asset_match_pattern`, `asset_match_precedence`,
+`asset_match_row`, and candidate count. Diagnostics also report ambiguous
+occurrences when a winner was selected from multiple matching rules.
+
+Legacy exact-only CSVs without `rule_id`, `match_mode`, or `precedence` keep the
+historical last-row-wins behavior for duplicate exact records, while conflict
+diagnostics make the overlap visible.
+
+## Operational Re-Score Semantics
+
+Asset context does not change the base `priority_label`, which remains driven by
+CVSS, EPSS, and CISA KEV. It can change the operational queue score and
+explanation text:
+
+- internet-facing exposure adds operational urgency
+- production environment adds operational urgency
+- critical asset criticality adds operational urgency
+- owner and business service add routing context without score points
+- missing asset context is neutral and explicitly not treated as safe
+
+When asset data changes after analysis, re-run analysis with the updated CSV or
+trigger the Workbench re-score path so findings carry current owner, service,
+environment, exposure, and operational score reasons.
+
+## Example
+
+```csv
+rule_id,target_kind,target_ref,asset_ref,asset_id,match_mode,precedence,criticality,exposure,environment,owner,business_service
+host-prod-01,host,app-01.example.internal,,app-01,exact,100,critical,internet-facing,prod,platform-team,customer-login
+host-prod-fleet,host,web-*.example.internal,,web-fleet,glob,40,high,dmz,prod,edge-team,public-web
+repo-payments,repository,,github.com/acme/payments,payments-repo,exact,80,high,internal,prod,payments-team,payments
+image-demo,image,ghcr.io/acme/demo-app:1.0.0 (alpine 3.19),,api-gateway,exact,90,critical,internet-facing,prod,platform-team,customer-login
+svc-regex,host,^svc-[0-9]+\.corp\.example$,,service-fleet,regex,50,medium,internal,staging,service-team,shared-services
+contains-batch,host,batch,,batch-fleet,contains,20,medium,internal,prod,data-team,batch-processing
+```

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -270,7 +270,10 @@ Current asset-context contract:
 
 - asset context is evaluated per occurrence, not per CVE aggregate
 - `target_kind` stays exact
-- `target_ref` supports deterministic `exact` and `glob` matching with precedence and CSV row tie-breaks
+- `target_ref` supports deterministic `exact`, `contains`, `regex`, and compatibility `glob` matching with precedence and CSV row tie-breaks
+- CSV files require `target_kind`, `asset_id`, and either `target_ref` or its `asset_ref` alias; see [Asset Context CSV](asset-context-csv.md)
+- unknown `criticality`, `exposure`, and `environment` enum values are ignored with warnings, while invalid `match_mode`, regex syntax, or non-integer `precedence` values fail validation
+- `input validate --format json` exposes `asset_context.exact_rules`, `contains_rules`, `regex_rules`, and `glob_rules`
 - occurrence metadata exposes the winning asset rule when one matched
 
 ### Waiver semantics

--- a/docs/evidence/vpw-062-asset-context-matching.md
+++ b/docs/evidence/vpw-062-asset-context-matching.md
@@ -1,0 +1,82 @@
+# VPW-062 Asset Context Matching
+
+VPW-062 documents the asset context CSV schema and deterministic matching rules
+used to attach local operational context to normalized findings.
+
+## Artifacts
+
+- Schema documentation: `docs/asset-context-csv.md`
+- Rule fixture: `data/input_fixtures/example_asset_context_rules.csv`
+- Existing exact-match fixture: `data/input_fixtures/example_asset_context.csv`
+- Contract references: `docs/contracts.md`, `docs/support_matrix.md`
+
+## Acceptance Coverage
+
+| Requirement | Evidence |
+| --- | --- |
+| Required columns are documented | `docs/asset-context-csv.md` lists `target_kind`, `target_ref` or `asset_ref`, and `asset_id`. |
+| `asset_ref` alias is documented | The schema doc states that `asset_ref` is a backward-compatible alias and that `target_ref` wins when both are present. |
+| Match modes are documented | The schema doc covers case-sensitive `exact`, `contains`, `regex`, and compatibility `glob`. |
+| Precedence and tie-breaks are documented | The schema doc lists deterministic ordering by precedence, match mode specificity, literal characters, wildcard count, and CSV row. |
+| Invalid enum warning behavior is documented | Unknown `criticality`, `exposure`, and `environment` values are documented as field-level warnings; invalid `match_mode`, regex, and precedence values remain validation errors. |
+| Operational re-score semantics are documented | The schema doc states that asset context changes operational score and explanation/routing context, not the base priority label. |
+| Sample artifact is present | `data/input_fixtures/example_asset_context_rules.csv` includes exact, contains, regex, glob, and `asset_ref` alias examples. |
+
+## Verification
+
+```text
+$ python3 -m ruff check backend/src/vuln_prioritizer/commands/input.py backend/src/vuln_prioritizer/inputs/loader.py backend/src/vuln_prioritizer/inputs/_occurrence_support.py backend/tests/test_asset_context_rules.py backend/tests/cli/test_input_validate.py
+All checks passed!
+```
+
+```text
+$ python3 -m pytest -q backend/tests/test_asset_context_rules.py backend/tests/cli/test_input_validate.py --no-cov
+14 passed in 0.12s
+```
+
+Schema coverage after adding the published `contains_rules` and `regex_rules`
+fields:
+
+```text
+$ python3 -m pytest -q backend/tests/test_asset_context_rules.py backend/tests/cli/test_input_validate.py backend/tests/test_output_schemas.py --no-cov
+45 passed in 1.02s
+```
+
+Compatibility coverage for existing exact/glob conflict behavior:
+
+```text
+$ python3 -m pytest -q backend/tests/cli/test_analyze.py::test_cli_analyze_reports_asset_and_vex_conflicts_with_deterministic_winners backend/tests/e2e/test_module_entrypoint.py::test_module_entrypoint_p2_context_round_trip --no-cov
+2 passed in 2.60s
+```
+
+Docs build:
+
+```text
+$ make docs-check
+Documentation built in 0.67 seconds
+```
+
+`mkdocs` still reports the pre-existing informational note that
+`architecture/vpw-011-api-skeleton.md` exists outside the nav.
+
+## CLI Validation Excerpt
+
+```text
+$ python3 -m vuln_prioritizer.cli input validate --asset-context data/input_fixtures/example_asset_context_rules.csv --format json
+
+asset_context.loaded_rows = 6
+asset_context.exact_rules = 3
+asset_context.contains_rules = 1
+asset_context.regex_rules = 1
+asset_context.glob_rules = 1
+asset_context.warnings = []
+summary.ok = true
+summary.asset_context_rules = 6
+summary.asset_context_skipped_rows = 0
+summary.warning_count = 0
+```
+
+## Notes
+
+Asset context remains a local defensive context layer. It does not fetch provider
+data, derive CVE-to-asset mappings, or scan infrastructure.

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,7 @@ During the FastAPI template migration, Compose starts the template backend shell
 - Start with [concept.md](concept.md) for positioning and scope.
 - Read [methodology.md](methodology.md) for scoring, ATT&CK, Asset Context, and VEX semantics.
 - Use [support_matrix.md](support_matrix.md) and [contracts.md](contracts.md) for stable consumer-facing surfaces.
+- Use [asset-context-csv.md](asset-context-csv.md) for the local asset-context CSV schema, match modes, precedence, and re-score semantics.
 - Use [playbooks.md](playbooks.md) when you want the shortest role-oriented path for CI scans, SBOM triage, or infrastructure scan triage.
 - Use [integrations/reporting_and_ci.md](integrations/reporting_and_ci.md) for SARIF, GitHub Action, HTML, and local workflow guidance.
 - Use [workbench-threat-model.md](workbench-threat-model.md) for Workbench security boundaries, residual risk, and release readiness checks.

--- a/docs/playbooks/infrastructure_scan_triage.md
+++ b/docs/playbooks/infrastructure_scan_triage.md
@@ -79,7 +79,12 @@ What to expect:
 
 ## 3. Add Asset Context Deliberately
 
-Asset context is only useful when the join is exact on `(target_kind, target_ref)`. Start from the checked-in CSV schema, adapt it to your infrastructure targets, then rerun `analyze` with `--asset-context`.
+Asset context is most reliable when the join is exact on
+`(target_kind, target_ref)`, but the CSV also supports `contains`, `regex`, and
+compatibility `glob` rules for normalized infrastructure exports. Start from
+the checked-in schema in [Asset Context CSV](../asset-context-csv.md) or
+`data/input_fixtures/example_asset_context_rules.csv`, adapt it to your
+infrastructure targets, then rerun `analyze` with `--asset-context`.
 
 ```bash
 vuln-prioritizer analyze \

--- a/docs/schemas/input-validation-report.schema.json
+++ b/docs/schemas/input-validation-report.schema.json
@@ -236,6 +236,8 @@
         "total_rows",
         "loaded_rows",
         "exact_rules",
+        "contains_rules",
+        "regex_rules",
         "glob_rules",
         "legacy_schema",
         "warnings"
@@ -248,6 +250,12 @@
           "type": "integer"
         },
         "exact_rules": {
+          "type": "integer"
+        },
+        "contains_rules": {
+          "type": "integer"
+        },
+        "regex_rules": {
           "type": "integer"
         },
         "glob_rules": {

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -58,7 +58,7 @@ Maintainer-facing parser fixture regression coverage is documented in
 | --- | --- | --- | --- | --- |
 | ATT&CK enrichment | yes | yes | yes | Sources: `none`, `local-csv`, `local-curated`, `ctid-json`. Prefer `ctid-json`; `local-curated` is for reviewed YAML/JSON CVE-to-ATT&CK mappings; `local-csv` remains legacy compatibility only. Technique metadata can use the simplified local JSON or a pinned ATT&CK STIX bundle. No remote ATT&CK dependency. |
 | Defensive context file | yes | yes | yes | `--defensive-context-file` reads a local/offline JSON overlay for OSV, GHSA, Vulnrichment, or SSVC evidence you already have. It is contextual evidence only; it does not fetch advisory data and does not change base priority scoring from CVSS, EPSS, and KEV. |
-| Asset context CSV | yes | yes | yes | `target_kind` stays exact; `target_ref` supports deterministic `exact` and `glob` rules with optional `rule_id`, `match_mode`, `precedence`, and aggregated conflict reporting. |
+| Asset context CSV | yes | yes | yes | `target_kind` stays exact; `target_ref` or `asset_ref` supports deterministic `exact`, `contains`, `regex`, and compatibility `glob` rules with optional `rule_id`, `match_mode`, `precedence`, and aggregated conflict reporting; see [Asset Context CSV](asset-context-csv.md). |
 | VEX files | yes | yes | yes | Supports OpenVEX JSON and CycloneDX VEX JSON with deterministic ranked matching, occurrence-level match provenance, aggregated conflict reporting, and visible `under_investigation` status. |
 | Policy profiles | yes | yes | yes | Built-ins: `default`, `enterprise`, `conservative`. |
 | Custom policy file | yes | yes | yes | YAML-defined profiles, selected by `--policy-profile`. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - SBOM and Dependency Triage: playbooks/sbom_triage.md
       - Infrastructure Scan Triage: playbooks/infrastructure_scan_triage.md
   - Contracts: contracts.md
+  - Asset Context CSV: asset-context-csv.md
   - ATT&CK Curated Mapping Schema: attack-ttp-methodology.md
   - Support Matrix: support_matrix.md
   - Integrations: integrations/reporting_and_ci.md
@@ -98,6 +99,7 @@ nav:
       - VPW-059 ATT&CK Summary Dashboard: evidence/vpw-059-attack-summary-dashboard.md
       - VPW-060 ATT&CK Navigator Layer: evidence/vpw-060-attack-navigator-layer.md
       - VPW-061 ATT&CK Methodology And Safety: evidence/vpw-061-attack-methodology-safety.md
+      - VPW-062 Asset Context Matching: evidence/vpw-062-asset-context-matching.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary

- extend asset context CSV loading with `asset_ref` alias support plus `exact`, `contains`, `regex`, and compatibility `glob` match modes
- add deterministic diagnostics and published input-validation schema coverage for all asset rule counters
- add focused parser/matcher/re-score tests, a rule-oriented CSV fixture, dedicated schema docs, and VPW-062 evidence

## Validation

- `python3 -m ruff check backend/src/vuln_prioritizer/commands/input.py backend/src/vuln_prioritizer/inputs/loader.py backend/src/vuln_prioritizer/inputs/_occurrence_support.py backend/tests/test_asset_context_rules.py backend/tests/cli/test_input_validate.py backend/tests/test_output_schemas.py`
- `python3 -m pytest -q backend/tests/test_asset_context_rules.py backend/tests/cli/test_input_validate.py backend/tests/test_output_schemas.py --no-cov`
- `python3 -m pytest -q backend/tests/cli/test_analyze.py::test_cli_analyze_reports_asset_and_vex_conflicts_with_deterministic_winners backend/tests/e2e/test_module_entrypoint.py::test_module_entrypoint_p2_context_round_trip --no-cov`
- `python3 -m vuln_prioritizer.cli input validate --asset-context data/input_fixtures/example_asset_context_rules.csv --format json`
- `make docs-check`
- `make demo-sync-check`
- `make check`

Refs #168