### PR TITLE
Implement VPW-080 SARIF validation

### DIFF
--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -57,6 +57,8 @@ def create_run_report(
                 project=project,
                 filter_value=payload.attack_filter,
             )
+        elif payload.format == "sarif":
+            report = report_service.create_sarif_report(run=run, project=project)
         elif payload.format == "zip":
             report = report_service.create_evidence_bundle(run=run, project=project)
         else:

--- a/backend/app/models/reports.py
+++ b/backend/app/models/reports.py
@@ -15,7 +15,9 @@ from app.models.base import get_datetime_utc
 class ReportCreate(SQLModel):
     """Request payload for creating a run report."""
 
-    format: Literal["markdown", "html", "json", "csv", "zip", "attack-navigator"] = "markdown"
+    format: Literal["markdown", "html", "json", "csv", "zip", "attack-navigator", "sarif"] = (
+        "markdown"
+    )
     attack_filter: Literal["all", "critical-high", "kev", "no-coverage"] = "all"
 
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -25,6 +25,7 @@ from app.services.reports import (
     render_findings_csv,
     render_html_executive_report,
     render_markdown_report,
+    render_sarif_report,
     verify_evidence_bundle_zip,
 )
 
@@ -51,5 +52,6 @@ __all__ = [
     "render_findings_csv",
     "render_html_executive_report",
     "render_markdown_report",
+    "render_sarif_report",
     "verify_evidence_bundle_zip",
 ]

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -44,6 +44,7 @@ REPORT_KIND_ANALYSIS_JSON = "analysis-result-json"
 REPORT_KIND_FINDINGS_CSV = "findings-csv"
 REPORT_KIND_EVIDENCE_BUNDLE = "evidence-bundle"
 REPORT_KIND_ATTACK_NAVIGATOR = "attack-navigator-layer"
+REPORT_KIND_SARIF_RESULTS = "sarif-results"
 REPORT_KIND_GOVERNANCE_ROLLUPS = "governance-rollups"
 REPORT_KIND_GOVERNANCE_WAIVERS = "governance-waivers"
 REPORT_KIND_GOVERNANCE_VEX = "governance-vex-summary"
@@ -54,6 +55,7 @@ REPORT_FILENAME_ANALYSIS_JSON = "analysis-result.v1.json"
 REPORT_FILENAME_FINDINGS_CSV = "findings.csv"
 REPORT_FILENAME_EVIDENCE_BUNDLE = "evidence-bundle.zip"
 REPORT_FILENAME_ATTACK_NAVIGATOR = "attack-navigator-layer.json"
+REPORT_FILENAME_SARIF_RESULTS = "results.sarif"
 REPORT_FILENAME_GOVERNANCE_ROLLUPS = "governance/rollups.json"
 REPORT_FILENAME_GOVERNANCE_WAIVERS = "governance/waivers.json"
 REPORT_FILENAME_GOVERNANCE_VEX = "governance/vex-summary.json"
@@ -62,6 +64,7 @@ REPORT_CONTENT_TYPE_MARKDOWN = "text/markdown; charset=utf-8"
 REPORT_CONTENT_TYPE_HTML = "text/html; charset=utf-8"
 REPORT_CONTENT_TYPE_JSON = "application/json; charset=utf-8"
 REPORT_CONTENT_TYPE_CSV = "text/csv; charset=utf-8"
+REPORT_CONTENT_TYPE_SARIF = "application/sarif+json; charset=utf-8"
 REPORT_CONTENT_TYPE_ZIP = "application/zip"
 ANALYSIS_RESULT_SCHEMA = "analysis-result.v1"
 ANALYSIS_RESULT_SCHEMA_VERSION = "1.0.0"
@@ -543,6 +546,31 @@ class ReportService:
                 "attack_filter": filter_value,
                 "navigator_version": layer.get("version"),
                 "technique_count": len(layer.get("techniques", [])),
+            },
+        )
+
+    def create_sarif_report(self, *, run: AnalysisRun, project: Project) -> Report:
+        """Generate a SARIF 2.1.0 results report and persist its metadata."""
+        payload, findings, generated_at = self._report_payload(run=run, project=project)
+        sarif_payload = render_sarif_report(payload)
+        content = json.dumps(sarif_payload, indent=2, sort_keys=True) + "\n"
+        results = sarif_payload["runs"][0]["results"]
+        rules = sarif_payload["runs"][0]["tool"]["driver"]["rules"]
+        return self._persist_report(
+            run=run,
+            project=project,
+            generated_at=generated_at,
+            finding_count=len(findings),
+            provider_snapshot_id=run.provider_snapshot_id,
+            content=content,
+            kind=REPORT_KIND_SARIF_RESULTS,
+            report_format="sarif",
+            filename=REPORT_FILENAME_SARIF_RESULTS,
+            content_type=REPORT_CONTENT_TYPE_SARIF,
+            extra_metadata={
+                "sarif_version": sarif_payload["version"],
+                "rule_count": len(rules),
+                "result_count": len(results),
             },
         )
 
@@ -1209,6 +1237,256 @@ def render_analysis_result_json(payload: MarkdownReportPayload) -> str:
     if payload.governance_rollups:
         result["governance_rollups"] = payload.governance_rollups
     return json.dumps(result, indent=2, sort_keys=True) + "\n"
