### PR TITLE
Extract Providers route container

### DIFF
--- a/frontend/src/components/providers/ProvidersRouteContainer.tsx
+++ b/frontend/src/components/providers/ProvidersRouteContainer.tsx
@@ -1,0 +1,26 @@
+import type { ProviderStatusPublic } from "@/api-client"
+
+import { ProvidersWorkbench } from "./ProvidersWorkbench"
+
+export type ProvidersRouteContainerProps = {
+  providerStatus: ProviderStatusPublic | null
+  providerStatusError: string
+  providerStatusLoading: boolean
+  onRefreshProviderStatus: () => Promise<void> | void
+}
+
+export function ProvidersRouteContainer({
+  onRefreshProviderStatus,
+  providerStatus,
+  providerStatusError,
+  providerStatusLoading,
+}: ProvidersRouteContainerProps) {
+  return (
+    <ProvidersWorkbench
+      onRefreshProviderStatus={() => void onRefreshProviderStatus()}
+      providerStatus={providerStatus}
+      providerStatusError={providerStatusError}
+      providerStatusLoading={providerStatusLoading}
+    />
+  )
+}

--- a/frontend/src/components/providers/index.ts
+++ b/frontend/src/components/providers/index.ts
@@ -1,1 +1,2 @@
+export { ProvidersRouteContainer } from "./ProvidersRouteContainer"
 export { ProvidersWorkbench } from "./ProvidersWorkbench"

--- a/frontend/src/workbench/WorkbenchShell.tsx
+++ b/frontend/src/workbench/WorkbenchShell.tsx
@@ -182,9 +182,9 @@ const ProjectsWorkbench = lazy(() =>
     default: module.ProjectsWorkbench,
   })),
 )
-const ProvidersWorkbench = lazy(() =>
-  import("../components/providers/ProvidersWorkbench").then((module) => ({
-    default: module.ProvidersWorkbench,
+const ProvidersRouteContainer = lazy(() =>
+  import("../components/providers/ProvidersRouteContainer").then((module) => ({
+    default: module.ProvidersRouteContainer,
   })),
 )
 const EvidenceCenter = lazy(() =>
@@ -4362,8 +4362,8 @@ export function WorkbenchShell({
                   ) : null}
                 </section>
               ) : currentPath === "/providers" ? (
-                <ProvidersWorkbench
-                  onRefreshProviderStatus={() => void refreshProviderStatus()}
+                <ProvidersRouteContainer
+                  onRefreshProviderStatus={refreshProviderStatus}
                   providerStatus={providerStatus}
                   providerStatusError={providerStatusError}
                   providerStatusLoading={providerStatusLoading}


### PR DESCRIPTION
## What changed
- Added a typed `ProvidersRouteContainer`.
- Kept provider status state, API loading, and refresh behavior in `WorkbenchShell` because the provider status is shared by the shell and other routes.
- Updated the providers component exports.
- Replaced direct `ProvidersWorkbench` route rendering with the route container.

## Scope
- Frontend architecture hygiene only.
- No UI changes.
- No backend changes.
- No generated API client changes.
- No evidence or data changes.

## Validation
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] npm --prefix frontend run test -- tests/ui-smoke.spec.ts
- [x] npm --prefix frontend run test
- [x] git diff --check

## Notes
- This is intentionally a small mechanical slice.
- `WorkbenchShell` line count does not drop yet because shared provider state remains in the shell by design.
- Later route container slices can apply the same pattern to Settings, Waivers, Imports, or Reports.