### PR TITLE
VPW-082: Add GitHub Action report artifacts

### DIFF
--- a/.github/examples/README.md
+++ b/.github/examples/README.md
@@ -11,6 +11,7 @@ Pin the action to a release tag or commit SHA in consumer repositories. The exam
 - [code-scanning-sarif.yml](./code-scanning-sarif.yml)
 - [pr-comment-report.yml](./pr-comment-report.yml)
 - [html-report-artifact.yml](./html-report-artifact.yml)
+- [workbench-report-artifacts.yml](./workbench-report-artifacts.yml)
 
 ## Current Contracts
 
@@ -20,6 +21,8 @@ The action and examples assume the current repository provides:
 - `analyze --format sarif`
 - deterministic `--fail-on` exit codes
 - `report html --input analysis.json --output report.html`
+- `report workbench --input analysis.json --format markdown|json`
+- `report validate-sarif --input results.sarif --format json`
 - a composite GitHub Action at repository root (`action.yml`)
 
 ## Integration Notes
@@ -29,3 +32,4 @@ The action and examples assume the current repository provides:
 - The action installs `vuln-prioritizer` from the action checkout and runs the local CLI entrypoint.
 - In `mode: analyze`, `input` and `input-format` support newline-delimited values for merged multi-source runs.
 - Consumers can pass `provider-snapshot-file` and `locked-provider-data` when they want deterministic provider replay in the action wrapper.
+- The Workbench report artifact example intentionally uses a local provider snapshot path and no `secrets.*` values so the default integration can run without live provider credentials.

--- a/.github/examples/code-scanning-sarif.yml
+++ b/.github/examples/code-scanning-sarif.yml
@@ -23,6 +23,7 @@ jobs:
           output-path: results.sarif
           summary-template: compact
           github-step-summary: "true"
+          validate-sarif: "true"
           asset-context: assets.csv
           vex-files: |
             openvex.json

