### PR TITLE
VPW-068: Integrate governance reports and evidence bundle

### DIFF
--- a/backend/app/models/governance.py
+++ b/backend/app/models/governance.py
@@ -7,7 +7,7 @@ from sqlmodel import Field, SQLModel
 
 
 class GovernanceRollupPublic(SQLModel):
-    """Aggregated finding risk for one owner, service, or environment."""
+    """Aggregated finding risk for one owner, service, asset, or environment."""
 
     dimension: str
     label: str
@@ -68,12 +68,14 @@ class GovernanceWaiverDebtPublic(SQLModel):
 
 
 class ProjectGovernanceRollupsPublic(SQLModel):
-    """Owner, service, environment, and waiver-debt rollups for one project."""
+    """Owner, service, asset, environment, and waiver-debt rollups for one project."""
 
     project_id: uuid.UUID
     generated_at: datetime
     owners: list[GovernanceRollupPublic] = Field(default_factory=list)
     services: list[GovernanceRollupPublic] = Field(default_factory=list)
+    assets: list[GovernanceRollupPublic] = Field(default_factory=list)
     environments: list[GovernanceRollupPublic] = Field(default_factory=list)
     top_services_by_risk: list[GovernanceRollupPublic] = Field(default_factory=list)
+    top_assets_by_risk: list[GovernanceRollupPublic] = Field(default_factory=list)
     waiver_debt: GovernanceWaiverDebtPublic = Field(default_factory=GovernanceWaiverDebtPublic)

--- a/backend/app/services/governance.py
+++ b/backend/app/services/governance.py
@@ -35,7 +35,7 @@ def build_project_governance_rollups_payload(
     waiver_repository: WaiverRepository | None = None,
     limit: int = 5,
 ) -> ProjectGovernanceRollupsPublic:
-    """Build owner, service, environment, and waiver-debt rollups for a project."""
+    """Build owner, service, asset, environment, and waiver-debt rollups for a project."""
     bounded_limit = max(1, min(limit, 50))
     owner_rollups = _rollups_for_dimension(
         findings,
@@ -49,6 +49,12 @@ def build_project_governance_rollups_payload(
         label_for_finding=_service_label,
         limit=bounded_limit,
     )
+    asset_rollups = _rollups_for_dimension(
+        findings,
+        dimension="asset",
+        label_for_finding=_asset_label,
+        limit=bounded_limit,
+    )
     environment_rollups = _rollups_for_dimension(
         findings,
         dimension="environment",
@@ -60,8 +66,10 @@ def build_project_governance_rollups_payload(
         generated_at=get_datetime_utc(),
         owners=owner_rollups,
         services=service_rollups,
+        assets=asset_rollups,
         environments=environment_rollups,
         top_services_by_risk=service_rollups[:bounded_limit],
+        top_assets_by_risk=asset_rollups[:bounded_limit],
         waiver_debt=_waiver_debt_summary(
             findings=findings,
             waivers=list(waivers or []),
@@ -233,6 +241,18 @@ def _service_label(finding: Finding) -> str:
             finding,
             ("business_service", "service", "asset_business_service", "waiver_service"),
         )
+        or UNKNOWN_LABEL
+    )
+
+
+def _asset_label(finding: Finding) -> str:
+    asset = getattr(finding, "asset", None)
+    asset_key = getattr(asset, "asset_key", None)
+    asset_name = getattr(asset, "name", None)
+    return _clean_label(
+        asset_key
+        or asset_name
+        or _record_string(finding, ("asset_key", "asset_ref", "target_ref"))
         or UNKNOWN_LABEL
     )
 

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -10,6 +10,7 @@ import re
 import uuid
 import zipfile
 from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from io import BytesIO, StringIO
@@ -43,12 +44,20 @@ REPORT_KIND_ANALYSIS_JSON = "analysis-result-json"
 REPORT_KIND_FINDINGS_CSV = "findings-csv"
 REPORT_KIND_EVIDENCE_BUNDLE = "evidence-bundle"
 REPORT_KIND_ATTACK_NAVIGATOR = "attack-navigator-layer"
+REPORT_KIND_GOVERNANCE_ROLLUPS = "governance-rollups"
+REPORT_KIND_GOVERNANCE_WAIVERS = "governance-waivers"
+REPORT_KIND_GOVERNANCE_VEX = "governance-vex-summary"
+REPORT_KIND_GOVERNANCE_ASSET_CONTEXT = "governance-asset-context"
 REPORT_FILENAME_TECHNICAL_MARKDOWN = "technical-report.md"
 REPORT_FILENAME_EXECUTIVE_HTML = "executive-report.html"
 REPORT_FILENAME_ANALYSIS_JSON = "analysis-result.v1.json"
 REPORT_FILENAME_FINDINGS_CSV = "findings.csv"
 REPORT_FILENAME_EVIDENCE_BUNDLE = "evidence-bundle.zip"
 REPORT_FILENAME_ATTACK_NAVIGATOR = "attack-navigator-layer.json"
+REPORT_FILENAME_GOVERNANCE_ROLLUPS = "governance/rollups.json"
+REPORT_FILENAME_GOVERNANCE_WAIVERS = "governance/waivers.json"
+REPORT_FILENAME_GOVERNANCE_VEX = "governance/vex-summary.json"
+REPORT_FILENAME_GOVERNANCE_ASSET_CONTEXT = "governance/asset-context.json"
 REPORT_CONTENT_TYPE_MARKDOWN = "text/markdown; charset=utf-8"
 REPORT_CONTENT_TYPE_HTML = "text/html; charset=utf-8"
 REPORT_CONTENT_TYPE_JSON = "application/json; charset=utf-8"
@@ -853,7 +862,7 @@ def render_markdown_report(payload: MarkdownReportPayload) -> str:
         f"| Low | {counts['Low']} |",
     ]
     if payload.governance_rollups:
-        lines.extend(_markdown_governance_section(payload.governance_rollups))
+        lines.extend(_markdown_governance_section(payload.governance_rollups, payload.findings))
     lines.extend(
         [
             "",
@@ -990,9 +999,17 @@ def render_markdown_report(payload: MarkdownReportPayload) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _markdown_governance_section(governance_rollups: dict[str, Any]) -> list[str]:
+def _markdown_governance_section(
+    governance_rollups: dict[str, Any],
+    findings: list[MarkdownReportFinding],
+) -> list[str]:
     services = _dict_list(governance_rollups.get("top_services_by_risk"))[:5]
+    assets = _dict_list(governance_rollups.get("top_assets_by_risk"))[:5]
+    owners = _dict_list(governance_rollups.get("owners"))[:5]
+    environments = _dict_list(governance_rollups.get("environments"))[:5]
     waiver_debt = _dict_value(governance_rollups.get("waiver_debt"))
+    waiver_items = _dict_list(waiver_debt.get("items"))[:5]
+    vex_summary = _governance_vex_summary(findings)
     lines = [
         "",
         "## Governance Rollups",
@@ -1000,41 +1017,152 @@ def _markdown_governance_section(governance_rollups: dict[str, Any]) -> list[str
         "| Field | Value |",
         "| --- | --- |",
         f"| Waivers | {_safe_cell(waiver_debt.get('waiver_count', 0))} |",
+        f"| Active Waivers | {_safe_cell(waiver_debt.get('active_count', 0))} |",
         f"| Expired Waivers | {_safe_cell(waiver_debt.get('expired_count', 0))} |",
         f"| Review Due Waivers | {_safe_cell(waiver_debt.get('review_due_count', 0))} |",
+        f"| Expiring Soon Waivers | {_safe_cell(waiver_debt.get('expiring_soon_count', 0))} |",
         f"| Accepted Findings | {_safe_cell(waiver_debt.get('accepted_finding_count', 0))} |",
+        f"| VEX Suppressed Findings | {_safe_cell(vex_summary['suppressed_by_vex_count'])} |",
+        f"| VEX Under Investigation | {_safe_cell(vex_summary['under_investigation_count'])} |",
         "",
         "### Top Services by Risk",
         "",
     ]
     if not services:
         lines.append("No service rollups are available for this analysis run.")
-        return lines
+    else:
+        lines.extend(
+            [
+                "| Service | Findings | Critical | High | Risk Score | Waiver Debt |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for service in services:
+            waiver_debt_count = int(service.get("expired_waiver_count") or 0) + int(
+                service.get("review_due_waiver_count") or 0
+            )
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _safe_cell(service.get("label")),
+                        _safe_cell(service.get("finding_count", 0)),
+                        _safe_cell(service.get("critical_count", 0)),
+                        _safe_cell(service.get("high_count", 0)),
+                        _safe_cell(_format_number(service.get("risk_score_total"))),
+                        _safe_cell(waiver_debt_count),
+                    ]
+                )
+                + " |"
+            )
+    lines.extend(
+        [
+            "",
+            "### Top Assets by Risk",
+            "",
+        ]
+    )
+    if not assets:
+        lines.append("No asset rollups are available for this analysis run.")
+    else:
+        lines.extend(
+            [
+                "| Asset | Findings | Critical | High | Risk Score | Accepted | VEX Suppressed |",
+                "| --- | --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for asset in assets:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _safe_cell(asset.get("label")),
+                        _safe_cell(asset.get("finding_count", 0)),
+                        _safe_cell(asset.get("critical_count", 0)),
+                        _safe_cell(asset.get("high_count", 0)),
+                        _safe_cell(_format_number(asset.get("risk_score_total"))),
+                        _safe_cell(asset.get("accepted_count", 0)),
+                        _safe_cell(asset.get("suppressed_by_vex_count", 0)),
+                    ]
+                )
+                + " |"
+            )
+    lines.extend(
+        [
+            "",
+            "### Accepted Risk and Expiring Waivers",
+            "",
+        ]
+    )
+    if waiver_items:
+        lines.extend(
+            [
+                "| Scope | Owner | Status | Expires | Review | Matched Findings |",
+                "| --- | --- | --- | --- | --- | --- |",
+            ]
+        )
+        for item in waiver_items:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _safe_cell(item.get("scope")),
+                        _safe_cell(item.get("owner")),
+                        _safe_cell(item.get("status")),
+                        _safe_cell(item.get("expires_at")),
+                        _safe_cell(item.get("review_at")),
+                        _safe_cell(item.get("matched_findings", 0)),
+                    ]
+                )
+                + " |"
+            )
+    else:
+        lines.append("No accepted-risk waiver debt is currently recorded for this run.")
 
     lines.extend(
         [
-            "| Service | Findings | Critical | High | Risk Score | Waiver Debt |",
-            "| --- | --- | --- | --- | --- | --- |",
+            "",
+            "### Owner and Environment Rollups",
+            "",
+            "| Dimension | Label | Findings | Critical | High | Accepted | Waiver Debt |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
-    for service in services:
-        waiver_debt_count = int(service.get("expired_waiver_count") or 0) + int(
-            service.get("review_due_waiver_count") or 0
-        )
-        lines.append(
-            "| "
-            + " | ".join(
-                [
-                    _safe_cell(service.get("label")),
-                    _safe_cell(service.get("finding_count", 0)),
-                    _safe_cell(service.get("critical_count", 0)),
-                    _safe_cell(service.get("high_count", 0)),
-                    _safe_cell(_format_number(service.get("risk_score_total"))),
-                    _safe_cell(waiver_debt_count),
-                ]
+    for dimension, rows in (("Owner", owners), ("Environment", environments)):
+        for row in rows:
+            waiver_debt_count = int(row.get("expired_waiver_count") or 0) + int(
+                row.get("review_due_waiver_count") or 0
             )
-            + " |"
-        )
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        _safe_cell(dimension),
+                        _safe_cell(row.get("label")),
+                        _safe_cell(row.get("finding_count", 0)),
+                        _safe_cell(row.get("critical_count", 0)),
+                        _safe_cell(row.get("high_count", 0)),
+                        _safe_cell(row.get("accepted_count", 0)),
+                        _safe_cell(waiver_debt_count),
+                    ]
+                )
+                + " |"
+            )
+    if not owners and not environments:
+        lines.append("| Owner | Unassigned | 0 | 0 | 0 | 0 | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "### VEX Summary",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            f"| Suppressed by VEX | {_safe_cell(vex_summary['suppressed_by_vex_count'])} |",
+            f"| Under Investigation | {_safe_cell(vex_summary['under_investigation_count'])} |",
+            f"| Fixed | {_safe_cell(vex_summary['fixed_count'])} |",
+        ]
+    )
     return lines
 
 
