### PR TITLE
VPW-078: Add CTID mapping quality report

### DIFF
--- a/backend/src/vuln_prioritizer/cli_support/attack_support.py
+++ b/backend/src/vuln_prioritizer/cli_support/attack_support.py
@@ -24,12 +24,14 @@ def validate_attack_inputs_or_exit(
     attack_source: str,
     attack_mapping_file: Path,
     attack_technique_metadata_file: Path | None,
+    comparison_mapping_file: Path | None = None,
 ) -> dict[str, Any]:
     try:
         return validate_attack_inputs(
             attack_source=attack_source,
             attack_mapping_file=attack_mapping_file,
             attack_technique_metadata_file=attack_technique_metadata_file,
+            comparison_mapping_file=comparison_mapping_file,
         )
     except (OSError, ValidationError, ValueError) as exc:
         exit_input_validation(str(exc))
@@ -41,6 +43,7 @@ def validate_attack_inputs(
     attack_source: str,
     attack_mapping_file: Path,
     attack_technique_metadata_file: Path | None,
+    comparison_mapping_file: Path | None = None,
 ) -> dict[str, Any]:
     if attack_source == AttackSource.none.value:
         raise ValueError(
@@ -60,8 +63,28 @@ def validate_attack_inputs(
     quality_report: dict[str, Any] | None = None
 
     if attack_source == AttackSource.ctid_json.value:
-        mappings_by_cve, mapping_metadata, mapping_warnings = CtidMappingsProvider().load(
+        ctid_provider = CtidMappingsProvider()
+        mappings_by_cve, mapping_metadata, mapping_warnings = ctid_provider.load(
             attack_mapping_file
+        )
+        comparison_mappings_by_cve = None
+        comparison_metadata = None
+        if comparison_mapping_file is not None:
+            comparison_bundle = CuratedAttackMappingProvider().load(comparison_mapping_file)
+            comparison_mappings_by_cve = comparison_bundle.mappings_by_cve
+            comparison_metadata = comparison_bundle.metadata
+            warnings.extend(comparison_bundle.warnings)
+        quality_report = ctid_provider.build_quality_report(
+            mappings_by_cve,
+            mapping_metadata,
+            comparison_mappings_by_cve=comparison_mappings_by_cve,
+            comparison_source=(
+                comparison_metadata.get("metadata_source") if comparison_metadata else None
+            ),
+            comparison_file=str(comparison_mapping_file) if comparison_mapping_file else None,
+            comparison_file_sha256=(
+                comparison_metadata.get("mapping_file_sha256") if comparison_metadata else None
+            ),
         )
         warnings.extend(mapping_warnings)
         mapping_count = sum(len(items) for items in mappings_by_cve.values())
@@ -152,6 +175,8 @@ def validate_attack_inputs(
     elif attack_source == AttackSource.local_curated.value:
         bundle = CuratedAttackMappingProvider().load(attack_mapping_file)
         warnings.extend(bundle.warnings)
+        if comparison_mapping_file is not None:
+            warnings.append("Comparison mapping file is only used when --attack-source ctid-json.")
         mapping_count = sum(len(items) for items in bundle.mappings_by_cve.values())
         unique_cves = len(bundle.mappings_by_cve)
         technique_count = len(bundle.techniques_by_id)

--- a/backend/src/vuln_prioritizer/commands/attack.py
+++ b/backend/src/vuln_prioritizer/commands/attack.py
@@ -44,6 +44,12 @@ def attack_validate(
     attack_technique_metadata_file: Path | None = typer.Option(
         None, "--attack-technique-metadata-file", dir_okay=False
     ),
+    comparison_mapping_file: Path | None = typer.Option(
+        None,
+        "--comparison-mapping-file",
+        dir_okay=False,
+        help="Optional local-curated mapping file to compare against CTID JSON.",
+    ),
     output: Path | None = typer.Option(None, "--output", dir_okay=False),
     format: ReportOutputFormat = output_format_option(
         ReportOutputFormat.table, REPORT_OUTPUT_FORMATS
@@ -61,6 +67,7 @@ def attack_validate(
         attack_source=attack_source.value,
         attack_mapping_file=attack_mapping_file,
         attack_technique_metadata_file=attack_technique_metadata_file,
+        comparison_mapping_file=comparison_mapping_file,
     )
 
     json_payload = json.dumps(result, indent=2, sort_keys=True)

--- a/backend/src/vuln_prioritizer/providers/ctid_mappings.py
+++ b/backend/src/vuln_prioritizer/providers/ctid_mappings.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import Counter
 from pathlib import Path
+from typing import Final
 
-from vuln_prioritizer.models import AttackMapping
+from vuln_prioritizer.attack_sources import ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER
+from vuln_prioritizer.models import AttackConfidence, AttackMapping, AttackReviewStatus
 from vuln_prioritizer.utils import normalize_cve_id
+
+CTID_MAPPING_CONFIDENCE: Final[AttackConfidence] = "high"
+CTID_MAPPING_REVIEW_STATUS: Final[AttackReviewStatus] = "reviewed"
+CTID_MAPPING_DEFENSIVE_NOTE: Final = (
+    "Source-backed CTID Mappings Explorer mapping; use as defensive ATT&CK context only."
+)
 
 
 class CtidMappingsProvider:
@@ -98,6 +107,10 @@ class CtidMappingsProvider:
                         raw_object.get("capability_description")
                     ),
                     comments=_normalize_optional_string(raw_object.get("comments")),
+                    source=ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER,
+                    confidence=CTID_MAPPING_CONFIDENCE,
+                    review_status=CTID_MAPPING_REVIEW_STATUS,
+                    defensive_note=CTID_MAPPING_DEFENSIVE_NOTE,
                     references=_normalize_references(raw_object.get("references")),
                 )
             )
@@ -119,6 +132,134 @@ class CtidMappingsProvider:
             "contact": _normalize_optional_string(metadata.get("contact")),
         }
         return grouped, normalized_metadata, warnings
+
+    def build_quality_report(
+        self,
+        mappings_by_cve: dict[str, list[AttackMapping]],
+        metadata: dict[str, str | None],
+        *,
+        comparison_mappings_by_cve: dict[str, list[AttackMapping]] | None = None,
+        comparison_source: str | None = None,
+        comparison_file: str | None = None,
+        comparison_file_sha256: str | None = None,
+    ) -> dict[str, object]:
+        """Build a deterministic CTID mapping quality/provenance summary."""
+        mappings = [mapping for items in mappings_by_cve.values() for mapping in items]
+        conflict_rows = _find_ctid_mapping_conflicts(mappings_by_cve)
+        local_ctid_conflicts = _find_local_ctid_conflicts(
+            mappings_by_cve,
+            comparison_mappings_by_cve or {},
+        )
+        confidence_counts = Counter(mapping.confidence or "unknown" for mapping in mappings)
+        review_status_counts = Counter(
+            mapping.review_status or "unreviewed" for mapping in mappings
+        )
+
+        return {
+            "schema_version": "1.0.0",
+            "source": ATTACK_SOURCE_CTID_MAPPINGS_EXPLORER,
+            "mapping_file": metadata.get("mapping_file"),
+            "mapping_file_sha256": metadata.get("mapping_file_sha256"),
+            "mapping_framework": metadata.get("mapping_framework"),
+            "mapping_framework_version": metadata.get("mapping_framework_version"),
+            "mapping_created_at": metadata.get("creation_date"),
+            "mapping_updated_at": metadata.get("last_update"),
+            "mapping_count": len(mappings),
+            "unique_cves": len(mappings_by_cve),
+            "unique_techniques": len({mapping.attack_object_id for mapping in mappings}),
+            "source_counts": dict(
+                sorted(Counter(mapping.source or "unknown" for mapping in mappings).items())
+            ),
+            "confidence_counts": dict(sorted(confidence_counts.items())),
+            "review_status_counts": dict(sorted(review_status_counts.items())),
+            "mapping_type_counts": dict(
+                sorted(Counter(mapping.mapping_type or "unknown" for mapping in mappings).items())
+            ),
+            "low_confidence_count": confidence_counts.get("low", 0),
+            "conflict_count": len(conflict_rows),
+            "conflicts": conflict_rows,
+            "conflict_policy": (
+                "ctid-json and local-curated sources are explicit alternatives; mappings are "
+                "not silently merged. Divergent duplicate CTID contexts are surfaced here."
+            ),
+            "comparison_source": comparison_source,
+            "comparison_file": comparison_file,
+            "comparison_file_sha256": comparison_file_sha256,
+            "local_ctid_conflict_count": len(local_ctid_conflicts),
+            "local_ctid_conflicts": local_ctid_conflicts,
+            "safety_review": {
+                "source_backed_ctid_context": True,
+                "heuristic_or_llm_sources_rejected": True,
+                "unmapped_cves_remain_unmapped": True,
+            },
+        }
+
+
+def _find_ctid_mapping_conflicts(
+    mappings_by_cve: dict[str, list[AttackMapping]],
+) -> list[dict[str, object]]:
+    conflicts: list[dict[str, object]] = []
+    for cve_id, mappings in sorted(mappings_by_cve.items()):
+        contexts_by_technique: dict[str, set[tuple[str, str]]] = {}
+        for mapping in mappings:
+            contexts_by_technique.setdefault(mapping.attack_object_id, set()).add(
+                (
+                    mapping.mapping_type or "unknown",
+                    mapping.capability_group or "unknown",
+                )
+            )
+
+        for technique_id, contexts in sorted(contexts_by_technique.items()):
+            if len(contexts) <= 1:
+                continue
+            conflicts.append(
+                {
+                    "cve_id": cve_id,
+                    "technique_id": technique_id,
+                    "contexts": [
+                        {
+                            "mapping_type": mapping_type,
+                            "capability_group": capability_group,
+                        }
+                        for mapping_type, capability_group in sorted(contexts)
+                    ],
+                }
+            )
+    return conflicts
+
+
+def _find_local_ctid_conflicts(
+    ctid_mappings_by_cve: dict[str, list[AttackMapping]],
+    local_mappings_by_cve: dict[str, list[AttackMapping]],
+) -> list[dict[str, object]]:
+    conflicts: list[dict[str, object]] = []
+    for cve_id in sorted(set(ctid_mappings_by_cve).intersection(local_mappings_by_cve)):
+        ctid_mappings = ctid_mappings_by_cve[cve_id]
+        local_mappings = local_mappings_by_cve[cve_id]
+        ctid_techniques = {mapping.attack_object_id for mapping in ctid_mappings}
+        local_techniques = {mapping.attack_object_id for mapping in local_mappings}
+        shared_techniques = ctid_techniques.intersection(local_techniques)
+        ctid_types = _mapping_type_set(ctid_mappings)
+        local_types = _mapping_type_set(local_mappings)
+
+        if ctid_techniques == local_techniques and ctid_types == local_types:
+            continue
+
+        conflicts.append(
+            {
+                "cve_id": cve_id,
+                "shared_techniques": sorted(shared_techniques),
+                "ctid_only_techniques": sorted(ctid_techniques - local_techniques),
+                "local_only_techniques": sorted(local_techniques - ctid_techniques),
+                "ctid_mapping_types": sorted(ctid_types),
+                "local_mapping_types": sorted(local_types),
+            }
+        )
+    return conflicts
+
+
+def _mapping_type_set(mappings: list[AttackMapping]) -> set[str]:
+    return {mapping.mapping_type or "unknown" for mapping in mappings}
 
 
 def _normalize_optional_string(value: object) -> str | None:

--- a/backend/tests/test_cli_attack.py
+++ b/backend/tests/test_cli_attack.py
@@ -331,6 +331,95 @@ def test_cli_attack_validate_json_reports_stix_and_hash_provenance(tmp_path: Pat
     assert payload["mapping_created_at"] == "07/28/2025"
     assert payload["mapping_updated_at"] == "08/28/2025"
     assert payload["revoked_or_deprecated_count"] == 1
+    assert payload["quality_report"]["source_counts"] == {"ctid-mappings-explorer": 2}
+    assert payload["quality_report"]["confidence_counts"] == {"high": 2}
+    assert payload["quality_report"]["review_status_counts"] == {"reviewed": 2}
+    assert payload["quality_report"]["conflict_count"] == 0
+
+
+def test_cli_attack_validate_ctid_json_reports_quality_for_fixture(tmp_path: Path) -> None:
+    output_file = tmp_path / "ctid-quality.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "attack",
+            "validate",
+            "--attack-source",
+            "ctid-json",
+            "--attack-mapping-file",
+            str(ATTACK_MAPPING_FILE),
+            "--attack-technique-metadata-file",
+            str(ATTACK_METADATA_FILE),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["source"] == "ctid-mappings-explorer"
+    assert (
+        payload["mapping_file_sha256"]
+        == hashlib.sha256(ATTACK_MAPPING_FILE.read_bytes()).hexdigest()
+    )
+    assert payload["quality_report"]["mapping_count"] == 27
+    assert payload["quality_report"]["unique_cves"] == 3
+    assert payload["quality_report"]["source_counts"] == {"ctid-mappings-explorer": 27}
+    assert payload["quality_report"]["confidence_counts"] == {"high": 27}
+    assert payload["quality_report"]["review_status_counts"] == {"reviewed": 27}
+    assert payload["quality_report"]["mapping_type_counts"] == {
+        "exploitation_technique": 4,
+        "primary_impact": 5,
+        "secondary_impact": 18,
+    }
+    assert payload["quality_report"]["conflict_count"] == 2
+    assert payload["quality_report"]["conflicts"][0]["cve_id"] == "CVE-2020-1472"
+
+
+def test_cli_attack_validate_ctid_json_compares_local_curated_mapping(
+    tmp_path: Path,
+) -> None:
+    output_file = tmp_path / "ctid-local-comparison.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "attack",
+            "validate",
+            "--attack-source",
+            "ctid-json",
+            "--attack-mapping-file",
+            str(ATTACK_MAPPING_FILE),
+            "--attack-technique-metadata-file",
+            str(ATTACK_METADATA_FILE),
+            "--comparison-mapping-file",
+            str(CURATED_ATTACK_MAPPING_FILE),
+            "--output",
+            str(output_file),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    quality_report = payload["quality_report"]
+    assert quality_report["comparison_source"] == "local-curated"
+    assert quality_report["comparison_file"] == str(CURATED_ATTACK_MAPPING_FILE)
+    assert quality_report["local_ctid_conflict_count"] == 1
+    assert quality_report["local_ctid_conflicts"][0]["cve_id"] == "CVE-2023-34362"
+    assert quality_report["local_ctid_conflicts"][0]["shared_techniques"] == ["T1190"]
+    assert quality_report["local_ctid_conflicts"][0]["ctid_only_techniques"] == [
+        "T1005",
+        "T1059",
+        "T1082",
+        "T1105",
+        "T1136",
+        "T1531",
+    ]
 
 
 def test_cli_attack_validate_missing_mapping_file_exits_cleanly(tmp_path: Path) -> None:

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1476,6 +1476,49 @@ def test_ctid_provider_loads_official_subset_fixture() -> None:
     assert metadata["domain"] == "enterprise"
     assert len(results["CVE-2023-34362"]) == 7
     assert results["CVE-2023-34362"][0].mapping_type == "exploitation_technique"
+    assert results["CVE-2023-34362"][0].source == "ctid-mappings-explorer"
+    assert results["CVE-2023-34362"][0].confidence == "high"
+    assert results["CVE-2023-34362"][0].review_status == "reviewed"
+    assert results["CVE-2023-34362"][0].defensive_note
+
+    quality_report = provider.build_quality_report(results, metadata)
+    assert quality_report["mapping_count"] == 27
+    assert quality_report["unique_cves"] == 3
+    assert quality_report["unique_techniques"] == 22
+    assert quality_report["source_counts"] == {"ctid-mappings-explorer": 27}
+    assert quality_report["confidence_counts"] == {"high": 27}
+    assert quality_report["review_status_counts"] == {"reviewed": 27}
+    assert quality_report["mapping_type_counts"] == {
+        "exploitation_technique": 4,
+        "primary_impact": 5,
+        "secondary_impact": 18,
+    }
+    assert quality_report["conflict_count"] == 2
+    assert quality_report["conflicts"][0]["cve_id"] == "CVE-2020-1472"
+
+    local_bundle = CuratedAttackMappingProvider().load(DATA_ROOT / "cve_attack_mappings.yml")
+    comparison_report = provider.build_quality_report(
+        results,
+        metadata,
+        comparison_mappings_by_cve=local_bundle.mappings_by_cve,
+        comparison_source=local_bundle.metadata["metadata_source"],
+        comparison_file=local_bundle.metadata["mapping_file"],
+        comparison_file_sha256=local_bundle.metadata["mapping_file_sha256"],
+    )
+    assert comparison_report["comparison_source"] == "local-curated"
+    assert comparison_report["local_ctid_conflict_count"] == 1
+    assert comparison_report["local_ctid_conflicts"][0] == {
+        "cve_id": "CVE-2023-34362",
+        "shared_techniques": ["T1190"],
+        "ctid_only_techniques": ["T1005", "T1059", "T1082", "T1105", "T1136", "T1531"],
+        "local_only_techniques": [],
+        "ctid_mapping_types": [
+            "exploitation_technique",
+            "primary_impact",
+            "secondary_impact",
+        ],
+        "local_mapping_types": ["exploitation"],
+    }
 
 
 def test_attack_metadata_provider_loads_subset_fixture() -> None:
@@ -1571,6 +1614,9 @@ def test_attack_provider_ctid_json_enriches_structured_attack_data() -> None:
     assert metadata["mapping_updated_at"] == "08/28/2025"
     assert results["CVE-2023-34362"].mapped is True
     assert results["CVE-2023-34362"].attack_relevance == "High"
+    assert results["CVE-2023-34362"].mappings[0].source == "ctid-mappings-explorer"
+    assert results["CVE-2023-34362"].mappings[0].confidence == "high"
+    assert results["CVE-2023-34362"].mappings[0].review_status == "reviewed"
     assert results["CVE-2023-34362"].mapping_types == [
         "exploitation_technique",
         "primary_impact",

--- a/docs/attack-ttp-methodology.md
+++ b/docs/attack-ttp-methodology.md
@@ -15,6 +15,18 @@ The preferred source for CVE-to-ATT&CK mapping remains CTID Mappings Explorer
 JSON. Local curated mappings are allowed only when every entry is explicitly
 reviewable.
 
+For imported CTID Mappings Explorer JSON, VPW normalizes each mapping to
+`source=ctid-mappings-explorer`, `confidence=high`, and
+`review_status=reviewed` because the local artifact is an explicit CTID source
+snapshot. The `attack validate` quality report still keeps source, confidence,
+review status, mapping-type counts, and duplicate-context conflicts visible so a
+reviewer can audit what the imported CTID file contributed.
+
+When reviewers need a local-vs-CTID comparison, `attack validate` accepts
+`--comparison-mapping-file` with a local curated mapping file while
+`--attack-source ctid-json` is selected. The resulting quality report emits
+`local_ctid_conflicts[]` instead of merging or overriding either source.
+
 ## Tactic, Technique, And Procedure Boundary
 
 ATT&CK content in this project is intentionally limited to defensive context:
@@ -76,6 +88,9 @@ Current limitations:
   priority.
 - CTID JSON is preferred. Local curated mappings are accepted only with source,
   rationale, confidence, review status, and defensive notes.
+- CTID JSON and local curated mappings are explicit alternative sources. They
+  are not silently merged; if a local override workflow is added later, it must
+  keep local-vs-CTID conflicts visible in evidence.
 - Unmapped CVEs stay unmapped. The tool does not fill gaps by guessing from CVE
   text, CWE, vendor names, products, exploit keywords, EPSS rank, or LLM output.
 - Free-text source notes can contain upstream vulnerability descriptions. VPW

--- a/docs/evidence/vpw-078-ctid-mapping-quality-report.json
+++ b/docs/evidence/vpw-078-ctid-mapping-quality-report.json
@@ -1,0 +1,138 @@
+{
+  "attack_version": "16.1",
+  "attack_version_mismatch": false,
+  "confidence_counts": {
+    "high": 27
+  },
+  "domain": "enterprise",
+  "domain_mismatch": false,
+  "low_confidence_count": 0,
+  "mapping_author": null,
+  "mapping_contact": null,
+  "mapping_count": 27,
+  "mapping_created_at": "07/28/2025",
+  "mapping_file": "data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json",
+  "mapping_file_sha256": "f604e08bd6370c2356a60c01963a9bc5c88f92fac0b2ee20102c0159d4a2c865",
+  "mapping_framework": "kev",
+  "mapping_framework_version": "07/28/2025",
+  "mapping_organization": null,
+  "mapping_type_counts": {
+    "exploitation_technique": 4,
+    "primary_impact": 5,
+    "secondary_impact": 18
+  },
+  "mapping_updated_at": "08/28/2025",
+  "metadata_format": "vuln-prioritizer-technique-json",
+  "metadata_source": "local-technique-metadata",
+  "missing_metadata_ids": [],
+  "quality_report": {
+    "comparison_file": "data/cve_attack_mappings.yml",
+    "comparison_file_sha256": "f8bee8c9ba0bac70c7d5fbd32d0f482a897d67aac6a7d7d048c9844761a96004",
+    "comparison_source": "local-curated",
+    "confidence_counts": {
+      "high": 27
+    },
+    "conflict_count": 2,
+    "conflict_policy": "ctid-json and local-curated sources are explicit alternatives; mappings are not silently merged. Divergent duplicate CTID contexts are surfaced here.",
+    "conflicts": [
+      {
+        "contexts": [
+          {
+            "capability_group": "priv_escalation",
+            "mapping_type": "primary_impact"
+          },
+          {
+            "capability_group": "priv_escalation",
+            "mapping_type": "secondary_impact"
+          }
+        ],
+        "cve_id": "CVE-2020-1472",
+        "technique_id": "T1087.002"
+      },
+      {
+        "contexts": [
+          {
+            "capability_group": "priv_escalation",
+            "mapping_type": "exploitation_technique"
+          },
+          {
+            "capability_group": "priv_escalation",
+            "mapping_type": "secondary_impact"
+          }
+        ],
+        "cve_id": "CVE-2020-1472",
+        "technique_id": "T1133"
+      }
+    ],
+    "local_ctid_conflict_count": 1,
+    "local_ctid_conflicts": [
+      {
+        "ctid_mapping_types": [
+          "exploitation_technique",
+          "primary_impact",
+          "secondary_impact"
+        ],
+        "ctid_only_techniques": [
+          "T1005",
+          "T1059",
+          "T1082",
+          "T1105",
+          "T1136",
+          "T1531"
+        ],
+        "cve_id": "CVE-2023-34362",
+        "local_mapping_types": [
+          "exploitation"
+        ],
+        "local_only_techniques": [],
+        "shared_techniques": [
+          "T1190"
+        ]
+      }
+    ],
+    "low_confidence_count": 0,
+    "mapping_count": 27,
+    "mapping_created_at": "07/28/2025",
+    "mapping_file": "data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json",
+    "mapping_file_sha256": "f604e08bd6370c2356a60c01963a9bc5c88f92fac0b2ee20102c0159d4a2c865",
+    "mapping_framework": "kev",
+    "mapping_framework_version": "07/28/2025",
+    "mapping_type_counts": {
+      "exploitation_technique": 4,
+      "primary_impact": 5,
+      "secondary_impact": 18
+    },
+    "mapping_updated_at": "08/28/2025",
+    "review_status_counts": {
+      "reviewed": 27
+    },
+    "safety_review": {
+      "heuristic_or_llm_sources_rejected": true,
+      "source_backed_ctid_context": true,
+      "unmapped_cves_remain_unmapped": true
+    },
+    "schema_version": "1.0.0",
+    "source": "ctid-mappings-explorer",
+    "source_counts": {
+      "ctid-mappings-explorer": 27
+    },
+    "unique_cves": 3,
+    "unique_techniques": 22
+  },
+  "review_status_counts": {
+    "reviewed": 27
+  },
+  "revoked_or_deprecated_count": 0,
+  "schema_version": "1.2.0",
+  "source": "ctid-mappings-explorer",
+  "source_version": "07/28/2025",
+  "stix_spec_version": null,
+  "technique_count": 22,
+  "technique_metadata_file": "data/attack/attack_techniques_enterprise_16.1_subset.json",
+  "technique_metadata_file_sha256": "486d0aa3aacf5c86cf5b8f9dd597210bcfd9d36cbd1331c1c303865dbd6c5c78",
+  "unique_cves": 3,
+  "warnings": [
+    "Low-confidence curated ATT&CK mapping marked for review: CVE-2021-26855 / T1046.",
+    "Curated ATT&CK mapping is not fully reviewed: CVE-2021-26855 / T1046 has status needs_review."
+  ]
+}

--- a/docs/evidence/vpw-078-ctid-mappings-provider.md
+++ b/docs/evidence/vpw-078-ctid-mappings-provider.md
@@ -1,0 +1,65 @@
+# VPW-078 CTID Mappings Provider Evidence
+
+## Scope
+
+VPW-078 implements the duplicate roadmap CTID Mappings Explorer provider MVP.
+It keeps CTID JSON as the canonical Workbench CVE-to-ATT&CK source and does not
+add generated or heuristic mappings.
+
+Implemented scope:
+
+- CTID dataset fixture import from
+  `data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json`.
+- CTID mapping normalization to `source=ctid-mappings-explorer`,
+  `confidence=high`, and `review_status=reviewed`.
+- Mapping quality report for `attack validate --attack-source ctid-json`.
+- Visible duplicate-context conflict reporting for CVE/technique pairs with
+  multiple CTID mapping contexts.
+- Explicit local-vs-CTID comparison via `--comparison-mapping-file`: CTID and
+  local curated mappings are selected sources, not silently merged.
+
+## Evidence Artifacts
+
+- CTID fixture:
+  `data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json`
+- Technique metadata fixture:
+  `data/attack/attack_techniques_enterprise_16.1_subset.json`
+- Mapping quality report:
+  `docs/evidence/vpw-078-ctid-mapping-quality-report.json`
+- Methodology:
+  `docs/attack-ttp-methodology.md`
+
+## Mapping Quality Summary
+
+The generated quality report records:
+
+- Mapping count: 27
+- Unique CVEs: 3
+- Unique techniques: 22
+- Source distribution: `ctid-mappings-explorer=27`
+- Confidence distribution: `high=27`
+- Review status distribution: `reviewed=27`
+- Mapping type distribution:
+  `exploitation_technique=4`, `primary_impact=5`, `secondary_impact=18`
+- Visible duplicate-context conflicts: 2
+- Local-vs-CTID conflicts when compared to `data/cve_attack_mappings.yml`: 1
+- Low-confidence mappings: 0
+
+The two visible conflicts are both for `CVE-2020-1472` and document CTID rows
+where the same technique appears with more than one mapping context:
+
+- `T1087.002`: `primary_impact` and `secondary_impact`
+- `T1133`: `exploitation_technique` and `secondary_impact`
+
+## Commands
+
+```bash
+python3 -m ruff check backend/src/vuln_prioritizer/providers/ctid_mappings.py backend/src/vuln_prioritizer/cli_support/attack_support.py backend/tests/test_providers.py backend/tests/test_cli_attack.py
+python3 -m pytest -q backend/tests/test_providers.py::test_ctid_provider_loads_official_subset_fixture backend/tests/test_providers.py::test_attack_provider_ctid_json_enriches_structured_attack_data backend/tests/test_cli_attack.py::test_cli_attack_validate_json_reports_stix_and_hash_provenance backend/tests/test_cli_attack.py::test_cli_attack_validate_ctid_json_reports_quality_for_fixture backend/tests/test_cli_attack.py::test_cli_attack_validate_ctid_json_compares_local_curated_mapping --no-cov
+python3 -m vuln_prioritizer.cli attack validate --attack-source ctid-json --attack-mapping-file data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json --attack-technique-metadata-file data/attack/attack_techniques_enterprise_16.1_subset.json --output docs/evidence/vpw-078-ctid-mapping-quality-report.json --format json
+python3 -m vuln_prioritizer.cli attack validate --attack-source ctid-json --attack-mapping-file data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json --attack-technique-metadata-file data/attack/attack_techniques_enterprise_16.1_subset.json --comparison-mapping-file data/cve_attack_mappings.yml --format json
+python3 -m vuln_prioritizer.cli attack coverage --input data/sample_cves_mixed.txt --attack-mapping-file data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json --attack-technique-metadata-file data/attack/attack_techniques_enterprise_16.1_subset.json --output build/vpw-078-attack-coverage.json --format json
+```
+
+Targeted result: 5 focused tests passed; the broader CTID/CLI/schema slice
+passed with 22 tests. `make docs-check` passed.

--- a/docs/schemas/attack-validation-report.schema.json
+++ b/docs/schemas/attack-validation-report.schema.json
@@ -116,7 +116,7 @@
     "quality_report": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Present for --attack-source local-curated. Contains mapping quality, review status, confidence, and safety-review counts."
+      "description": "Present for --attack-source ctid-json and local-curated. Contains mapping quality, review status, confidence, conflict, and safety-review counts."
     },
     "low_confidence_count": {
       "type": "integer",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - VPW-075 Docker Compose Quickstart: evidence/vpw-075-docker-compose-quickstart.md
       - VPW-076 Release Story: evidence/vpw-076-release-story.md
       - VPW-077 ATT&CK STIX Snapshot Import: evidence/vpw-077-attack-stix-snapshot-import.md
+      - VPW-078 CTID Mappings Provider: evidence/vpw-078-ctid-mappings-provider.md
       - VPW-080 SARIF Export Validation: evidence/vpw-080-sarif-export-validation.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md


### PR DESCRIPTION
## Summary\n- Normalizes CTID mappings with source, confidence, review status, and defensive note metadata.\n- Adds CTID quality reporting to `attack validate`, including duplicate-context conflicts and optional local-curated comparison via `--comparison-mapping-file`.\n- Adds VPW-078 evidence docs and generated CTID quality-report JSON.\n\n## Validation\n- `python3 -m ruff check backend/src/vuln_prioritizer/providers/ctid_mappings.py backend/src/vuln_prioritizer/cli_support/attack_support.py backend/src/vuln_prioritizer/commands/attack.py backend/tests/test_providers.py backend/tests/test_cli_attack.py`\n- `python3 -m pytest -q backend/tests/test_providers.py::test_ctid_provider_loads_official_subset_fixture backend/tests/test_providers.py::test_attack_provider_ctid_json_enriches_structured_attack_data backend/tests/test_cli_attack.py::test_cli_attack_validate_json_reports_stix_and_hash_provenance backend/tests/test_cli_attack.py::test_cli_attack_validate_ctid_json_reports_quality_for_fixture backend/tests/test_cli_attack.py::test_cli_attack_validate_ctid_json_compares_local_curated_mapping --no-cov`\n- `python3 -m pytest -q backend/tests/test_cli_attack.py backend/tests/test_providers.py::test_ctid_provider_loads_official_subset_fixture backend/tests/test_providers.py::test_attack_provider_ctid_json_enriches_structured_attack_data backend/tests/test_output_schemas.py::test_attack_validation_json_matches_published_schema backend/tests/test_output_schemas.py::test_attack_validation_local_curated_json_matches_published_schema --no-cov`\n- `python3 -m vuln_prioritizer.cli attack validate --attack-source ctid-json --attack-mapping-file data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json --attack-technique-metadata-file data/attack/attack_techniques_enterprise_16.1_subset.json --comparison-mapping-file data/cve_attack_mappings.yml --output docs/evidence/vpw-078-ctid-mapping-quality-report.json --format json`\n- `python3 -m vuln_prioritizer.cli attack coverage --input data/sample_cves_mixed.txt --attack-mapping-file data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json --attack-technique-metadata-file data/attack/attack_techniques_enterprise_16.1_subset.json --output build/vpw-078-attack-coverage.json --format json`\n- `make docs-check`\n- `make check` -> 884 passed, 7 skipped, coverage 90.81%\n\nRefs #184