### PR TITLE
Extract Settings route container

### DIFF
--- a/frontend/src/components/settings/SettingsRouteContainer.tsx
+++ b/frontend/src/components/settings/SettingsRouteContainer.tsx
@@ -1,0 +1,10 @@
+import {
+  SettingsWorkbench,
+  type SettingsWorkbenchProps,
+} from "./SettingsWorkbench"
+
+export type SettingsRouteContainerProps = SettingsWorkbenchProps
+
+export function SettingsRouteContainer(props: SettingsRouteContainerProps) {
+  return <SettingsWorkbench {...props} />
+}

--- a/frontend/src/components/settings/SettingsWorkbench.tsx
+++ b/frontend/src/components/settings/SettingsWorkbench.tsx
@@ -36,9 +36,9 @@ import {
 } from "@/components/vpw"
 import { formatCacheAge, providerSnapshotSummary } from "@/lib/provider-format"
 
-type ApiTokenScope = NonNullable<ApiTokenCreate["scopes"]>[number]
+export type ApiTokenScope = NonNullable<ApiTokenCreate["scopes"]>[number]
 
-type SettingsWorkbenchProps = {
+export type SettingsWorkbenchProps = {
   apiTokenActionLoading: boolean
   apiTokenError: string
   apiTokenMessage: string

--- a/frontend/src/components/settings/index.ts
+++ b/frontend/src/components/settings/index.ts
@@ -1,1 +1,2 @@
 export * from "./SettingsWorkbench"
+export * from "./SettingsRouteContainer"

--- a/frontend/src/workbench/WorkbenchShell.tsx
+++ b/frontend/src/workbench/WorkbenchShell.tsx
@@ -192,9 +192,9 @@ const EvidenceCenter = lazy(() =>
     default: module.EvidenceCenter,
   })),
 )
-const SettingsWorkbench = lazy(() =>
-  import("../components/settings/SettingsWorkbench").then((module) => ({
-    default: module.SettingsWorkbench,
+const SettingsRouteContainer = lazy(() =>
+  import("../components/settings/SettingsRouteContainer").then((module) => ({
+    default: module.SettingsRouteContainer,
   })),
 )
 const WaiversWorkbench = lazy(() =>
@@ -4369,7 +4369,7 @@ export function WorkbenchShell({
                   providerStatusLoading={providerStatusLoading}
                 />
               ) : currentPath === "/settings" ? (
-                <SettingsWorkbench
+                <SettingsRouteContainer
                   apiTokenActionLoading={apiTokenActionLoading}
                   apiTokenError={apiTokenError}
                   apiTokenMessage={apiTokenMessage}


### PR DESCRIPTION
## What changed
- Added a typed `SettingsRouteContainer`.
- Kept Settings token state, create/revoke handlers, user/session/status and provider data ownership in `WorkbenchShell` to preserve behavior exactly.
- Updated Settings exports and lazy route wiring.

## Scope
- Frontend architecture hygiene only.
- No UI changes.
- No backend changes.
- No generated API client changes.
- No evidence, data or CSS changes.

## Validation
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] npm --prefix frontend run test -- tests/ui-smoke.spec.ts
- [x] npm --prefix frontend run test
- [x] git diff --check

## Notes
- This is intentionally a small wrapper extraction.
- `WorkbenchShell` line count does not drop yet because state remains in the shell by design.
- A later refactor should only move Settings token state if route navigation reset semantics are explicitly accepted.