### PR TITLE
Clean up stale frontend styles and helpers

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -606,7 +606,6 @@ textarea:focus-visible,
   background: #c2410c;
 }
 
-.template-status,
 .data-services-summary {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -617,21 +616,17 @@ textarea:focus-visible,
   background: #d7e0dd;
 }
 
-.template-status div,
 .data-services-summary div {
   min-height: 74px;
   padding: 14px;
   background: #ffffff;
 }
 
-.template-status span,
-.template-status strong,
 .data-services-summary span,
 .data-services-summary strong {
   display: block;
 }
 
-.template-status span,
 .data-services-summary span {
   color: #64748b;
   font-size: 0.78rem;
@@ -639,7 +634,6 @@ textarea:focus-visible,
   text-transform: uppercase;
 }
 
-.template-status strong,
 .data-services-summary strong {
   margin-top: 6px;
   overflow-wrap: anywhere;
@@ -4127,301 +4121,6 @@ td {
   padding: 18px;
 }
 
-.reports-workflow {
-  display: grid;
-  gap: 18px;
-  padding: 18px;
-}
-
-.reports-readiness-panel,
-.report-run-panel,
-.report-action-card,
-.report-history-panel {
-  border: 1px solid #d7e0dd;
-  border-radius: 8px;
-  background: #ffffff;
-}
-
-.reports-readiness-panel {
-  display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.9fr);
-  gap: 16px;
-  padding: 18px;
-}
-
-.reports-readiness-panel span {
-  color: #64748b;
-  font-size: 0.78rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.reports-readiness-panel h3,
-.reports-readiness-panel p {
-  margin: 0;
-}
-
-.reports-readiness-panel h3 {
-  margin-top: 6px;
-  color: #111827;
-  font-size: 1.1rem;
-}
-
-.reports-readiness-panel p {
-  margin-top: 8px;
-  max-width: 72ch;
-  color: #475569;
-  line-height: 1.45;
-}
-
-.report-readiness-facts {
-  display: grid;
-  gap: 1px;
-  margin: 0;
-  overflow: hidden;
-  border: 1px solid #edf1ef;
-  border-radius: 8px;
-  background: #edf1ef;
-}
-
-.report-readiness-facts div {
-  display: grid;
-  grid-template-columns: 120px minmax(0, 1fr);
-  gap: 10px;
-  min-height: 38px;
-  padding: 9px 10px;
-  background: #f8fafc;
-}
-
-.report-readiness-facts dt,
-.report-readiness-facts dd {
-  margin: 0;
-}
-
-.report-readiness-facts dt {
-  color: #64748b;
-  font-size: 0.72rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.report-readiness-facts dd {
-  overflow-wrap: anywhere;
-  color: #111827;
-  font-size: 0.88rem;
-}
-
-.report-card-grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.report-run-panel {
-  display: grid;
-  grid-template-columns: minmax(260px, 1.4fr) repeat(2, minmax(140px, 0.6fr));
-  gap: 12px;
-  align-items: end;
-  padding: 16px;
-}
-
-.report-run-panel label,
-.report-run-panel div {
-  display: grid;
-  gap: 7px;
-}
-
-.report-run-panel span {
-  color: #64748b;
-  font-size: 0.74rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.report-run-panel strong {
-  overflow-wrap: anywhere;
-  color: #111827;
-}
-
-.report-run-panel select {
-  min-height: 40px;
-  width: 100%;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 0 11px;
-  background: #ffffff;
-  color: #111827;
-  font: inherit;
-}
-
-.report-action-card {
-  display: grid;
-  align-content: space-between;
-  gap: 16px;
-  min-height: 238px;
-  padding: 16px;
-}
-
-.report-card-header {
-  display: grid;
-  grid-template-columns: 32px minmax(0, 1fr);
-  gap: 10px;
-  align-items: start;
-}
-
-.report-card-header svg {
-  color: #0f766e;
-}
-
-.report-card-header span {
-  display: block;
-  color: #64748b;
-  font-size: 0.76rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.report-card-header h3 {
-  margin: 4px 0 0;
-  color: #111827;
-  font-size: 1rem;
-  line-height: 1.25;
-}
-
-.report-action-card p {
-  margin: 0;
-  color: #475569;
-  font-size: 0.9rem;
-  line-height: 1.45;
-}
-
-.report-card-footer {
-  display: grid;
-  gap: 10px;
-}
-
-.report-stage-pill {
-  width: fit-content;
-  border-radius: 8px;
-  padding: 5px 9px;
-  background: #eff6ff;
-  color: #1d4ed8;
-  font-size: 0.72rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.report-placeholder-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 38px;
-  border: 1px solid #d7e0dd;
-  border-radius: 8px;
-  padding: 0 12px;
-  background: #f8fafc;
-  color: #334155;
-  font-weight: 800;
-}
-
-.report-placeholder-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.72;
-}
-
-.report-placeholder-button:not(:disabled) {
-  cursor: pointer;
-  background: #0f766e;
-  color: #ffffff;
-}
-
-.report-placeholder-button:not(:disabled):hover {
-  background: #115e59;
-}
-
-.report-history-panel {
-  display: grid;
-  gap: 14px;
-  padding: 18px;
-}
-
-.report-history-list {
-  display: grid;
-  gap: 1px;
-  margin: 0;
-  overflow: hidden;
-  border: 1px solid #edf1ef;
-  border-radius: 8px;
-  padding: 0;
-  background: #edf1ef;
-  list-style: none;
-}
-
-.report-history-row {
-  display: grid;
-  grid-template-columns: minmax(180px, 1.4fr) minmax(100px, 0.7fr) minmax(
-      150px,
-      0.9fr
-    ) minmax(180px, 1fr);
-  gap: 10px;
-  min-height: 42px;
-  align-items: center;
-  padding: 10px 12px;
-  background: #ffffff;
-  color: #1f2937;
-  font-size: 0.9rem;
-}
-
-.report-history-row.heading {
-  color: #64748b;
-  font-size: 0.74rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.report-history-row.empty {
-  background: #f8fafc;
-}
-
-.report-history-row strong,
-.report-history-row small {
-  display: block;
-  overflow-wrap: anywhere;
-}
-
-.report-history-row small {
-  margin-top: 3px;
-  color: #64748b;
-  font-size: 0.76rem;
-}
-
-.report-history-actions {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-}
-
-.report-download-button {
-  display: inline-flex;
-  min-height: 36px;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  border: 1px solid #0f766e;
-  border-radius: 8px;
-  padding: 0 11px;
-  background: #ffffff;
-  color: #0f766e;
-  font-weight: 800;
-  cursor: pointer;
-}
-
-.report-download-button:hover {
-  background: #ecfdf5;
-}
-
 .panel-header {
   display: flex;
   align-items: center;
@@ -5057,16 +4756,10 @@ td {
   .run-counts,
   .provider-summary-grid,
   .provider-card-grid,
-  .reports-readiness-panel,
-  .report-run-panel,
-  .report-card-grid,
-  .report-readiness-facts,
-  .report-history-row,
   .governance-debt-grid,
   .summary-list,
   .project-meta,
   .content-grid,
-  .template-status,
   .data-services-summary {
     grid-template-columns: 1fr;
   }
@@ -5204,23 +4897,19 @@ td {
   }
 
   /* Data services bar */
-  .template-status,
   .data-services-summary {
     background: #2d3b40;
     border-color: #2d3b40;
   }
 
-  .template-status div,
   .data-services-summary div {
     background: #1a2428;
   }
 
-  .template-status span,
   .data-services-summary span {
     color: #94a3b8;
   }
 
-  .template-status strong,
   .data-services-summary strong {
     color: #f1f5f9;
   }
@@ -5231,13 +4920,10 @@ td {
   .finding-overview-card,
   .provider-summary-card,
   .provider-source-card,
-  .report-action-card,
   .project-meta,
   .why-priority-panel,
   .occurrences-panel,
-  .ttp-panel,
-  .report-history-panel,
-  .reports-readiness-panel {
+  .ttp-panel {
     background: #1a2428;
     border-color: #2d3b40;
   }

--- a/frontend/src/lib/risk-format.ts
+++ b/frontend/src/lib/risk-format.ts
@@ -15,12 +15,6 @@ export function findingPriorityLabel(
   return formatLabel(priority)
 }
 
-export function findingPriorityClass(
-  priority: FindingPriority | null | undefined,
-) {
-  return priority ?? "low"
-}
-
 export function findingPriorityTone(
   priority: FindingPriority | null | undefined,
 ): FindingPriorityTone {
@@ -43,44 +37,8 @@ export function formatEpss(value: number | null | undefined) {
     : `${Math.round(value * 1000) / 10}%`
 }
 
-export function epssThresholdLabel(value: number | null | undefined) {
-  if (value === null || value === undefined) {
-    return "Missing"
-  }
-  if (value >= 0.7) {
-    return "Very high"
-  }
-  if (value >= 0.4) {
-    return "High"
-  }
-  if (value >= 0.1) {
-    return "Elevated"
-  }
-  return "Low"
-}
-
-export function cvssSeverityLabel(value: number | null | undefined) {
-  if (value === null || value === undefined) {
-    return "Missing"
-  }
-  if (value >= 9) {
-    return "Critical"
-  }
-  if (value >= 7) {
-    return "High"
-  }
-  if (value >= 4) {
-    return "Medium"
-  }
-  return "Low"
-}
-
 export function formatKev(value: boolean | null | undefined) {
   return value ? "Yes" : "No"
-}
-
-export function kevBadgeClass(value: boolean | null | undefined) {
-  return value ? "kev-pill matched" : "kev-pill"
 }
 
 export function runStatusLabel(status: AnalysisRunPublic["status"]) {


### PR DESCRIPTION
## What changed
- Removed stale legacy report and template status CSS that is no longer used after VPW route integration.
- Removed unused legacy formatting helpers from risk-format.ts.
- Kept behavior unchanged.

## Scope
- Frontend hygiene only.
- No UI redesign.
- No backend changes.
- No generated API client changes.
- No evidence or screenshot changes.

## Validation
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] npm --prefix frontend run test -- tests/ui-smoke.spec.ts
- [x] npm --prefix frontend run test
- [x] git diff --check

## Notes
- App.tsx and index.css remain large and should be handled in a separate route architecture refactor.
- Existing Vite large chunk warning remains non-blocking.