### PR TITLE
Optimize GitHub Actions cost and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,18 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
+
+# Cancel superseded commits on the same PR or branch so stale CI does not
+# continue consuming runner minutes after a newer push arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -102,6 +112,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: vpw-082-action-smoke-reports
+          retention-days: 3
           path: |
             build/vpw-082-action-smoke/analysis.json
             build/vpw-082-action-smoke/summary.md
@@ -155,13 +166,19 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run frontend Playwright smoke
+        if: github.event_name == 'pull_request'
+        run: npm --prefix frontend run test -- tests/ui-smoke.spec.ts
+
+      - name: Run full frontend Playwright suite
+        if: github.event_name != 'pull_request'
         run: npm --prefix frontend run test
 
-      - name: Upload frontend Playwright evidence
-        if: always()
+      - name: Upload frontend Playwright failure evidence
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: frontend-playwright-evidence
+          retention-days: 3
           path: |
             docs/evidence/vpw-047-core-workbench-flow.png
             frontend/test-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,12 @@ on:
     - cron: "17 4 * * 1"
   workflow_dispatch:
 
+# Cancel superseded CodeQL runs for the same PR/branch while keeping the
+# weekly and manual security analysis entry points intact.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,24 +2,76 @@ name: Docker
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
+
+# Keep only the newest Docker smoke run for each PR/branch. Docker builds are
+# the most expensive check in this repo, so stale runs should stop quickly.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  compose-smoke:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      run-docker: ${{ steps.scope.outputs.run-docker }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether Docker smoke is needed
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run-docker=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed_files="$(git diff --name-only "$base_sha"...HEAD)"
+          printf '%s\n' "$changed_files"
+
+          # Docs/evidence-only PRs still get a successful Docker workflow, but
+          # skip the expensive compose build because runtime behavior cannot
+          # change from those paths.
+          if printf '%s\n' "$changed_files" | grep -Ev '^(docs/|.*\.md$)' >/dev/null; then
+            echo "run-docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-docker=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  compose-smoke:
+    runs-on: ubuntu-latest
+    needs: changes
+
+    steps:
+      - name: Skip Docker smoke for docs/evidence-only PR
+        if: needs.changes.outputs.run-docker != 'true'
+        run: echo "No runtime-impacting files changed; Docker compose smoke skipped."
+
+      - name: Check out repository
+        if: needs.changes.outputs.run-docker == 'true'
+        uses: actions/checkout@v6
 
       - name: Build and start Workbench
+        if: needs.changes.outputs.run-docker == 'true'
         run: docker compose -f compose.yml -f compose.override.yml up -d --build backend frontend
 
       - name: Wait for health endpoint
+        if: needs.changes.outputs.run-docker == 'true'
         run: |
           curl --retry 20 --retry-delay 2 --retry-connrefused --retry-all-errors --fail \
             http://127.0.0.1:8000/api/v1/workbench/status
@@ -27,6 +79,7 @@ jobs:
             http://127.0.0.1:8000/api/v1/utils/health-check/
 
       - name: Wait for frontend shell
+        if: needs.changes.outputs.run-docker == 'true'
         run: |
           curl --retry 20 --retry-delay 2 --retry-connrefused --retry-all-errors --fail \
             http://127.0.0.1:5173/
@@ -34,12 +87,13 @@ jobs:
             http://127.0.0.1:5173/login
 
       - name: Show service status
+        if: needs.changes.outputs.run-docker == 'true'
         run: docker compose -f compose.yml -f compose.override.yml ps
 
       - name: Show service logs on failure
-        if: failure()
+        if: failure() && needs.changes.outputs.run-docker == 'true'
         run: docker compose -f compose.yml -f compose.override.yml logs --no-color
 
       - name: Stop Workbench
-        if: always()
+        if: always() && needs.changes.outputs.run-docker == 'true'
         run: docker compose -f compose.yml -f compose.override.yml down -v --remove-orphans

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -5,6 +5,12 @@ on:
     - cron: "23 4 * * 1"
   workflow_dispatch:
 
+# Weekly/manual maintenance can be expensive; cancel an older copy when the
+# same workflow is re-run for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -38,6 +44,7 @@ jobs:
         with:
           name: maintenance-release-check-debug
           if-no-files-found: ignore
+          retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
             docs/example*.json
@@ -99,6 +106,7 @@ jobs:
         with:
           name: maintenance-install-smoke-debug-${{ matrix.os }}-${{ matrix.install-path }}
           if-no-files-found: ignore
+          retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
             docs/example*.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - "v*"
   workflow_dispatch:
 
