### PR TITLE
VPW-069: Harden upload security handling

### DIFF
--- a/backend/app/api/routes/assets.py
+++ b/backend/app/api/routes/assets.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
 
 from app.api.deps import CurrentUser, SessionDep
 from app.api.routes.workbench_access import require_visible_project
-from app.core.config import settings
+from app.core.config import Settings
 from app.models import (
     Asset,
     AssetContextImportPublic,
@@ -78,6 +78,7 @@ def create_project_asset(
 async def import_project_assets(
     *,
     project_id: uuid.UUID,
+    request: Request,
     session: SessionDep,
     current_user: CurrentUser,
     asset_context_file: UploadFile | None = File(None),
@@ -87,8 +88,9 @@ async def import_project_assets(
     if asset_context_file is None or not asset_context_file.filename:
         raise HTTPException(status_code=422, detail="Asset context CSV file is required.")
     _validate_asset_context_upload(asset_context_file)
-    content = await asset_context_file.read(settings.max_upload_bytes + 1)
-    if len(content) > settings.max_upload_bytes:
+    active_settings = _template_settings(request)
+    content = await asset_context_file.read(active_settings.max_upload_bytes + 1)
+    if len(content) > active_settings.max_upload_bytes:
         raise HTTPException(status_code=413, detail="Upload exceeds configured limit.")
     if not content:
         raise HTTPException(status_code=422, detail="Asset context CSV file is required.")
@@ -188,6 +190,7 @@ def _finding_rescore_needed(finding: Any) -> bool:
 
 
 def _validate_asset_context_upload(file: UploadFile) -> None:
+    _reject_unsafe_upload_filename(file.filename or "")
     if Path(file.filename or "").suffix.lower() != ".csv":
         raise HTTPException(status_code=422, detail="Asset context file must be a CSV.")
     normalized = (file.content_type or "").split(";", maxsplit=1)[0].strip().lower()
@@ -198,3 +201,17 @@ def _validate_asset_context_upload(file: UploadFile) -> None:
             status_code=422,
             detail="Asset context content type must be text/csv.",
         )
+
+
+def _reject_unsafe_upload_filename(filename: str) -> None:
+    if "/" in filename or "\\" in filename or Path(filename).name != filename:
+        raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+    if any(ord(character) < 32 for character in filename):
+        raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+
+
+def _template_settings(request: Request) -> Settings:
+    candidate = getattr(request.app.state, "template_settings", None)
+    if isinstance(candidate, Settings):
+        return candidate
+    raise HTTPException(status_code=500, detail="Template settings are not configured.")

--- a/backend/app/api/routes/imports.py
+++ b/backend/app/api/routes/imports.py
@@ -71,6 +71,7 @@ ALLOWED_UPLOAD_MIME_HINTS = {
     "openvas-xml": {"application/xml", "text/xml"},
 }
 SAFE_ATTACK_FILENAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+SAFE_SNAPSHOT_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*[.]json$")
 
 
 @router.post("/projects/{project_id}/imports", response_model=AnalysisRunPublic)
@@ -138,16 +139,32 @@ async def import_project_upload(
         attack_metadata_path=attack_metadata_path,
     )
 
-    upload_bytes = await _read_bounded_upload(file, settings=_template_settings(request))
+    active_settings = _template_settings(request)
+    upload_bytes = await _read_bounded_upload(file, settings=active_settings)
+    remaining_upload_bytes = active_settings.max_upload_bytes - len(upload_bytes)
     asset_context_bytes = (
-        await _read_bounded_upload(asset_context_upload, settings=_template_settings(request))
+        await _read_bounded_upload(
+            asset_context_upload,
+            settings=active_settings,
+            max_bytes=remaining_upload_bytes,
+        )
         if asset_context_upload is not None
         else None
     )
+    if asset_context_bytes is not None:
+        remaining_upload_bytes -= len(asset_context_bytes)
     vex_bytes = (
-        await _read_bounded_upload(vex_upload, settings=_template_settings(request))
+        await _read_bounded_upload(
+            vex_upload,
+            settings=active_settings,
+            max_bytes=remaining_upload_bytes,
+        )
         if vex_upload is not None
         else None
+    )
+    _validate_aggregate_upload_size(
+        settings=active_settings,
+        payloads=[upload_bytes, asset_context_bytes, vex_bytes],
     )
     upload_sha256 = hashlib.sha256(upload_bytes).hexdigest()
     asset_context_sha256 = (
@@ -271,7 +288,7 @@ async def import_project_upload(
         failed_run = run_repo.finish_analysis_run(
             run.id,
             status=AnalysisRunStatus.FAILED,
-            error_message=str(exc),
+            error_message=_sanitize_parser_error_message(str(exc)),
             error_json={
                 "parse_errors": parse_errors,
                 "created_findings": 0,
@@ -315,8 +332,9 @@ async def import_project_upload(
                 asset_context_path=asset_context_path,
             )
         except ValueError as exc:
+            error_message = _sanitize_parser_error_message(str(exc))
             asset_context_error = {
-                "message": str(exc),
+                "message": error_message,
                 "filename": asset_context_stored_filename,
                 "stage": "asset_context_parse",
                 "error_type": exc.__class__.__name__,
@@ -325,7 +343,7 @@ async def import_project_upload(
             failed_run = run_repo.finish_analysis_run(
                 run.id,
                 status=AnalysisRunStatus.FAILED,
-                error_message=str(exc),
+                error_message=error_message,
                 error_json={
                     "asset_context_error": asset_context_error,
                     "created_findings": 0,
@@ -369,8 +387,9 @@ async def import_project_upload(
                 vex_path=vex_path,
             )
         except ValueError as exc:
+            error_message = _sanitize_parser_error_message(str(exc))
             vex_error = {
-                "message": str(exc),
+                "message": error_message,
                 "filename": vex_stored_filename,
                 "stage": "vex_parse",
                 "error_type": exc.__class__.__name__,
@@ -379,7 +398,7 @@ async def import_project_upload(
             failed_run = run_repo.finish_analysis_run(
                 run.id,
                 status=AnalysisRunStatus.FAILED,
-                error_message=str(exc),
+                error_message=error_message,
                 error_json={
                     "vex_error": vex_error,
                     "created_findings": 0,
@@ -428,14 +447,15 @@ async def import_project_upload(
             vex_files=[vex_path] if vex_path is not None else [],
         )
     except TemplateAnalysisError as exc:
+        analysis_error_message = _sanitize_parser_error_message(str(exc))
         failed_history = [*job_history, _job_status_entry("failed")]
         failed_run = run_repo.finish_analysis_run(
             run.id,
             status=AnalysisRunStatus.FAILED,
-            error_message=str(exc),
+            error_message=analysis_error_message,
             error_json={
                 "analysis_error": {
-                    "message": str(exc),
+                    "message": analysis_error_message,
                     "stage": "enrich_score_explain",
                     "error_type": exc.__class__.__name__,
                 },
@@ -456,7 +476,7 @@ async def import_project_upload(
                     status_history=failed_history,
                 ),
                 "analysis_error": {
-                    "message": str(exc),
+                    "message": analysis_error_message,
                     "stage": "enrich_score_explain",
                     "error_type": exc.__class__.__name__,
                 },
@@ -508,18 +528,40 @@ async def import_project_upload(
     return finished_run
 
 
-async def _read_bounded_upload(file: UploadFile, *, settings: Settings) -> bytes:
+async def _read_bounded_upload(
+    file: UploadFile,
+    *,
+    settings: Settings,
+    max_bytes: int | None = None,
+) -> bytes:
+    limit = (
+        settings.max_upload_bytes
+        if max_bytes is None
+        else min(settings.max_upload_bytes, max_bytes)
+    )
     total = 0
     chunks: list[bytes] = []
     while chunk := await file.read(1024 * 1024):
         total += len(chunk)
-        if total > settings.max_upload_bytes:
+        if total > limit:
             raise HTTPException(
                 status_code=413,
                 detail="Upload exceeds configured limit.",
             )
         chunks.append(chunk)
     return b"".join(chunks)
+
+
+def _validate_aggregate_upload_size(
+    *,
+    settings: Settings,
+    payloads: list[bytes | None],
+) -> None:
+    if sum(len(payload) for payload in payloads if payload is not None) > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail="Upload exceeds configured limit.",
+        )
 
 
 def _has_optional_upload(file: UploadFile | None) -> bool:
@@ -724,7 +766,9 @@ def _template_occurrence_with_vex(
         "vex_match_type": enriched.vex_match_type,
         "vex_source_format": enriched.vex_source_format,
         "vex_source_record_id": enriched.vex_source_record_id,
-        "vex_source_path": enriched.vex_source_path,
+        "vex_source_path": Path(enriched.vex_source_path).name
+        if enriched.vex_source_path
+        else None,
         "vex_candidate_count": enriched.vex_candidate_count,
     }
     evidence.update({key: value for key, value in updates.items() if value not in {None, ""}})
@@ -1163,13 +1207,18 @@ def _resolve_template_provider_snapshot_path(
     value = provider_snapshot_file.strip() if provider_snapshot_file else ""
     if not value:
         return None
-    if "/" in value or "\\" in value or Path(value).name != value:
+    if (
+        not SAFE_SNAPSHOT_FILENAME_RE.fullmatch(value)
+        or "/" in value
+        or "\\" in value
+        or Path(value).name != value
+    ):
         raise HTTPException(status_code=422, detail="Provider snapshot path is not allowed.")
     snapshot_root = _template_settings(request).provider_snapshot_dir_path.resolve(strict=False)
     candidate = (snapshot_root / value).resolve(strict=False)
     if not candidate.is_relative_to(snapshot_root):
         raise HTTPException(status_code=422, detail="Provider snapshot path is not allowed.")
-    if not candidate.exists():
+    if not candidate.exists() or not candidate.is_file():
         raise HTTPException(status_code=422, detail="Provider snapshot file does not exist.")
     return candidate
 
@@ -1304,7 +1353,7 @@ def _parse_errors(
     filename: str,
     input_type: str,
 ) -> list[dict[str, Any]]:
-    message = str(exc)
+    message = _sanitize_parser_error_message(str(exc))
     row_prefix = "generic-occurrence-csv row errors: "
     messages = (
         [item.strip() for item in message.removeprefix(row_prefix).split(";") if item.strip()]
@@ -1357,6 +1406,13 @@ def _parse_error_field(message: str) -> str | None:
 def _parse_error_value(message: str) -> str | None:
     match = re.search(r"(?P<quote>['\"])(?P<value>.+?)(?P=quote)", message)
     return match.group("value") if match else None
+
+
+def _sanitize_parser_error_message(message: str) -> str:
+    """Remove local filesystem paths from parser-facing error text."""
+    unix_path = r"(?:/(?:Users|home|private|tmp|var|Volumes)/[^\s`'\"<>:;,)]*)"
+    windows_path = r"(?:[A-Za-z]:\\[^\s`'\"<>:;,)]*)"
+    return re.sub(f"{unix_path}|{windows_path}", "uploaded file", message)
 
 
 def _ignored_line_count(input_type: str, payload: bytes) -> int:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request
 from fastapi.routing import APIRoute
 from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import JSONResponse, Response
 
 from app.api.main import api_router
 from app.core.config import Settings, settings
@@ -34,8 +37,37 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
             allow_methods=["*"],
             allow_headers=["*"],
         )
+    app.middleware("http")(_upload_size_guard)
     app.include_router(api_router, prefix=selected_settings.API_V1_STR)
     return app
+
+
+async def _upload_size_guard(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    if request.method == "POST" and _is_template_upload_path(request.url.path):
+        raw_content_length = request.headers.get("content-length")
+        if raw_content_length is not None:
+            try:
+                content_length = int(raw_content_length)
+            except ValueError:
+                content_length = 0
+            active_settings = getattr(request.app.state, "template_settings", None)
+            if isinstance(active_settings, Settings):
+                multipart_overhead = 64 * 1024
+                if content_length > active_settings.max_upload_bytes + multipart_overhead:
+                    return JSONResponse(
+                        status_code=413,
+                        content={"detail": "Upload exceeds configured limit."},
+                    )
+    return await call_next(request)
+
+
+def _is_template_upload_path(path: str) -> bool:
+    return path.startswith("/api/v1/projects/") and (
+        path.endswith("/imports") or path.endswith("/assets/import")
+    )
 
 
 app = create_app()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "aiofiles>=24.1,<26.0",
   "alembic>=1.13,<2.0",
   "fastapi>=0.115,<1.0",
+  "defusedxml>=0.7,<1.0",
   "jinja2>=3.1,<4.0",
   "jsonschema>=4.23,<5.0",
   "pydantic>=2.6,<3.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ aiofiles>=24.1,<26.0
 alembic>=1.13,<2.0
 beautifulsoup4>=4.12,<5.0
 build>=1.2,<2.0
+defusedxml>=0.7,<1.0
 fastapi>=0.115,<1.0
 httpx>=0.27,<1.0
 jinja2>=3.1,<4.0

--- a/backend/src/vuln_prioritizer/inputs/_xml_support.py
+++ b/backend/src/vuln_prioritizer/inputs/_xml_support.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import re
-import xml.etree.ElementTree as ET
 from pathlib import Path
+from xml.etree.ElementTree import Element, ParseError
+
+from defusedxml import ElementTree as DefusedET  # type: ignore[import-untyped]
+from defusedxml.common import DefusedXmlException  # type: ignore[import-untyped]
 
 from vuln_prioritizer.utils import normalize_cve_id
 
 
-def load_xml_root(path: Path) -> ET.Element:
+def load_xml_root(path: Path) -> Element:
     raw = path.read_bytes()
     uppercase = raw.upper()
     if b"<!DOCTYPE" in uppercase or b"<!ENTITY" in uppercase:
@@ -17,18 +20,20 @@ def load_xml_root(path: Path) -> ET.Element:
             "XML input contains a DOCTYPE or ENTITY declaration, which is not supported."
         )
     try:
-        return ET.fromstring(raw)
-    except ET.ParseError as exc:
-        raise ValueError(f"XML input is not valid XML: {path}") from exc
+        return DefusedET.fromstring(raw)
+    except DefusedXmlException as exc:
+        raise ValueError("XML input contains unsupported XML declarations.") from exc
+    except ParseError as exc:
+        raise ValueError("XML input is not valid XML.") from exc
 
 
-def looks_like_nessus_document(root: ET.Element) -> bool:
+def looks_like_nessus_document(root: Element) -> bool:
     if xml_local_name(root.tag) in {"nessusclientdata_v2", "nessusclientdata"}:
         return True
     return xml_has_descendant(root, "reporthost")
 
 
-def looks_like_openvas_document(root: ET.Element) -> bool:
+def looks_like_openvas_document(root: Element) -> bool:
     return xml_has_descendant(root, "result") and xml_has_descendant(root, "nvt")
 
 
@@ -38,14 +43,14 @@ def xml_local_name(tag: str) -> str:
     return tag.lower()
 
 
-def xml_child(element: ET.Element, name: str) -> ET.Element | None:
+def xml_child(element: Element, name: str) -> Element | None:
     for child in element:
         if xml_local_name(child.tag) == name.lower():
             return child
     return None
 
 
-def xml_child_text(element: ET.Element, name: str) -> str | None:
+def xml_child_text(element: Element, name: str) -> str | None:
     child = xml_child(element, name)
     if child is None or child.text is None:
         return None
@@ -53,17 +58,17 @@ def xml_child_text(element: ET.Element, name: str) -> str | None:
     return text or None
 
 
-def xml_descendants(root: ET.Element, name: str) -> list[ET.Element]:
+def xml_descendants(root: Element, name: str) -> list[Element]:
     expected_name = name.lower()
     return [element for element in root.iter() if xml_local_name(element.tag) == expected_name]
 
 
-def xml_has_descendant(root: ET.Element, name: str) -> bool:
+def xml_has_descendant(root: Element, name: str) -> bool:
     expected_name = name.lower()
     return any(xml_local_name(element.tag) == expected_name for element in root.iter())
 
 
-def nessus_target_ref(report_host: ET.Element, host_index: int) -> str:
+def nessus_target_ref(report_host: Element, host_index: int) -> str:
     host_properties = xml_child(report_host, "hostproperties")
     if host_properties is not None:
         preferred_names = ("host-fqdn", "host-ip", "host_dns", "netbios-name")
@@ -87,7 +92,7 @@ def nessus_target_ref(report_host: ET.Element, host_index: int) -> str:
     return f"nessus-host-{host_index}"
 
 
-def nessus_cve_tokens(report_item: ET.Element) -> list[str]:
+def nessus_cve_tokens(report_item: Element) -> list[str]:
     tokens: list[str] = []
     for child in report_item:
         if xml_local_name(child.tag) != "cve" or child.text is None:
@@ -96,7 +101,7 @@ def nessus_cve_tokens(report_item: ET.Element) -> list[str]:
     return deduplicate_preserving_order(tokens)
 
 
-def openvas_cve_tokens(result: ET.Element) -> list[str]:
+def openvas_cve_tokens(result: Element) -> list[str]:
     tokens: list[str] = []
     nvt = xml_child(result, "nvt")
     if nvt is not None:
@@ -150,7 +155,7 @@ def deduplicate_preserving_order(values: list[str]) -> list[str]:
     return result
 
 
-def nessus_service_label(report_item: ET.Element) -> str | None:
+def nessus_service_label(report_item: Element) -> str | None:
     svc_name = (report_item.attrib.get("svc_name") or "").strip()
     port = (report_item.attrib.get("port") or "").strip()
     protocol = (report_item.attrib.get("protocol") or "").strip()
@@ -160,7 +165,7 @@ def nessus_service_label(report_item: ET.Element) -> str | None:
     return "/".join(parts)
 
 
-def nessus_severity(report_item: ET.Element) -> str | None:
+def nessus_severity(report_item: Element) -> str | None:
     risk_factor = xml_child_text(report_item, "risk_factor")
     if risk_factor:
         return risk_factor

--- a/backend/src/vuln_prioritizer/services/workbench_analysis.py
+++ b/backend/src/vuln_prioritizer/services/workbench_analysis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -54,6 +55,10 @@ SUPPORTED_WORKBENCH_INPUT_FORMATS = {
     InputFormat.nessus_xml.value,
     InputFormat.openvas_xml.value,
 }
+SENSITIVE_ERROR_PATH_RE = re.compile(
+    r"(?:/(?:Users|home|private|tmp|var|Volumes)/[^\s`'\"<>:;,)]*)"
+    r"|(?:[A-Za-z]:\\[^\s`'\"<>:;,)]*)"
+)
 
 
 class WorkbenchAnalysisError(RuntimeError):
@@ -200,9 +205,10 @@ def run_workbench_import(
                 original_filenames=original_filenames,
                 input_formats=input_formats,
             )
+            message = _sanitize_parser_error_message(str(exc))
             _mark_analysis_run_failed(repo, run, exc, parse_errors=parse_errors)
             raise WorkbenchAnalysisError(
-                str(exc),
+                message,
                 parse_errors=parse_errors,
                 analysis_run_id=run.id,
             ) from exc
@@ -235,8 +241,9 @@ def run_workbench_import(
     except WorkbenchAnalysisError:
         raise
     except Exception as exc:
+        message = _sanitize_parser_error_message(str(exc))
         _mark_analysis_run_failed(repo, run, exc, parse_errors=[])
-        raise WorkbenchAnalysisError(str(exc), analysis_run_id=run.id) from exc
+        raise WorkbenchAnalysisError(message, analysis_run_id=run.id) from exc
     session.flush()
     return WorkbenchImportResult(run=run, payload=payload)
 
@@ -312,7 +319,7 @@ def _input_parse_errors(
     original_filenames: list[str],
     input_formats: list[str],
 ) -> list[dict[str, Any]]:
-    message = str(exc)
+    message = _sanitize_parser_error_message(str(exc))
     return [
         {
             "input_format": input_format,
@@ -340,13 +347,18 @@ def _mark_analysis_run_failed(
     repo.finish_analysis_run(
         run.id,
         status="failed",
-        error_message=str(exc),
+        error_message=_sanitize_parser_error_message(str(exc)),
         metadata_json={
             **run.metadata_json,
             "parse_errors": parse_errors,
             "lifecycle_status": "failed",
         },
     )
+
+
+def _sanitize_parser_error_message(message: str) -> str:
+    """Remove local filesystem paths from parser-facing error text."""
+    return SENSITIVE_ERROR_PATH_RE.sub("uploaded file", message)
 
 
 def _effective_workbench_input_type(input_formats: list[str]) -> str:

--- a/backend/tests/api/test_app_guards.py
+++ b/backend/tests/api/test_app_guards.py
@@ -11,6 +11,8 @@ from fastapi.exceptions import RequestValidationError
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
+from app import main as template_app_module
+from app.core.config import Settings as TemplateSettings
 from vuln_prioritizer.api import app as app_module
 from vuln_prioritizer.api import routes as api_routes
 from vuln_prioritizer.workbench_config import WorkbenchSettings
@@ -31,6 +33,44 @@ def test_upload_size_guard_rejects_oversized_import_upload() -> None:
 
         assert response.status_code == 413
         assert json.loads(response.body)["detail"] == "Upload exceeds configured limit."
+
+    asyncio.run(_exercise())
+
+
+def test_template_upload_size_guard_rejects_oversized_import_and_asset_uploads() -> None:
+    async def _exercise() -> None:
+        import_request = _template_request(
+            path="/api/v1/projects/project-1/imports",
+            method="POST",
+            content_length=str((1 * 1024 * 1024) + (64 * 1024) + 1),
+        )
+        asset_request = _template_request(
+            path="/api/v1/projects/project-1/assets/import",
+            method="POST",
+            content_length=str((1 * 1024 * 1024) + (64 * 1024) + 1),
+        )
+        non_upload_request = _template_request(
+            path="/api/v1/projects/project-1/assets/",
+            method="POST",
+            content_length=str((1 * 1024 * 1024) + (64 * 1024) + 1),
+        )
+
+        import_response = await template_app_module._upload_size_guard(  # noqa: SLF001
+            import_request,
+            _ok_response,
+        )
+        asset_response = await template_app_module._upload_size_guard(  # noqa: SLF001
+            asset_request,
+            _ok_response,
+        )
+        non_upload_response = await template_app_module._upload_size_guard(  # noqa: SLF001
+            non_upload_request,
+            _ok_response,
+        )
+
+        assert import_response.status_code == 413
+        assert asset_response.status_code == 413
+        assert non_upload_response.status_code == 200
 
     asyncio.run(_exercise())
 
@@ -228,6 +268,33 @@ def _request(
         headers.append((b"content-length", content_length.encode("ascii")))
     app = FastAPI()
     app.state.workbench_settings = WorkbenchSettings(max_upload_mb=1)
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": headers,
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "app": app,
+        },
+        receive=_empty_receive,
+    )
+
+
+def _template_request(
+    *,
+    path: str,
+    method: str = "GET",
+    content_length: str | None = None,
+) -> Request:
+    headers = []
+    if content_length is not None:
+        headers.append((b"content-length", content_length.encode("ascii")))
+    app = FastAPI()
+    app.state.template_settings = TemplateSettings(MAX_UPLOAD_MB=1)
     return Request(
         {
             "type": "http",

--- a/backend/tests/api/test_template_import_upload_api.py
+++ b/backend/tests/api/test_template_import_upload_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import uuid
 from dataclasses import replace
 from pathlib import Path
@@ -69,8 +70,9 @@ def test_valid_cve_list_upload_creates_analysis_run_and_stores_sha256(
     assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
     assert payload["summary_json"]["input_upload"]["original_filename"] == "Team Scan (prod).txt"
     assert payload["summary_json"]["input_upload"]["stored_filename"] == "Team_Scan__prod_.txt"
-    assert payload["summary_json"]["input_upload"]["path"].startswith(str(upload_dir))
-    assert Path(payload["summary_json"]["input_upload"]["path"]).read_bytes() == content
+    stored_path = Path(payload["summary_json"]["input_upload"]["path"])
+    assert stored_path == upload_dir / project["id"] / payload["id"] / "Team_Scan__prod_.txt"
+    assert stored_path.read_bytes() == content
     assert payload["summary_json"]["import_job"]["status"] == "succeeded"
     assert [item["status"] for item in payload["summary_json"]["import_job"]["status_history"]] == [
         "pending",
@@ -596,7 +598,9 @@ def test_import_upload_applies_openvex_sidecar_to_template_findings(
     assert occurrence["vex_status"] == "fixed"
     assert occurrence["vex_match_type"] == "purl"
     assert occurrence["vex_source_format"] == "openvex-json"
+    assert occurrence["vex_source_path"] == "openvex.json"
     assert occurrence["vex_action_statement"] == "Upgrade completed for the scoped component."
+    _assert_no_sensitive_path_leak(occurrence, tmp_path, upload_dir)
 
 
 def test_import_upload_applies_cyclonedx_vex_sidecar_to_template_findings(
@@ -669,7 +673,7 @@ def test_import_upload_rejects_invalid_vex_sidecar_with_clear_error(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
 ) -> None:
-    _configure_upload_dir(template_api_env, tmp_path)
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
     headers = auth_headers(template_api_env.client)
     project = create_project_via_api(template_api_env.client, headers)
 
@@ -693,6 +697,8 @@ def test_import_upload_rejects_invalid_vex_sidecar_with_clear_error(
     assert detail["analysis_run_id"]
     assert detail["vex_error"]["stage"] == "vex_parse"
     assert "OpenVEX JSON `statements`" in detail["vex_error"]["message"]
+    assert "uploaded file" in detail["vex_error"]["message"]
+    _assert_no_sensitive_path_leak(detail["vex_error"], tmp_path, upload_dir)
 
     run = template_api_env.client.get(
         f"/api/v1/runs/{detail['analysis_run_id']}",
@@ -702,6 +708,8 @@ def test_import_upload_rejects_invalid_vex_sidecar_with_clear_error(
     run_payload = run.json()
     assert run_payload["status"] == "failed"
     assert run_payload["summary_json"]["vex_error"]["stage"] == "vex_parse"
+    _assert_no_sensitive_path_leak(run_payload["error_json"]["vex_error"], tmp_path, upload_dir)
+    _assert_no_sensitive_path_leak(run_payload["summary_json"]["vex_error"], tmp_path, upload_dir)
     assert run_payload["summary_json"]["created_findings"] == 0
     assert run_payload["summary_json"]["updated_findings"] == 0
 
@@ -717,7 +725,7 @@ def test_import_upload_rejects_invalid_asset_context_sidecar_with_clear_error(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
 ) -> None:
-    _configure_upload_dir(template_api_env, tmp_path)
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
     headers = auth_headers(template_api_env.client)
     project = create_project_via_api(template_api_env.client, headers)
 
@@ -745,6 +753,7 @@ def test_import_upload_rejects_invalid_asset_context_sidecar_with_clear_error(
     assert detail["analysis_run_id"]
     assert detail["asset_context_error"]["stage"] == "asset_context_parse"
     assert "asset_id" in detail["asset_context_error"]["message"]
+    _assert_no_sensitive_path_leak(detail["asset_context_error"], tmp_path, upload_dir)
 
     run = template_api_env.client.get(
         f"/api/v1/runs/{detail['analysis_run_id']}",
@@ -754,6 +763,16 @@ def test_import_upload_rejects_invalid_asset_context_sidecar_with_clear_error(
     run_payload = run.json()
     assert run_payload["status"] == "failed"
     assert run_payload["summary_json"]["asset_context_error"]["stage"] == ("asset_context_parse")
+    _assert_no_sensitive_path_leak(
+        run_payload["error_json"]["asset_context_error"],
+        tmp_path,
+        upload_dir,
+    )
+    _assert_no_sensitive_path_leak(
+        run_payload["summary_json"]["asset_context_error"],
+        tmp_path,
+        upload_dir,
+    )
     assert run_payload["summary_json"]["created_findings"] == 0
     assert run_payload["summary_json"]["updated_findings"] == 0
 
@@ -770,12 +789,12 @@ def test_analysis_failure_persists_failed_run_without_partial_findings(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
 ) -> None:
-    _configure_upload_dir(template_api_env, tmp_path)
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
     headers = auth_headers(template_api_env.client)
     project = create_project_via_api(template_api_env.client, headers)
 
     def _fail_analysis(*args: object, **kwargs: object) -> object:
-        raise TemplateAnalysisError("scoring failed")
+        raise TemplateAnalysisError(f"scoring failed for {upload_dir / 'private.json'}")
 
     monkeypatch.setattr(
         "app.api.routes.imports.AnalysisService.analyze_import",
@@ -794,6 +813,8 @@ def test_analysis_failure_persists_failed_run_without_partial_findings(
     assert detail["message"] == "Import analysis failed."
     assert detail["analysis_error"]["stage"] == "enrich_score_explain"
     assert "scoring failed" in detail["analysis_error"]["message"]
+    assert "uploaded file" in detail["analysis_error"]["message"]
+    _assert_no_sensitive_path_leak(detail["analysis_error"], tmp_path, upload_dir)
 
     run = template_api_env.client.get(
         f"/api/v1/runs/{detail['analysis_run_id']}",
@@ -803,6 +824,16 @@ def test_analysis_failure_persists_failed_run_without_partial_findings(
     run_payload = run.json()
     assert run_payload["status"] == "failed"
     assert run_payload["summary_json"]["analysis_error"]["stage"] == "enrich_score_explain"
+    _assert_no_sensitive_path_leak(
+        run_payload["summary_json"]["analysis_error"],
+        tmp_path,
+        upload_dir,
+    )
+    _assert_no_sensitive_path_leak(
+        run_payload["error_json"]["analysis_error"],
+        tmp_path,
+        upload_dir,
+    )
     assert run_payload["summary_json"]["created_findings"] == 0
     assert run_payload["summary_json"]["updated_findings"] == 0
 
@@ -910,6 +941,35 @@ def test_upload_rejects_oversized_file_without_persisting_run_or_file(
     assert not upload_dir.exists()
 
 
+def test_upload_rejects_aggregate_primary_and_sidecar_size_before_persisting(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path, max_upload_mb=1)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    max_bytes = 1024 * 1024
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list"},
+        files={
+            "file": ("sample.txt", b"A" * (max_bytes // 2), "text/plain"),
+            "asset_context_file": (
+                "asset-context.csv",
+                b"B" * ((max_bytes // 2) + 1),
+                "text/csv",
+            ),
+        },
+    )
+
+    assert response.status_code == 413
+    assert "Upload exceeds configured limit" in response.text
+    assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
+    assert not upload_dir.exists()
+
+
 def test_upload_rejects_path_traversal_filename(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
@@ -930,6 +990,117 @@ def test_upload_rejects_path_traversal_filename(
     assert "Upload filename is not allowed" in response.text
     assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
     assert not outside.exists()
+    assert not upload_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "filename", "content_type", "expected_detail"),
+    [
+        (
+            "asset_context_file",
+            "../asset-context.csv",
+            "text/csv",
+            "Upload filename is not allowed",
+        ),
+        ("vex_file", "..\\openvex.json", "application/json", "Upload filename is not allowed"),
+        ("asset_context_file", "asset-context.txt", "text/csv", "Asset context file must be a CSV"),
+        (
+            "asset_context_file",
+            "asset-context.csv",
+            "application/json",
+            "Asset context content type must be text/csv",
+        ),
+        ("vex_file", "openvex.txt", "application/json", "VEX file must be a JSON document"),
+        (
+            "vex_file",
+            "openvex.json",
+            "text/plain",
+            "VEX content type must be application/json",
+        ),
+    ],
+)
+def test_upload_rejects_unsafe_or_unsupported_sidecar_uploads(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+    field_name: str,
+    filename: str,
+    content_type: str,
+    expected_detail: str,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list"},
+        files={
+            "file": ("sample.txt", b"CVE-2024-3094\n", "text/plain"),
+            field_name: (filename, b"{}", content_type),
+        },
+    )
+
+    assert response.status_code == 422
+    assert expected_detail in response.text
+    assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
+    assert not upload_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("form_data", "expected_detail"),
+    [
+        (
+            {
+                "provider_snapshot_file": "/tmp/private-snapshot.json",
+                "locked_provider_data": "true",
+            },
+            "Provider snapshot path is not allowed",
+        ),
+        (
+            {
+                "provider_snapshot_file": "../demo_provider_snapshot.json",
+                "locked_provider_data": "true",
+            },
+            "Provider snapshot path is not allowed",
+        ),
+        (
+            {
+                "provider_snapshot_file": "demo_provider_snapshot.txt",
+                "locked_provider_data": "true",
+            },
+            "Provider snapshot path is not allowed",
+        ),
+        (
+            {"provider_snapshot_file": "missing.json", "locked_provider_data": "true"},
+            "Provider snapshot file does not exist",
+        ),
+        (
+            {"attack_mapping_file": "../mapping.json"},
+            "ATT&CK artifact path is not allowed",
+        ),
+    ],
+)
+def test_upload_rejects_untrusted_provider_and_attack_artifact_paths(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+    form_data: dict[str, str],
+    expected_detail: str,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "cve-list", **form_data},
+        files={"file": ("sample.txt", b"CVE-2024-3094\n", "text/plain")},
+    )
+
+    assert response.status_code == 422
+    assert expected_detail in response.text
+    assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
     assert not upload_dir.exists()
 
 
@@ -962,6 +1133,7 @@ def test_parse_errors_are_structured_and_failed_run_is_persisted(
     assert detail["parse_errors"][0]["value"] == "not-a-cve"
     assert "line 2" in detail["parse_errors"][0]["message"]
     assert "not-a-cve" in detail["parse_errors"][0]["message"]
+    _assert_no_sensitive_path_leak(detail["parse_errors"], tmp_path, upload_dir)
 
     run = template_api_env.client.get(
         f"/api/v1/runs/{detail['analysis_run_id']}",
@@ -977,6 +1149,8 @@ def test_parse_errors_are_structured_and_failed_run_is_persisted(
     ]
     assert payload["error_json"]["parse_errors"] == detail["parse_errors"]
     assert payload["summary_json"]["parse_errors"] == detail["parse_errors"]
+    _assert_no_sensitive_path_leak(payload["error_json"]["parse_errors"], tmp_path, upload_dir)
+    _assert_no_sensitive_path_leak(payload["summary_json"]["parse_errors"], tmp_path, upload_dir)
     assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
     assert Path(payload["summary_json"]["input_upload"]["path"]).is_relative_to(upload_dir)
     assert Path(payload["summary_json"]["input_upload"]["path"]).read_bytes() == content
@@ -992,6 +1166,105 @@ def test_parse_errors_are_structured_and_failed_run_is_persisted(
     assert summary_payload["updated_findings"] == 0
     assert summary_payload["ignored_lines"] == 0
     assert summary_payload["parse_errors"] == detail["parse_errors"]
+
+
+def test_xml_parse_errors_redact_local_upload_paths(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "nessus-xml"},
+        files={
+            "file": (
+                "broken.nessus",
+                b"<NessusClientData_v2><Report>",
+                "application/xml",
+            ),
+        },
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["message"] == "Import parsing failed."
+    assert detail["parse_errors"][0]["filename"] == "broken.nessus"
+    assert detail["parse_errors"][0]["input_type"] == "nessus-xml"
+    _assert_no_sensitive_path_leak(detail["parse_errors"], tmp_path, upload_dir)
+
+    run = template_api_env.client.get(
+        f"/api/v1/runs/{detail['analysis_run_id']}",
+        headers=headers,
+    )
+    assert run.status_code == 200
+    run_payload = run.json()
+    assert run_payload["status"] == "failed"
+    assert run_payload["error_json"]["parse_errors"] == detail["parse_errors"]
+    assert run_payload["summary_json"]["parse_errors"] == detail["parse_errors"]
+    _assert_no_sensitive_path_leak(run_payload["error_json"]["parse_errors"], tmp_path, upload_dir)
+    _assert_no_sensitive_path_leak(
+        run_payload["summary_json"]["parse_errors"], tmp_path, upload_dir
+    )
+
+
+@pytest.mark.parametrize(
+    ("filename", "content_type", "content", "expected_status", "expected_detail"),
+    [
+        (
+            "../assets.csv",
+            "text/csv",
+            b"target_kind,target_ref,asset_id\n",
+            422,
+            "Upload filename is not allowed",
+        ),
+        (
+            "assets.txt",
+            "text/csv",
+            b"target_kind,target_ref,asset_id\n",
+            422,
+            "Asset context file must be a CSV",
+        ),
+        (
+            "assets.csv",
+            "application/json",
+            b"target_kind,target_ref,asset_id\n",
+            422,
+            "Asset context content type must be text/csv",
+        ),
+        (
+            "assets.csv",
+            "text/csv",
+            b"A" * ((1024 * 1024) + 1),
+            413,
+            "Upload exceeds configured limit",
+        ),
+    ],
+)
+def test_asset_context_import_rejects_unsafe_uploads(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+    filename: str,
+    content_type: str,
+    content: bytes,
+    expected_status: int,
+    expected_detail: str,
+) -> None:
+    _configure_upload_dir(template_api_env, tmp_path, max_upload_mb=1)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/assets/import",
+        headers=headers,
+        files={"asset_context_file": (filename, content, content_type)},
+    )
+
+    assert response.status_code == expected_status
+    assert expected_detail in response.text
 
 
 def test_summary_tracks_ignored_cve_list_lines(
@@ -1037,6 +1310,21 @@ def _configure_upload_dir(
         MAX_UPLOAD_MB=max_upload_mb,
     )
     return upload_dir.resolve(strict=False)
+
+
+def _assert_no_sensitive_path_leak(payload: object, *paths: Path) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden_fragments = [
+        "/Users/",
+        "/private/",
+        "/tmp/",
+        "/var/",
+        "\\Users\\",
+    ]
+    for path in paths:
+        forbidden_fragments.append(str(path))
+    for fragment in forbidden_fragments:
+        assert fragment not in text
 
 
 def _run_count(template_api_env: TemplateApiEnv, project_id: uuid.UUID) -> int:

--- a/backend/tests/test_input_loader_contracts.py
+++ b/backend/tests/test_input_loader_contracts.py
@@ -135,8 +135,9 @@ def test_input_loader_rejects_invalid_xml_with_explicit_format(tmp_path: Path) -
     xml_file.write_text("<NessusClientData_v2><Report>", encoding="utf-8")
 
     loader = loader_module.InputLoader()
-    with pytest.raises(ValueError, match="XML input is not valid XML"):
+    with pytest.raises(ValueError, match="XML input is not valid XML") as exc_info:
         loader.load(path=xml_file, input_format="nessus-xml")
+    assert str(tmp_path) not in str(exc_info.value)
 
 
 def test_json_parser_rejects_wrong_top_level_type_before_parser_access(tmp_path: Path) -> None:

--- a/docs/evidence/vpw-069-upload-security-hardening.md
+++ b/docs/evidence/vpw-069-upload-security-hardening.md
@@ -1,0 +1,71 @@
+# VPW-069 Upload Security Hardening Evidence
+
+VPW-069 captures upload hardening evidence for both the template FastAPI
+Workbench import path and the older local Workbench import path.
+
+## Scope
+
+- Template FastAPI imports through `POST /api/v1/projects/{project_id}/imports`,
+  including primary input files and supported sidecar uploads.
+- Older Workbench imports through `POST /api/projects/{project_id}/imports`,
+  including primary input files and supported context uploads.
+- Parser handoff for supported text, CSV, JSON, Nessus XML, and OpenVAS XML
+  input formats.
+- Upload filesystem placement under configured upload roots, including
+  server-owned stored filenames and project/run isolation.
+- Client-visible upload and parser error responses.
+
+Out of scope:
+
+- New scanner behavior, remote probing, exploit validation, or public
+  multi-tenant deployment hardening.
+- Report and evidence bundle download controls except where they inherit upload
+  provenance or path-redaction expectations.
+
+## Definition of Done
+
+| Requirement | Done when |
+| --- | --- |
+| Size bounded | Template and older Workbench import requests reject oversized payloads with a 413 response before creating runs or persisting upload bytes. |
+| Suffix and MIME allowlisted | Each accepted input type maps to explicit filename suffixes and MIME hints; unknown input types, unsupported suffixes, and mismatched MIME hints return 422. |
+| Traversal safe | Absolute paths, `..` segments, unsafe path separators, and traversal-style upload names are rejected before filesystem writes. |
+| Per project/run isolated | Stored uploads stay under the configured upload root and are isolated by server-owned project/run or equivalent UUID-scoped directories. |
+| Parser errors path-redacted | Client-visible parser errors include structured context such as input type, sanitized filename, line, field, and value when known, but do not expose absolute upload paths, temporary directories, stack traces, or local filesystem layout. |
+| XML defused | Nessus/OpenVAS XML import uses defused XML handling, rejects DOCTYPE, ENTITY, and XXE-style constructs before parsing, and returns malformed XML as a sanitized parser error. |
+| Threat model aligned | The upload control row in [Workbench Threat Model and Readiness](../workbench-threat-model.md#control-evidence-for-v12) names both template FastAPI imports and older Workbench imports. |
+
+## Evidence Requirements
+
+| Control area | Required evidence |
+| --- | --- |
+| Template FastAPI upload guard | Focused API tests cover oversize rejection, suffix/MIME allowlists, traversal filename rejection, project/run-scoped storage, and path-redacted parse errors for `/api/v1/projects/{project_id}/imports`. |
+| Older Workbench upload guard | Focused API tests cover unsupported or oversized uploads, traversal rejection for primary and context uploads, and no writes outside the configured upload root for `/api/projects/{project_id}/imports`. |
+| Parser and XML safety | Input-loader contract tests cover XML DOCTYPE/ENTITY rejection, malformed XML handling, and safe Nessus/OpenVAS parser behavior. |
+| Documentation | `docs/workbench-threat-model.md` records the upload hardening readiness expectation, and this page is linked from `mkdocs.yml` under Historical Appendix after VPW-068. |
+
+## Local Gates
+
+| Gate | Expected coverage | Status |
+| --- | --- | --- |
+| `python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py --no-cov` | Template imports reject bad type/suffix/MIME, oversized primary uploads, aggregate primary-plus-sidecar oversize, traversal filenames, unsafe sidecars, untrusted provider/ATT&CK artifact paths, and path-redacted parser/sidecar/analysis errors. Also verifies successful VEX imports expose only the VEX basename in finding evidence. | Passed: 36 passed. |
+| `python3 -m pytest -q backend/tests/api/test_app_guards.py backend/tests/test_input_loader_contracts.py --no-cov` | Template and legacy request-size guards return 413 for oversized upload requests; XML input detection and explicit XML parsing reject unsafe or malformed XML without leaking local paths. | Passed: 36 passed. |
+| `python3 -m pytest -q backend/tests/api/test_workbench_api.py::test_workbench_rejects_unsupported_and_oversized_uploads backend/tests/api/test_workbench_api.py::test_workbench_rejects_untrusted_provider_snapshot_path --no-cov` | Older Workbench imports reject unsupported/oversized uploads, traversal upload names, unsafe context upload names, and untrusted snapshot paths. | Passed: 2 passed. |
+| `python3 -m ruff check backend/app/main.py backend/app/api/routes/imports.py backend/app/api/routes/assets.py backend/src/vuln_prioritizer/inputs/_xml_support.py backend/src/vuln_prioritizer/services/workbench_analysis.py backend/tests/api/test_template_import_upload_api.py backend/tests/api/test_app_guards.py backend/tests/test_input_loader_contracts.py` | Focused lint for changed code and test files. | Passed: all checks passed. |
+| `make docs-check` | MkDocs navigation includes this evidence page and the threat-model link remains valid. Existing nav warning remains for `docs/architecture/vpw-011-api-skeleton.md`. | Passed. |
+| `make check` | Full local gate: Ruff format check, Ruff lint, mypy, and Python test suite with coverage. | Passed: 833 passed, 6 skipped, 90.69% coverage. |
+| `make dependency-audit` | Dependency review after adding `defusedxml`. | Passed: no known vulnerabilities found. |
+| `make docker-demo-smoke` | Template backend/frontend image build and `/api/v1/workbench/status` smoke. | Passed. |
+
+## Static Safety Check
+
+`rg -n "extractall|extract\\(|shutil\\.unpack_archive|tarfile\\.extract|subprocess|shell=True|os\\.system|eval\\(" backend/app backend/src/vuln_prioritizer`
+returned no production matches for unsafe archive extraction or shell execution
+patterns in the upload/application code paths.
+
+## Threat Model Reference
+
+The upload control is tracked in
+[docs/workbench-threat-model.md](../workbench-threat-model.md#control-evidence-for-v12).
+The readiness expectation is that template FastAPI imports and older Workbench
+imports are size bounded, suffix/MIME allowlisted, traversal-safe, isolated per
+project/run, path-redacted on parser errors, and safe for XML scanner exports.

--- a/docs/workbench-threat-model.md
+++ b/docs/workbench-threat-model.md
@@ -1,6 +1,6 @@
 # Workbench Threat Model and Readiness
 
-Status: current local-first Workbench threat model. Last reviewed: 2026-04-25.
+Status: current local-first Workbench threat model. Last reviewed: 2026-04-30.
 
 This page defines the defensive threat model and operational readiness assumptions for the local Workbench. It keeps the same product boundaries as the rest of the project: `vuln-prioritizer` prioritizes known CVEs and existing findings. It is not a scanner, exploit tool, proof-of-concept generator, or general-purpose vulnerability-management platform.
 
@@ -78,7 +78,7 @@ Primary boundaries:
 
 | Threat | Impact | Mitigations and readiness expectation |
 | --- | --- | --- |
-| Malicious or malformed import file | Parser failure, resource exhaustion, misleading findings | Enforce input-format validation, upload size limits, structured parsers, safe XML parsing, and clear parse warnings. Do not execute content from imports. |
+| Malicious or malformed import file | Parser failure, resource exhaustion, misleading findings | Enforce input-format validation, upload size limits, suffix/MIME allowlists, structured parsers, safe XML parsing, path-redacted parser errors, and clear parse warnings. Do not execute content from imports. |
 | Path traversal in uploads, snapshots, or report downloads | Unauthorized local file read/write | Resolve configured directories server-side, reject arbitrary snapshot paths in Workbench forms, generate server-owned artifact names, and avoid reflecting user-supplied paths into downloads. |
 | Cross-site request forgery against local Workbench forms | Unauthorized imports, report generation, or state changes | Require CSRF token validation for state-changing web forms and keep the token local to the process or configured environment. |
 | Stored or reflected HTML/script from imported metadata | Browser compromise, misleading reports | Escape all user-controlled values in Jinja2 templates and generated HTML. Treat scanner fields, asset names, owners, paths, and descriptions as untrusted text. |
@@ -134,7 +134,9 @@ The current local-first Workbench is readiness-aligned when:
 
 - scope text in README, architecture docs, and Workbench docs consistently says known-CVE prioritizer, not scanner
 - Workbench runtime docs identify SQLite as the default single-node persistence model and the Postgres profile as optional/private
-- imports have size limits, format validation, and parser warnings
+- imports have size limits, suffix/MIME allowlists, traversal-safe filenames,
+  project/run isolation, path-redacted parser errors, safe XML handling, and
+  parser warnings
 - locked provider snapshot replay is explicit and path-restricted
 - reports and evidence bundles include provider provenance and do not leak configured secrets
 - web forms use CSRF protection for state-changing operations
@@ -151,7 +153,7 @@ The current local-first Workbench is readiness-aligned when:
 | Control | Code evidence | Test or smoke evidence |
 | --- | --- | --- |
 | Security headers | `backend/src/vuln_prioritizer/api/app.py` installs `_security_headers` for `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Cross-Origin-Opener-Policy`, `Permissions-Policy`, and a restrictive CSP. | `backend/tests/api/test_workbench_api.py::test_workbench_health_and_project_crud` asserts `nosniff`, `DENY`, and `object-src 'none'` on `/api/health`. |
-| Upload filename and path validation | `backend/src/vuln_prioritizer/api/routes.py` rejects unsafe upload filenames, sanitizes stored names, restricts extensions per Workbench input/context type, stores uploads under UUID-owned directories, and restricts provider/ATT&CK artifact names to configured roots. | `backend/tests/api/test_workbench_api.py::test_workbench_rejects_unsupported_and_oversized_uploads` covers traversal filenames and oversized uploads; `test_workbench_rejects_untrusted_provider_snapshot_path` covers snapshot path rejection. |
+| Template and legacy import upload hardening | Template FastAPI imports in `backend/app/api/routes/imports.py`, asset-context imports in `backend/app/api/routes/assets.py`, and older Workbench imports in `backend/src/vuln_prioritizer/api/routes.py` are size bounded, suffix/MIME allowlisted, traversal-safe, and isolated under configured upload roots by project/run or equivalent UUID-owned directories. Parser errors returned to clients are path-redacted. Nessus/OpenVAS XML handling uses defused XML handling and rejects DOCTYPE, ENTITY, and XXE-style constructs before parsing. VPW-069 evidence is tracked in `docs/evidence/vpw-069-upload-security-hardening.md`. | `backend/tests/api/test_template_import_upload_api.py`, `backend/tests/api/test_app_guards.py`, focused older Workbench upload tests, XML input-loader contract tests, `make check`, `make dependency-audit`, and `make docker-demo-smoke` passed for VPW-069. |
 | Report and evidence artifact downloads | `backend/src/vuln_prioritizer/services/workbench_reports.py` writes run artifacts under the configured report directory; `backend/src/vuln_prioritizer/api/routes.py` resolves downloads back under that root, verifies SHA-256, returns attachment downloads, and disables caching. | `backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence` verifies JSON, Markdown, HTML, CSV, SARIF, evidence ZIP, manifest hashes, and verification URLs; `test_workbench_downloads_reject_tampered_artifact_paths` covers outside-root and checksum-tamper rejection. |
 | CSV report formula handling | `backend/src/vuln_prioritizer/services/workbench_reports.py` prefixes formula-like CSV cells before writing Workbench findings reports. | `backend/tests/api/test_workbench_api.py::test_workbench_csv_report_escapes_spreadsheet_formulas` covers component, owner, and service cells that begin with spreadsheet formula characters. |
 | API token bootstrap | `backend/src/vuln_prioritizer/api/routes.py` creates one-time token values and stores SHA-256 hashes; `backend/src/vuln_prioritizer/api/app.py` gates mutating `/api/*` requests once any active token exists and accepts `Authorization: Bearer` or `X-API-Token`. | `backend/tests/api/test_workbench_api.py::test_workbench_api_tokens_config_provider_jobs_and_github_preview` verifies hash storage, blocked unauthenticated mutations after token creation, bad-token rejection, accepted token use, and `last_used_at` updates. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - VPW-066 CycloneDX VEX Parser: evidence/vpw-066-cyclonedx-vex-parser.md
       - VPW-067 Governance Rollups and Waiver Debt: evidence/vpw-067-governance-rollups-waiver-debt.md
       - VPW-068 Governance Reports and Evidence Bundle: evidence/vpw-068-governance-report-evidence-bundle.md
+      - VPW-069 Upload Security Hardening: evidence/vpw-069-upload-security-hardening.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
Closes #175.

## Summary
- Add request-level and aggregate upload size enforcement for template FastAPI imports and asset-context uploads.
- Harden upload validation for template sidecars, provider snapshots, ATT&CK artifacts, and successful VEX provenance so public finding evidence keeps only the VEX basename.
- Switch Nessus/OpenVAS XML parsing to defused XML handling and redact local filesystem paths from parser-facing errors in both template and older Workbench import paths.
- Add VPW-069 evidence docs and update the threat model control row.

## Evidence
- `python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py --no-cov` -> 36 passed.
- `python3 -m pytest -q backend/tests/api/test_app_guards.py backend/tests/test_input_loader_contracts.py --no-cov` -> 36 passed.
- `python3 -m pytest -q backend/tests/api/test_workbench_api.py::test_workbench_rejects_unsupported_and_oversized_uploads backend/tests/api/test_workbench_api.py::test_workbench_rejects_untrusted_provider_snapshot_path --no-cov` -> 2 passed.
- `python3 -m ruff check backend/app/main.py backend/app/api/routes/imports.py backend/app/api/routes/assets.py backend/src/vuln_prioritizer/inputs/_xml_support.py backend/src/vuln_prioritizer/services/workbench_analysis.py backend/tests/api/test_template_import_upload_api.py backend/tests/api/test_app_guards.py backend/tests/test_input_loader_contracts.py` -> passed.
- `make docs-check` -> passed; existing nav warning remains for `docs/architecture/vpw-011-api-skeleton.md`.
- `make check` -> 833 passed, 6 skipped, 90.69% coverage.
- `make dependency-audit` -> no known vulnerabilities found.
- `make docker-demo-smoke` -> passed on the final diff.

## Static safety check
- `rg -n "extractall|extract\(|shutil\.unpack_archive|tarfile\.extract|subprocess|shell=True|os\.system|eval\(" backend/app backend/src/vuln_prioritizer` returned no production matches for unsafe archive extraction or shell execution patterns in the upload/application code paths.

## Residual risk
- Evidence-bundle ZIP memory hardening is adjacent but outside VPW-069's upload API boundary; this PR does not change evidence bundle archive verification behavior.

