### PR TITLE
VPW-076: Document release story evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-- No notable changes yet.
+### Added
+
+- VPW-076 release-story evidence that links v1.0 release notes, changelog, demo evidence bundle verification, screenshots, roadmap state, 15-minute technical/CISO storyline, and backup plan.
 
 ## [1.1.0] - 2026-04-25
 

--- a/docs/evidence/vpw-076-demo-evidence-bundle-verification.json
+++ b/docs/evidence/vpw-076-demo-evidence-bundle-verification.json
@@ -1,0 +1,81 @@
+{
+  "items": [
+    {
+      "actual_sha256": "1d0073b2025def2581892b26b33036b3bcaff196355f490914fc10d14f86a8c1",
+      "actual_size_bytes": 92969,
+      "detail": "Archive member matches the manifest checksum.",
+      "expected_sha256": "1d0073b2025def2581892b26b33036b3bcaff196355f490914fc10d14f86a8c1",
+      "expected_size_bytes": 92969,
+      "kind": "analysis-json",
+      "path": "analysis.json",
+      "status": "ok"
+    },
+    {
+      "actual_sha256": "7dd81e81df2034beb08ddba2699d806eaf7797892fb6b6e7185975d729994b7a",
+      "actual_size_bytes": 100721,
+      "detail": "Archive member matches the manifest checksum.",
+      "expected_sha256": "7dd81e81df2034beb08ddba2699d806eaf7797892fb6b6e7185975d729994b7a",
+      "expected_size_bytes": 100721,
+      "kind": "html-report",
+      "path": "report.html",
+      "status": "ok"
+    },
+    {
+      "actual_sha256": "206e3e9d10e426f7f6fd413ce6c988a3b0b8de2a060d50f0e75f78b09977202b",
+      "actual_size_bytes": 3950,
+      "detail": "Archive member matches the manifest checksum.",
+      "expected_sha256": "206e3e9d10e426f7f6fd413ce6c988a3b0b8de2a060d50f0e75f78b09977202b",
+      "expected_size_bytes": 3950,
+      "kind": "markdown-summary",
+      "path": "summary.md",
+      "status": "ok"
+    },
+    {
+      "actual_sha256": "18d94bbe54e47b27c10db18eeaade92b4ceddd3ab08b2370625f08c866f9d331",
+      "actual_size_bytes": 1825,
+      "detail": "Archive member matches the manifest checksum.",
+      "expected_sha256": "18d94bbe54e47b27c10db18eeaade92b4ceddd3ab08b2370625f08c866f9d331",
+      "expected_size_bytes": 1825,
+      "kind": "attack-navigator-layer",
+      "path": "attack-navigator-layer.json",
+      "status": "ok"
+    },
+    {
+      "actual_sha256": "d94b51defd676be1b852612d82d7f70aa213f1995af67a717c1ca6afb6c48f0c",
+      "actual_size_bytes": 60530,
+      "detail": "Archive member matches the manifest checksum.",
+      "expected_sha256": "d94b51defd676be1b852612d82d7f70aa213f1995af67a717c1ca6afb6c48f0c",
+      "expected_size_bytes": 60530,
+      "kind": "provider-snapshot",
+      "path": "provider/provider-snapshot.json",
+      "status": "ok"
+    },
+    {
+      "actual_sha256": "24d65249ea6f77b56c7870df3dd98bc8120294b886e226117c40b22e4825a81d",
+      "actual_size_bytes": 2188,
+      "detail": "Archive member matches the manifest checksum.",
+      "expected_sha256": "24d65249ea6f77b56c7870df3dd98bc8120294b886e226117c40b22e4825a81d",
+      "expected_size_bytes": 2188,
+      "kind": "source-input",
+      "path": "input/trivy_report.json",
+      "status": "ok"
+    }
+  ],
+  "metadata": {
+    "bundle_kind": "evidence-bundle",
+    "bundle_path": "build/v1.0-demo-evidence-bundle.zip",
+    "generated_at": "2026-04-21T12:00:00+00:00",
+    "manifest_schema_version": "1.1.0",
+    "schema_version": "1.2.0"
+  },
+  "summary": {
+    "expected_files": 6,
+    "manifest_errors": 0,
+    "missing_files": 0,
+    "modified_files": 0,
+    "ok": true,
+    "total_members": 7,
+    "unexpected_files": 0,
+    "verified_files": 6
+  }
+}