+# Release runs are scoped by ref, so a new tag does not cancel another tag.
+# Re-running the same ref cancels stale work before publishing artifacts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -90,6 +96,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-dist
+          retention-days: 3
           path: dist/*
 
       - name: Upload release debug artifacts on failure
@@ -98,6 +105,7 @@ jobs:
         with:
           name: release-debug-artifacts
           if-no-files-found: ignore
+          retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
             docs/example*.json
@@ -199,6 +207,7 @@ jobs:
         with:
           name: verify-pypi-debug-artifacts
           if-no-files-found: ignore
+          retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
             docs/example*.json

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -3,6 +3,12 @@ name: TestPyPI Publish
 on:
   workflow_dispatch:
 
+# Manual TestPyPI runs can be repeated while debugging packaging. Keep only the
+# newest run for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -54,6 +60,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-dist
+          retention-days: 3
           path: dist/*
 
       - name: Upload TestPyPI build debug artifacts on failure
@@ -62,6 +69,7 @@ jobs:
         with:
           name: testpypi-build-debug-artifacts
           if-no-files-found: ignore
+          retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
             docs/example*.json
@@ -149,6 +157,7 @@ jobs:
         with:
           name: verify-testpypi-debug-artifacts
           if-no-files-found: ignore
+          retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
             docs/example*.json

--- a/docs/ci-cost-optimization.md
+++ b/docs/ci-cost-optimization.md
@@ -1,0 +1,79 @@
+# CI Cost Optimization
+
+This repository keeps PR safety checks active while reducing duplicate and
+long-running GitHub Actions work.
+
+## Pull Requests
+
+Pull requests to `main` run:
+
+- `CI / check` for the Python workflow gate on the supported Python matrix.
+- `CI / action-smoke` for the local GitHub Action smoke path.
+- `CI / frontend` for frontend lint, build, generated-client drift, and the
+  Playwright smoke spec.
+- `Docker / compose-smoke` for runtime-impacting changes.
+- `CodeQL / Analyze Python` for security analysis.
+
+Docs/evidence-only PRs still run a Docker workflow check, but the expensive
+Docker compose build is skipped after the workflow confirms that only
+documentation/evidence paths changed. This keeps the check from staying pending
+while avoiding container build minutes for non-runtime changes.
+
+## Pushes To Main
+
+Pushes to `main` run the post-merge version of the same CI workflows. The
+frontend job runs the full Playwright suite on `main`, while PRs run the smoke
+spec for faster feedback.
+
+## Manual Validation
+
+Use `workflow_dispatch` for manual full validation:
+
+- `CI` runs the Python gate, action smoke, frontend build/lint/client drift, and
+  full Playwright suite.
+- `Docker` runs the compose smoke check.
+- `Maintenance`, `Release`, and `TestPyPI Publish` remain manually runnable for
+  release and packaging validation.
+
+## Nightly Or Scheduled Validation
+
+Scheduled jobs remain limited to:
+
+- weekly CodeQL security analysis
+- weekly Maintenance release-check and install-smoke dry runs
+
+No new scheduled workflow was added.
+
+## Moved Out Of Every-Commit Execution
+
+- Feature-branch `push` events no longer run duplicate `CI` and `Docker`
+  workflows when a PR already runs the same validation.
+- Full Playwright no longer runs on every PR commit; PRs use the smoke spec,
+  while full Playwright runs on `main` and manual CI runs.
+- Playwright evidence is uploaded only on failure.
+
+## Artifact And Cache Policy
+
+- Failure/debug artifacts use short retention windows of three days.
+- Release/TestPyPI build artifacts use three-day retention because downstream
+  jobs in the same workflow consume them.
+- Existing `setup-python` pip caching remains in place.
+
+## Expected Cost Reduction
+
+The main savings come from:
+
+- cancelling stale runs after new pushes
+- avoiding duplicate feature-branch push workflows
+- replacing PR full Playwright with the smoke spec
+- skipping Docker compose for docs/evidence-only PRs
+- limiting artifact uploads and retention
+
+## Risks And Tradeoffs
+
+- Full Playwright regressions may be found after merge instead of during every
+  PR. The PR smoke suite still covers core route rendering.
+- Docker compose is skipped for docs/evidence-only changes based on changed file
+  paths. Runtime-impacting files still run Docker.
+- Required checks should not remain pending because workflows still run; expensive
+  steps are skipped inside jobs rather than by workflow path filters.


### PR DESCRIPTION
## What changed
- Added concurrency cancellation to reduce duplicate workflow runs.
- Limited duplicate feature-branch push workflows while keeping PR validation.
- Changed PR frontend validation to run Playwright smoke tests instead of the full suite.
- Kept full Playwright validation on main and manual workflow dispatch.
- Kept CodeQL active.
- Kept Docker compose smoke for runtime-impacting changes while skipping expensive compose steps for docs/evidence-only PRs.
- Reduced artifact retention and limited Playwright evidence uploads to failures.
- Documented the CI cost model in docs/ci-cost-optimization.md.

## Why
Recent frontend and evidence-heavy work caused expensive GitHub Actions usage because full CI, full Playwright and Docker ran too often on every commit. This keeps meaningful PR safety while reducing duplicate and long-running work.

## Scope
- GitHub Actions workflow optimization only.
- No frontend source changes.
- No backend source changes.
- No generated API client changes.
- No evidence screenshot changes.

## Validation
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] npm --prefix frontend run test -- tests/ui-smoke.spec.ts
- [x] Basic YAML parse for workflow files
- [x] git diff --check

## Tradeoffs
- Full Playwright regressions may now be found on main or manual full validation rather than every PR commit.
- Docker compose is skipped for docs/evidence-only PRs after path detection inside the job.
- Required checks should not remain pending because workflows still run and skip expensive steps internally.