@@ -1183,6 +1311,8 @@ def render_evidence_bundle_zip(
             "provider-snapshot",
         ),
     ]
+    governance_entries = _governance_bundle_entries(bundle_payload)
+    entries.extend(governance_entries)
     if attack_navigator_layer is not None:
         redacted_layer, layer_redactions = _redact_bundle_value(
             attack_navigator_layer,
@@ -1240,6 +1370,15 @@ def render_evidence_bundle_zip(
         },
         "files": file_entries,
     }
+    if governance_entries:
+        manifest["governance_artifacts"] = [
+            {
+                "bundle_path": path,
+                "kind": kind,
+                "sha256": artifact_hashes[path],
+            }
+            for path, _content, kind in governance_entries
+        ]
     if REPORT_FILENAME_ATTACK_NAVIGATOR in artifact_hashes:
         manifest["attack_navigator_layer"] = {
             "bundle_path": REPORT_FILENAME_ATTACK_NAVIGATOR,
@@ -1312,6 +1451,184 @@ def _bundle_input_hashes(payload: MarkdownReportPayload) -> list[dict[str, Any]]
 def _safe_bundle_filename(value: object) -> str:
     filename = Path(str(value)).name.strip() if value is not None else ""
     return filename or "uploaded-input"
+
+
+def _governance_bundle_entries(
+    payload: MarkdownReportPayload,
+) -> list[tuple[str, bytes, str]]:
+    if not payload.governance_rollups:
+        return []
+    artifacts = [
+        (
+            REPORT_FILENAME_GOVERNANCE_ROLLUPS,
+            _governance_rollups_export(payload),
+            REPORT_KIND_GOVERNANCE_ROLLUPS,
+        ),
+        (
+            REPORT_FILENAME_GOVERNANCE_WAIVERS,
+            _governance_waivers_export(payload),
+            REPORT_KIND_GOVERNANCE_WAIVERS,
+        ),
+        (
+            REPORT_FILENAME_GOVERNANCE_VEX,
+            _governance_vex_export(payload),
+            REPORT_KIND_GOVERNANCE_VEX,
+        ),
+        (
+            REPORT_FILENAME_GOVERNANCE_ASSET_CONTEXT,
+            _governance_asset_context_export(payload),
+            REPORT_KIND_GOVERNANCE_ASSET_CONTEXT,
+        ),
+    ]
+    return [(path, _json_bytes(content), kind) for path, content, kind in artifacts]
+
+
+def _governance_rollups_export(payload: MarkdownReportPayload) -> dict[str, Any]:
+    return {
+        "schema": "governance-rollups.v1",
+        "schema_version": "1.0.0",
+        "generated_at": _iso_datetime(payload.generated_at),
+        "project_id": payload.project_id,
+        "run_id": payload.run_id,
+        "rollups": payload.governance_rollups,
+    }
+
+
+def _governance_waivers_export(payload: MarkdownReportPayload) -> dict[str, Any]:
+    waiver_debt = _dict_value(payload.governance_rollups.get("waiver_debt"))
+    accepted_findings = [
+        _governance_finding_row(finding)
+        for finding in payload.findings
+        if _boolish_signal(finding, "waived") or finding.status.lower().endswith("accepted")
+    ]
+    return {
+        "schema": "governance-waivers.v1",
+        "schema_version": "1.0.0",
+        "generated_at": _iso_datetime(payload.generated_at),
+        "project_id": payload.project_id,
+        "run_id": payload.run_id,
+        "waiver_debt": waiver_debt,
+        "accepted_findings": accepted_findings,
+    }
+
+
+def _governance_vex_export(payload: MarkdownReportPayload) -> dict[str, Any]:
+    vex_findings = [
+        _governance_finding_row(finding)
+        for finding in payload.findings
+        if _boolish_signal(finding, "suppressed_by_vex")
+        or _boolish_signal(finding, "under_investigation")
+        or _vex_statuses_label(finding)
+    ]
+    return {
+        "schema": "governance-vex-summary.v1",
+        "schema_version": "1.0.0",
+        "generated_at": _iso_datetime(payload.generated_at),
+        "project_id": payload.project_id,
+        "run_id": payload.run_id,
+        "summary": _governance_vex_summary(payload.findings),
+        "findings": vex_findings,
+    }
+
+
+def _governance_asset_context_export(payload: MarkdownReportPayload) -> dict[str, Any]:
+    return {
+        "schema": "governance-asset-context.v1",
+        "schema_version": "1.0.0",
+        "generated_at": _iso_datetime(payload.generated_at),
+        "project_id": payload.project_id,
+        "run_id": payload.run_id,
+        "owners": _dict_list(payload.governance_rollups.get("owners")),
+        "services": _dict_list(payload.governance_rollups.get("services")),
+        "top_assets_by_risk": _dict_list(payload.governance_rollups.get("top_assets_by_risk")),
+        "environments": _dict_list(payload.governance_rollups.get("environments")),
+        "assets": _asset_context_rows(payload.findings),
+    }
+
+
+def _asset_context_rows(findings: list[MarkdownReportFinding]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[MarkdownReportFinding]] = {}
+    for finding in findings:
+        label = finding.asset_key or finding.asset or "Unassigned"
+        grouped.setdefault(label, []).append(finding)
+    rows: list[dict[str, Any]] = []
+    for label, items in grouped.items():
+        first = items[0]
+        rows.append(
+            {
+                "asset_key": first.asset_key,
+                "label": label,
+                "owner": first.owner,
+                "business_service": first.business_service,
+                "environment": first.environment,
+                "exposure": first.exposure,
+                "criticality": first.criticality,
+                "finding_count": len(items),
+                "accepted_count": sum(
+                    1
+                    for finding in items
+                    if _boolish_signal(finding, "waived")
+                    or finding.status.lower().endswith("accepted")
+                ),
+                "suppressed_by_vex_count": sum(
+                    1 for finding in items if _boolish_signal(finding, "suppressed_by_vex")
+                ),
+                "top_cves": [finding.cve_id for finding in items[:5]],
+            }
+        )
+    rows.sort(
+        key=lambda item: (
+            -int(item["finding_count"]),
+            str(item["business_service"] or ""),
+            str(item["label"]),
+        )
+    )
+    return rows
+
+
+def _governance_finding_row(finding: MarkdownReportFinding) -> dict[str, Any]:
+    waiver = _dict_value(finding.explanation.get("waiver"))
+    return {
+        "id": finding.id,
+        "cve_id": finding.cve_id,
+        "priority": _priority_label(finding.priority),
+        "status": finding.status,
+        "risk_score": finding.risk_score,
+        "asset": finding.asset,
+        "asset_key": finding.asset_key,
+        "owner": finding.owner,
+        "business_service": finding.business_service,
+        "environment": finding.environment,
+        "waived": _boolish_signal(finding, "waived"),
+        "waiver_status": _string_from_mapping(waiver, "waiver_status")
+        or _string_from_mapping(finding.explanation, "waiver_status"),
+        "waiver_owner": _string_from_mapping(waiver, "waiver_owner")
+        or _string_from_mapping(finding.explanation, "waiver_owner"),
+        "waiver_expires_on": _string_from_mapping(waiver, "waiver_expires_on")
+        or _string_from_mapping(finding.explanation, "waiver_expires_on"),
+        "waiver_review_on": _string_from_mapping(waiver, "waiver_review_on")
+        or _string_from_mapping(finding.explanation, "waiver_review_on"),
+        "suppressed_by_vex": _boolish_signal(finding, "suppressed_by_vex"),
+        "under_investigation": _boolish_signal(finding, "under_investigation"),
+        "vex_statuses": _vex_statuses_label(finding),
+        "decision_statement": finding.decision_statement,
+    }
+
+
+def _governance_vex_summary(findings: list[MarkdownReportFinding]) -> dict[str, Any]:
+    status_counts: Counter[str] = Counter()
+    for finding in findings:
+        status_counts.update(_vex_status_counts_from_explanation(finding.explanation))
+    return {
+        "suppressed_by_vex_count": sum(
+            1 for finding in findings if _boolish_signal(finding, "suppressed_by_vex")
+        ),
+        "under_investigation_count": sum(
+            1 for finding in findings if _boolish_signal(finding, "under_investigation")
+        ),
+        "fixed_count": sum(1 for finding in findings if finding.status.lower().endswith("fixed")),
+        "status_counts": dict(sorted(status_counts.items())),
+    }
 
 
 def _redacted_bundle_payload(
@@ -1519,7 +1836,7 @@ def render_html_executive_report(payload: MarkdownReportPayload) -> str:
     if not recommendations:
         recommendations = "<li>No remediation recommendations are available for this run.</li>"
     governance_section = (
-        f"{_html_governance_rollups(payload.governance_rollups)}\n\n"
+        f"{_html_governance_rollups(payload.governance_rollups, payload.findings)}\n\n"
         if payload.governance_rollups
         else ""
     )
@@ -1622,35 +1939,76 @@ def _html_metric(label: str, value: object) -> str:
     )
 
 
-def _html_governance_rollups(governance_rollups: dict[str, Any]) -> str:
+def _html_governance_rollups(
+    governance_rollups: dict[str, Any],
+    findings: list[MarkdownReportFinding],
+) -> str:
     services = _dict_list(governance_rollups.get("top_services_by_risk"))[:5]
+    assets = _dict_list(governance_rollups.get("top_assets_by_risk"))[:5]
     waiver_debt = _dict_value(governance_rollups.get("waiver_debt"))
-    rows = "\n".join(_html_service_rollup_row(service) for service in services)
-    if not rows:
-        rows = (
+    waiver_items = _dict_list(waiver_debt.get("items"))[:5]
+    vex_summary = _governance_vex_summary(findings)
+    service_rows = "\n".join(_html_service_rollup_row(service) for service in services)
+    if not service_rows:
+        service_rows = (
             '<tr><td colspan="6" class="empty-state">'
             "No service rollups are available for this analysis run.</td></tr>"
+        )
+    asset_rows = "\n".join(_html_asset_rollup_row(asset) for asset in assets)
+    if not asset_rows:
+        asset_rows = (
+            '<tr><td colspan="7" class="empty-state">'
+            "No asset rollups are available for this analysis run.</td></tr>"
+        )
+    waiver_rows = "\n".join(_html_waiver_debt_row(item) for item in waiver_items)
+    if not waiver_rows:
+        waiver_rows = (
+            '<tr><td colspan="6" class="empty-state">'
+            "No accepted-risk waiver debt is currently recorded for this run.</td></tr>"
         )
     return (
         '    <section aria-labelledby="governance-rollups">\n'
         '      <div class="section-heading">\n'
         '        <p class="eyebrow">Governance</p>\n'
-        '        <h2 id="governance-rollups">Service Risk and Waiver Debt</h2>\n'
+        '        <h2 id="governance-rollups">Service Risk, Accepted Risk, and VEX</h2>\n'
         "      </div>\n"
         '      <div class="metric-grid">\n'
         f"        {_html_metric('Waivers', waiver_debt.get('waiver_count', 0))}\n"
         f"        {_html_metric('Expired', waiver_debt.get('expired_count', 0))}\n"
         f"        {_html_metric('Review Due', waiver_debt.get('review_due_count', 0))}\n"
+        f"        {_html_metric('Expiring Soon', waiver_debt.get('expiring_soon_count', 0))}\n"
         "        "
         f"{_html_metric('Accepted Findings', waiver_debt.get('accepted_finding_count', 0))}\n"
+        f"        {_html_metric('VEX Suppressed', vex_summary['suppressed_by_vex_count'])}\n"
         "      </div>\n"
+        "      <h3>Service Rollup</h3>\n"
         '      <div class="table-wrap">\n'
         "        <table>\n"
         "          <thead>\n"
         "            <tr><th>Service</th><th>Findings</th><th>Critical</th><th>High</th>"
         "<th>Risk Score</th><th>Waiver Debt</th></tr>\n"
         "          </thead>\n"
-        f"          <tbody>\n{rows}\n          </tbody>\n"
+        f"          <tbody>\n{service_rows}\n          </tbody>\n"
+        "        </table>\n"
+        "      </div>\n"
+        "      <h3>Asset Rollup</h3>\n"
+        '      <div class="table-wrap">\n'
+        "        <table>\n"
+        "          <thead>\n"
+        "            <tr><th>Asset</th><th>Findings</th><th>Critical</th><th>High</th>"
+        "<th>Risk Score</th><th>Accepted</th><th>VEX Suppressed</th></tr>\n"
+        "          </thead>\n"
+        f"          <tbody>\n{asset_rows}\n          </tbody>\n"
+        "        </table>\n"
+        "      </div>\n"
+        "      <h3>Accepted Risk and Expiring Waivers</h3>\n"
+        '      <div class="table-wrap">\n'
+        "        <table>\n"
+        "          <thead>\n"
+        "            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th>"
+        "<th>Review</th><th>Matched</th></tr>\n"
+        "          </thead>\n"
+        f"          <tbody>\n{waiver_rows}\n          </tbody>\n"
         "        </table>\n"
         "      </div>\n"
         "    </section>"
@@ -1669,6 +2027,33 @@ def _html_service_rollup_row(service: dict[str, Any]) -> str:
         f"<td>{_safe_html(service.get('high_count', 0))}</td>"
         f"<td>{_safe_html(_format_number(service.get('risk_score_total')))}</td>"
         f"<td>{_safe_html(waiver_debt_count)}</td>"
+        "</tr>"
+    )
+
+
+def _html_asset_rollup_row(asset: dict[str, Any]) -> str:
+    return (
+        "            <tr>"
+        f"<td>{_safe_html(asset.get('label'))}</td>"
+        f"<td>{_safe_html(asset.get('finding_count', 0))}</td>"
+        f"<td>{_safe_html(asset.get('critical_count', 0))}</td>"
+        f"<td>{_safe_html(asset.get('high_count', 0))}</td>"
+        f"<td>{_safe_html(_format_number(asset.get('risk_score_total')))}</td>"
+        f"<td>{_safe_html(asset.get('accepted_count', 0))}</td>"
+        f"<td>{_safe_html(asset.get('suppressed_by_vex_count', 0))}</td>"
+        "</tr>"
+    )
+
+
+def _html_waiver_debt_row(item: dict[str, Any]) -> str:
+    return (
+        "            <tr>"
+        f"<td>{_safe_html(item.get('scope'))}</td>"
+        f"<td>{_safe_html(item.get('owner'))}</td>"
+        f"<td>{_safe_html(item.get('status'))}</td>"
+        f"<td>{_safe_html(item.get('expires_at'))}</td>"
+        f"<td>{_safe_html(item.get('review_at'))}</td>"
+        f"<td>{_safe_html(item.get('matched_findings', 0))}</td>"
         "</tr>"
     )
 
@@ -1848,6 +2233,12 @@ def _finding_payload(
     occurrences: list[FindingOccurrence],
 ) -> MarkdownReportFinding:
     decision_guidance = _decision_guidance(finding)
+    explanation = _dict_value(finding.explanation_json)
+    base_decision_statement = _decision_text(
+        decision_guidance,
+        "decision_statement",
+        fallback=finding.recommended_action,
+    )
     return MarkdownReportFinding(
         id=str(finding.id),
         dedup_key=finding.dedup_key,
@@ -1876,15 +2267,15 @@ def _finding_payload(
         vulnerability=_vulnerability_payload(finding),
         rationale=finding.rationale,
         recommended_action=finding.recommended_action,
-        explanation=_dict_value(finding.explanation_json),
+        explanation=explanation,
         data_quality=_dict_value(finding.data_quality_json),
         evidence=_dict_value(finding.evidence_json),
         occurrences=[_occurrence_payload(occurrence) for occurrence in occurrences],
         data_quality_confidence=_data_quality_confidence(finding),
-        decision_statement=_decision_text(
-            decision_guidance,
-            "decision_statement",
-            fallback=finding.recommended_action,
+        decision_statement=_governance_decision_statement(
+            finding=finding,
+            explanation=explanation,
+            base_statement=base_decision_statement,
         ),
         business_impact=_decision_text(decision_guidance, "business_impact"),
         decision_sla=_decision_sla(decision_guidance),
@@ -1894,6 +2285,67 @@ def _finding_payload(
         created_at=finding.created_at,
         updated_at=finding.updated_at,
     )
+
+
+def _governance_decision_statement(
+    *,
+    finding: Finding,
+    explanation: dict[str, Any],
+    base_statement: str | None,
+) -> str | None:
+    statement = base_statement
+    additions: list[str] = []
+    waiver = _dict_value(explanation.get("waiver"))
+    waiver_status = _string_from_mapping(waiver, "waiver_status") or _string_from_mapping(
+        explanation, "waiver_status"
+    )
+    if finding.waived or waiver_status:
+        additions.append(
+            "Accepted-risk governance remains visible"
+            + _governance_detail_clause(
+                (
+                    (
+                        "owner",
+                        _string_from_mapping(waiver, "waiver_owner")
+                        or _string_from_mapping(explanation, "waiver_owner"),
+                    ),
+                    ("status", waiver_status),
+                    (
+                        "review",
+                        _string_from_mapping(waiver, "waiver_review_on")
+                        or _string_from_mapping(explanation, "waiver_review_on"),
+                    ),
+                    (
+                        "expires",
+                        _string_from_mapping(waiver, "waiver_expires_on")
+                        or _string_from_mapping(explanation, "waiver_expires_on"),
+                    ),
+                )
+            )
+            + "."
+        )
+    if finding.suppressed_by_vex or finding.under_investigation:
+        vex_statuses = _vex_statuses_label_from_explanation(explanation)
+        additions.append(
+            "VEX governance applies"
+            + _governance_detail_clause(
+                (
+                    ("status", vex_statuses),
+                    ("source", _string_from_mapping(explanation, "vex_source_format")),
+                    ("record", _string_from_mapping(explanation, "vex_source_record_id")),
+                )
+            )
+            + "."
+        )
+    if not additions:
+        return statement
+    prefix = statement.rstrip() if statement else "Decision Statement: review finding governance."
+    return f"{prefix} {' '.join(additions)}"
+
+
+def _governance_detail_clause(items: Sequence[tuple[str, str | None]]) -> str:
+    details = [f"{label} {value}" for label, value in items if value]
+    return f" ({'; '.join(details)})" if details else ""
 
 
 def _provider_snapshot_payload(
@@ -2092,6 +2544,11 @@ def _decision_guidance_from_payload(finding: MarkdownReportFinding) -> dict[str,
     return dict(value) if isinstance(value, dict) else {}
 
 
+def _string_from_mapping(mapping: dict[str, Any], key: str) -> str | None:
+    value = mapping.get(key)
+    return value if isinstance(value, str) and value.strip() else None
+
+
 def _boolish_signal(finding: MarkdownReportFinding, key: str) -> bool:
     if hasattr(finding, key):
         return bool(getattr(finding, key))
@@ -2116,10 +2573,35 @@ def _dict_list(value: Any) -> list[dict[str, Any]]:
 
 
 def _vex_statuses_label(finding: MarkdownReportFinding) -> str:
-    statuses = finding.explanation.get("vex_statuses")
-    if isinstance(statuses, dict):
-        return ";".join(f"{status}:{count}" for status, count in sorted(statuses.items()))
+    return _vex_statuses_label_from_explanation(finding.explanation)
+
+
+def _vex_statuses_label_from_explanation(explanation: dict[str, Any]) -> str:
+    status_counts = _vex_status_counts_from_explanation(explanation)
+    if status_counts:
+        return ";".join(f"{status}:{count}" for status, count in sorted(status_counts.items()))
     return ""
+
+
+def _vex_status_counts_from_explanation(explanation: dict[str, Any]) -> Counter[str]:
+    status_counts: Counter[str] = Counter()
+    for record in (explanation, _dict_value(explanation.get("provenance"))):
+        statuses = record.get("vex_statuses")
+        if isinstance(statuses, dict) and statuses:
+            for status, count in statuses.items():
+                status_text = str(status).strip()
+                if not status_text:
+                    continue
+                if isinstance(count, int | float):
+                    status_counts[status_text] += int(count)
+                elif count:
+                    status_counts[status_text] += 1
+            return status_counts
+        status = record.get("vex_status")
+        if isinstance(status, str) and status.strip():
+            status_counts[status.strip()] += 1
+            return status_counts
+    return status_counts
 
 
 def _format_number(value: float | None) -> str:

--- a/backend/src/vuln_prioritizer/models.py
+++ b/backend/src/vuln_prioritizer/models.py
@@ -35,6 +35,7 @@ DoctorCheck = _models_artifacts.DoctorCheck
 DoctorReport = _models_artifacts.DoctorReport
 DoctorSummary = _models_artifacts.DoctorSummary
 EvidenceBundleFile = _models_artifacts.EvidenceBundleFile
+EvidenceBundleGovernanceArtifact = _models_artifacts.EvidenceBundleGovernanceArtifact
 EvidenceBundleInputHash = _models_artifacts.EvidenceBundleInputHash
 EvidenceBundleManifest = _models_artifacts.EvidenceBundleManifest
 EvidenceBundleVerificationItem = _models_artifacts.EvidenceBundleVerificationItem

--- a/backend/src/vuln_prioritizer/models_artifacts.py
+++ b/backend/src/vuln_prioritizer/models_artifacts.py
@@ -48,6 +48,12 @@ class EvidenceBundleInputHash(StrictModel):
     sha256: str
 
 
+class EvidenceBundleGovernanceArtifact(StrictModel):
+    bundle_path: str
+    kind: str
+    sha256: str
+
+
 class EvidenceBundleManifest(StrictModel):
     schema_version: str = "1.1.0"
     bundle_kind: str = "evidence-bundle"
@@ -58,6 +64,7 @@ class EvidenceBundleManifest(StrictModel):
     source_input_paths: list[str] = Field(default_factory=list)
     source_input_hashes: list[EvidenceBundleInputHash] = Field(default_factory=list)
     provider_snapshot: dict[str, Any] = Field(default_factory=dict)
+    governance_artifacts: list[EvidenceBundleGovernanceArtifact] = Field(default_factory=list)
     attack_navigator_layer: dict[str, Any] | None = None
     artifact_hashes: dict[str, str] = Field(default_factory=dict)
     findings_count: int = 0

--- a/backend/tests/api/snapshots/vpw_068_governance_report.md
+++ b/backend/tests/api/snapshots/vpw_068_governance_report.md
@@ -1,0 +1,99 @@
+# Technical Vulnerability Report
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Project | VPW-050 Snapshot |
+| Project ID | 00000000-0000-4000-8000-000000000156 |
+| Analysis Run | 00000000-0000-4000-8000-000000000050 |
+| Run Status | completed |
+| Input Type | cve-list |
+| Input File | known-cves.txt |
+| Generated At | 2026-04-29T12:00:00Z |
+| Finding Count | 2 |
+| Critical | 1 |
+| High | 1 |
+| Medium | 0 |
+| Low | 0 |
+
+## Governance Rollups
+
+| Field | Value |
+| --- | --- |
+| Waivers | 1 |
+| Active Waivers | 0 |
+| Expired Waivers | 0 |
+| Review Due Waivers | 1 |
+| Expiring Soon Waivers | 1 |
+| Accepted Findings | 1 |
+| VEX Suppressed Findings | 1 |
+| VEX Under Investigation | 0 |
+
+### Top Services by Risk
+
+| Service | Findings | Critical | High | Risk Score | Waiver Debt |
+| --- | --- | --- | --- | --- | --- |
+| checkout | 1 | 1 | 0 | 100 | 1 |
+
+### Top Assets by Risk
+
+| Asset | Findings | Critical | High | Risk Score | Accepted | VEX Suppressed |
+| --- | --- | --- | --- | --- | --- | --- |
+| payments-api | 1 | 1 | 0 | 100 | 1 | 0 |
+
+### Accepted Risk and Expiring Waivers
+
+| Scope | Owner | Status | Expires | Review | Matched Findings |
+| --- | --- | --- | --- | --- | --- |
+| service:checkout | risk-team | review\_due | 2026-05-07 | 2026-04-30 | 2 |
+
+### Owner and Environment Rollups
+
+| Dimension | Label | Findings | Critical | High | Accepted | Waiver Debt |
+| --- | --- | --- | --- | --- | --- | --- |
+| Owner | platform-team | 1 | 1 | 0 | 1 | 1 |
+| Owner | secops | 1 | 0 | 1 | 0 | 0 |
+| Environment | prod | 2 | 1 | 1 | 1 | 1 |
+
+### VEX Summary
+
+| Field | Value |
+| --- | --- |
+| Suppressed by VEX | 1 |
+| Under Investigation | 0 |
+| Fixed | 0 |
+
+## Top Findings
+
+| Operational Rank | CVE | Priority | Score | EPSS | CVSS | KEV | Status | Asset | Component | Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | CVE-2024-3094 | Critical | 100 | 0.846 | 10 | No | accepted | Payments API | xz 5.6.0-r0 | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| 2 | CVE-2021-44228 | High | 94.2 | 0.944 | 10 | Yes | suppressed | Ops API | log4j-core 2.14.1 | Patch via vendor upgrade. |
+
+## Reasons
+
+| CVE | Rationale | Recommended Action |
+| --- | --- | --- |
+| CVE-2024-3094 | Internet-facing production asset with critical score. | Patch \[open\]\(javascript:alert\(1\)\) now. |
+| CVE-2021-44228 | CISA KEV listing and vulnerable component evidence. | Patch via vendor upgrade. |
+
+## Data Quality
+
+| CVE | Confidence | Flags |
+| --- | --- | --- |
+| CVE-2024-3094 | high | None |
+| CVE-2021-44228 | medium | missing\_asset\_owner - Owner is not set |
+
+## Provider Snapshot
+
+| Field | Value |
+| --- | --- |
+| Snapshot ID | 00000000-0000-4000-8000-000000000650 |
+| Content Hash | sha256:vpw050-snapshot |
+| NVD Last Sync | 2026-04-28T10:15:00Z |
+| EPSS Date | 2026-04-28 |
+| KEV Catalog Version | 2026-04-28 |
+| Locked Provider Data | Yes |
+| Selected Sources | nvd, epss, kev |
+| Source Hash: provider\_snapshot | sha256:vpw050-snapshot |

--- a/backend/tests/api/snapshots/vpw_068_governance_report.normalized.html
+++ b/backend/tests/api/snapshots/vpw_068_governance_report.normalized.html
@@ -1,0 +1,347 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Executive Vulnerability Report</title>
+  <style>
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --text: #18202f;
+  --muted: #5d6a7d;
+  --border: #d8dee8;
+  --accent: #1665d8;
+  --accent-soft: #e8f1ff;
+  --critical: #b42318;
+  --high: #b54708;
+  --medium: #8a6116;
+  --low: #186a3b;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 15px;
+  line-height: 1.55;
+}
+.report-shell {
+  width: min(1160px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+header,
+section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 18px;
+  padding: 24px;
+}
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+h1 {
+  margin-bottom: 10px;
+  font-size: 32px;
+  line-height: 1.15;
+}
+h2 {
+  margin-bottom: 12px;
+  font-size: 22px;
+  line-height: 1.25;
+}
+.eyebrow {
+  margin-bottom: 6px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.lede {
+  max-width: 840px;
+  color: var(--muted);
+}
+.section-heading {
+  margin-bottom: 14px;
+}
+.meta-grid,
+.metric-grid,
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+.meta-grid {
+  margin: 18px 0 0;
+}
+.meta-grid div,
+.metric,
+.provider-grid div {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  background: #fbfcfe;
+}
+dt,
+.metric span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+.metric strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 26px;
+  line-height: 1.1;
+}
+.table-wrap {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: collapse;
+}
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+td {
+  overflow-wrap: anywhere;
+}
+.badge {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+tbody td:nth-child(-n + 7),
+thead th:nth-child(-n + 7) {
+  white-space: nowrap;
+}
+.badge-critical {
+  background: #fee4e2;
+  color: var(--critical);
+}
+.badge-high {
+  background: #ffead5;
+  color: var(--high);
+}
+.badge-medium {
+  background: #fef3c7;
+  color: var(--medium);
+}
+.badge-low {
+  background: #dcfae6;
+  color: var(--low);
+}
+.recommendation-list {
+  margin: 0;
+  padding-left: 24px;
+}
+.recommendation-list li + li {
+  margin-top: 12px;
+}
+.recommendation-list strong {
+  display: block;
+}
+.empty-state {
+  color: var(--muted);
+}
+@media (max-width: 820px) {
+  .report-shell {
+    width: min(100% - 20px, 1160px);
+    padding-top: 16px;
+  }
+  header,
+  section {
+    padding: 16px;
+  }
+  h1 {
+    font-size: 26px;
+  }
+  .meta-grid,
+  .metric-grid,
+  .provider-grid {
+    grid-template-columns: 1fr;
+  }
+}
+@media print {
+  body {
+    background: #ffffff;
+    color: #000000;
+  }
+  .report-shell {
+    width: 100%;
+    padding: 0;
+  }
+  header,
+  section {
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  .table-wrap {
+    overflow: visible;
+  }
+  table {
+    min-width: 0;
+  }
+}
+  </style>
+</head>
+<body>
+  <main class="report-shell">
+    <header>
+      <p class="eyebrow">Executive Vulnerability Report</p>
+      <h1>VPW-050 Snapshot</h1>
+      <p class="lede">Decision-ready vulnerability prioritization summary for analysis run 00000000-0000-4000-8000-000000000050 generated at 2026-04-29T12:00:00Z.</p>
+      <dl class="meta-grid">
+        <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000156</dd></div>
+        <div><dt>Run Status</dt><dd>completed</dd></div>
+        <div><dt>Input Type</dt><dd>cve-list</dd></div>
+        <div><dt>Input File</dt><dd>known-cves.txt</dd></div>
+      </dl>
+    </header>
+    <section aria-labelledby="executive-summary">
+      <div class="section-heading">
+        <p class="eyebrow">Summary</p>
+        <h2 id="executive-summary">Executive Summary</h2>
+      </div>
+      <div class="metric-grid">
+        <div class="metric"><span>Findings</span><strong>2</strong></div>
+        <div class="metric"><span>Critical</span><strong>1</strong></div>
+        <div class="metric"><span>High</span><strong>1</strong></div>
+        <div class="metric"><span>Critical or High</span><strong>2</strong></div>
+      </div>
+      <p>The run contains 2 finding(s), including 2 critical or high priority item(s). Prioritize the listed top risks first and validate execution against provider freshness. Locked provider data: Yes.</p>
+    </section>
+    <section aria-labelledby="governance-rollups">
+      <div class="section-heading">
+        <p class="eyebrow">Governance</p>
+        <h2 id="governance-rollups">Service Risk, Accepted Risk, and VEX</h2>
+      </div>
+      <div class="metric-grid">
+        <div class="metric"><span>Waivers</span><strong>1</strong></div>
+        <div class="metric"><span>Expired</span><strong>0</strong></div>
+        <div class="metric"><span>Review Due</span><strong>1</strong></div>
+        <div class="metric"><span>Expiring Soon</span><strong>1</strong></div>
+        <div class="metric"><span>Accepted Findings</span><strong>1</strong></div>
+        <div class="metric"><span>VEX Suppressed</span><strong>1</strong></div>
+      </div>
+      <h3>Service Rollup</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Service</th><th>Findings</th><th>Critical</th><th>High</th><th>Risk Score</th><th>Waiver Debt</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>checkout</td><td>1</td><td>1</td><td>0</td><td>100</td><td>1</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <h3>Asset Rollup</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Asset</th><th>Findings</th><th>Critical</th><th>High</th><th>Risk Score</th><th>Accepted</th><th>VEX Suppressed</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>payments-api</td><td>1</td><td>1</td><td>0</td><td>100</td><td>1</td><td>0</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <h3>Accepted Risk and Expiring Waivers</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th><th>Review</th><th>Matched</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>service:checkout</td><td>risk-team</td><td>review_due</td><td>2026-05-07</td><td>2026-04-30</td><td>2</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section aria-labelledby="business-impact">
+      <div class="section-heading">
+        <p class="eyebrow">Impact</p>
+        <h2 id="business-impact">Business Impact</h2>
+      </div>
+      <p>Checkout traffic depends on the affected service.</p>
+    </section>
+    <section aria-labelledby="top-risks">
+      <div class="section-heading">
+        <p class="eyebrow">Priorities</p>
+        <h2 id="top-risks">Top Risks</h2>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Rank</th><th>CVE</th><th>Priority</th><th>Score</th><th>EPSS</th><th>CVSS</th><th>KEV</th><th>Asset</th><th>Decision Statement</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>CVE-2024-3094</td><td><span class="badge badge-critical">Critical</span></td><td>100</td><td>0.846</td><td>10</td><td>No</td><td>Payments API</td><td>Decision Statement: maintain accepted risk for CVE-2024-3094 until owner review completes. Accepted-risk governance remains visible (owner risk-team; status review_due; review 2026-04-30; expires 2026-05-07).</td></tr>
+            <tr><td>2</td><td>CVE-2021-44228</td><td><span class="badge badge-high">High</span></td><td>94.2</td><td>0.944</td><td>10</td><td>Yes</td><td>Ops API</td><td>Decision Statement: monitor VEX-suppressed CVE-2021-44228. VEX governance applies (status not_affected; source openvex; record VEX-068-1).</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section aria-labelledby="recommendations">
+      <div class="section-heading">
+        <p class="eyebrow">Actions</p>
+        <h2 id="recommendations">Recommendations</h2>
+      </div>
+      <ol class="recommendation-list">
+        <li><strong>CVE-2024-3094 - Critical</strong><span>Patch [open](javascript:alert(1)) now. SLA: Emergency / 24h</span></li>
+        <li><strong>CVE-2021-44228 - High</strong><span>Patch via vendor upgrade. SLA: Emergency / 24h</span></li>
+      </ol>
+    </section>
+    <section aria-labelledby="provider-freshness">
+      <div class="section-heading">
+        <p class="eyebrow">Evidence</p>
+        <h2 id="provider-freshness">Provider Freshness</h2>
+      </div>
+      <dl class="provider-grid">
+        <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
+        <div><dt>Content Hash</dt><dd>sha256:vpw050-snapshot</dd></div>
+        <div><dt>NVD Last Sync</dt><dd>2026-04-28T10:15:00Z</dd></div>
+        <div><dt>EPSS Date</dt><dd>2026-04-28</dd></div>
+        <div><dt>KEV Catalog Version</dt><dd>2026-04-28</dd></div>
+        <div><dt>Locked Provider Data</dt><dd>Yes</dd></div>
+        <div><dt>Selected Sources</dt><dd>nvd, epss, kev</dd></div>
+        <div><dt>Source Hash: provider_snapshot</dt><dd>sha256:vpw050-snapshot</dd></div>
+      </dl>
+    </section>
+  </main>
+</body>
+</html>

--- a/backend/tests/api/test_template_governance_rollups_api.py
+++ b/backend/tests/api/test_template_governance_rollups_api.py
@@ -47,6 +47,13 @@ def test_vpw067_governance_rollups_count_owner_service_environment_and_waiver_de
     assert checkout["status_counts"]["accepted"] == 2
     assert checkout["top_cves"] == ["CVE-2026-6701", "CVE-2026-6702"]
 
+    top_asset = payload["top_assets_by_risk"][0]
+    assert top_asset["dimension"] == "asset"
+    assert top_asset["label"] == "payments-api"
+    assert top_asset["finding_count"] == 2
+    assert top_asset["accepted_count"] == 2
+    assert top_asset["suppressed_by_vex_count"] == 1
+
     production = next(item for item in payload["environments"] if item["label"] == "production")
     assert production["finding_count"] == 3
     assert production["expired_waiver_count"] == 1

--- a/backend/tests/api/test_template_reports_api.py
+++ b/backend/tests/api/test_template_reports_api.py
@@ -79,6 +79,8 @@ VPW054_DEMO_ARTIFACTS = {
     "json": Path("docs/examples/vpw-054-template-analysis-result.v1.json"),
 }
 VPW054_HTML_SNAPSHOT = Path("backend/tests/api/snapshots/vpw_054_executive_report.normalized.html")
+VPW068_MARKDOWN_SNAPSHOT = Path("backend/tests/api/snapshots/vpw_068_governance_report.md")
+VPW068_HTML_SNAPSHOT = Path("backend/tests/api/snapshots/vpw_068_governance_report.normalized.html")
 VPW054_SECRET_MARKERS = (
     "super-secret-token",
     "provider-secret-key",
@@ -218,7 +220,7 @@ def test_vpw049_html_report_create_downloads_executive_report(
     body = download.text
     assert "<!doctype html>" in body
     assert "Executive Summary" in body
-    assert "Service Risk and Waiver Debt" in body
+    assert "Service Risk, Accepted Risk, and VEX" in body
     assert "Business Impact" in body
     assert "Top Risks" in body
     assert "Recommendations" in body
@@ -281,6 +283,8 @@ def test_vpw050_analysis_json_export_create_downloads_schema_valid_result(
     assert body["provider_snapshot"]["content_hash"] == "sha256:vpw048-snapshot"
     assert body["governance_rollups"]["top_services_by_risk"][0]["label"] == "Unassigned"
     assert body["governance_rollups"]["top_services_by_risk"][0]["finding_count"] == 2
+    assert body["governance_rollups"]["top_assets_by_risk"][0]["label"] == "payments-api"
+    assert body["governance_rollups"]["top_assets_by_risk"][0]["finding_count"] == 1
     assert [finding["cve_id"] for finding in body["findings"]] == [
         DEMO_CVE_XZ,
         DEMO_CVE_LOG4SHELL,
@@ -537,12 +541,20 @@ def test_vpw051_evidence_bundle_zip_create_downloads_manifest_integrity(
         assert names == [
             "analysis.json",
             "executive.html",
+            "governance/asset-context.json",
+            "governance/rollups.json",
+            "governance/vex-summary.json",
+            "governance/waivers.json",
             "manifest.json",
             "provider-snapshot.json",
             "technical.md",
         ]
         manifest = json.loads(archive.read("manifest.json"))
         analysis = json.loads(archive.read("analysis.json"))
+        governance_rollups = json.loads(archive.read("governance/rollups.json"))
+        governance_waivers = json.loads(archive.read("governance/waivers.json"))
+        governance_vex = json.loads(archive.read("governance/vex-summary.json"))
+        governance_asset_context = json.loads(archive.read("governance/asset-context.json"))
         technical_report = archive.read("technical.md").decode("utf-8")
         executive_report = archive.read("executive.html").decode("utf-8")
         jsonschema.validate(manifest, _load_schema("evidence-bundle-manifest.schema.json"))
@@ -554,8 +566,42 @@ def test_vpw051_evidence_bundle_zip_create_downloads_manifest_integrity(
         assert manifest["provider_snapshot"]["bundle_path"] == "provider-snapshot.json"
         assert manifest["redaction"]["enabled"] is True
         assert analysis["governance_rollups"]["top_services_by_risk"][0]["label"] == "Unassigned"
+        assert manifest["governance_artifacts"] == [
+            {
+                "bundle_path": "governance/rollups.json",
+                "kind": "governance-rollups",
+                "sha256": manifest["artifact_hashes"]["governance/rollups.json"],
+            },
+            {
+                "bundle_path": "governance/waivers.json",
+                "kind": "governance-waivers",
+                "sha256": manifest["artifact_hashes"]["governance/waivers.json"],
+            },
+            {
+                "bundle_path": "governance/vex-summary.json",
+                "kind": "governance-vex-summary",
+                "sha256": manifest["artifact_hashes"]["governance/vex-summary.json"],
+            },
+            {
+                "bundle_path": "governance/asset-context.json",
+                "kind": "governance-asset-context",
+                "sha256": manifest["artifact_hashes"]["governance/asset-context.json"],
+            },
+        ]
+        assert governance_rollups["schema"] == "governance-rollups.v1"
+        assert governance_waivers["schema"] == "governance-waivers.v1"
+        assert governance_vex["schema"] == "governance-vex-summary.v1"
+        assert governance_asset_context["schema"] == "governance-asset-context.v1"
+        assert {item["asset_key"] for item in governance_asset_context["assets"]} == {
+            "ops-api",
+            "payments-api",
+        }
+        assert sum(item["finding_count"] for item in governance_asset_context["assets"]) == 2
         assert "Governance Rollups" in technical_report
-        assert "Service Risk and Waiver Debt" in executive_report
+        assert "Top Assets by Risk" in technical_report
+        assert "Accepted Risk and Expiring Waivers" in technical_report
+        assert "VEX Summary" in technical_report
+        assert "Service Risk, Accepted Risk, and VEX" in executive_report
         assert "manifest.json" not in {item["path"] for item in manifest["files"]}
         for item in manifest["files"]:
             content = archive.read(item["path"])
@@ -572,6 +618,63 @@ def test_vpw051_evidence_bundle_zip_create_downloads_manifest_integrity(
         assert "provider-secret-key" not in bundle_text
         assert str(tmp_path) not in bundle_text
         assert "[REDACTED]" in bundle_text
+
+
+def test_vpw068_reports_and_evidence_bundle_export_governance_context() -> None:
+    payload = _vpw068_governance_payload()
+
+    markdown = render_markdown_report(payload)
+    assert markdown == (_repo_root() / VPW068_MARKDOWN_SNAPSHOT).read_text(encoding="utf-8")
+    assert "### Top Assets by Risk" in markdown
+    assert "### Accepted Risk and Expiring Waivers" in markdown
+    assert "### VEX Summary" in markdown
+    assert (
+        "| service:checkout | risk-team | review\\_due | 2026-05-07 | 2026-04-30 | 2 |" in markdown
+    )
+    assert "| Suppressed by VEX | 1 |" in markdown
+
+    html = render_html_executive_report(payload)
+    assert _normalize_html_snapshot(html) == (_repo_root() / VPW068_HTML_SNAPSHOT).read_text(
+        encoding="utf-8"
+    )
+    assert "Service Risk, Accepted Risk, and VEX" in html
+    assert "Accepted Risk and Expiring Waivers" in html
+    assert "Expiring Soon" in html
+    assert "service:checkout" in html
+
+    analysis = json.loads(render_analysis_result_json(payload))
+    jsonschema.validate(analysis, _load_schema("analysis-result.v1.schema.json"))
+    assert analysis["governance_rollups"]["top_assets_by_risk"][0]["label"] == "payments-api"
+    assert analysis["governance_rollups"]["waiver_debt"]["expiring_soon_count"] == 1
+
+    bundle, manifest = render_evidence_bundle_zip(payload)
+    jsonschema.validate(manifest, _load_schema("evidence-bundle-manifest.schema.json"))
+    with zipfile.ZipFile(BytesIO(bundle)) as archive:
+        assert {
+            "governance/asset-context.json",
+            "governance/rollups.json",
+            "governance/vex-summary.json",
+            "governance/waivers.json",
+        }.issubset(set(archive.namelist()))
+        waivers = json.loads(archive.read("governance/waivers.json"))
+        vex = json.loads(archive.read("governance/vex-summary.json"))
+        asset_context = json.loads(archive.read("governance/asset-context.json"))
+
+    assert [item["kind"] for item in manifest["governance_artifacts"]] == [
+        "governance-rollups",
+        "governance-waivers",
+        "governance-vex-summary",
+        "governance-asset-context",
+    ]
+    assert waivers["accepted_findings"][0]["waiver_status"] == "review_due"
+    assert (
+        "Accepted-risk governance remains visible"
+        in waivers["accepted_findings"][0]["decision_statement"]
+    )
+    assert vex["summary"]["suppressed_by_vex_count"] == 1
+    assert vex["summary"]["status_counts"] == {"not_affected": 1}
+    assert vex["findings"][0]["vex_statuses"] == "not_affected:1"
+    assert asset_context["top_assets_by_risk"][0]["label"] == "payments-api"
 
 
 def test_vpw060_evidence_bundle_includes_attack_navigator_layer_when_mapped(
@@ -643,9 +746,9 @@ def test_vpw052_evidence_bundle_verify_api_reports_clean_bundle(
     assert payload["metadata"]["manifest_schema_version"] == "1.1.0"
     assert payload["summary"] == {
         "ok": True,
-        "total_members": 5,
-        "expected_files": 4,
-        "verified_files": 4,
+        "total_members": 9,
+        "expected_files": 8,
+        "verified_files": 8,
         "missing_files": 0,
         "modified_files": 0,
         "unexpected_files": 0,
@@ -699,7 +802,7 @@ def test_vpw052_evidence_bundle_verify_api_reports_modified_member(
     jsonschema.validate(payload, _load_schema("evidence-bundle-verification-report.schema.json"))
     assert payload["summary"]["ok"] is False
     assert payload["summary"]["modified_files"] == 1
-    assert payload["summary"]["verified_files"] == 3
+    assert payload["summary"]["verified_files"] == 7
     modified_items = [item for item in payload["items"] if item["status"] == "modified"]
     assert len(modified_items) == 1
     assert modified_items[0]["path"] == "analysis.json"
@@ -1421,6 +1524,271 @@ def _vpw051_snapshot_payload() -> MarkdownReportPayload:
         findings=[first_finding, *payload.findings[1:]],
         provider_snapshot=provider_snapshot,
     )
+
+
+def _vpw068_governance_payload() -> MarkdownReportPayload:
+    payload = _vpw050_snapshot_payload()
+    waiver = {
+        "source": "template-api",
+        "waiver_id": "00000000-0000-4000-8000-000000000681",
+        "waiver_status": "review_due",
+        "waiver_owner": "risk-team",
+        "waiver_expires_on": "2026-05-07",
+        "waiver_review_on": "2026-04-30",
+        "waiver_scope": "service:checkout",
+        "waiver_approval_ref": "CAB-068",
+    }
+    accepted = replace(
+        payload.findings[0],
+        status="accepted",
+        waived=True,
+        explanation={
+            **payload.findings[0].explanation,
+            "waiver": waiver,
+            "waiver_status": "review_due",
+            "waiver_owner": "risk-team",
+            "waiver_expires_on": "2026-05-07",
+            "waiver_review_on": "2026-04-30",
+        },
+        decision_statement=(
+            "Decision Statement: maintain accepted risk for CVE-2024-3094 until "
+            "owner review completes. Accepted-risk governance remains visible "
+            "(owner risk-team; status review_due; review 2026-04-30; expires 2026-05-07)."
+        ),
+    )
+    vex_suppressed = replace(
+        payload.findings[1],
+        status="suppressed",
+        suppressed_by_vex=True,
+        explanation={
+            **payload.findings[1].explanation,
+            "provenance": {
+                "vex_statuses": {"not_affected": 1},
+                "occurrences": [
+                    {
+                        "vex_status": "not_affected",
+                        "source_format": "openvex",
+                        "source_record_id": "VEX-068-1",
+                    }
+                ],
+            },
+            "vex_justification": "component_not_present",
+            "vex_action_statement": "Reopen if the affected package is redeployed.",
+            "vex_source_format": "openvex",
+            "vex_source_record_id": "VEX-068-1",
+        },
+        decision_statement=(
+            "Decision Statement: monitor VEX-suppressed CVE-2021-44228. "
+            "VEX governance applies (status not_affected; source openvex; record VEX-068-1)."
+        ),
+    )
+    return replace(
+        payload,
+        findings=[accepted, vex_suppressed],
+        governance_rollups={
+            "project_id": payload.project_id,
+            "generated_at": "2026-04-29T12:00:00Z",
+            "owners": [
+                _vpw068_rollup(
+                    "owner",
+                    "platform-team",
+                    finding_count=1,
+                    critical_count=1,
+                    accepted_count=1,
+                    waived_count=1,
+                    review_due_waiver_count=1,
+                    risk_score_total=100.0,
+                    top_cves=[DEMO_CVE_XZ],
+                ),
+                _vpw068_rollup(
+                    "owner",
+                    "secops",
+                    finding_count=1,
+                    high_count=1,
+                    suppressed_count=1,
+                    suppressed_by_vex_count=1,
+                    risk_score_total=94.2,
+                    top_cves=[DEMO_CVE_LOG4SHELL],
+                ),
+            ],
+            "services": [
+                _vpw068_rollup(
+                    "service",
+                    "checkout",
+                    finding_count=1,
+                    critical_count=1,
+                    accepted_count=1,
+                    waived_count=1,
+                    review_due_waiver_count=1,
+                    risk_score_total=100.0,
+                    top_cves=[DEMO_CVE_XZ],
+                ),
+                _vpw068_rollup(
+                    "service",
+                    "operations",
+                    finding_count=1,
+                    high_count=1,
+                    suppressed_count=1,
+                    suppressed_by_vex_count=1,
+                    risk_score_total=94.2,
+                    top_cves=[DEMO_CVE_LOG4SHELL],
+                ),
+            ],
+            "assets": [
+                _vpw068_rollup(
+                    "asset",
+                    "payments-api",
+                    finding_count=1,
+                    critical_count=1,
+                    accepted_count=1,
+                    waived_count=1,
+                    review_due_waiver_count=1,
+                    risk_score_total=100.0,
+                    top_cves=[DEMO_CVE_XZ],
+                ),
+                _vpw068_rollup(
+                    "asset",
+                    "ops-api",
+                    finding_count=1,
+                    high_count=1,
+                    suppressed_count=1,
+                    suppressed_by_vex_count=1,
+                    risk_score_total=94.2,
+                    top_cves=[DEMO_CVE_LOG4SHELL],
+                ),
+            ],
+            "environments": [
+                _vpw068_rollup(
+                    "environment",
+                    "prod",
+                    finding_count=2,
+                    critical_count=1,
+                    high_count=1,
+                    accepted_count=1,
+                    suppressed_count=1,
+                    waived_count=1,
+                    suppressed_by_vex_count=1,
+                    review_due_waiver_count=1,
+                    risk_score_total=194.2,
+                    top_cves=[DEMO_CVE_XZ, DEMO_CVE_LOG4SHELL],
+                )
+            ],
+            "top_services_by_risk": [
+                _vpw068_rollup(
+                    "service",
+                    "checkout",
+                    finding_count=1,
+                    critical_count=1,
+                    accepted_count=1,
+                    waived_count=1,
+                    review_due_waiver_count=1,
+                    risk_score_total=100.0,
+                    top_cves=[DEMO_CVE_XZ],
+                )
+            ],
+            "top_assets_by_risk": [
+                _vpw068_rollup(
+                    "asset",
+                    "payments-api",
+                    finding_count=1,
+                    critical_count=1,
+                    accepted_count=1,
+                    waived_count=1,
+                    review_due_waiver_count=1,
+                    risk_score_total=100.0,
+                    top_cves=[DEMO_CVE_XZ],
+                )
+            ],
+            "waiver_debt": {
+                "waiver_count": 1,
+                "active_count": 0,
+                "review_due_count": 1,
+                "expired_count": 0,
+                "expiring_soon_count": 1,
+                "matched_finding_count": 2,
+                "accepted_finding_count": 1,
+                "expired_finding_count": 0,
+                "review_due_finding_count": 1,
+                "owner_counts": {"risk-team": 1},
+                "service_counts": {"checkout": 1},
+                "items": [
+                    {
+                        "id": "00000000-0000-4000-8000-000000000681",
+                        "owner": "risk-team",
+                        "scope": "service:checkout",
+                        "status": "review_due",
+                        "days_remaining": 7,
+                        "expires_at": "2026-05-07",
+                        "review_at": "2026-04-30",
+                        "matched_findings": 2,
+                        "cve_id": None,
+                        "service": "checkout",
+                        "asset_key": None,
+                        "finding_id": None,
+                    }
+                ],
+            },
+        },
+    )
+
+
+def _vpw068_rollup(
+    dimension: str,
+    label: str,
+    *,
+    finding_count: int,
+    risk_score_total: float,
+    top_cves: list[str],
+    open_count: int = 0,
+    accepted_count: int = 0,
+    fixed_count: int = 0,
+    suppressed_count: int = 0,
+    critical_count: int = 0,
+    high_count: int = 0,
+    kev_count: int = 0,
+    attack_mapped_count: int = 0,
+    suppressed_by_vex_count: int = 0,
+    under_investigation_count: int = 0,
+    waived_count: int = 0,
+    expired_waiver_count: int = 0,
+    review_due_waiver_count: int = 0,
+) -> dict[str, Any]:
+    return {
+        "dimension": dimension,
+        "label": label,
+        "finding_count": finding_count,
+        "open_count": open_count,
+        "accepted_count": accepted_count,
+        "fixed_count": fixed_count,
+        "suppressed_count": suppressed_count,
+        "critical_count": critical_count,
+        "high_count": high_count,
+        "kev_count": kev_count,
+        "attack_mapped_count": attack_mapped_count,
+        "suppressed_by_vex_count": suppressed_by_vex_count,
+        "under_investigation_count": under_investigation_count,
+        "waived_count": waived_count,
+        "expired_waiver_count": expired_waiver_count,
+        "review_due_waiver_count": review_due_waiver_count,
+        "risk_score_total": risk_score_total,
+        "risk_score_max": risk_score_total,
+        "highest_priority": "Critical" if critical_count else "High" if high_count else None,
+        "priority_counts": {
+            "Critical": critical_count,
+            "High": high_count,
+            "Medium": 0,
+            "Low": 0,
+        },
+        "status_counts": {
+            "open": open_count,
+            "in_review": 0,
+            "remediating": 0,
+            "fixed": fixed_count,
+            "accepted": accepted_count,
+            "suppressed": suppressed_count,
+        },
+        "top_cves": top_cves,
+    }
 
 
 def _add_vpw051_bundle_metadata(

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -119,7 +119,7 @@ Primary payload keys by command:
 - `attack validate`: validation counts and warning arrays
 - `attack coverage`: `items`, plus ATT&CK coverage `summary`
 - `rollup`: `buckets`
-- `report evidence-bundle`: `manifest.json` with `files`
+- `report evidence-bundle`: `manifest.json` with `files` and optional `governance_artifacts`
 - `report verify-evidence-bundle`: `items`, plus `summary`
 
 ### Schema versioning
@@ -372,6 +372,18 @@ Current defensive-context contract:
 - `defensive_contexts` on findings and provider snapshot items contains the local overlay records used for review and locked replay
 - defensive context does not change `priority_label`, `priority_rank`, operational rank, or base scoring
 
+### Evidence bundle governance artifacts
+
+Current evidence-bundle governance additions:
+
+- governance bundle members are additive ZIP members under `governance/`
+- supported member paths are `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`
+- these members are included only when the corresponding governance source payload is available
+- `manifest.json` may include an additive `governance_artifacts` array
+- each `governance_artifacts[]` item contains `bundle_path`, `kind`, and `sha256`
+- `bundle_path` is the ZIP member path, `kind` identifies the governance artifact type, and `sha256` is the checksum of that member content
+- consumers should verify governance artifacts against their manifest SHA-256 entries and ignore unknown future governance artifact kinds
+
 ### Workbench API additions
 
 Workbench API changes are additive:
@@ -391,7 +403,7 @@ Workbench API changes are additive:
 - `GET /api/v1/projects/{project_id}/summary` returns a dashboard-oriented decision summary with finding counts, priority/status buckets, provider-signal hit counts, latest run status, and latest run summary
 - `GET /api/v1/projects/{project_id}/compare/cvss-only` returns the CVSS-only baseline comparison for stored template findings, using the same methodology payload as the core decision engine
 - `GET /api/v1/providers/status` returns an authenticated template adapter provider-status envelope for the React status card, including `status`, `snapshot`, `sources`, `latest_update_job`, `cache_dir`, `snapshot_dir`, `warnings`, `last_sync`, `last_error`, `cache_age_seconds`, and `snapshot_mode`; the legacy `GET /api/providers/status` route still exists with its current behavior during migration
-- `POST /api/v1/runs/{run_id}/reports` accepts `markdown`, `html`, `json`, `csv`, `zip`, and `attack-navigator` for completed visible template runs. JSON exports use `analysis-result.v1.json` with `project`, `analysis_run`, `provider_snapshot`, `findings`, and `explanations`. CSV exports use `findings.csv` with stable spreadsheet-safe finding columns. `attack-navigator` exports `attack-navigator-layer.json` with Navigator v4.5-compatible `techniques`, `techniqueID`, risk score, comments, and metadata; `attack_filter` accepts `all`, `critical-high`, `kev`, and the `no-coverage` placeholder. ZIP exports use `evidence-bundle.zip` with `manifest.json`, `analysis.json`, `technical.md`, `executive.html`, `provider-snapshot.json`, optional `attack-navigator-layer.json`, per-file SHA-256 entries, input hashes when available, and redaction of sensitive/local-path fields.
+- `POST /api/v1/runs/{run_id}/reports` accepts `markdown`, `html`, `json`, `csv`, `zip`, and `attack-navigator` for completed visible template runs. JSON exports use `analysis-result.v1.json` with `project`, `analysis_run`, `provider_snapshot`, `findings`, and `explanations`. CSV exports use `findings.csv` with stable spreadsheet-safe finding columns. `attack-navigator` exports `attack-navigator-layer.json` with Navigator v4.5-compatible `techniques`, `techniqueID`, risk score, comments, and metadata; `attack_filter` accepts `all`, `critical-high`, `kev`, and the `no-coverage` placeholder. ZIP exports use `evidence-bundle.zip` with `manifest.json`, `analysis.json`, `technical.md`, `executive.html`, `provider-snapshot.json`, optional `attack-navigator-layer.json`, optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`, per-file SHA-256 entries, input hashes when available, and redaction of sensitive/local-path fields.
 - `POST /api/v1/reports/{report_id}/verify` verifies a visible template `evidence-bundle.zip` report without extracting ZIP members. It validates the stored artifact path and report SHA-256 before returning the same `metadata`, `summary`, and `items` shape as `report verify-evidence-bundle --format json`; non-bundle reports return 422.
 - `POST /api/projects/{project_id}/imports` accepts single-upload and additive multi-upload imports for all CLI input formats
 - `GET /api/jobs`, `GET /api/jobs/{id}`, `POST /api/jobs`, and `POST /api/jobs/{id}/retry` expose durable local job state for compatible synchronous operations
@@ -476,7 +488,7 @@ The public combinations currently intended for use are:
 - `data verify`: `table`, `json`
 - `data export-provider-snapshot`: JSON file output
 - `report html`: HTML file output
-- `report evidence-bundle`: ZIP file output containing `analysis.json`, `report.html`, `summary.md`, and `manifest.json`
+- `report evidence-bundle`: ZIP file output containing `analysis.json`, `report.html`, `summary.md`, `manifest.json`, and optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`
 - `report verify-evidence-bundle`: `table` and `json`
 - `report validate-sarif`: `table` and `json`
 

--- a/docs/evidence/vpw-068-governance-report-evidence-bundle.md
+++ b/docs/evidence/vpw-068-governance-report-evidence-bundle.md
@@ -1,0 +1,136 @@
+# VPW-068 Governance Reports and Evidence Bundle
+
+VPW-068 integrates governance context into template-stack reports and evidence
+bundles. The implementation keeps governance as explicit project context for
+known findings; it does not add scanner behavior or change base prioritization.
+
+## Scope
+
+- Added asset rollups and `top_assets_by_risk` to project governance rollups.
+- Expanded technical Markdown and executive HTML reports with:
+  - service and asset risk rollups
+  - accepted-risk and expiring waiver rows
+  - VEX suppressed and under-investigation summary counts
+- Added governance-specific evidence bundle members:
+  - `governance/rollups.json`
+  - `governance/waivers.json`
+  - `governance/vex-summary.json`
+  - `governance/asset-context.json`
+- Added manifest `governance_artifacts` entries and schema coverage.
+- Preserved governance-aware decision statements for accepted-risk and VEX
+  findings inside report and bundle exports.
+- Added committed report snapshots for the VPW-068 governance Markdown report
+  and normalized executive HTML report.
+- Updated the contract documentation for additive governance bundle members.
+
+## Report Excerpt
+
+```markdown
+### Top Assets by Risk
+
+| Asset | Findings | Critical | High | Risk Score | Accepted | VEX Suppressed |
+| --- | --- | --- | --- | --- | --- | --- |
+| payments-api | 1 | 1 | 0 | 100 | 1 | 0 |
+
+### Accepted Risk and Expiring Waivers
+
+| Scope | Owner | Status | Expires | Review | Matched Findings |
+| --- | --- | --- | --- | --- | --- |
+| service:checkout | risk-team | review_due | 2026-05-07 | 2026-04-30 | 2 |
+
+### VEX Summary
+
+| Field | Value |
+| --- | --- |
+| Suppressed by VEX | 1 |
+```
+
+## Manifest Excerpt
+
+```json
+{
+  "governance_artifacts": [
+    {
+      "bundle_path": "governance/rollups.json",
+      "kind": "governance-rollups"
+    },
+    {
+      "bundle_path": "governance/waivers.json",
+      "kind": "governance-waivers"
+    },
+    {
+      "bundle_path": "governance/vex-summary.json",
+      "kind": "governance-vex-summary"
+    },
+    {
+      "bundle_path": "governance/asset-context.json",
+      "kind": "governance-asset-context"
+    }
+  ],
+  "files": [
+    "analysis.json",
+    "technical.md",
+    "executive.html",
+    "provider-snapshot.json",
+    "governance/rollups.json",
+    "governance/waivers.json",
+    "governance/vex-summary.json",
+    "governance/asset-context.json"
+  ]
+}
+```
+
+## Definition of Done Evidence
+
+| Requirement | Evidence |
+| --- | --- |
+| Report snapshot tests | `test_vpw068_reports_and_evidence_bundle_export_governance_context` asserts Markdown and HTML report sections for top assets, accepted risk, expiring waivers, and VEX. |
+| Evidence integrity test | `test_vpw051_evidence_bundle_zip_create_downloads_manifest_integrity` validates the ZIP, manifest schema, hashes, and the four governance members; VPW-052 verification tests cover clean and modified bundles. |
+| Docs updated | This evidence page is included in `mkdocs.yml` under the Evidence nav; `docs/contracts.md` documents the governance ZIP members and `governance_artifacts` manifest field. |
+| Report excerpt | The excerpt above shows accepted risk and VEX in the report output. |
+| Evidence manifest excerpt | The excerpt above shows all `governance_artifacts` with bundle paths and kinds. |
+| Waiver does not hide risk | Accepted findings remain in report and bundle exports with `accepted_count`, waiver status, owner/review/expiry, and the decision statement text `Accepted-risk governance remains visible`. |
+
+Snapshot artifacts:
+
+- `backend/tests/api/snapshots/vpw_068_governance_report.md`
+- `backend/tests/api/snapshots/vpw_068_governance_report.normalized.html`
+
+## Validation
+
+Commands run locally:
+
+```bash
+make frontend-generate-client
+python3 -m pytest -q backend/tests/api/test_template_reports_api.py::test_vpw068_reports_and_evidence_bundle_export_governance_context --no-cov
+python3 -m pytest -q backend/tests/api/test_template_governance_rollups_api.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov
+python3 -m pytest -q backend/tests/api/test_template_governance_rollups_api.py \
+  backend/tests/api/test_template_reports_api.py \
+  backend/tests/api/test_template_workbench_api_skeleton.py --no-cov
+npm --prefix frontend run build
+npm --prefix frontend run lint
+make docs-check
+make check
+```
+
+Results:
+
+- Frontend OpenAPI client generation: passed; output refreshed under
+  `frontend/src/client`.
+- VPW-068 focused report and evidence bundle test: 1 passed; includes exact
+  Markdown and normalized HTML snapshot comparisons.
+- Governance rollups API test: 1 passed.
+- Template report suite: 27 passed.
+- Governance/report/OpenAPI skeleton suite: 42 passed.
+- Frontend build: passed.
+- Frontend lint: passed.
+- Docs build: passed, with the existing nav warning for
+  `docs/architecture/vpw-011-api-skeleton.md`.
+- Full backend `make check`: 815 passed, 6 skipped, 90.70% coverage.
+
+## Residual Risk
+
+Governance bundle members include owner, service, waiver, and VEX context from
+the Workbench project and finding evidence. Existing bundle redaction still
+applies to secret-looking fields and local path fields.

--- a/docs/schemas/analysis-result.v1.schema.json
+++ b/docs/schemas/analysis-result.v1.schema.json
@@ -240,8 +240,10 @@
         "generated_at",
         "owners",
         "services",
+        "assets",
         "environments",
         "top_services_by_risk",
+        "top_assets_by_risk",
         "waiver_debt"
       ],
       "properties": {
@@ -263,6 +265,12 @@
             "$ref": "#/$defs/governanceRollup"
           }
         },
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/governanceRollup"
+          }
+        },
         "environments": {
           "type": "array",
           "items": {
@@ -270,6 +278,12 @@
           }
         },
         "top_services_by_risk": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/governanceRollup"
+          }
+        },
+        "top_assets_by_risk": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/governanceRollup"
@@ -312,6 +326,7 @@
           "enum": [
             "owner",
             "service",
+            "asset",
             "environment"
           ]
         },

--- a/docs/schemas/evidence-bundle-manifest.schema.json
+++ b/docs/schemas/evidence-bundle-manifest.schema.json
@@ -49,6 +49,12 @@
       "type": "object",
       "additionalProperties": true
     },
+    "governance_artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/governanceArtifact"
+      }
+    },
     "attack_navigator_layer": {
       "type": ["object", "null"],
       "additionalProperties": true,
@@ -140,6 +146,29 @@
         },
         "size_bytes": {
           "type": "integer"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "governanceArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bundle_path", "kind", "sha256"],
+      "properties": {
+        "bundle_path": {
+          "type": "string",
+          "pattern": "^governance/.+\\.json$"
+        },
+        "kind": {
+          "enum": [
+            "governance-rollups",
+            "governance-waivers",
+            "governance-vex-summary",
+            "governance-asset-context"
+          ]
         },
         "sha256": {
           "type": "string",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2255,7 +2255,7 @@ export const FindingsPublicSchema = {
 } as const;
 
 export const GovernanceRollupPublicSchema = {
-    description: 'Aggregated finding risk for one owner, service, or environment.',
+    description: 'Aggregated finding risk for one owner, service, asset, or environment.',
     properties: {
         accepted_count: {
             default: 0,
@@ -2990,8 +2990,15 @@ export const ProjectDecisionSummaryPublicSchema = {
 } as const;
 
 export const ProjectGovernanceRollupsPublicSchema = {
-    description: 'Owner, service, environment, and waiver-debt rollups for one project.',
+    description: 'Owner, service, asset, environment, and waiver-debt rollups for one project.',
     properties: {
+        assets: {
+            items: {
+                '$ref': '#/components/schemas/GovernanceRollupPublic'
+            },
+            title: 'Assets',
+            type: 'array'
+        },
         environments: {
             items: {
                 '$ref': '#/components/schemas/GovernanceRollupPublic'
@@ -3021,6 +3028,13 @@ export const ProjectGovernanceRollupsPublicSchema = {
                 '$ref': '#/components/schemas/GovernanceRollupPublic'
             },
             title: 'Services',
+            type: 'array'
+        },
+        top_assets_by_risk: {
+            items: {
+                '$ref': '#/components/schemas/GovernanceRollupPublic'
+            },
+            title: 'Top Assets By Risk',
             type: 'array'
         },
         top_services_by_risk: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -438,7 +438,7 @@ export type FindingsPublic = {
 export type FindingStatus = 'open' | 'in_review' | 'remediating' | 'fixed' | 'accepted' | 'suppressed';
 
 /**
- * Aggregated finding risk for one owner, service, or environment.
+ * Aggregated finding risk for one owner, service, asset, or environment.
  */
 export type GovernanceRollupPublic = {
     accepted_count?: number;
@@ -645,14 +645,16 @@ export type ProjectDecisionSummaryPublic = {
 };
 
 /**
- * Owner, service, environment, and waiver-debt rollups for one project.
+ * Owner, service, asset, environment, and waiver-debt rollups for one project.
  */
 export type ProjectGovernanceRollupsPublic = {
+    assets?: Array<GovernanceRollupPublic>;
     environments?: Array<GovernanceRollupPublic>;
     generated_at: string;
     owners?: Array<GovernanceRollupPublic>;
     project_id: string;
     services?: Array<GovernanceRollupPublic>;
+    top_assets_by_risk?: Array<GovernanceRollupPublic>;
     top_services_by_risk?: Array<GovernanceRollupPublic>;
     waiver_debt?: GovernanceWaiverDebtPublic;
 };

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - VPW-065 OpenVEX Status Application: evidence/vpw-065-openvex-status-application.md
       - VPW-066 CycloneDX VEX Parser: evidence/vpw-066-cyclonedx-vex-parser.md
       - VPW-067 Governance Rollups and Waiver Debt: evidence/vpw-067-governance-rollups-waiver-debt.md
+      - VPW-068 Governance Reports and Evidence Bundle: evidence/vpw-068-governance-report-evidence-bundle.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary

Closes #174.

Implements VPW-068 as fresh strict-DoD work for the duplicate VPW roadmap cycle.

- Adds asset rollups and `top_assets_by_risk` to governance rollup DTOs, schemas, and generated frontend client types.
- Expands technical Markdown and executive HTML reports with service/asset rollups, accepted risk, expiring waiver debt, and VEX summary sections.
- Adds evidence bundle governance artifacts: `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`.
- Adds manifest `governance_artifacts[]` entries with `bundle_path`, `kind`, and `sha256` and updates schemas/models/contracts.
- Keeps waived/accepted findings visible in reports and governance exports, including decision statements with accepted-risk governance details.
- Computes report VEX summary from all findings instead of limited top rollups, and reads VEX status details from `explanation.provenance.vex_statuses`.
- Adds VPW-068 Markdown and normalized HTML golden snapshots plus evidence documentation.

## Strict DoD Evidence

- Report snapshot tests: `backend/tests/api/snapshots/vpw_068_governance_report.md` and `backend/tests/api/snapshots/vpw_068_governance_report.normalized.html` are asserted by `test_vpw068_reports_and_evidence_bundle_export_governance_context`.
- Evidence integrity: ZIP manifest and governance member hashes are covered in `test_vpw051_evidence_bundle_zip_create_downloads_manifest_integrity`; clean/tampered verification expectations are updated.
- Docs: `docs/evidence/vpw-068-governance-report-evidence-bundle.md`, `docs/contracts.md`, and `mkdocs.yml` are updated.
- UI/Playwright: not applicable to this issue; no UI behavior was changed beyond generated OpenAPI client types.
- DB/Migration: not applicable; no database schema changes.

## Commands Run

- `make frontend-generate-client` - passed
- `python3 -m py_compile backend/app/services/reports.py backend/app/services/governance.py backend/app/models/governance.py` - passed
- `python3 -m json.tool docs/schemas/analysis-result.v1.schema.json >/dev/null && python3 -m json.tool docs/schemas/evidence-bundle-manifest.schema.json >/dev/null` - passed
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py::test_vpw068_reports_and_evidence_bundle_export_governance_context --no-cov` - 1 passed
- `python3 -m pytest -q backend/tests/api/test_template_governance_rollups_api.py --no-cov` - 1 passed
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov` - 27 passed
- `python3 -m pytest -q backend/tests/api/test_template_governance_rollups_api.py backend/tests/api/test_template_reports_api.py backend/tests/api/test_template_workbench_api_skeleton.py --no-cov` - 42 passed
- `npm --prefix frontend run build` - passed
- `npm --prefix frontend run lint` - passed
- `make docs-check` - passed, with existing nav warning for `docs/architecture/vpw-011-api-skeleton.md`
- `make check` - 815 passed, 6 skipped, 90.70% coverage

## Evidence Paths

- `docs/evidence/vpw-068-governance-report-evidence-bundle.md`
- `backend/tests/api/snapshots/vpw_068_governance_report.md`
- `backend/tests/api/snapshots/vpw_068_governance_report.normalized.html`

## Residual Risk

No known VPW-068 implementation gaps remain. Optional live provider and Playwright tests remain skipped by default unless their environment flags are enabled.