+
+
+def render_sarif_report(payload: MarkdownReportPayload) -> dict[str, Any]:
+    """Render a SARIF 2.1.0 vulnerability results payload for code scanning imports."""
+    rules_by_id: dict[str, dict[str, Any]] = {}
+    results: list[dict[str, Any]] = []
+    for finding in payload.findings:
+        rule_id = _sarif_rule_id(finding.cve_id)
+        references = _sarif_references(finding)
+        rules_by_id.setdefault(rule_id, _sarif_rule(finding, references=references))
+        results.append(_sarif_result(finding, references=references))
+
+    return {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "vuln-prioritizer-workbench",
+                        "informationUri": "https://github.com/Noetheon/vuln-prioritizer-workbench",
+                        "rules": list(rules_by_id.values()),
+                        "version": ANALYSIS_RESULT_SCHEMA_VERSION,
+                    }
+                },
+                "invocations": [
+                    {
+                        "executionSuccessful": True,
+                        "endTimeUtc": _iso_datetime(payload.generated_at),
+                        "properties": {
+                            "analysis_run_id": payload.run_id,
+                            "project_id": payload.project_id,
+                        },
+                    }
+                ],
+                "results": results,
+            }
+        ],
+    }
+
+
+def _sarif_result(
+    finding: MarkdownReportFinding,
+    *,
+    references: list[str],
+) -> dict[str, Any]:
+    location_uri = _sarif_location_uri(finding)
+    return {
+        "ruleId": _sarif_rule_id(finding.cve_id),
+        "level": _sarif_level(finding.priority),
+        "message": {
+            "text": (
+                f"{finding.cve_id}: {_priority_label(finding.priority)} priority "
+                "vulnerability from Workbench CVSS, EPSS, KEV, asset, and governance context."
+            )
+        },
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": location_uri,
+                        "uriBaseId": "%SRCROOT%",
+                    }
+                },
+                "logicalLocations": [
+                    {
+                        "fullyQualifiedName": _sarif_logical_location(finding),
+                        "kind": "component",
+                    }
+                ],
+            }
+        ],
+        "partialFingerprints": {
+            "vuln-prioritizer-workbench/v1": _sarif_fingerprint(
+                finding=finding,
+                uri=location_uri,
+            )
+        },
+        "properties": {
+            "cve": finding.cve_id,
+            "priority": _priority_label(finding.priority),
+            "cvss": finding.cvss_base_score,
+            "epss": finding.epss,
+            "in_kev": finding.in_kev,
+            "asset": finding.asset,
+            "asset_key": finding.asset_key,
+            "component": finding.component,
+            "component_purl": finding.component_purl,
+            "status": finding.status,
+            "references": references,
+            "cve_url": references[0],
+            "data_quality_confidence": finding.data_quality_confidence,
+            "data_quality_flags": finding.data_quality_flags,
+            "suppressed_by_vex": _boolish_signal(finding, "suppressed_by_vex"),
+            "under_investigation": _boolish_signal(finding, "under_investigation"),
+            "waived": _boolish_signal(finding, "waived"),
+            "decision_sla": finding.decision_sla,
+            "decision_statement": finding.decision_statement,
+            "business_impact": finding.business_impact,
+        },
+    }
+
+
+def _sarif_rule(
+    finding: MarkdownReportFinding,
+    *,
+    references: list[str],
+) -> dict[str, Any]:
+    priority = _priority_label(finding.priority)
+    return {
+        "id": _sarif_rule_id(finding.cve_id),
+        "name": f"{finding.cve_id} prioritized vulnerability",
+        "shortDescription": {"text": f"{finding.cve_id}: {priority} Workbench priority."},
+        "fullDescription": {
+            "text": (
+                "Known CVE prioritized from CVSS, EPSS, CISA KEV, asset context, "
+                "and optional Workbench governance layers."
+            )
+        },
+        "defaultConfiguration": {"level": _sarif_level(finding.priority)},
+        "helpUri": references[0],
+        "properties": {
+            "cve": finding.cve_id,
+            "priority": priority,
+            "precision": "very-high",
+            "security-severity": _sarif_security_severity(finding),
+            "tags": ["security", "external/cve", f"priority/{priority.lower()}"],
+            "references": references,
+        },
+    }
+
+
+def _sarif_rule_id(cve_id: str) -> str:
+    return f"vuln-prioritizer/{cve_id.lower()}"
+
+
+def _sarif_level(priority: str) -> str:
+    return {
+        "Critical": "error",
+        "High": "error",
+        "Medium": "warning",
+        "Low": "note",
+    }[_priority_label(priority)]
+
+
+def _sarif_security_severity(finding: MarkdownReportFinding) -> str:
+    if finding.cvss_base_score is not None:
+        return f"{min(max(float(finding.cvss_base_score), 0.0), 10.0):.1f}"
+    return {
+        "Critical": "9.0",
+        "High": "7.0",
+        "Medium": "5.0",
+        "Low": "3.0",
+    }[_priority_label(finding.priority)]
+
+
+def _sarif_references(finding: MarkdownReportFinding) -> list[str]:
+    candidates = [f"https://nvd.nist.gov/vuln/detail/{finding.cve_id}"]
+    candidates.extend(_http_references_from_mapping(finding.vulnerability))
+    candidates.extend(_http_references_from_mapping(finding.evidence))
+    candidates.extend(_http_references_from_mapping(finding.explanation))
+    return _dedupe_http_urls(candidates)
+
+
+def _http_references_from_mapping(mapping: dict[str, Any]) -> list[str]:
+    urls: list[str] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for child in value.values():
+                walk(child)
+            return
+        if isinstance(value, list):
+            for child in value:
+                walk(child)
+            return
+        if isinstance(value, str) and value.startswith(("http://", "https://")):
+            urls.append(value)
+
+    for key in ("references", "reference_urls", "urls", "url", "href", "link", "provider"):
+        if key in mapping:
+            walk(mapping[key])
+    return urls
+
+
+def _dedupe_http_urls(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized.startswith(("http://", "https://")) or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def _sarif_location_uri(finding: MarkdownReportFinding) -> str:
+    for occurrence in finding.occurrences:
+        evidence = _dict_value(occurrence.get("evidence"))
+        for key in ("path", "file", "target_ref", "artifact_uri"):
+            value = evidence.get(key) or occurrence.get(key)
+            if isinstance(value, str) and value.strip():
+                return _sarif_safe_uri(value)
+    return _sarif_safe_uri(finding.component_purl or finding.component or finding.cve_id)
+
+
+def _sarif_safe_uri(value: str) -> str:
+    stripped = value.strip().replace("\\", "/")
+    if not stripped or stripped.startswith(("/", "../")) or "://" in stripped:
+        return "workbench-input"
+    return stripped.lstrip("./")
+
+
+def _sarif_logical_location(finding: MarkdownReportFinding) -> str:
+    parts = [
+        finding.asset_key or finding.asset,
+        finding.component_purl or finding.component,
+        finding.cve_id,
+    ]
+    return " / ".join(str(part) for part in parts if part) or finding.cve_id
+
+
+def _sarif_fingerprint(*, finding: MarkdownReportFinding, uri: str) -> str:
+    occurrence_parts: list[str] = []
+    for occurrence in finding.occurrences:
+        evidence = _dict_value(occurrence.get("evidence"))
+        occurrence_parts.append(
+            "|".join(
+                str(value or "")
+                for value in (
+                    occurrence.get("source"),
+                    occurrence.get("scanner"),
+                    occurrence.get("raw_reference"),
+                    occurrence.get("fix_version"),
+                    evidence.get("target_ref"),
+                    evidence.get("path"),
+                )
+            )
+        )
+    identity = "|".join(
+        [
+            finding.cve_id,
+            finding.asset_key or finding.asset or "",
+            finding.component_purl or finding.component or "",
+            uri,
+            "||".join(occurrence_parts),
+        ]
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
 
 
 def render_findings_csv(payload: MarkdownReportPayload) -> str:

--- a/backend/src/vuln_prioritizer/reporting_payloads.py
+++ b/backend/src/vuln_prioritizer/reporting_payloads.py
@@ -490,6 +490,7 @@ def generate_sarif_report(
         "Low": "note",
     }
     results: list[dict[str, Any]] = []
+    rules_by_id: dict[str, dict[str, Any]] = {}
     for finding in findings:
         artifact_uri = (
             finding.provenance.affected_paths[0]
@@ -500,9 +501,20 @@ def generate_sarif_report(
             f"{finding.cve_id}: {finding.priority_label} priority "
             "based on CVSS/EPSS/KEV with contextual enrichment."
         )
+        references = _sarif_reference_urls(
+            finding.cve_id,
+            nvd_references=(
+                finding.provider_evidence.nvd.references
+                if finding.provider_evidence is not None
+                else []
+            ),
+            defensive_contexts=finding.defensive_contexts,
+        )
+        rule_id = _sarif_rule_id(finding.cve_id)
+        rules_by_id.setdefault(rule_id, _sarif_rule(finding, references=references))
         results.append(
             {
-                "ruleId": f"vuln-prioritizer/{finding.priority_label.lower()}",
+                "ruleId": rule_id,
                 "level": level_map.get(finding.priority_label, "note"),
                 "message": {"text": message},
                 "properties": {
@@ -529,6 +541,8 @@ def generate_sarif_report(
                     ],
                     "data_quality_flag_codes": [flag.code for flag in finding.data_quality_flags],
                     "data_quality_confidence": finding.data_quality_confidence,
+                    "references": references,
+                    "cve_url": references[0],
                     "attack_relevance": finding.attack_relevance,
                     "defensive_context_sources": sorted(
                         {context_item.source for context_item in finding.defensive_contexts}
@@ -581,7 +595,7 @@ def generate_sarif_report(
                     "driver": {
                         "name": "vuln-prioritizer",
                         "version": context.schema_version,
-                        "rules": _sarif_rules(),
+                        "rules": list(rules_by_id.values()),
                     }
                 },
                 "results": results,
@@ -591,37 +605,85 @@ def generate_sarif_report(
     return json.dumps(payload, indent=2, sort_keys=True)
 
 
-def _sarif_rules() -> list[dict[str, Any]]:
-    rules = []
-    for priority, level in (
-        ("critical", "Critical"),
-        ("high", "High"),
-        ("medium", "Medium"),
-        ("low", "Low"),
-    ):
-        rules.append(
-            {
-                "id": f"vuln-prioritizer/{priority}",
-                "name": f"{level} prioritized vulnerability",
-                "shortDescription": {"text": f"{level} vulnerability prioritization result."},
-                "fullDescription": {
-                    "text": (
-                        "Known CVE prioritized from CVSS, EPSS, and CISA KEV with "
-                        "optional contextual layers such as asset context, VEX, waivers, "
-                        "remediation, and ATT&CK mapping provenance."
-                    )
-                },
-                "help": {
-                    "text": (
-                        "Review the CVE, provider evidence, affected component or asset, "
-                        "and recommended remediation action. This tool prioritizes supplied "
-                        "findings and does not scan systems."
-                    )
-                },
-                "properties": {"priority": level},
-            }
-        )
-    return rules
+def _sarif_rule_id(cve_id: str) -> str:
+    return f"vuln-prioritizer/{cve_id.lower()}"
+
+
+def _sarif_rule(finding: PrioritizedFinding, *, references: list[str]) -> dict[str, Any]:
+    level_map = {
+        "Critical": "error",
+        "High": "error",
+        "Medium": "warning",
+        "Low": "note",
+    }
+    priority = finding.priority_label
+    return {
+        "id": _sarif_rule_id(finding.cve_id),
+        "name": f"{finding.cve_id} prioritized vulnerability",
+        "shortDescription": {"text": f"{finding.cve_id}: {priority} priority."},
+        "fullDescription": {
+            "text": (
+                "Known CVE prioritized from CVSS, EPSS, and CISA KEV with "
+                "optional contextual layers such as asset context, VEX, waivers, "
+                "remediation, and ATT&CK mapping provenance."
+            )
+        },
+        "defaultConfiguration": {"level": level_map.get(priority, "note")},
+        "helpUri": references[0],
+        "help": {
+            "text": (
+                "Review the CVE, provider evidence, affected component or asset, "
+                "and recommended remediation action. This tool prioritizes supplied "
+                "findings and does not scan systems."
+            )
+        },
+        "properties": {
+            "cve": finding.cve_id,
+            "priority": priority,
+            "precision": "very-high",
+            "security-severity": _sarif_security_severity(finding),
+            "tags": ["security", "external/cve", f"priority/{priority.lower()}"],
+            "references": references,
+        },
+    }
+
+
+def _sarif_security_severity(finding: PrioritizedFinding) -> str:
+    if finding.cvss_base_score is not None:
+        return f"{min(max(finding.cvss_base_score, 0.0), 10.0):.1f}"
+    return {
+        "Critical": "9.0",
+        "High": "7.0",
+        "Medium": "5.0",
+        "Low": "3.0",
+    }.get(finding.priority_label, "0.0")
+
+
+def _sarif_reference_urls(
+    cve_id: str,
+    *,
+    nvd_references: list[str],
+    defensive_contexts: list[Any],
+) -> list[str]:
+    urls = [f"https://nvd.nist.gov/vuln/detail/{cve_id}"]
+    urls.extend(nvd_references)
+    for context in defensive_contexts:
+        url = getattr(context, "url", None)
+        if url:
+            urls.append(str(url))
+        urls.extend(str(reference) for reference in getattr(context, "references", []) if reference)
+    return _dedupe_strings(urls)
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        normalized = str(value).strip()
+        if normalized.startswith(("http://", "https://")) and normalized not in seen:
+            seen.add(normalized)
+            deduped.append(normalized)
+    return deduped
 
 
 def _sarif_fingerprint(finding: PrioritizedFinding, artifact_uri: str | None) -> str:

--- a/backend/src/vuln_prioritizer/sarif_validation.py
+++ b/backend/src/vuln_prioritizer/sarif_validation.py
@@ -42,7 +42,6 @@ SARIF_MINIMUM_SCHEMA: dict[str, Any] = {
                                     "version": {"type": "string"},
                                     "rules": {
                                         "type": "array",
-                                        "minItems": 1,
                                         "items": {
                                             "type": "object",
                                             "required": ["id"],
@@ -121,6 +120,7 @@ SARIF_MINIMUM_SCHEMA: dict[str, Any] = {
                                         "minLength": 1,
                                     },
                                 },
+                                "properties": {"type": "object", "additionalProperties": True},
                             },
                         },
                     },
@@ -152,6 +152,7 @@ def validate_sarif_payload(payload: dict[str, Any]) -> list[str]:
         location = ".".join(str(part) for part in error.path) or "$"
         errors.append(f"{location}: {error.message}")
     errors.extend(_validate_rule_references(payload))
+    errors.extend(_validate_vuln_prioritizer_results(payload))
     return errors
 
 
@@ -173,11 +174,53 @@ def _validate_rule_references(payload: dict[str, Any]) -> list[str]:
             if not isinstance(result, dict):
                 continue
             rule_id = str(result.get("ruleId") or "")
-            if rule_id and rule_ids and rule_id not in rule_ids:
+            if rule_id and rule_id not in rule_ids:
                 errors.append(
                     f"runs.{run_index}.results.{result_index}.ruleId: "
                     f"{rule_id!r} is not declared in tool.driver.rules"
                 )
+    return errors
+
+
+def _validate_vuln_prioritizer_results(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for run_index, run in enumerate(payload.get("runs", [])):
+        if not isinstance(run, dict):
+            continue
+        raw_tool = run.get("tool")
+        tool = raw_tool if isinstance(raw_tool, dict) else {}
+        raw_driver = tool.get("driver")
+        driver = raw_driver if isinstance(raw_driver, dict) else {}
+        tool_name = str(driver.get("name") or "")
+        if not tool_name.startswith("vuln-prioritizer"):
+            continue
+        for result_index, result in enumerate(run.get("results", [])):
+            if not isinstance(result, dict):
+                continue
+            raw_properties = result.get("properties")
+            properties = raw_properties if isinstance(raw_properties, dict) else {}
+            cve = properties.get("cve")
+            if not isinstance(cve, str) or not cve.startswith("CVE-"):
+                errors.append(
+                    f"runs.{run_index}.results.{result_index}.properties.cve: "
+                    "vuln-prioritizer SARIF results must declare a CVE ID"
+                )
+            references = properties.get("references")
+            if not isinstance(references, list) or not references:
+                errors.append(
+                    f"runs.{run_index}.results.{result_index}.properties.references: "
+                    "vuln-prioritizer SARIF results must declare at least one reference URL"
+                )
+                continue
+            for reference_index, reference in enumerate(references):
+                if not isinstance(reference, str) or not reference.startswith(
+                    ("http://", "https://")
+                ):
+                    errors.append(
+                        f"runs.{run_index}.results.{result_index}."
+                        f"properties.references.{reference_index}: "
+                        "reference must be an HTTP(S) URL"
+                    )
     return errors
 
 

--- a/backend/src/vuln_prioritizer/services/workbench_reports.py
+++ b/backend/src/vuln_prioritizer/services/workbench_reports.py
@@ -247,6 +247,7 @@ def generate_workbench_sarif(report_payload: dict[str, Any]) -> str:
         metadata.get("input_path") or metadata.get("input_format") or "workbench-input"
     )
     results: list[dict[str, Any]] = []
+    rules_by_id: dict[str, dict[str, Any]] = {}
     for finding in report_payload.get("findings", []):
         if not isinstance(finding, dict):
             continue
@@ -261,9 +262,15 @@ def generate_workbench_sarif(report_payload: dict[str, Any]) -> str:
             item for item in finding.get("defensive_contexts", []) if isinstance(item, dict)
         ]
         decision_guidance = _decision_guidance(finding)
+        references = _workbench_sarif_reference_urls(cve_id, finding, defensive_contexts)
+        rule_id = _workbench_sarif_rule_id(cve_id)
+        rules_by_id.setdefault(
+            rule_id,
+            _workbench_sarif_rule(cve_id, priority, finding, references=references),
+        )
         results.append(
             {
-                "ruleId": f"vuln-prioritizer/{priority.lower()}",
+                "ruleId": rule_id,
                 "level": level_map.get(priority, "note"),
                 "message": {
                     "text": (
@@ -282,6 +289,8 @@ def generate_workbench_sarif(report_payload: dict[str, Any]) -> str:
                     "data_quality_confidence": str(
                         finding.get("data_quality_confidence") or "high"
                     ),
+                    "references": references,
+                    "cve_url": references[0],
                     "attack_relevance": finding.get("attack_relevance"),
                     "defensive_context_sources": sorted(
                         {
@@ -319,7 +328,7 @@ def generate_workbench_sarif(report_payload: dict[str, Any]) -> str:
                     "driver": {
                         "name": "vuln-prioritizer-workbench",
                         "version": str(metadata.get("schema_version") or "1.1.0"),
-                        "rules": _workbench_sarif_rules(),
+                        "rules": list(rules_by_id.values()),
                     }
                 },
                 "results": results,
@@ -329,22 +338,91 @@ def generate_workbench_sarif(report_payload: dict[str, Any]) -> str:
     return json.dumps(payload, indent=2, sort_keys=True)
 
 
-def _workbench_sarif_rules() -> list[dict[str, Any]]:
-    return [
-        {
-            "id": f"vuln-prioritizer/{priority.lower()}",
-            "name": f"{priority} prioritized vulnerability",
-            "shortDescription": {"text": f"{priority} Workbench prioritization result."},
-            "fullDescription": {
-                "text": (
-                    "Known CVE prioritized from CVSS, EPSS, and CISA KEV with explicit "
-                    "Workbench context for assets, VEX, waivers, remediation, and ATT&CK."
-                )
-            },
-            "properties": {"priority": priority},
-        }
-        for priority in ("Critical", "High", "Medium", "Low")
-    ]
+def _workbench_sarif_rule_id(cve_id: str) -> str:
+    return f"vuln-prioritizer/{cve_id.lower()}"
+
+
+def _workbench_sarif_rule(
+    cve_id: str,
+    priority: str,
+    finding: dict[str, Any],
+    *,
+    references: list[str],
+) -> dict[str, Any]:
+    level_map = {
+        "Critical": "error",
+        "High": "error",
+        "Medium": "warning",
+        "Low": "note",
+    }
+    return {
+        "id": _workbench_sarif_rule_id(cve_id),
+        "name": f"{cve_id} prioritized vulnerability",
+        "shortDescription": {"text": f"{cve_id}: {priority} Workbench priority."},
+        "fullDescription": {
+            "text": (
+                "Known CVE prioritized from CVSS, EPSS, and CISA KEV with explicit "
+                "Workbench context for assets, VEX, waivers, remediation, and ATT&CK."
+            )
+        },
+        "defaultConfiguration": {"level": level_map.get(priority, "note")},
+        "helpUri": references[0],
+        "properties": {
+            "cve": cve_id,
+            "priority": priority,
+            "precision": "very-high",
+            "security-severity": _workbench_sarif_security_severity(priority, finding),
+            "tags": ["security", "external/cve", f"priority/{priority.lower()}"],
+            "references": references,
+        },
+    }
+
+
+def _workbench_sarif_security_severity(priority: str, finding: dict[str, Any]) -> str:
+    cvss_score = finding.get("cvss_base_score")
+    if isinstance(cvss_score, int | float):
+        return f"{min(max(float(cvss_score), 0.0), 10.0):.1f}"
+    return {
+        "Critical": "9.0",
+        "High": "7.0",
+        "Medium": "5.0",
+        "Low": "3.0",
+    }.get(priority, "0.0")
+
+
+def _workbench_sarif_reference_urls(
+    cve_id: str,
+    finding: dict[str, Any],
+    defensive_contexts: list[dict[str, Any]],
+) -> list[str]:
+    urls = [f"https://nvd.nist.gov/vuln/detail/{cve_id}"]
+    raw_provider_evidence = finding.get("provider_evidence")
+    provider_evidence: dict[str, Any] = (
+        raw_provider_evidence if isinstance(raw_provider_evidence, dict) else {}
+    )
+    raw_nvd_evidence = provider_evidence.get("nvd")
+    nvd_evidence: dict[str, Any] = raw_nvd_evidence if isinstance(raw_nvd_evidence, dict) else {}
+    references = nvd_evidence.get("references")
+    if isinstance(references, list):
+        urls.extend(str(reference) for reference in references if reference)
+    for context in defensive_contexts:
+        if context.get("url"):
+            urls.append(str(context["url"]))
+        context_references = context.get("references")
+        if isinstance(context_references, list):
+            urls.extend(str(reference) for reference in context_references if reference)
+    return _dedupe_strings(urls)
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        normalized = str(value).strip()
+        if normalized.startswith(("http://", "https://")) and normalized not in seen:
+            seen.add(normalized)
+            deduped.append(normalized)
+    return deduped
 
 
 def _workbench_sarif_fingerprint(

--- a/backend/tests/api/test_template_reports_api.py
+++ b/backend/tests/api/test_template_reports_api.py
@@ -41,6 +41,7 @@ from app.services import (
     render_html_executive_report,
     render_markdown_report,
 )
+from vuln_prioritizer.sarif_validation import validate_sarif_payload
 
 CSV_FINDINGS_COLUMNS = [
     "cve_id",
@@ -112,6 +113,7 @@ def test_vpw049_openapi_exposes_report_format_contract() -> None:
         "csv",
         "zip",
         "attack-navigator",
+        "sarif",
     ]
     assert report_create["attack_filter"]["enum"] == [
         "all",
@@ -386,6 +388,78 @@ def test_vpw050_findings_csv_export_create_downloads_stable_columns(
     assert rows[0]["decision_sla"] == "Emergency / 24h"
     assert rows[0]["decision_statement"].startswith("Decision Statement:")
     assert rows[1]["data_quality_flags"] == "missing_asset_owner - Owner missing <img>"
+
+
+def test_vpw080_sarif_report_create_downloads_valid_results(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    report_dir = _configure_report_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    run_id = _seed_reportable_run(template_api_env, uuid.UUID(project["id"]))
+
+    response = template_api_env.client.post(
+        f"/api/v1/runs/{run_id}/reports",
+        headers=headers,
+        json={"format": "sarif"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["format"] == "sarif"
+    assert payload["kind"] == "sarif-results"
+    assert payload["filename"] == "results.sarif"
+    assert payload["content_type"] == "application/sarif+json; charset=utf-8"
+    assert payload["metadata_json"]["sarif_version"] == "2.1.0"
+    assert payload["metadata_json"]["rule_count"] == 2
+    assert payload["metadata_json"]["result_count"] == 2
+
+    with Session(template_api_env.engine) as session:
+        report = session.get(template_api_env.app_models.Report, uuid.UUID(payload["id"]))
+        assert report is not None
+        assert Path(report.path).resolve(strict=True).is_relative_to(report_dir)
+        assert report.path.endswith("results.sarif")
+
+    download = template_api_env.client.get(payload["download_url"], headers=headers)
+
+    assert download.status_code == 200
+    assert download.headers["cache-control"] == "no-store"
+    assert download.headers["x-content-type-options"] == "nosniff"
+    assert "results.sarif" in download.headers["content-disposition"]
+    assert download.headers["content-type"].startswith("application/sarif+json")
+    assert hashlib.sha256(download.content).hexdigest() == payload["sha256"]
+
+    sarif = download.json()
+    assert validate_sarif_payload(sarif) == []
+    assert sarif["version"] == "2.1.0"
+    assert sarif["$schema"] == "https://json.schemastore.org/sarif-2.1.0.json"
+    run = sarif["runs"][0]
+    rules = run["tool"]["driver"]["rules"]
+    results = run["results"]
+    assert run["tool"]["driver"]["name"] == "vuln-prioritizer-workbench"
+    assert [rule["id"] for rule in rules] == [
+        "vuln-prioritizer/cve-2024-3094",
+        "vuln-prioritizer/cve-2021-44228",
+    ]
+    assert [result["ruleId"] for result in results] == [rule["id"] for rule in rules]
+    assert [result["level"] for result in results] == ["error", "error"]
+    assert [rule["defaultConfiguration"]["level"] for rule in rules] == ["error", "error"]
+    assert [rule["properties"]["security-severity"] for rule in rules] == ["10.0", "10.0"]
+
+    first = results[0]
+    assert first["properties"]["cve"] == DEMO_CVE_XZ
+    assert first["properties"]["references"][0] == f"https://nvd.nist.gov/vuln/detail/{DEMO_CVE_XZ}"
+    assert all(
+        reference.startswith(("http://", "https://"))
+        for result in results
+        for reference in result["properties"]["references"]
+    )
+    assert first["partialFingerprints"]["vuln-prioritizer-workbench/v1"]
+    assert (
+        first["partialFingerprints"]["vuln-prioritizer-workbench/v1"]
+        != results[1]["partialFingerprints"]["vuln-prioritizer-workbench/v1"]
+    )
 
 
 def test_vpw060_attack_navigator_report_create_downloads_filtered_layer(

--- a/backend/tests/api/test_workbench_api.py
+++ b/backend/tests/api/test_workbench_api.py
@@ -423,11 +423,20 @@ def test_workbench_import_findings_reports_and_evidence(tmp_path: Path) -> None:
             assert sarif_payload["runs"][0]["tool"]["driver"]["name"] == (
                 "vuln-prioritizer-workbench"
             )
+            sarif_rules = {
+                rule["id"]: rule for rule in sarif_payload["runs"][0]["tool"]["driver"]["rules"]
+            }
             log4shell_sarif = next(
                 result
                 for result in sarif_payload["runs"][0]["results"]
                 if result["properties"]["cve"] == "CVE-2021-44228"
             )
+            assert log4shell_sarif["ruleId"] == "vuln-prioritizer/cve-2021-44228"
+            assert (
+                "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+                in log4shell_sarif["properties"]["references"]
+            )
+            assert sarif_rules[log4shell_sarif["ruleId"]]["properties"]["security-severity"]
             assert "snapshot_locked" in log4shell_sarif["properties"]["data_quality_flag_codes"]
             assert log4shell_sarif["properties"]["data_quality_confidence"] == "high"
         if report_format == "csv":
@@ -813,6 +822,8 @@ def test_workbench_finding_lifecycle_audit_and_exports(tmp_path: Path) -> None:
         if item["properties"]["cve"] == "CVE-2021-44228"
     )
     assert result["properties"]["status"] == "in_review"
+    assert result["properties"]["references"]
+    assert result["ruleId"] == "vuln-prioritizer/cve-2021-44228"
     assert result["partialFingerprints"]["vuln-prioritizer-workbench/v1"]
     assert sarif_payload["runs"][0]["tool"]["driver"]["rules"]
 

--- a/backend/tests/cli/test_analyze.py
+++ b/backend/tests/cli/test_analyze.py
@@ -23,6 +23,7 @@ from vuln_prioritizer.providers.attack import AttackProvider
 from vuln_prioritizer.providers.epss import EpssProvider
 from vuln_prioritizer.providers.kev import KevProvider
 from vuln_prioritizer.providers.nvd import NvdProvider
+from vuln_prioritizer.sarif_validation import validate_sarif_payload
 from vuln_prioritizer.services.analysis import stale_provider_sources
 
 
@@ -1091,8 +1092,22 @@ def test_cli_analyze_sarif_export_and_fail_on(
     assert output_file.exists()
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert payload["version"] == "2.1.0"
-    assert payload["runs"][0]["tool"]["driver"]["name"] == "vuln-prioritizer"
-    assert len(payload["runs"][0]["results"]) == 4
+    assert validate_sarif_payload(payload) == []
+    run = payload["runs"][0]
+    assert run["tool"]["driver"]["name"] == "vuln-prioritizer"
+    assert len(run["results"]) == 4
+    rules = {rule["id"]: rule for rule in run["tool"]["driver"]["rules"]}
+    log4shell = next(
+        result for result in run["results"] if result["properties"]["cve"] == "CVE-2021-44228"
+    )
+    assert log4shell["ruleId"] == "vuln-prioritizer/cve-2021-44228"
+    assert log4shell["properties"]["references"] == [
+        "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+    ]
+    rule = rules[log4shell["ruleId"]]
+    assert rule["helpUri"] == "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+    assert rule["defaultConfiguration"]["level"] == "error"
+    assert rule["properties"]["security-severity"] == "10.0"
 
 
 def test_cli_analyze_supports_nessus_auto_detection(

--- a/backend/tests/cli/test_report.py
+++ b/backend/tests/cli/test_report.py
@@ -13,6 +13,7 @@ from vuln_prioritizer.services.workbench_reports import (
     _finding_status_label,
     _first_occurrence_value,
     _vex_statuses_label,
+    generate_workbench_sarif,
 )
 
 
@@ -173,7 +174,18 @@ def test_cli_report_workbench_sarif_and_validation(
     assert report_result.exit_code == 0
     sarif_payload = json.loads(sarif_file.read_text(encoding="utf-8"))
     assert sarif_payload["version"] == "2.1.0"
-    assert sarif_payload["runs"][0]["tool"]["driver"]["name"] == "vuln-prioritizer-workbench"
+    assert validate_sarif_payload(sarif_payload) == []
+    run = sarif_payload["runs"][0]
+    assert run["tool"]["driver"]["name"] == "vuln-prioritizer-workbench"
+    rules = {rule["id"]: rule for rule in run["tool"]["driver"]["rules"]}
+    log4shell = next(
+        result for result in run["results"] if result["properties"]["cve"] == "CVE-2021-44228"
+    )
+    assert log4shell["ruleId"] == "vuln-prioritizer/cve-2021-44228"
+    assert log4shell["properties"]["references"] == [
+        "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+    ]
+    assert rules[log4shell["ruleId"]]["properties"]["security-severity"] == "10.0"
 
     validation_result = runner.invoke(
         app,
@@ -265,6 +277,18 @@ def test_cli_report_validate_sarif_rejects_invalid_document(runner, tmp_path: Pa
     assert "Validation result: failed" in table_result.stdout
 
 
+def test_checked_in_sarif_example_validates() -> None:
+    example = Path(__file__).resolve().parents[3] / "docs/examples/example_results.sarif"
+    payload = json.loads(example.read_text(encoding="utf-8"))
+
+    assert validate_sarif_payload(payload) == []
+    assert payload["runs"][0]["tool"]["driver"]["rules"]
+    assert all(
+        result["ruleId"] == f"vuln-prioritizer/{result['properties']['cve'].lower()}"
+        for result in payload["runs"][0]["results"]
+    )
+
+
 def test_sarif_validation_requires_declared_rules_and_fingerprints() -> None:
     payload = {
         "version": "2.1.0",
@@ -281,6 +305,10 @@ def test_sarif_validation_requires_declared_rules_and_fingerprints() -> None:
                         "locations": [
                             {"physicalLocation": {"artifactLocation": {"uri": "sbom.json"}}}
                         ],
+                        "properties": {
+                            "cve": "CVE-2024-0001",
+                            "references": ["not-a-url"],
+                        },
                     },
                     "not-a-result",
                 ],
@@ -291,7 +319,85 @@ def test_sarif_validation_requires_declared_rules_and_fingerprints() -> None:
     errors = validate_sarif_payload(payload)
 
     assert any("partialFingerprints" in error for error in errors)
+    assert any("properties.references.0" in error and "HTTP(S)" in error for error in errors)
     assert any("is not declared in tool.driver.rules" in error for error in errors)
+
+
+def test_sarif_validation_allows_foreign_tool_properties_without_cve() -> None:
+    payload = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "other-tool", "rules": [{"id": "other-rule"}]}},
+                "results": [
+                    {
+                        "ruleId": "other-rule",
+                        "level": "warning",
+                        "message": {"text": "Other SARIF finding"},
+                        "locations": [
+                            {"physicalLocation": {"artifactLocation": {"uri": "src/app.py"}}}
+                        ],
+                        "partialFingerprints": {"other/v1": "stable"},
+                    }
+                ],
+            }
+        ],
+    }
+
+    assert validate_sarif_payload(payload) == []
+
+
+def test_workbench_sarif_validates_with_no_findings() -> None:
+    payload = {
+        "metadata": {"schema_version": "1.1.0", "input_path": "empty.csv"},
+        "findings": [],
+    }
+
+    sarif_payload = json.loads(generate_workbench_sarif(payload))
+
+    assert sarif_payload["runs"][0]["tool"]["driver"]["rules"] == []
+    assert sarif_payload["runs"][0]["results"] == []
+    assert validate_sarif_payload(sarif_payload) == []
+
+
+def test_workbench_sarif_filters_non_http_references() -> None:
+    payload = {
+        "metadata": {"schema_version": "1.1.0", "input_path": "findings.csv"},
+        "findings": [
+            {
+                "cve_id": "CVE-2024-0001",
+                "priority_label": "High",
+                "cvss_base_score": 7.5,
+                "provider_evidence": {
+                    "nvd": {
+                        "references": [
+                            "GHSA-0000",
+                            "https://vendor.example/advisory",
+                            "https://vendor.example/advisory",
+                        ]
+                    }
+                },
+                "defensive_contexts": [
+                    {
+                        "source": "osv",
+                        "url": "OSV-2024-0001",
+                        "references": ["https://osv.dev/vulnerability/OSV-2024-0001"],
+                    }
+                ],
+                "provenance": {"affected_paths": ["requirements.txt"]},
+            }
+        ],
+    }
+
+    sarif_payload = json.loads(generate_workbench_sarif(payload))
+    references = sarif_payload["runs"][0]["results"][0]["properties"]["references"]
+
+    assert references == [
+        "https://nvd.nist.gov/vuln/detail/CVE-2024-0001",
+        "https://vendor.example/advisory",
+        "https://osv.dev/vulnerability/OSV-2024-0001",
+    ]
+    assert validate_sarif_payload(sarif_payload) == []
 
 
 def test_workbench_report_lifecycle_overlay_uses_id_and_stable_identity() -> None:

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -41,6 +41,7 @@ The following outputs are the current documented machine interfaces:
 - `rollup --format json`
 - `analyze --format sarif`
 - `analyze --summary-output <path>`
+- `report workbench --input <analysis-json> --format sarif`
 - `report html --input <analysis-json>`
 - `report evidence-bundle --input <analysis-json>`
 - `report verify-evidence-bundle --input <evidence-zip> --format json`
@@ -403,7 +404,7 @@ Workbench API changes are additive:
 - `GET /api/v1/projects/{project_id}/summary` returns a dashboard-oriented decision summary with finding counts, priority/status buckets, provider-signal hit counts, latest run status, and latest run summary
 - `GET /api/v1/projects/{project_id}/compare/cvss-only` returns the CVSS-only baseline comparison for stored template findings, using the same methodology payload as the core decision engine
 - `GET /api/v1/providers/status` returns an authenticated template adapter provider-status envelope for the React status card, including `status`, `snapshot`, `sources`, `latest_update_job`, `cache_dir`, `snapshot_dir`, `warnings`, `last_sync`, `last_error`, `cache_age_seconds`, and `snapshot_mode`; the legacy `GET /api/providers/status` route still exists with its current behavior during migration
-- `POST /api/v1/runs/{run_id}/reports` accepts `markdown`, `html`, `json`, `csv`, `zip`, and `attack-navigator` for completed visible template runs. JSON exports use `analysis-result.v1.json` with `project`, `analysis_run`, `provider_snapshot`, `findings`, and `explanations`. CSV exports use `findings.csv` with stable spreadsheet-safe finding columns. `attack-navigator` exports `attack-navigator-layer.json` with Navigator v4.5-compatible `techniques`, `techniqueID`, risk score, comments, and metadata; `attack_filter` accepts `all`, `critical-high`, `kev`, and the `no-coverage` placeholder. ZIP exports use `evidence-bundle.zip` with `manifest.json`, `analysis.json`, `technical.md`, `executive.html`, `provider-snapshot.json`, optional `attack-navigator-layer.json`, optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`, per-file SHA-256 entries, input hashes when available, and redaction of sensitive/local-path fields.
+- `POST /api/v1/runs/{run_id}/reports` accepts `markdown`, `html`, `json`, `csv`, `zip`, `attack-navigator`, and `sarif` for completed visible template runs. JSON exports use `analysis-result.v1.json` with `project`, `analysis_run`, `provider_snapshot`, `findings`, and `explanations`. CSV exports use `findings.csv` with stable spreadsheet-safe finding columns. SARIF exports use `results.sarif` with SARIF 2.1.0, CVE-addressable rule/result IDs, priority/CVSS-derived levels and `security-severity`, stable fingerprints, and HTTP(S) references including the canonical NVD CVE URL. `attack-navigator` exports `attack-navigator-layer.json` with Navigator v4.5-compatible `techniques`, `techniqueID`, risk score, comments, and metadata; `attack_filter` accepts `all`, `critical-high`, `kev`, and the `no-coverage` placeholder. ZIP exports use `evidence-bundle.zip` with `manifest.json`, `analysis.json`, `technical.md`, `executive.html`, `provider-snapshot.json`, optional `attack-navigator-layer.json`, optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`, per-file SHA-256 entries, input hashes when available, and redaction of sensitive/local-path fields.
 - `POST /api/v1/reports/{report_id}/verify` verifies a visible template `evidence-bundle.zip` report without extracting ZIP members. It validates the stored artifact path and report SHA-256 before returning the same `metadata`, `summary`, and `items` shape as `report verify-evidence-bundle --format json`; non-bundle reports return 422.
 - `POST /api/projects/{project_id}/imports` accepts single-upload and additive multi-upload imports for all CLI input formats
 - `GET /api/jobs`, `GET /api/jobs/{id}`, `POST /api/jobs`, and `POST /api/jobs/{id}/retry` expose durable local job state for compatible synchronous operations
@@ -487,6 +488,7 @@ The public combinations currently intended for use are:
 - `data update`: `table`, `json`
 - `data verify`: `table`, `json`
 - `data export-provider-snapshot`: JSON file output
+- `report workbench`: `json`, `markdown`, `html`, `csv`, `sarif`
 - `report html`: HTML file output
 - `report evidence-bundle`: ZIP file output containing `analysis.json`, `report.html`, `summary.md`, `manifest.json`, and optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, and `governance/asset-context.json`
 - `report verify-evidence-bundle`: `table` and `json`
@@ -495,7 +497,10 @@ The public combinations currently intended for use are:
 Important boundary:
 
 - `table` is a terminal view and must not be combined with `--output`
-- `sarif` is a documented export only for `analyze`
+- `sarif` is a documented export for `analyze` and saved analysis JSON rendered
+  through `report workbench`
+- Template Workbench report creation also exposes SARIF as `results.sarif`
+  through `POST /api/v1/runs/{run_id}/reports`
 - `analyze --summary-output` is a Markdown sidecar derived from the same in-memory analysis payload and does not replace the JSON contract
 
 ### Runtime config

--- a/docs/evidence/vpw-080-sarif-export-validation.md
+++ b/docs/evidence/vpw-080-sarif-export-validation.md
@@ -1,0 +1,77 @@
+# VPW-080 SARIF Export Validation Evidence
+
+VPW-080 hardens the SARIF export contract used by CLI analysis, saved Workbench
+analysis JSON rendering, local-first Workbench reports, template Workbench
+reports, the composite GitHub Action, and checked-in example artifacts.
+
+## Delivered Scope
+
+- SARIF results now use CVE-addressable rule IDs such as
+  `vuln-prioritizer/cve-2024-3094`.
+- Declared rules include `defaultConfiguration.level`,
+  `properties.security-severity`, priority tags, `helpUri`, and references.
+- Each result includes `properties.cve`, `properties.references`, `cve_url`,
+  stable partial fingerprints, source/asset context, and existing priority,
+  EPSS/CVSS/KEV, governance, waiver, and data-quality metadata.
+- The local SARIF validator now rejects results without CVE metadata or at
+  least one reference URL, in addition to version, rules, locations, and
+  fingerprints.
+- The checked-in SARIF example is covered by a regression test.
+- Template Workbench reports now expose SARIF through
+  `POST /api/v1/runs/{run_id}/reports` as `results.sarif`.
+- Reporting docs now describe SARIF mapping, validation semantics, and
+  limitations.
+
+## Example Export
+
+Example artifact:
+
+- `docs/examples/example_results.sarif`
+
+Expected properties for every result:
+
+- `ruleId` equals `vuln-prioritizer/<lowercase-cve-id>`
+- `properties.cve` contains the CVE ID
+- `properties.references` contains at least the NVD CVE detail URL
+- `partialFingerprints` contains a stable project fingerprint
+
+## Validation Commands
+
+```text
+python3 -m pytest -q backend/tests/cli/test_analyze.py::test_cli_analyze_sarif_export_and_fail_on backend/tests/cli/test_report.py::test_cli_report_workbench_sarif_and_validation backend/tests/cli/test_report.py::test_checked_in_sarif_example_validates backend/tests/cli/test_report.py::test_sarif_validation_requires_declared_rules_and_fingerprints backend/tests/cli/test_report.py::test_sarif_validation_allows_foreign_tool_properties_without_cve backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence backend/tests/api/test_workbench_api.py::test_workbench_finding_lifecycle_audit_and_exports backend/tests/api/test_template_reports_api.py::test_vpw049_openapi_exposes_report_format_contract backend/tests/api/test_template_reports_api.py::test_vpw080_sarif_report_create_downloads_valid_results --no-cov
+```
+
+```text
+PYTHONPATH=backend/src python3 -m vuln_prioritizer.cli report validate-sarif --input docs/examples/example_results.sarif --format json --output docs/evidence/vpw-080-sarif-validation.json
+```
+
+Observed validation output:
+
+- `docs/evidence/vpw-080-sarif-validation.json`
+- `ok: true`
+- `error_count: 0`
+- `sarif_version: 2.1.0`
+
+Additional gates run:
+
+- `make frontend-generate-client` -> passed
+- `python3 -m ruff check backend/app backend/src/vuln_prioritizer backend/tests/api/test_template_reports_api.py backend/tests/api/test_workbench_api.py backend/tests/cli/test_analyze.py backend/tests/cli/test_report.py` -> passed
+- `git diff --check` -> passed
+- `python3 -m pytest -q backend/tests/cli/test_analyze.py::test_cli_analyze_sarif_export_and_fail_on backend/tests/cli/test_report.py::test_cli_report_workbench_sarif_and_validation backend/tests/cli/test_report.py::test_checked_in_sarif_example_validates backend/tests/cli/test_report.py::test_sarif_validation_requires_declared_rules_and_fingerprints backend/tests/cli/test_report.py::test_sarif_validation_allows_foreign_tool_properties_without_cve backend/tests/cli/test_report.py::test_workbench_sarif_validates_with_no_findings backend/tests/cli/test_report.py::test_workbench_sarif_filters_non_http_references backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence backend/tests/api/test_workbench_api.py::test_workbench_finding_lifecycle_audit_and_exports backend/tests/api/test_template_reports_api.py::test_vpw049_openapi_exposes_report_format_contract backend/tests/api/test_template_reports_api.py::test_vpw080_sarif_report_create_downloads_valid_results --no-cov` -> 11 passed
+- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov` -> 29 passed
+- `npm --prefix frontend run lint` -> passed
+- `npm --prefix frontend run build` -> passed
+- `npm --prefix frontend test -- template-login-status.spec.ts` -> 3 passed
+- `make docs-check` -> passed with the pre-existing unnaved `docs/architecture/vpw-011-api-skeleton.md` info message
+- `make check` -> 848 passed, 7 skipped, coverage 90.71%
+- `make docker-demo-smoke` -> passed
+
+## Limitations
+
+- The local validator enforces the project SARIF contract and a compact SARIF
+  2.1.0 shape. The CVE/reference checks are scoped to `vuln-prioritizer*`
+  runs; the validator does not vendor the full external SARIF schema.
+- Final acceptance by GitHub Code Scanning can still depend on repository
+  permissions, upload category, branch policy, and platform-specific limits.
+- SARIF output prioritizes supplied CVE findings. It is not a source-code,
+  container, host, cloud, or exploit scanner.

--- a/docs/evidence/vpw-080-sarif-validation.json
+++ b/docs/evidence/vpw-080-sarif-validation.json
@@ -1,0 +1,10 @@
+{
+  "artifact_kind": "sarif-validation-report",
+  "error_count": 0,
+  "errors": [],
+  "input_path": "docs/examples/example_results.sarif",
+  "ok": true,
+  "run_count": 1,
+  "sarif_version": "2.1.0",
+  "schema_version": "1.2.0"
+}

--- a/docs/examples/example_results.sarif
+++ b/docs/examples/example_results.sarif
@@ -36,6 +36,7 @@
               "php-cgi 8.1.28"
             ],
             "cve": "CVE-2024-4577",
+            "cve_url": "https://nvd.nist.gov/vuln/detail/CVE-2024-4577",
             "cvss": 9.8,
             "data_quality_confidence": "high",
             "data_quality_flag_codes": [
@@ -99,6 +100,32 @@
             ],
             "priority": "Critical",
             "priority_state": "Critical",
+            "references": [
+              "https://nvd.nist.gov/vuln/detail/CVE-2024-4577",
+              "http://www.openwall.com/lists/oss-security/2024/06/07/1",
+              "https://arstechnica.com/security/2024/06/php-vulnerability-allows-attackers-to-run-malicious-code-on-windows-servers/",
+              "https://blog.orange.tw/2024/06/cve-2024-4577-yet-another-php-rce.html",
+              "https://cert.be/en/advisory/warning-php-remote-code-execution-patch-immediately",
+              "https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en/",
+              "https://github.com/11whoami99/CVE-2024-4577",
+              "https://github.com/php/php-src/security/advisories/GHSA-3qgc-jrrr-25jv",
+              "https://github.com/rapid7/metasploit-framework/pull/19247",
+              "https://github.com/watchtowrlabs/CVE-2024-4577",
+              "https://github.com/xcanwin/CVE-2024-4577-PHP-RCE",
+              "https://isc.sans.edu/diary/30994",
+              "https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/",
+              "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PKGTQUOA2NTZ3RXN22CSAUJPIRUYRB4B/",
+              "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/W45DBOH56NQDRTOM2DN2LNA2FZIMC3PK/",
+              "https://security.netapp.com/advisory/ntap-20240621-0008/",
+              "https://www.imperva.com/blog/imperva-protects-against-critical-php-vulnerability-cve-2024-4577/",
+              "https://www.php.net/ChangeLog-8.php#8.1.29",
+              "https://www.php.net/ChangeLog-8.php#8.2.20",
+              "https://www.php.net/ChangeLog-8.php#8.3.8",
+              "https://blog.talosintelligence.com/new-persistent-attacks-japan/",
+              "https://www.vicarius.io/vsociety/posts/php-cgi-argument-injection-to-rce-cve-2024-4577",
+              "https://www.vicarius.io/vsociety/posts/php-cgi-os-command-injection-vulnerability-cve-2024-4577",
+              "https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2024-4577"
+            ],
             "remediation_ecosystem": null,
             "remediation_strategy": "upgrade",
             "sources": [
@@ -107,7 +134,7 @@
             "suppressed_by_vex": false,
             "under_investigation": true
           },
-          "ruleId": "vuln-prioritizer/critical"
+          "ruleId": "vuln-prioritizer/cve-2024-4577"
         },
         {
           "level": "error",
@@ -145,6 +172,7 @@
               "xz 5.6.0-r0"
             ],
             "cve": "CVE-2024-3094",
+            "cve_url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094",
             "cvss": 10.0,
             "data_quality_confidence": "high",
             "data_quality_flag_codes": [
@@ -206,6 +234,64 @@
             ],
             "priority": "Critical",
             "priority_state": "Critical",
+            "references": [
+              "https://nvd.nist.gov/vuln/detail/CVE-2024-3094",
+              "https://access.redhat.com/security/cve/CVE-2024-3094",
+              "https://bugzilla.redhat.com/show_bug.cgi?id=2272210",
+              "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+              "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users",
+              "http://www.openwall.com/lists/oss-security/2024/03/29/10",
+              "http://www.openwall.com/lists/oss-security/2024/03/29/12",
+              "http://www.openwall.com/lists/oss-security/2024/03/29/4",
+              "http://www.openwall.com/lists/oss-security/2024/03/29/5",
+              "http://www.openwall.com/lists/oss-security/2024/03/29/8",
+              "http://www.openwall.com/lists/oss-security/2024/03/30/12",
+              "http://www.openwall.com/lists/oss-security/2024/03/30/27",
+              "http://www.openwall.com/lists/oss-security/2024/03/30/36",
+              "http://www.openwall.com/lists/oss-security/2024/03/30/5",
+              "http://www.openwall.com/lists/oss-security/2024/04/16/5",
+              "https://ariadne.space/2024/04/02/the-xz-utils-backdoor-is-a-symptom-of-a-larger-problem/",
+              "https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/",
+              "https://aws.amazon.com/security/security-bulletins/AWS-2024-002/",
+              "https://blog.netbsd.org/tnf/entry/statement_on_backdoor_in_xz",
+              "https://boehs.org/node/everything-i-know-about-the-xz-backdoor",
+              "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068024",
+              "https://bugs.gentoo.org/928134",
+              "https://bugzilla.suse.com/show_bug.cgi?id=1222124",
+              "https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405",
+              "https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27",
+              "https://github.com/advisories/GHSA-rxwq-x6h5-x525",
+              "https://github.com/amlweems/xzbot",
+              "https://github.com/karcherm/xz-malware",
+              "https://gynvael.coldwind.pl/?lang=en&id=782",
+              "https://lists.debian.org/debian-security-announce/2024/msg00057.html",
+              "https://lists.freebsd.org/archives/freebsd-security/2024-March/000248.html",
+              "https://lwn.net/Articles/967180/",
+              "https://news.ycombinator.com/item?id=39865810",
+              "https://news.ycombinator.com/item?id=39877267",
+              "https://news.ycombinator.com/item?id=39895344",
+              "https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/",
+              "https://research.swtch.com/xz-script",
+              "https://research.swtch.com/xz-timeline",
+              "https://security-tracker.debian.org/tracker/CVE-2024-3094",
+              "https://security.alpinelinux.org/vuln/CVE-2024-3094",
+              "https://security.archlinux.org/CVE-2024-3094",
+              "https://security.netapp.com/advisory/ntap-20240402-0001/",
+              "https://tukaani.org/xz-backdoor/",
+              "https://twitter.com/LetsDefendIO/status/1774804387417751958",
+              "https://twitter.com/debian/status/1774219194638409898",
+              "https://twitter.com/infosecb/status/1774595540233167206",
+              "https://twitter.com/infosecb/status/1774597228864139400",
+              "https://ubuntu.com/security/CVE-2024-3094",
+              "https://www.binarly.io/blog/persistent-risk-xz-utils-backdoor-still-lurking-in-docker-images",
+              "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094",
+              "https://www.darkreading.com/vulnerabilities-threats/are-you-affected-by-the-backdoor-in-xz-utils",
+              "https://www.kali.org/blog/about-the-xz-backdoor/",
+              "https://www.tenable.com/blog/frequently-asked-questions-cve-2024-3094-supply-chain-backdoor-in-xz-utils",
+              "https://www.theregister.com/2024/03/29/malicious_backdoor_xz/",
+              "https://www.vicarius.io/vsociety/vulnerabilities/cve-2024-3094",
+              "https://xeiaso.net/notes/2024/xz-vuln/"
+            ],
             "remediation_ecosystem": "apk",
             "remediation_strategy": "upgrade",
             "sources": [
@@ -214,7 +300,7 @@
             "suppressed_by_vex": false,
             "under_investigation": false
           },
-          "ruleId": "vuln-prioritizer/critical"
+          "ruleId": "vuln-prioritizer/cve-2024-3094"
         }
       ],
       "tool": {
@@ -222,67 +308,143 @@
           "name": "vuln-prioritizer",
           "rules": [
             {
+              "defaultConfiguration": {
+                "level": "error"
+              },
               "fullDescription": {
                 "text": "Known CVE prioritized from CVSS, EPSS, and CISA KEV with optional contextual layers such as asset context, VEX, waivers, remediation, and ATT&CK mapping provenance."
               },
               "help": {
                 "text": "Review the CVE, provider evidence, affected component or asset, and recommended remediation action. This tool prioritizes supplied findings and does not scan systems."
               },
-              "id": "vuln-prioritizer/critical",
-              "name": "Critical prioritized vulnerability",
+              "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2024-4577",
+              "id": "vuln-prioritizer/cve-2024-4577",
+              "name": "CVE-2024-4577 prioritized vulnerability",
               "properties": {
-                "priority": "Critical"
+                "cve": "CVE-2024-4577",
+                "precision": "very-high",
+                "priority": "Critical",
+                "references": [
+                  "https://nvd.nist.gov/vuln/detail/CVE-2024-4577",
+                  "http://www.openwall.com/lists/oss-security/2024/06/07/1",
+                  "https://arstechnica.com/security/2024/06/php-vulnerability-allows-attackers-to-run-malicious-code-on-windows-servers/",
+                  "https://blog.orange.tw/2024/06/cve-2024-4577-yet-another-php-rce.html",
+                  "https://cert.be/en/advisory/warning-php-remote-code-execution-patch-immediately",
+                  "https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en/",
+                  "https://github.com/11whoami99/CVE-2024-4577",
+                  "https://github.com/php/php-src/security/advisories/GHSA-3qgc-jrrr-25jv",
+                  "https://github.com/rapid7/metasploit-framework/pull/19247",
+                  "https://github.com/watchtowrlabs/CVE-2024-4577",
+                  "https://github.com/xcanwin/CVE-2024-4577-PHP-RCE",
+                  "https://isc.sans.edu/diary/30994",
+                  "https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/",
+                  "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PKGTQUOA2NTZ3RXN22CSAUJPIRUYRB4B/",
+                  "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/W45DBOH56NQDRTOM2DN2LNA2FZIMC3PK/",
+                  "https://security.netapp.com/advisory/ntap-20240621-0008/",
+                  "https://www.imperva.com/blog/imperva-protects-against-critical-php-vulnerability-cve-2024-4577/",
+                  "https://www.php.net/ChangeLog-8.php#8.1.29",
+                  "https://www.php.net/ChangeLog-8.php#8.2.20",
+                  "https://www.php.net/ChangeLog-8.php#8.3.8",
+                  "https://blog.talosintelligence.com/new-persistent-attacks-japan/",
+                  "https://www.vicarius.io/vsociety/posts/php-cgi-argument-injection-to-rce-cve-2024-4577",
+                  "https://www.vicarius.io/vsociety/posts/php-cgi-os-command-injection-vulnerability-cve-2024-4577",
+                  "https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2024-4577"
+                ],
+                "security-severity": "9.8",
+                "tags": [
+                  "security",
+                  "external/cve",
+                  "priority/critical"
+                ]
               },
               "shortDescription": {
-                "text": "Critical vulnerability prioritization result."
+                "text": "CVE-2024-4577: Critical priority."
               }
             },
             {
+              "defaultConfiguration": {
+                "level": "error"
+              },
               "fullDescription": {
                 "text": "Known CVE prioritized from CVSS, EPSS, and CISA KEV with optional contextual layers such as asset context, VEX, waivers, remediation, and ATT&CK mapping provenance."
               },
               "help": {
                 "text": "Review the CVE, provider evidence, affected component or asset, and recommended remediation action. This tool prioritizes supplied findings and does not scan systems."
               },
-              "id": "vuln-prioritizer/high",
-              "name": "High prioritized vulnerability",
+              "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094",
+              "id": "vuln-prioritizer/cve-2024-3094",
+              "name": "CVE-2024-3094 prioritized vulnerability",
               "properties": {
-                "priority": "High"
+                "cve": "CVE-2024-3094",
+                "precision": "very-high",
+                "priority": "Critical",
+                "references": [
+                  "https://nvd.nist.gov/vuln/detail/CVE-2024-3094",
+                  "https://access.redhat.com/security/cve/CVE-2024-3094",
+                  "https://bugzilla.redhat.com/show_bug.cgi?id=2272210",
+                  "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+                  "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users",
+                  "http://www.openwall.com/lists/oss-security/2024/03/29/10",
+                  "http://www.openwall.com/lists/oss-security/2024/03/29/12",
+                  "http://www.openwall.com/lists/oss-security/2024/03/29/4",
+                  "http://www.openwall.com/lists/oss-security/2024/03/29/5",
+                  "http://www.openwall.com/lists/oss-security/2024/03/29/8",
+                  "http://www.openwall.com/lists/oss-security/2024/03/30/12",
+                  "http://www.openwall.com/lists/oss-security/2024/03/30/27",
+                  "http://www.openwall.com/lists/oss-security/2024/03/30/36",
+                  "http://www.openwall.com/lists/oss-security/2024/03/30/5",
+                  "http://www.openwall.com/lists/oss-security/2024/04/16/5",
+                  "https://ariadne.space/2024/04/02/the-xz-utils-backdoor-is-a-symptom-of-a-larger-problem/",
+                  "https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/",
+                  "https://aws.amazon.com/security/security-bulletins/AWS-2024-002/",
+                  "https://blog.netbsd.org/tnf/entry/statement_on_backdoor_in_xz",
+                  "https://boehs.org/node/everything-i-know-about-the-xz-backdoor",
+                  "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068024",
+                  "https://bugs.gentoo.org/928134",
+                  "https://bugzilla.suse.com/show_bug.cgi?id=1222124",
+                  "https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405",
+                  "https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27",
+                  "https://github.com/advisories/GHSA-rxwq-x6h5-x525",
+                  "https://github.com/amlweems/xzbot",
+                  "https://github.com/karcherm/xz-malware",
+                  "https://gynvael.coldwind.pl/?lang=en&id=782",
+                  "https://lists.debian.org/debian-security-announce/2024/msg00057.html",
+                  "https://lists.freebsd.org/archives/freebsd-security/2024-March/000248.html",
+                  "https://lwn.net/Articles/967180/",
+                  "https://news.ycombinator.com/item?id=39865810",
+                  "https://news.ycombinator.com/item?id=39877267",
+                  "https://news.ycombinator.com/item?id=39895344",
+                  "https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/",
+                  "https://research.swtch.com/xz-script",
+                  "https://research.swtch.com/xz-timeline",
+                  "https://security-tracker.debian.org/tracker/CVE-2024-3094",
+                  "https://security.alpinelinux.org/vuln/CVE-2024-3094",
+                  "https://security.archlinux.org/CVE-2024-3094",
+                  "https://security.netapp.com/advisory/ntap-20240402-0001/",
+                  "https://tukaani.org/xz-backdoor/",
+                  "https://twitter.com/LetsDefendIO/status/1774804387417751958",
+                  "https://twitter.com/debian/status/1774219194638409898",
+                  "https://twitter.com/infosecb/status/1774595540233167206",
+                  "https://twitter.com/infosecb/status/1774597228864139400",
+                  "https://ubuntu.com/security/CVE-2024-3094",
+                  "https://www.binarly.io/blog/persistent-risk-xz-utils-backdoor-still-lurking-in-docker-images",
+                  "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094",
+                  "https://www.darkreading.com/vulnerabilities-threats/are-you-affected-by-the-backdoor-in-xz-utils",
+                  "https://www.kali.org/blog/about-the-xz-backdoor/",
+                  "https://www.tenable.com/blog/frequently-asked-questions-cve-2024-3094-supply-chain-backdoor-in-xz-utils",
+                  "https://www.theregister.com/2024/03/29/malicious_backdoor_xz/",
+                  "https://www.vicarius.io/vsociety/vulnerabilities/cve-2024-3094",
+                  "https://xeiaso.net/notes/2024/xz-vuln/"
+                ],
+                "security-severity": "10.0",
+                "tags": [
+                  "security",
+                  "external/cve",
+                  "priority/critical"
+                ]
               },
               "shortDescription": {
-                "text": "High vulnerability prioritization result."
-              }
-            },
-            {
-              "fullDescription": {
-                "text": "Known CVE prioritized from CVSS, EPSS, and CISA KEV with optional contextual layers such as asset context, VEX, waivers, remediation, and ATT&CK mapping provenance."
-              },
-              "help": {
-                "text": "Review the CVE, provider evidence, affected component or asset, and recommended remediation action. This tool prioritizes supplied findings and does not scan systems."
-              },
-              "id": "vuln-prioritizer/medium",
-              "name": "Medium prioritized vulnerability",
-              "properties": {
-                "priority": "Medium"
-              },
-              "shortDescription": {
-                "text": "Medium vulnerability prioritization result."
-              }
-            },
-            {
-              "fullDescription": {
-                "text": "Known CVE prioritized from CVSS, EPSS, and CISA KEV with optional contextual layers such as asset context, VEX, waivers, remediation, and ATT&CK mapping provenance."
-              },
-              "help": {
-                "text": "Review the CVE, provider evidence, affected component or asset, and recommended remediation action. This tool prioritizes supplied findings and does not scan systems."
-              },
-              "id": "vuln-prioritizer/low",
-              "name": "Low prioritized vulnerability",
-              "properties": {
-                "priority": "Low"
-              },
-              "shortDescription": {
-                "text": "Low vulnerability prioritization result."
+                "text": "CVE-2024-3094: Critical priority."
               }
             }
           ],

--- a/docs/integrations/reporting_and_ci.md
+++ b/docs/integrations/reporting_and_ci.md
@@ -120,7 +120,32 @@ vuln-prioritizer analyze \
   --fail-on high
 ```
 
-GitHub Code Scanning accepts SARIF 2.1.0 uploads. The current reporter emits SARIF `2.1.0` and is suitable for upload via `github/codeql-action/upload-sarif`.
+GitHub Code Scanning accepts SARIF 2.1.0 uploads. The current reporter emits
+SARIF `2.1.0` and is suitable for upload via
+`github/codeql-action/upload-sarif`.
+
+Current mapping:
+
+- Each result uses a CVE-addressable `ruleId` such as
+  `vuln-prioritizer/cve-2024-3094`.
+- Each result declares `properties.cve`, `properties.references`, `cve_url`,
+  priority, EPSS/CVSS/KEV flags, data-quality flags, and governance context.
+- Each declared rule includes `defaultConfiguration.level`,
+  `properties.security-severity`, priority tags, and `helpUri` pointing to the
+  primary CVE reference.
+- `report validate-sarif` checks the local upload contract before CI upload:
+  SARIF `2.1.0`, declared rules, result locations, fingerprints, CVE metadata,
+  and references. This is a deterministic local gate, not a replacement for the
+  final GitHub Code Scanning upload response.
+
+Limitations:
+
+- SARIF output prioritizes already-supplied CVEs; it is not a source-code,
+  container, host, or exploit scanner.
+- The local validator intentionally enforces the project contract plus a compact
+  SARIF shape rather than vendoring the complete external SARIF schema.
+- GitHub may still reject uploads for repository policy, permissions, duplicate
+  category handling, or platform-specific constraints outside this local check.
 
 ### PR Comment Reporting
 
@@ -192,6 +217,9 @@ The verifier:
 Current Workbench contract:
 
 - `POST /api/analysis-runs/{run_id}/reports` creates a run artifact in one of the supported Workbench formats: `json`, `markdown`, `html`, `csv`, or `sarif`.
+- `POST /api/v1/runs/{run_id}/reports` creates the same template Workbench
+  report family for completed visible template runs, including SARIF as
+  `results.sarif`.
 - `GET /api/reports/{report_id}/download` downloads the server-owned artifact after path and checksum validation.
 - The Workbench web UI exposes the same report creation flow from `/analysis-runs/{run_id}/reports`.
 - CSV report cells that could be interpreted as spreadsheet formulas are escaped before output.

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -22,7 +22,7 @@
 | `rollup` | analysis JSON or snapshot JSON | `markdown`, `json` | JSON schema | Aggregates findings by `asset_id` or `asset_business_service`, keeps waiver lifecycle debt visible, and ranks buckets for remediation planning without rerunning enrichment. |
 | `attack validate` | ATT&CK local files | `markdown`, `json` | JSON schema | Validates local mapping and metadata artifacts; `ctid-json` is the preferred workflow. |
 | `attack coverage` | `--input PATH` | `markdown`, `json` | JSON schema | Uses the same input loader for CVE extraction. |
-| `attack navigator-layer` | `--input PATH` | Navigator layer JSON | Navigator JSON, no local schema here | Exports a frequency-based ATT&CK Navigator layer. The template Workbench also exposes `attack-navigator` as a run report artifact. |
+| `attack navigator-layer` | `--input PATH` | Navigator layer JSON | Navigator JSON, no local schema here | Exports a frequency-based ATT&CK Navigator layer. The template Workbench also exposes `attack-navigator` and `sarif` as run report artifacts. |
 | `data status` | none | `json` | JSON schema | Cache namespace inspection plus optional local ATT&CK metadata validation. |
 | `data update` | optional repeatable `--input PATH` / `--cve` | `json` | JSON schema | Cache refresh for `nvd`, `epss`, and `kev`; `table` remains the default terminal view. |
 | `data verify` | optional repeatable `--input PATH` / `--cve` | `json` | JSON schema | Cache coverage, checksum, and pinned local file verification; `table` remains the default terminal view. |
@@ -30,6 +30,7 @@
 | `db init` | Workbench environment settings | terminal status | Workbench schema/migration side effect | Initializes the Workbench SQLite database named by `VULN_PRIORITIZER_DB_URL`. |
 | `db cleanup-artifacts` | Workbench environment settings | terminal status | Workbench report/evidence cleanup side effect | Dry-runs by default; `--delete` removes expired/orphaned managed artifacts. |
 | `web serve` | Workbench environment settings | local HTTP service | FastAPI/OpenAPI + HTML UI | Serves the Workbench app with `--host`, `--port`, and optional `--reload`. |
+| `report workbench` | analysis JSON | `json`, `markdown`, `html`, `csv`, `sarif` | Saved analysis JSON contract + SARIF 2.1.0 | No live enrichment during rendering. SARIF results use CVE-addressable rules and references. |
 | `report html` | analysis JSON | `html` | Consumes analysis JSON contract | No live enrichment during rendering. |
 | `report evidence-bundle` | analysis JSON | `zip` | Manifest schema inside bundle | Packages saved analysis JSON, regenerated HTML, Markdown summary, optional source input copy, and optional ATT&CK Navigator layer when mappings exist. |
 | `report verify-evidence-bundle` | evidence ZIP | `json` | JSON schema | Verifies ZIP members against the embedded manifest and reports missing, modified, unexpected, or malformed bundle content. |
@@ -93,7 +94,8 @@ Without a matching target, the explain flow still works, but asset-context and V
 - Prefer `report evidence-bundle` when a review board or release gate needs a reproducible offline artifact set from a saved analysis run.
 - Prefer `report verify-evidence-bundle` before shipping or archiving an evidence ZIP outside the repository or CI workspace.
 - `report html` expects an analysis JSON export, not compare JSON or explain JSON.
-- `sarif` is part of the documented contract only for `analyze`.
+- `sarif` is part of the documented contract for `analyze`, `report workbench`,
+  and template Workbench run reports.
 - `data status`, `data update`, `data verify`, and `data export-provider-snapshot` publish JSON contracts; their Rich table layout remains human-facing where applicable.
 - The optional SQLite state store is separate from the existing file cache and does not change `analyze`, `snapshot`, or `report` output semantics.
 - The Workbench SQLite database is a separate application store controlled by `VULN_PRIORITIZER_DB_URL`; it does not replace the CLI state store or provider cache.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -221,6 +221,7 @@ type TemplateReportFormat =
   | "csv"
   | "zip"
   | "attack-navigator"
+  | "sarif"
 
 const reportActionCards: Array<{
   actionLabel: string
@@ -280,6 +281,16 @@ const reportActionCards: Array<{
     reportFormat: "attack-navigator",
     stage: "VPW-060",
     title: "ATT&CK Navigator Layer",
+  },
+  {
+    actionLabel: "Export SARIF",
+    detail:
+      "SARIF 2.1.0 results for GitHub code scanning and CI security evidence workflows.",
+    format: "SARIF",
+    icon: FileJson,
+    reportFormat: "sarif",
+    stage: "VPW-080",
+    title: "SARIF Results",
   },
   {
     actionLabel: "Build Evidence Bundle",
@@ -1255,6 +1266,9 @@ function reportFormatLabel(format: string) {
   }
   if (format === "attack-navigator") {
     return "ATT&CK Navigator"
+  }
+  if (format === "sarif") {
+    return "SARIF"
   }
   return format.toUpperCase()
 }
@@ -5098,10 +5112,10 @@ export function App() {
                     <span>Report generation</span>
                     <h3>Generate and download reports for the selected run</h3>
                     <p>
-                      Create Markdown, HTML, JSON, CSV, ATT&CK Navigator, and
-                      evidence ZIP artifacts from completed template analysis
-                      runs. History rows stay linked to backend downloads and
-                      checksum-backed metadata.
+                      Create Markdown, HTML, JSON, CSV, ATT&CK Navigator, SARIF,
+                      and evidence ZIP artifacts from completed template
+                      analysis runs. History rows stay linked to backend
+                      downloads and checksum-backed metadata.
                     </p>
                   </div>
                   <dl className="report-readiness-facts">
@@ -5266,7 +5280,7 @@ export function App() {
                       <li className="report-history-row empty">
                         <span>No generated reports yet</span>
                         <span>
-                          Markdown / HTML / JSON / CSV / Navigator / ZIP
+                          Markdown / HTML / JSON / CSV / Navigator / SARIF / ZIP
                         </span>
                         <span>
                           {reportsLoading ? "Loading" : "Ready for VPW-053"}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3541,7 +3541,7 @@ export const ReportCreateSchema = {
         },
         format: {
             default: 'markdown',
-            enum: ['markdown', 'html', 'json', 'csv', 'zip', 'attack-navigator'],
+            enum: ['markdown', 'html', 'json', 'csv', 'zip', 'attack-navigator', 'sarif'],
             title: 'Format',
             type: 'string'
         }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -764,12 +764,12 @@ export type ProviderUpdateJobPublic = {
  */
 export type ReportCreate = {
     attack_filter?: 'all' | 'critical-high' | 'kev' | 'no-coverage';
-    format?: 'markdown' | 'html' | 'json' | 'csv' | 'zip' | 'attack-navigator';
+    format?: 'markdown' | 'html' | 'json' | 'csv' | 'zip' | 'attack-navigator' | 'sarif';
 };
 
 export type attack_filter = 'all' | 'critical-high' | 'kev' | 'no-coverage';
 
-export type format = 'markdown' | 'html' | 'json' | 'csv' | 'zip' | 'attack-navigator';
+export type format = 'markdown' | 'html' | 'json' | 'csv' | 'zip' | 'attack-navigator' | 'sarif';
 
 /**
  * Public report metadata without exposing server filesystem paths.

--- a/frontend/tests/template-login-status.spec.ts
+++ b/frontend/tests/template-login-status.spec.ts
@@ -441,6 +441,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(reportCards).toContainText("JSON Findings Export")
   await expect(reportCards).toContainText("CSV Findings Export")
   await expect(reportCards).toContainText("ATT&CK Navigator Layer")
+  await expect(reportCards).toContainText("SARIF Results")
   await expect(reportCards).toContainText("Evidence Bundle")
   const expectedReports = [
     { action: "Generate Markdown", filename: "technical-report.md" },
@@ -451,6 +452,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
       action: "Export Navigator Layer",
       filename: "attack-navigator-layer.json",
     },
+    { action: "Export SARIF", filename: "results.sarif" },
     { action: "Build Evidence Bundle", filename: "evidence-bundle.zip" },
   ]
   for (const report of expectedReports) {
@@ -467,6 +469,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(reportHistory).toContainText("analysis-result.v1.json")
   await expect(reportHistory).toContainText("findings.csv")
   await expect(reportHistory).toContainText("attack-navigator-layer.json")
+  await expect(reportHistory).toContainText("results.sarif")
   await expect(reportHistory).toContainText("evidence-bundle.zip")
   await page.screenshot({
     fullPage: true,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - VPW-074 CI Gates: evidence/vpw-074-ci-gates.md
       - VPW-075 Docker Compose Quickstart: evidence/vpw-075-docker-compose-quickstart.md
       - VPW-077 ATT&CK STIX Snapshot Import: evidence/vpw-077-attack-stix-snapshot-import.md
+      - VPW-080 SARIF Export Validation: evidence/vpw-080-sarif-export-validation.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary

Refs #186.

Implements VPW-080 SARIF export validation across the current CLI/local-first Workbench and template Workbench surfaces:

- changes SARIF rules/results from priority-only IDs to CVE-addressable IDs like `vuln-prioritizer/cve-2024-3094`
- adds rule metadata with `defaultConfiguration.level`, `security-severity`, priority tags, `helpUri`, and references
- adds result `properties.cve`, HTTP(S) `properties.references`, `cve_url`, stable fingerprints, and existing priority/governance/data-quality metadata
- tightens local SARIF validation for `vuln-prioritizer*` runs while allowing zero-finding SARIF exports
- adds template Workbench SARIF report generation as `results.sarif` with API, React card, generated client enum, and API/frontend coverage
- refreshes checked-in SARIF example and adds VPW-080 evidence artifacts/docs

## Validation

- `make frontend-generate-client` -> passed
- `python3 -m ruff check backend/app backend/src/vuln_prioritizer backend/tests/api/test_template_reports_api.py backend/tests/api/test_workbench_api.py backend/tests/cli/test_analyze.py backend/tests/cli/test_report.py` -> passed
- `git diff --check` -> passed
- `PYTHONPATH=backend/src python3 -m vuln_prioritizer.cli report validate-sarif --input docs/examples/example_results.sarif --format json --output docs/evidence/vpw-080-sarif-validation.json` -> passed, `ok: true`, `error_count: 0`
- `python3 -m pytest -q backend/tests/cli/test_analyze.py::test_cli_analyze_sarif_export_and_fail_on backend/tests/cli/test_report.py::test_cli_report_workbench_sarif_and_validation backend/tests/cli/test_report.py::test_checked_in_sarif_example_validates backend/tests/cli/test_report.py::test_sarif_validation_requires_declared_rules_and_fingerprints backend/tests/cli/test_report.py::test_sarif_validation_allows_foreign_tool_properties_without_cve backend/tests/cli/test_report.py::test_workbench_sarif_validates_with_no_findings backend/tests/cli/test_report.py::test_workbench_sarif_filters_non_http_references backend/tests/api/test_workbench_api.py::test_workbench_import_findings_reports_and_evidence backend/tests/api/test_workbench_api.py::test_workbench_finding_lifecycle_audit_and_exports backend/tests/api/test_template_reports_api.py::test_vpw049_openapi_exposes_report_format_contract backend/tests/api/test_template_reports_api.py::test_vpw080_sarif_report_create_downloads_valid_results --no-cov` -> 11 passed
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov` -> 29 passed
- `npm --prefix frontend run lint` -> passed
- `npm --prefix frontend run build` -> passed
- `npm --prefix frontend test -- template-login-status.spec.ts` -> 3 passed
- `make docs-check` -> passed; pre-existing info: `docs/architecture/vpw-011-api-skeleton.md` is not in mkdocs nav
- `make check` -> 848 passed, 7 skipped, coverage 90.71%
- `make docker-demo-smoke` -> passed

## Evidence

- `docs/examples/example_results.sarif`
- `docs/evidence/vpw-080-sarif-validation.json`
- `docs/evidence/vpw-080-sarif-export-validation.md`

## Residual risk

- The local validator enforces the project SARIF contract plus a compact SARIF 2.1.0 shape; it intentionally does not vendor the full external SARIF schema.
- GitHub Code Scanning upload can still depend on repository permissions, upload category, branch policy, and platform limits.