--- a/docs/evidence/vpw-076-release-story.md
+++ b/docs/evidence/vpw-076-release-story.md
@@ -1,0 +1,126 @@
+# VPW-076 Release Story Evidence
+
+VPW-076 closes the duplicated release-hardening roadmap item for v1.0 release notes, changelog evidence, demo evidence bundle verification, screenshots, and an exam-ready story. It does not add product scope. It collects and verifies the already shipped Workbench v1.0/v1.1 release artifacts into one strict-DoD evidence package.
+
+## Release Artifact Map
+
+| Requirement | Evidence |
+| --- | --- |
+| Changelog | `CHANGELOG.md` documents the Workbench-capable `1.1.0` package line and preserves `1.0.0` as the stable OSS release line. |
+| Release notes | `docs/releases/workbench-v1.0.0.md` explicitly documents Features, Non-Goals, Known Limitations, demo evidence, and bundle verification expectations. `docs/releases/v1.1.0.md` documents the package tag that carries the current Workbench tree. |
+| Release checklist | `docs/workbench-v1-release-checklist.md` records the v1.0 milestone checklist, gate expectations, screenshot set, residual risks, and sign-off table. |
+| Demo evidence bundle | `make demo-evidence-bundle-check` generates and verifies `build/v1.0-demo-evidence-bundle.zip`; the PR-visible verify output is committed as `docs/evidence/vpw-076-demo-evidence-bundle-verification.json`. |
+| Screenshots | `docs/examples/media/workbench-dashboard.png`, `docs/examples/media/workbench-findings.png`, `docs/examples/media/workbench-finding-detail-ttp.png`, `docs/examples/media/workbench-reports-evidence.png`, plus VPW-075 evidence screenshots. |
+| Roadmap v1.1/v1.2 | `docs/roadmap.md` records the implemented `v1.1.0` release surface and current Workbench app direction through the integration slices. |
+| Backup plan | See "Demo Backup Plan" below. |
+
+## Verification Run
+
+Run date: 2026-04-30
+
+Commands:
+
+```bash
+make demo-evidence-bundle-check
+shasum -a 256 \
+  build/v1.0-demo-analysis.json \
+  build/v1.0-demo-evidence-bundle.zip \
+  build/v1.0-demo-evidence-bundle-verification.json
+make docs-check
+```
+
+Verification summary from `build/v1.0-demo-evidence-bundle-verification.json`:
+
+```json
+{
+  "summary": {
+    "expected_files": 6,
+    "manifest_errors": 0,
+    "missing_files": 0,
+    "modified_files": 0,
+    "ok": true,
+    "total_members": 7,
+    "unexpected_files": 0,
+    "verified_files": 6
+  },
+  "metadata": {
+    "bundle_kind": "evidence-bundle",
+    "bundle_path": "build/v1.0-demo-evidence-bundle.zip",
+    "generated_at": "2026-04-21T12:00:00+00:00",
+    "manifest_schema_version": "1.1.0",
+    "schema_version": "1.2.0"
+  }
+}
+```
+
+Current artifact hashes:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `build/v1.0-demo-analysis.json` | `9264e7cf94fdd4e343ce6a991476f89cb71b5f9e0f8185d87ea73684610587b0` |
+| `build/v1.0-demo-evidence-bundle.zip` | `f478f0334964defba2cf815c4f09037a99743a80528f7a41db0e05b5a21fbce5` |
+| `build/v1.0-demo-evidence-bundle-verification.json` | `da6791865a2c70116d9d00c2ebf21d4a9a7fdfeb6de8ad8c52d7060614b7a854` |
+
+The same verification output is committed in `docs/evidence/vpw-076-demo-evidence-bundle-verification.json` so the issue and PR retain durable evidence even though `build/` remains ignored.
+
+## 15-Minute Demo Story
+
+### Technical flow, 7 minutes
+
+1. Start from the local-first boundary: the Workbench prioritizes known CVEs from imported files; it does not scan or exploit targets.
+2. Open the Docker quickstart evidence and show the local backend/frontend entry points.
+3. Import the locked demo input with provider snapshot replay enabled so feed drift does not affect the story.
+4. Show the technical finding path: input source, CVE, component, CVSS, EPSS, KEV, data-quality flags, ATT&CK context, asset context, and VEX applicability.
+5. Generate reports and the evidence bundle, then verify the bundle manifest and hashes.
+6. Point to the release checks: `make check`, Docker smoke, dependency audit, docs check, and demo evidence verification.
+
+### CISO flow, 7 minutes
+
+1. Start with the dashboard and priority counts, emphasizing that priority is explainable from CVSS, EPSS, and KEV.
+2. Show the same finding as business risk: threat signal, impacted service/owner, exposure context, accepted risk status, and recommended action.
+3. Use the reports page to show executive HTML/Markdown and evidence ZIP outputs.
+4. Explain governance: waivers do not hide findings, VEX statuses are visible, and missing asset context remains explicit unknown context.
+5. Close with release boundaries: local-first, single-node, no public-internet hardening promise, no scanner, no exploit tooling, no heuristic ATT&CK mapping.
+
+The remaining minute is reserved for questions or for switching to the backup path if a live browser flow is unavailable.
+
+### Required review path
+
+| Step | Demo point |
+| --- | --- |
+| Technical Finding | The locked Trivy import surfaces a concrete CVE occurrence with package/version, CVSS, EPSS, KEV, data-quality flags, ATT&CK context, asset context, and VEX status. |
+| Threat | KEV, EPSS, and source-backed ATT&CK context explain the exploitation and adversary-technique signal without inventing mappings. |
+| Asset | Asset context links the occurrence to service, owner, environment, exposure, and criticality so the finding is not just a package row. |
+| Business Impact | The CISO path translates the same finding into service risk, accepted or suppressed status, unknown context, and reporting evidence. |
+| Measure | Recommended action, governance state, waivers/VEX visibility, and report/evidence exports show the mitigation or decision path. |
+| Priority | Final priority remains explainable from CVSS, EPSS, and KEV, with contextual fields visible as evidence instead of hidden scoring changes. |
+
+## Demo Backup Plan
+
+If Docker, browser automation, or local ports are unavailable during the review:
+
+1. Use the checked-in release notes and this evidence document as the narrative source.
+2. Show the static screenshots in `docs/examples/media/` and VPW-075 evidence screenshots instead of a live Workbench session.
+3. Use the already generated build artifacts from the locked demo path and rerun only `report verify-evidence-bundle` against the ZIP if Docker is not available.
+4. If a live provider is unavailable or rate-limited, keep using `data/demo_provider_snapshot.json` with locked provider data.
+5. If a release gate fails for environmental reasons, record the failing command, environment detail, and retry decision in the issue/PR closeout instead of hiding the failure.
+
+## Non-Goals And Known Limitations
+
+- The Workbench is local-first and is not a hardened public internet deployment.
+- Evidence bundles provide integrity checks, not encryption or detached signatures.
+- Imported files may contain sensitive hostnames, package paths, image names, services, owners, and environment labels.
+- ATT&CK context is source-backed defensive context only. Unmapped CVEs remain unmapped.
+- The project does not scan infrastructure, run exploits, generate proof-of-concept steps, or use AI/fuzzy CVE-to-ATT&CK mapping.
+
+## Closeout
+
+VPW-076 is verified by this PR when:
+
+- this evidence file is committed and linked from MkDocs,
+- `docs/evidence/vpw-076-demo-evidence-bundle-verification.json` preserves the verification output in the PR,
+- `CHANGELOG.md` records the added release-story evidence,
+- `docs/releases/workbench-v1.0.0.md` explicitly lists Features, Non-Goals, and Known Limitations,
+- `docs/workbench-v1-release-checklist.md` links the VPW-076 closeout evidence,
+- `make demo-evidence-bundle-check` passes with `summary.ok=true`,
+- `make docs-check` passes.