--- a/.github/examples/workbench-report-artifacts.yml
+++ b/.github/examples/workbench-report-artifacts.yml
@@ -1,0 +1,58 @@
+name: Example Consumer Workflow - Workbench Report Artifacts
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  reports:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Generate locked analysis JSON
+        id: analyze
+        uses: Noetheon/vuln-prioritizer-workbench@vX.Y.Z
+        with:
+          mode: analyze
+          input: trivy-results.json
+          input-format: trivy-json
+          output-format: json
+          output-path: analysis.json
+          provider-snapshot-file: provider-snapshot.json
+          locked-provider-data: "true"
+          summary-output-path: summary.md
+          summary-template: compact
+          github-step-summary: "true"
+
+      - name: Render Workbench Markdown report
+        id: markdown-report
+        uses: Noetheon/vuln-prioritizer-workbench@vX.Y.Z
+        with:
+          mode: workbench-report
+          input: ${{ steps.analyze.outputs.report-path }}
+          output-format: markdown
+          output-path: workbench-report.md
+
+      - name: Render Workbench JSON report
+        id: json-report
+        uses: Noetheon/vuln-prioritizer-workbench@vX.Y.Z
+        with:
+          mode: workbench-report
+          input: ${{ steps.analyze.outputs.report-path }}
+          output-format: json
+          output-path: workbench-report.json
+
+      - name: Upload report artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: vuln-prioritization-workbench-reports
+          path: |
+            ${{ steps.markdown-report.outputs.report-path }}
+            ${{ steps.json-report.outputs.report-path }}
+            ${{ steps.analyze.outputs.summary-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,78 @@ jobs:
       - name: Run local-equivalent workflow gate
         run: make workflow-check
 
+  action-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Prepare action smoke output directory
+        run: mkdir -p build/vpw-082-action-smoke
+
+      - name: Generate locked analysis JSON
+        id: analyze
+        uses: ./
+        with:
+          mode: analyze
+          input: data/input_fixtures/trivy_report.json
+          input-format: trivy-json
+          output-format: json
+          output-path: build/vpw-082-action-smoke/analysis.json
+          provider-snapshot-file: data/demo_provider_snapshot.json
+          locked-provider-data: "true"
+          summary-output-path: build/vpw-082-action-smoke/summary.md
+          summary-template: compact
+          github-step-summary: "true"
+
+      - name: Render Workbench Markdown report
+        id: markdown-report
+        uses: ./
+        with:
+          mode: workbench-report
+          input: ${{ steps.analyze.outputs.report-path }}
+          output-format: markdown
+          output-path: build/vpw-082-action-smoke/workbench-report.md
+
+      - name: Render Workbench JSON report
+        id: json-report
+        uses: ./
+        with:
+          mode: workbench-report
+          input: ${{ steps.analyze.outputs.report-path }}
+          output-format: json
+          output-path: build/vpw-082-action-smoke/workbench-report.json
+
+      - name: Verify action smoke artifacts
+        run: |
+          test -s build/vpw-082-action-smoke/analysis.json
+          test -s build/vpw-082-action-smoke/summary.md
+          test -s build/vpw-082-action-smoke/workbench-report.md
+          test -s build/vpw-082-action-smoke/workbench-report.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path("build/vpw-082-action-smoke")
+          analysis = json.loads((root / "analysis.json").read_text(encoding="utf-8"))
+          report = json.loads((root / "workbench-report.json").read_text(encoding="utf-8"))
+          assert analysis["metadata"]["locked_provider_data"] is True
+          assert analysis["metadata"]["provider_snapshot_file"] == "data/demo_provider_snapshot.json"
+          assert report["metadata"]["output_format"] == "json"
+          assert (root / "workbench-report.md").read_text(encoding="utf-8").startswith("# ")
+          PY
+
+      - name: Upload VPW-082 action smoke artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: vpw-082-action-smoke-reports
+          path: |
+            build/vpw-082-action-smoke/analysis.json
+            build/vpw-082-action-smoke/summary.md
+            build/vpw-082-action-smoke/workbench-report.md
+            build/vpw-082-action-smoke/workbench-report.json
+
   frontend:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Replace `vX.Y.Z` with the release tag or commit SHA you want to consume. `summar
 
 Common analyze/compare/snapshot Action inputs include `waiver-file`, `defensive-context-file`, `hide-waived`, `fail-on-provider-error`, `fail-on-expired-waivers`, `fail-on-review-due-waivers`, `priority`, `kev-only`, `min-cvss`, `min-epss`, `sort-by`, `max-cves`, `provider-snapshot-file`, `locked-provider-data`, `max-provider-age-hours`, `fail-on-stale-provider-data`, `no-cache`, `cache-dir`, `cache-ttl-hours`, `nvd-api-key-env`, `offline-kev-file`, and `offline-attack-file`. `defensive-context-file` passes a local/offline JSON context overlay only; it does not fetch advisory data and does not change base priority scoring. Report modes include `report-html`, `workbench-report`, `report-evidence-bundle`, `verify-evidence-bundle`, and `validate-sarif`; set `validate-sarif: "true"` in analysis/report steps when a SARIF output should fail the job before upload if the local SARIF contract is not met.
 
-See [docs/integrations/reporting_and_ci.md](docs/integrations/reporting_and_ci.md) for the full contract and CI patterns, plus [docs/examples/github_action_summary_templates.md](docs/examples/github_action_summary_templates.md) for compact vs detailed examples.
+See [docs/integrations/reporting_and_ci.md](docs/integrations/reporting_and_ci.md) for the full contract and CI patterns, including the checked-in [Workbench Markdown/JSON artifact workflow](.github/examples/workbench-report-artifacts.yml), plus [docs/examples/github_action_summary_templates.md](docs/examples/github_action_summary_templates.md) for compact vs detailed examples.
 
 ## Development
 

--- a/backend/tests/test_github_action_contract.py
+++ b/backend/tests/test_github_action_contract.py
@@ -4,6 +4,15 @@ import yaml
 from paths import REPO_ROOT
 
 ACTION_FILE = REPO_ROOT / "action.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+EXAMPLES_DIR = REPO_ROOT / ".github" / "examples"
+EXAMPLES_README = EXAMPLES_DIR / "README.md"
+INTEGRATION_DOC = REPO_ROOT / "docs" / "integrations" / "reporting_and_ci.md"
+README_FILE = REPO_ROOT / "README.md"
+MKDOCS_FILE = REPO_ROOT / "mkdocs.yml"
+VPW_082_EVIDENCE = REPO_ROOT / "docs" / "evidence" / "vpw-082-github-action-reports.md"
+SARIF_EXAMPLE = EXAMPLES_DIR / "code-scanning-sarif.yml"
+WORKBENCH_REPORT_EXAMPLE = EXAMPLES_DIR / "workbench-report-artifacts.yml"
 
 
 def _load_action_definition() -> dict[str, object]:
@@ -146,3 +155,136 @@ def test_action_installs_backend_package_from_composite_checkout() -> None:
 
     assert install_step["name"] == "Install vuln-prioritizer from action checkout"
     assert 'python -m pip install "${{ github.action_path }}/backend"' in install_step["run"]
+
+
+def test_vpw082_workbench_report_example_generates_markdown_and_json_secretless() -> None:
+    raw = WORKBENCH_REPORT_EXAMPLE.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(raw)
+    steps = workflow["jobs"]["reports"]["steps"]
+    steps_by_id = {step["id"]: step for step in steps if "id" in step}
+    upload_step = next(step for step in steps if step.get("uses") == "actions/upload-artifact@v7")
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert "secrets." not in raw
+    assert "nvd-api-key-env" not in raw
+
+    analyze = steps_by_id["analyze"]
+    assert analyze["uses"] == "Noetheon/vuln-prioritizer-workbench@vX.Y.Z"
+    assert analyze["with"] == {
+        "mode": "analyze",
+        "input": "trivy-results.json",
+        "input-format": "trivy-json",
+        "output-format": "json",
+        "output-path": "analysis.json",
+        "provider-snapshot-file": "provider-snapshot.json",
+        "locked-provider-data": "true",
+        "summary-output-path": "summary.md",
+        "summary-template": "compact",
+        "github-step-summary": "true",
+    }
+
+    markdown_report = steps_by_id["markdown-report"]
+    json_report = steps_by_id["json-report"]
+    for step in (markdown_report, json_report):
+        assert step["uses"] == "Noetheon/vuln-prioritizer-workbench@vX.Y.Z"
+        assert step["with"]["mode"] == "workbench-report"
+        assert step["with"]["input"] == "${{ steps.analyze.outputs.report-path }}"
+
+    assert markdown_report["with"]["output-format"] == "markdown"
+    assert markdown_report["with"]["output-path"] == "workbench-report.md"
+    assert json_report["with"]["output-format"] == "json"
+    assert json_report["with"]["output-path"] == "workbench-report.json"
+    assert upload_step["with"]["name"] == "vuln-prioritization-workbench-reports"
+    upload_paths = upload_step["with"]["path"]
+    assert "${{ steps.markdown-report.outputs.report-path }}" in upload_paths
+    assert "${{ steps.json-report.outputs.report-path }}" in upload_paths
+    assert "${{ steps.analyze.outputs.summary-path }}" in upload_paths
+
+
+def test_vpw082_sarif_example_validates_before_upload() -> None:
+    workflow = yaml.safe_load(SARIF_EXAMPLE.read_text(encoding="utf-8"))
+    prioritize_step = next(
+        step for step in workflow["jobs"]["prioritize"]["steps"] if step.get("id") == "prioritize"
+    )
+    upload_step = next(
+        step
+        for step in workflow["jobs"]["prioritize"]["steps"]
+        if step.get("uses") == "github/codeql-action/upload-sarif@v4"
+    )
+
+    assert prioritize_step["with"]["output-format"] == "sarif"
+    assert prioritize_step["with"]["validate-sarif"] == "true"
+    assert upload_step["with"]["sarif_file"] == "${{ steps.prioritize.outputs.report-path }}"
+
+
+def test_vpw082_ci_action_smoke_runs_local_action_and_uploads_artifacts() -> None:
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["action-smoke"]
+    steps = job["steps"]
+    steps_by_id = {step["id"]: step for step in steps if "id" in step}
+    upload_step = next(
+        step for step in steps if step.get("name") == "Upload VPW-082 action smoke artifacts"
+    )
+
+    assert job["runs-on"] == "ubuntu-latest"
+
+    local_action_steps = [step for step in steps if step.get("uses") == "./"]
+    assert [step["id"] for step in local_action_steps] == [
+        "analyze",
+        "markdown-report",
+        "json-report",
+    ]
+
+    analyze = steps_by_id["analyze"]
+    assert analyze["with"]["mode"] == "analyze"
+    assert analyze["with"]["input"] == "data/input_fixtures/trivy_report.json"
+    assert analyze["with"]["input-format"] == "trivy-json"
+    assert analyze["with"]["output-format"] == "json"
+    assert analyze["with"]["provider-snapshot-file"] == "data/demo_provider_snapshot.json"
+    assert analyze["with"]["locked-provider-data"] == "true"
+    assert analyze["with"]["github-step-summary"] == "true"
+
+    markdown_report = steps_by_id["markdown-report"]
+    json_report = steps_by_id["json-report"]
+    for step in (markdown_report, json_report):
+        assert step["with"]["mode"] == "workbench-report"
+        assert step["with"]["input"] == "${{ steps.analyze.outputs.report-path }}"
+    assert markdown_report["with"]["output-format"] == "markdown"
+    assert json_report["with"]["output-format"] == "json"
+
+    verify_step = next(
+        step for step in steps if step.get("name") == "Verify action smoke artifacts"
+    )
+    verify_script = verify_step["run"]
+    assert "test -s build/vpw-082-action-smoke/analysis.json" in verify_script
+    assert "test -s build/vpw-082-action-smoke/workbench-report.md" in verify_script
+    assert "test -s build/vpw-082-action-smoke/workbench-report.json" in verify_script
+    assert 'analysis["metadata"]["locked_provider_data"] is True' in verify_script
+    assert (
+        'analysis["metadata"]["provider_snapshot_file"] == "data/demo_provider_snapshot.json"'
+        in verify_script
+    )
+    assert 'report["metadata"]["output_format"] == "json"' in verify_script
+
+    assert upload_step["uses"] == "actions/upload-artifact@v7"
+    assert upload_step["with"]["name"] == "vpw-082-action-smoke-reports"
+    assert "build/vpw-082-action-smoke/workbench-report.md" in upload_step["with"]["path"]
+    assert "build/vpw-082-action-smoke/workbench-report.json" in upload_step["with"]["path"]
+
+
+def test_vpw082_docs_and_evidence_link_the_action_report_flow() -> None:
+    examples_readme = EXAMPLES_README.read_text(encoding="utf-8")
+    integration_doc = INTEGRATION_DOC.read_text(encoding="utf-8")
+    readme = README_FILE.read_text(encoding="utf-8")
+    evidence = VPW_082_EVIDENCE.read_text(encoding="utf-8")
+    mkdocs = MKDOCS_FILE.read_text(encoding="utf-8")
+
+    assert "workbench-report-artifacts.yml" in examples_readme
+    assert "report workbench --input analysis.json --format markdown|json" in examples_readme
+    assert "workbench-report-artifacts.yml" in integration_doc
+    assert "provider-snapshot-file: provider-snapshot.json" in integration_doc
+    assert 'locked-provider-data: "true"' in integration_doc
+    assert "workbench-report-artifacts.yml" in readme
+    assert "action-smoke" in evidence
+    assert "no `secrets.*`" in evidence
+    assert "evidence/vpw-082-github-action-reports.md" in mkdocs

--- a/docs/evidence/vpw-082-github-action-reports.md
+++ b/docs/evidence/vpw-082-github-action-reports.md
@@ -1,0 +1,39 @@
+# VPW-082 GitHub Action Reports
+
+## Scope
+
+VPW-082 requires a documented GitHub Action path for CI/CD vulnerability prioritization reports, including scan-artifact input, provider snapshot replay, output format selection, Markdown/JSON report artifacts, no live secrets by default, example workflow coverage, and a CI smoke.
+
+## Implementation Evidence
+
+- The composite action remains rooted at `action.yml` and exposes `mode: analyze`, `mode: workbench-report`, `provider-snapshot-file`, `locked-provider-data`, `output-format`, and `output-path`.
+- `.github/examples/workbench-report-artifacts.yml` documents a consumer workflow that analyzes `trivy-results.json` with `provider-snapshot-file: provider-snapshot.json`, renders Workbench Markdown and JSON reports, uploads them as artifacts, and uses no `secrets.*` or `nvd-api-key-env` references.
+- `.github/examples/code-scanning-sarif.yml` enables `validate-sarif: "true"` so SARIF uploads have a local contract gate before Code Scanning upload.
+- `.github/workflows/ci.yml` includes an `action-smoke` job that runs the local composite action with `data/input_fixtures/trivy_report.json` and `data/demo_provider_snapshot.json`, then renders and verifies Markdown/JSON Workbench artifacts.
+
+## Local Evidence
+
+| Check | Result |
+| --- | --- |
+| `python3 -m pytest -q backend/tests/test_github_action_contract.py --no-cov` | Passed: 9 passed in 0.11s. Validates the action contract, no-secret Workbench report example, SARIF validation example, CI `action-smoke` wiring, and docs/evidence links. |
+| `python3 -m pytest -q backend/tests/test_v11_output_contracts.py --no-cov` | Passed: 24 passed in 0.48s. Revalidates existing output/action workflow contracts. |
+| Direct CLI smoke equivalent for the `action-smoke` artifact flow | Passed. Generated `build/vpw-082-action-smoke-local/analysis.json`, `summary.md`, `workbench-report.md`, and `workbench-report.json`; verified `locked_provider_data: true`, `provider_snapshot_file: data/demo_provider_snapshot.json`, JSON `metadata.output_format: json`, and Markdown heading output. |
+| `make actionlint-check` | Passed. Validates `.github/workflows/*.yml` and `.github/examples/*.yml`. |
+| `make docs-check` | Passed. MkDocs built successfully with this evidence page in navigation. |
+| `make check` | Passed: ruff format/check, mypy, 891 passed, 7 skipped, total coverage 90.75%. |
+| `make workflow-check` | Passed. Reran `make check`, `make docs-check`, `make actionlint-check`, pre-commit, package build, and `twine check dist/*` for the local CI-equivalent gate. |
+
+## CI Artifact Evidence
+
+The checked-in `.github/workflows/ci.yml` `action-smoke` job uploads the hosted runner artifacts under `vpw-082-action-smoke-reports`:
+
+- `build/vpw-082-action-smoke/analysis.json`
+- `build/vpw-082-action-smoke/summary.md`
+- `build/vpw-082-action-smoke/workbench-report.md`
+- `build/vpw-082-action-smoke/workbench-report.json`
+
+The PR closeout should link the successful hosted Actions run after GitHub executes this job.
+
+## Residual Risk
+
+The checked-in `action-smoke` job proves the local composite action and fixture-backed report artifact flow. It does not prove each consumer repository has a matching scanner export or provider snapshot file; consumer workflows must provide their own `trivy-results.json` and `provider-snapshot.json` paths or adapt the example names.

--- a/docs/integrations/reporting_and_ci.md
+++ b/docs/integrations/reporting_and_ci.md
@@ -23,8 +23,11 @@ Today the CLI supports:
 - `data verify`
 - `data export-provider-snapshot`
 - `report html --input analysis.json --output report.html`
+- `report workbench --input analysis.json --output report.md --format markdown`
+- `report workbench --input analysis.json --output report.json --format json`
 - `report evidence-bundle --input analysis.json --output evidence.zip`
 - `report verify-evidence-bundle --input evidence.zip --format json`
+- `report validate-sarif --input results.sarif --format json`
 - `attack validate|coverage|navigator-layer`
 
 The repository root also exposes a composite GitHub Action via [`action.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/action.yml).
@@ -294,6 +297,7 @@ Consumer workflow examples:
 - [`.github/examples/code-scanning-sarif.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/code-scanning-sarif.yml)
 - [`.github/examples/pr-comment-report.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/pr-comment-report.yml)
 - [`.github/examples/html-report-artifact.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/html-report-artifact.yml)
+- [`.github/examples/workbench-report-artifacts.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/workbench-report-artifacts.yml)
 - [GitHub Action summary templates](../examples/github_action_summary_templates.md)
 
 Example output artifacts:
@@ -374,6 +378,40 @@ Detailed HTML artifact flow with a reusable Markdown summary:
     summary-output-path: report-summary.md
     summary-template: detailed
     github-step-summary: "true"
+```
+
+Workbench Markdown and JSON artifact flow with deterministic provider replay:
+
+```yaml
+- name: Generate locked analysis JSON
+  id: analyze
+  uses: Noetheon/vuln-prioritizer-workbench@vX.Y.Z
+  with:
+    mode: analyze
+    input: trivy-results.json
+    input-format: trivy-json
+    output-format: json
+    output-path: analysis.json
+    provider-snapshot-file: provider-snapshot.json
+    locked-provider-data: "true"
+
+- name: Render Workbench Markdown report
+  id: markdown-report
+  uses: Noetheon/vuln-prioritizer-workbench@vX.Y.Z
+  with:
+    mode: workbench-report
+    input: ${{ steps.analyze.outputs.report-path }}
+    output-format: markdown
+    output-path: workbench-report.md
+
+- name: Render Workbench JSON report
+  id: json-report
+  uses: Noetheon/vuln-prioritizer-workbench@vX.Y.Z
+  with:
+    mode: workbench-report
+    input: ${{ steps.analyze.outputs.report-path }}
+    output-format: json
+    output-path: workbench-report.json
 ```
 
 Replace `vX.Y.Z` with the release tag or commit SHA you intend to consume. This document tracks the current `main` branch contract, so do not assume the latest tagged release already includes every example shown here.

--- a/docs/playbooks/ci_container_scanning.md
+++ b/docs/playbooks/ci_container_scanning.md
@@ -88,6 +88,7 @@ The examples here stay current:
 - [SARIF example workflow](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/code-scanning-sarif.yml)
 - [PR comment example workflow](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/pr-comment-report.yml)
 - [HTML artifact example workflow](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/html-report-artifact.yml)
+- [Workbench Markdown/JSON artifact workflow](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/examples/workbench-report-artifacts.yml)
 
 ## Suggested operator sequence
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - VPW-078 CTID Mappings Provider: evidence/vpw-078-ctid-mappings-provider.md
       - VPW-080 SARIF Export Validation: evidence/vpw-080-sarif-export-validation.md
       - VPW-081 Scoped API Tokens: evidence/vpw-081-api-token-scopes.md
+      - VPW-082 GitHub Action Reports: evidence/vpw-082-github-action-reports.md
       - Historical Evidence Archive: evidence.md
       - Current State Audit: evidence/current_state_audit.md
       - V0.3 Submission Checklist: evidence/final_submission_checklist.md


### PR DESCRIPTION
## Summary
- add a consumer workflow example for locked provider snapshot replay plus Workbench Markdown and JSON report artifacts
- add a CI `action-smoke` job that runs the local composite action with fixture input, verifies generated Markdown/JSON artifacts, and uploads them
- document the VPW-082 evidence path and tighten action contract tests for no-secret defaults, SARIF validation, docs, and CI wiring

## Verification
- `python3 -m pytest -q backend/tests/test_github_action_contract.py --no-cov` -> 9 passed
- `python3 -m pytest -q backend/tests/test_v11_output_contracts.py --no-cov` -> 24 passed
- direct CLI smoke equivalent for `action-smoke` -> generated and verified locked analysis JSON, summary, Workbench Markdown, and Workbench JSON
- `make actionlint-check` -> passed
- `make docs-check` -> passed
- `make check` -> 891 passed, 7 skipped, total coverage 90.75%
- `make workflow-check` -> passed, including package build and `twine check dist/*`

## Evidence
- `docs/evidence/vpw-082-github-action-reports.md`
- `.github/examples/workbench-report-artifacts.yml`
- `.github/workflows/ci.yml` `action-smoke` job uploads `vpw-082-action-smoke-reports`

## Residual Risk
- Hosted Actions output will be linked on issue closeout after GitHub runs the new `action-smoke` job.
- Consumer repositories still need to provide their own scanner export and provider snapshot paths.

Refs #188
