### PR TITLE
VPW-074: Finalize CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -62,6 +65,9 @@ jobs:
 
       - name: Lint frontend
         run: make frontend-lint
+
+      - name: Check frontend lint drift
+        run: git diff --exit-code -- frontend
 
       - name: Build frontend
         run: make frontend-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    outputs:
+      release_notes_body_path: ${{ steps.release_notes.outputs.body_path }}
 
     steps:
       - name: Check out repository
@@ -101,15 +103,32 @@ jobs:
             docs/example*.json
             docs/examples/*.json
 
+  publish-github-release:
+    needs: build-and-release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Download built distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: release-dist
+          path: dist
+
       - name: Publish GitHub release from checked-in notes
-        if: startsWith(github.ref, 'refs/tags/v') && steps.release_notes.outputs.body_path != ''
+        if: needs.build-and-release.outputs.release_notes_body_path != ''
         uses: softprops/action-gh-release@v3
         with:
-          body_path: ${{ steps.release_notes.outputs.body_path }}
+          body_path: ${{ needs.build-and-release.outputs.release_notes_body_path }}
           files: dist/*
 
       - name: Publish GitHub release with generated notes
-        if: startsWith(github.ref, 'refs/tags/v') && steps.release_notes.outputs.body_path == ''
+        if: needs.build-and-release.outputs.release_notes_body_path == ''
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -3,6 +3,9 @@ name: TestPyPI Publish
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/backend/tests/test_v11_output_contracts.py
+++ b/backend/tests/test_v11_output_contracts.py
@@ -71,6 +71,8 @@ runner = CliRunner()
 SCHEMA_ROOT = Path(__file__).resolve().parents[2] / "docs" / "schemas"
 ACTION_FILE = Path(__file__).resolve().parents[2] / "action.yml"
 CI_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+DOCKER_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "docker.yml"
+CODEQL_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "codeql.yml"
 MAINTENANCE_WORKFLOW = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "maintenance.yml"
 )
@@ -573,6 +575,7 @@ def test_action_contract_exposes_summary_and_config_wiring() -> None:
 def test_ci_workflow_runs_workflow_check_on_supported_python_versions() -> None:
     payload = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
     check_job = payload["jobs"]["check"]
+    frontend_job = payload["jobs"]["frontend"]
     setup_step = next(
         step for step in check_job["steps"] if step.get("uses") == "actions/setup-python@v6"
     )
@@ -585,6 +588,39 @@ def test_ci_workflow_runs_workflow_check_on_supported_python_versions() -> None:
     assert check_job["strategy"]["matrix"]["python-version"] == ["3.11", "3.12"]
     assert setup_step["with"]["python-version"] == "${{ matrix.python-version }}"
     assert gate_step["run"] == "make workflow-check"
+    assert payload["permissions"] == {"contents": "read"}
+    assert any(step.get("name") == "Lint frontend" for step in frontend_job["steps"])
+    frontend_lint_drift_step = next(
+        step for step in frontend_job["steps"] if step.get("name") == "Check frontend lint drift"
+    )
+    client_drift_step = next(
+        step
+        for step in frontend_job["steps"]
+        if step.get("name") == "Check generated frontend client drift"
+    )
+    assert frontend_lint_drift_step["run"] == "git diff --exit-code -- frontend"
+    assert client_drift_step["run"] == "git diff --exit-code -- frontend/src/client"
+
+
+def test_ci_workflow_permissions_are_minimal() -> None:
+    ci = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    docker = yaml.safe_load(DOCKER_WORKFLOW.read_text(encoding="utf-8"))
+    codeql = yaml.safe_load(CODEQL_WORKFLOW.read_text(encoding="utf-8"))
+    release = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    testpypi = yaml.safe_load(TESTPYPI_WORKFLOW.read_text(encoding="utf-8"))
+
+    assert ci["permissions"] == {"contents": "read"}
+    assert docker["permissions"] == {"contents": "read"}
+    assert testpypi["permissions"] == {"contents": "read"}
+    assert codeql["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+        "security-events": "write",
+    }
+    assert release["permissions"] == {"contents": "read"}
+    assert "permissions" not in release["jobs"]["build-and-release"]
+    assert release["jobs"]["publish-github-release"]["permissions"] == {"contents": "write"}
+    assert release["jobs"]["publish-pypi"]["permissions"] == {"id-token": "write"}
 
 
 def test_maintenance_workflow_runs_weekly_release_check_and_install_smokes() -> None:
@@ -627,18 +663,44 @@ def test_release_workflow_is_tag_bound_and_verifies_pypi_install() -> None:
     payload = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
     jobs = payload["jobs"]
     build_steps = jobs["build-and-release"]["steps"]
+    github_release_job = jobs["publish-github-release"]
     github_release_steps = [
-        step for step in build_steps if step.get("uses") == "softprops/action-gh-release@v3"
+        step
+        for step in github_release_job["steps"]
+        if step.get("uses") == "softprops/action-gh-release@v3"
     ]
 
-    assert github_release_steps
-    assert all(
-        "startsWith(github.ref, 'refs/tags/v')" in step["if"] for step in github_release_steps
+    assert payload["permissions"] == {"contents": "read"}
+    assert jobs["build-and-release"]["outputs"]["release_notes_body_path"] == (
+        "${{ steps.release_notes.outputs.body_path }}"
     )
+    assert github_release_job["needs"] == "build-and-release"
+    assert github_release_job["if"] == "startsWith(github.ref, 'refs/tags/v')"
+    assert github_release_job["permissions"] == {"contents": "write"}
+    assert github_release_steps
     release_gate_step = next(
         step for step in build_steps if step.get("name") == "Run release gate before publishing"
     )
     assert release_gate_step["run"] == "make release-check"
+    checked_in_notes_step = next(
+        step
+        for step in github_release_steps
+        if step.get("name") == "Publish GitHub release from checked-in notes"
+    )
+    generated_notes_step = next(
+        step
+        for step in github_release_steps
+        if step.get("name") == "Publish GitHub release with generated notes"
+    )
+    assert checked_in_notes_step["if"] == (
+        "needs.build-and-release.outputs.release_notes_body_path != ''"
+    )
+    assert checked_in_notes_step["with"]["body_path"] == (
+        "${{ needs.build-and-release.outputs.release_notes_body_path }}"
+    )
+    assert generated_notes_step["if"] == (
+        "needs.build-and-release.outputs.release_notes_body_path == ''"
+    )
 
     tag_install_step = next(
         step for step in build_steps if step.get("name") == "Smoke test source-at-tag install path"

--- a/docs/evidence/vpw-074-ci-gates.md
+++ b/docs/evidence/vpw-074-ci-gates.md
@@ -1,0 +1,120 @@
+# VPW-074 CI Gates
+
+VPW-074 finalizes the CI gate evidence for backend, frontend, generated
+client, Docker, and security checks. The implementation keeps the current
+template-aligned backend/frontend CI path and tightens workflow permissions.
+
+## Scope
+
+- Added explicit read-only repository permissions to the normal CI workflow.
+- Added explicit read-only repository permissions to the TestPyPI workflow.
+- Reduced the release workflow default permission from `contents: write` to
+  `contents: read`, then moved GitHub Release publishing into a dedicated job
+  with `contents: write`.
+- Added a CI drift check after frontend linting so Biome write-mode fixes cannot
+  pass without checked-in frontend changes.
+- Added workflow contract tests for minimal permissions, frontend drift checks,
+  and the split release publishing job.
+- Documented the permission expectation in the Workbench release checklist.
+- Preserved existing CI gates:
+  - backend Ruff format check, Ruff lint, mypy, pytest, docs build,
+    actionlint, pre-commit, and package check through `make workflow-check`
+  - frontend lint, build, generated client regeneration, client drift check,
+    and Playwright smoke
+  - Docker Compose build/smoke through the Docker workflow and
+    `make docker-demo-smoke`
+  - CodeQL security analysis with `security-and-quality` queries
+
+## Gate Matrix
+
+| VPW-074 requirement | Workflow or command evidence |
+| --- | --- |
+| Backend pytest/lint/type | `.github/workflows/ci.yml` runs `make workflow-check`; `Makefile` `workflow-check` includes `make check`, and `make check` runs Ruff format, Ruff lint, mypy, and backend pytest. |
+| Frontend lint/build/Playwright smoke | `.github/workflows/ci.yml` frontend job runs `make frontend-lint`, `git diff --exit-code -- frontend`, `make frontend-build`, installs Chromium, and runs `npm --prefix frontend run test`. |
+| Generated client drift | `.github/workflows/ci.yml` frontend job runs `make frontend-generate-client` and `git diff --exit-code -- frontend/src/client`. |
+| Docker build/smoke | `.github/workflows/docker.yml` builds and starts `backend` and `frontend`, polls `/api/v1/workbench/status`, `/api/v1/utils/health-check/`, `/`, and `/login`, then tears down volumes. |
+| Security analysis | `.github/workflows/codeql.yml` runs CodeQL for Python with `security-and-quality` queries and minimal CodeQL permissions. |
+| Dependency audit path | `Makefile` exposes `make dependency-audit`; release and threat-model docs document the gate and exception handling. |
+| Workflow permissions minimal | `ci.yml`, `docker.yml`, `maintenance.yml`, and `testpypi.yml` use `contents: read` by default; `codeql.yml` grants only `actions: read`, `contents: read`, and `security-events: write`; `release.yml` grants `contents: write` only to the dedicated GitHub Release publishing job. |
+| Failing gates documented | CI uploads Playwright evidence on frontend runs, Docker logs on failure, release/TestPyPI/maintenance debug artifacts on failure, and the PR template asks contributors to list local checks. |
+
+## GitHub Actions Evidence
+
+Fresh GitHub Actions evidence collected on 2026-04-30 before this patch:
+
+- Latest `main` CI run: `25159396534`, `success`, display title
+  `VPW-070: Harden HTML rendering and security headers`.
+- Latest `main` Docker run: `25159396521`, `success`, display title
+  `VPW-070: Harden HTML rendering and security headers`.
+- Latest `main` CodeQL run: `25159396539`, `success`, display title
+  `VPW-070: Harden HTML rendering and security headers`.
+- PR #268 visible check output showed CI `check (3.11)`, CI `check (3.12)`,
+  frontend, Docker `compose-smoke`, and CodeQL all passed.
+- Branch protection required status checks were updated on 2026-04-30 to keep
+  strict mode enabled and require `Analyze Python`, `check (3.11)`,
+  `check (3.12)`, `compose-smoke`, and `frontend`.
+
+The VPW-074 PR closeout comment should add the PR-specific GitHub Actions URLs
+after this branch is pushed and the checks finish.
+
+## Validation
+
+Commands to run for this closeout:
+
+```bash
+python3 -m json.tool docs/examples/example_results.sarif
+python3 -m pytest -q backend/tests/test_v11_output_contracts.py::test_ci_workflow_runs_workflow_check_on_supported_python_versions backend/tests/test_v11_output_contracts.py::test_ci_workflow_permissions_are_minimal backend/tests/test_v11_output_contracts.py::test_release_workflow_is_tag_bound_and_verifies_pypi_install --no-cov
+python3 -m pytest -q backend/tests/test_workbench_integration_contracts.py backend/tests/test_github_action_contract.py --no-cov
+npm --prefix frontend run lint
+git diff --exit-code -- frontend
+npm --prefix frontend run build
+make frontend-generate-client
+git diff --exit-code -- frontend/src/client
+npm --prefix frontend run test
+make docs-check
+make actionlint-check
+make workflow-check
+make dependency-audit
+make docker-demo-smoke
+git diff --check
+```
+
+Results from the VPW-074 local validation pass:
+
+- Workflow YAML parse check for `ci.yml`, `docker.yml`, `codeql.yml`,
+  `release.yml`, `testpypi.yml`, and `maintenance.yml`: passed.
+- `python3 -m json.tool docs/examples/example_results.sarif`: passed.
+- `python3 -m pytest -q backend/tests/test_v11_output_contracts.py::test_ci_workflow_runs_workflow_check_on_supported_python_versions backend/tests/test_v11_output_contracts.py::test_ci_workflow_permissions_are_minimal backend/tests/test_v11_output_contracts.py::test_release_workflow_is_tag_bound_and_verifies_pypi_install --no-cov`:
+  3 passed in 0.24s.
+- `python3 -m pytest -q backend/tests/test_workbench_integration_contracts.py backend/tests/test_github_action_contract.py --no-cov`:
+  8 passed in 0.09s.
+- `npm --prefix frontend run lint`: passed; Biome checked 28 files and applied
+  no fixes.
+- `git diff --exit-code -- frontend`: passed after frontend lint.
+- `npm --prefix frontend run build`: passed; Vite built successfully.
+- `make frontend-generate-client`: passed.
+- `git diff --exit-code -- frontend/src/client`: passed.
+- `npm --prefix frontend run test`: passed; 5 Playwright smoke tests passed in
+  16.3s.
+- `make docs-check`: passed. MkDocs still reports the pre-existing unnaved page
+  `docs/architecture/vpw-011-api-skeleton.md`.
+- `make actionlint-check`: passed.
+- `make workflow-check`: passed; includes Ruff format check, Ruff lint, mypy,
+  full backend pytest, docs build, actionlint, pre-commit, package build, and
+  `twine check`. Backend pytest collected 844 items with 6 skipped; coverage
+  remains above the 90% gate (`python3 -m coverage report --format=total`
+  reported 91).
+- `make dependency-audit`: passed; no known vulnerabilities found.
+- `make docker-demo-smoke`: passed; backend `status=ok`, utility health check
+  returned `true`, and frontend `/` plus `/login` returned HTTP 200 before
+  teardown.
+- `git diff --check`: passed.
+- `gh api .../required_status_checks`: passed after update; strict required
+  checks include `frontend`.
+
+## Residual Risk
+
+The CI workflows cover the local backend, frontend, generated client, Docker,
+and CodeQL paths. They do not make optional live-provider tests mandatory, and
+they do not replace manual release-owner review for publishing credentials,
+PyPI trusted-publisher settings, or GitHub repository security settings.

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -140,6 +140,7 @@ make docker-demo-smoke
 
 - [x] Run `make workflow-check` before merge or tagging when Docker and pre-commit tooling are available.
 - [x] Run `make demo-sync-check-temp` before tagging when examples or report outputs changed.
+- [x] Confirm normal CI/TestPyPI workflows use read-only repository permissions by default and that the release workflow scopes `contents: write` only to the job that publishes GitHub Release assets.
 - [x] Confirm release workflow configuration still builds distributions, validates them, creates the GitHub Release from checked-in notes, and only publishes to PyPI when the repository gate allows it.
 - [x] Confirm the tagged release notes file exists under `docs/releases/`.
 - [x] Confirm GitHub Release, tag, package metadata, and docs version all match.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - VPW-069 Upload Security Hardening: evidence/vpw-069-upload-security-hardening.md
       - VPW-070 HTML Rendering and Security Headers: evidence/vpw-070-html-security-xss.md
       - VPW-073 User Documentation: evidence/vpw-073-user-documentation.md
+      - VPW-074 CI Gates: evidence/vpw-074-ci-gates.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
Refs #180

## Summary
- Tighten CI workflow defaults to read-only repository permissions and keep release write permission scoped to a dedicated GitHub Release publishing job.
- Make frontend lint write-mode safe by checking `git diff --exit-code -- frontend` immediately after lint.
- Add workflow contract coverage for CI/frontend drift, minimal workflow permissions, and the split release publishing job.
- Add VPW-074 evidence under `docs/evidence/vpw-074-ci-gates.md` and link it from MkDocs.
- Updated `main` branch protection so `frontend` is now a strict required status check alongside `Analyze Python`, `check (3.11)`, `check (3.12)`, and `compose-smoke`.

## Validation
- `python3 -m json.tool docs/examples/example_results.sarif` -> passed
- `python3 -m pytest -q backend/tests/test_v11_output_contracts.py::test_ci_workflow_runs_workflow_check_on_supported_python_versions backend/tests/test_v11_output_contracts.py::test_ci_workflow_permissions_are_minimal backend/tests/test_v11_output_contracts.py::test_release_workflow_is_tag_bound_and_verifies_pypi_install --no-cov` -> 3 passed
- `python3 -m pytest -q backend/tests/test_workbench_integration_contracts.py backend/tests/test_github_action_contract.py --no-cov` -> 8 passed
- `npm --prefix frontend run lint` -> passed, no fixes applied
- `git diff --exit-code -- frontend` -> passed
- `npm --prefix frontend run build` -> passed
- `make frontend-generate-client` -> passed
- `git diff --exit-code -- frontend/src/client` -> passed
- `npm --prefix frontend run test` -> 5 passed
- `make docs-check` -> passed with pre-existing unnaved page warning for `docs/architecture/vpw-011-api-skeleton.md`
- `make actionlint-check` -> passed
- `make workflow-check` -> passed; backend pytest collected 844 items with 6 skipped, coverage total 91
- `make dependency-audit` -> passed, no known vulnerabilities found
- `make docker-demo-smoke` -> passed
- `git diff --check` -> passed
- `gh api .../required_status_checks` -> strict required checks now include `frontend`

## Residual Risk
- PR-specific GitHub Actions URLs will be added to #180 after checks finish.
- Optional live-provider tests remain non-blocking by design.