--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -6,7 +6,7 @@ Workbench `v1.0.0` is the first release-ready Workbench milestone on top of the 
 
 These notes are Workbench milestone notes. The current package tree is versioned `1.1.0`, so a public package tag cut from `main` must use `v1.1.0` and the matching [v1.1.0 release notes](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/v1.1.0.md).
 
-## Included Scope
+## Features
 
 - Local-first FastAPI and Jinja2 Workbench with SQLite default storage.
 - Project, import, findings, vulnerability-intelligence, settings, governance, reports, and evidence views.
@@ -17,6 +17,20 @@ These notes are Workbench milestone notes. The current package tree is versioned
 - Asset context, VEX, and waiver upload visibility with owner/service/governance rollups.
 - JSON, Markdown, HTML, CSV, Navigator layer, and evidence bundle artifacts.
 - Hardened local runtime defaults for host headers, upload paths, artifact downloads, security headers, secret redaction, and dependency audit checks.
+
+## Non-Goals
+
+- The Workbench is not a vulnerability scanner and does not probe, exploit, or validate live targets.
+- Public-internet hosting, SaaS multi-tenancy, and organization-wide deployment hardening are outside this release scope.
+- Heuristic, fuzzy, or AI-generated CVE-to-ATT&CK mapping is not a supported source of record.
+- Evidence bundles are release and audit integrity artifacts, not encrypted vaults or detached-signature packages.
+
+## Known Limitations
+
+- The default deployment model is local-first and single-node.
+- Repeatable release demos require the checked-in provider snapshot path; live provider feeds can drift after the release run.
+- ATT&CK context is defensive and source-backed only; unmapped CVEs remain visibly unmapped.
+- Imported vulnerability files can contain sensitive hostnames, package paths, image names, service names, owners, and environment labels, so demo and release evidence must avoid customer exports.
 
 ## Release Evidence
 

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -17,6 +17,7 @@ The Workbench v1.0 milestone evidence is preserved here, but the current package
 - `python3 -m pip check` is not used as release evidence in the shared user-site environment because unrelated globally installed packages conflict with each other outside this project.
 - Public package tag and GitHub Release object: `v1.1.0` published from `23199ef85fb9ac08b9bb0e301b2aadbf3377f791`.
 - Duplicate VPW-072 performance smoke evidence: `make performance-smoke` passed on 2026-04-30 with 10,000 findings, import `1.1442s`, tail page `0.2420s`, and peak RSS delta `208.594 MiB`.
+- Duplicate VPW-076 release-story closeout evidence is collected in `docs/evidence/vpw-076-release-story.md`.
 
 ## GitHub Tracker Mapping
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - VPW-073 User Documentation: evidence/vpw-073-user-documentation.md
       - VPW-074 CI Gates: evidence/vpw-074-ci-gates.md
       - VPW-075 Docker Compose Quickstart: evidence/vpw-075-docker-compose-quickstart.md
+      - VPW-076 Release Story: evidence/vpw-076-release-story.md
       - VPW-077 ATT&CK STIX Snapshot Import: evidence/vpw-077-attack-stix-snapshot-import.md
       - VPW-080 SARIF Export Validation: evidence/vpw-080-sarif-export-validation.md
       - Historical Evidence Archive: evidence.md


### PR DESCRIPTION
## Summary\n- Adds VPW-076 release-story evidence linking changelog, release notes, demo evidence bundle verification, screenshots, roadmap state, the 15-minute technical/CISO story, and the demo backup plan.\n- Makes the Workbench v1.0 release notes explicitly list Features, Non-Goals, and Known Limitations.\n- Commits PR-visible evidence bundle verification output at docs/evidence/vpw-076-demo-evidence-bundle-verification.json.\n\n## Validation\n- git diff --check\n- make demo-evidence-bundle-check\n- make docs-check\n\nRefs #182