### PR TITLE
Extract Findings data table

### DIFF
--- a/frontend/src/components/findings/FindingsDataTable.tsx
+++ b/frontend/src/components/findings/FindingsDataTable.tsx
@@ -1,0 +1,462 @@
+import { Link } from "@tanstack/react-router"
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Eye,
+} from "lucide-react"
+import type {
+  FindingPublic,
+  FindingsReadProjectFindingsData,
+} from "@/api-client"
+import {
+  CvssBadge,
+  EpssBadge,
+  FindingStatusBadge,
+  KevBadge,
+  PriorityBadge,
+  RiskScore,
+} from "@/components/risk"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
+  type ReactNode,
+} from "react"
+import { formatLabel as labelize, optionalText } from "@/lib/ui-copy"
+import { cn } from "@/lib/utils"
+
+type FindingsSort = NonNullable<FindingsReadProjectFindingsData["sort"]>
+type FindingsDirection = NonNullable<
+  FindingsReadProjectFindingsData["direction"]
+>
+export type QueueSort = FindingsSort | "component" | "owner"
+
+const defaultSortDirections: Record<QueueSort, FindingsDirection> = {
+  operational: "asc",
+  priority: "asc",
+  score: "desc",
+  cve: "asc",
+  component: "asc",
+  owner: "asc",
+  status: "asc",
+  epss: "desc",
+  cvss: "desc",
+  kev: "desc",
+  last_seen: "desc",
+}
+
+function componentLabel(finding: FindingPublic) {
+  const name = optionalText(finding.component_name)
+  return finding.component_version ? `${name} ${finding.component_version}` : name
+}
+
+function serviceLabel(finding: FindingPublic) {
+  return finding.business_service ?? finding.component_purl ?? "Service not linked"
+}
+
+function assetLabel(finding: FindingPublic) {
+  return finding.asset_name ?? finding.asset_key ?? finding.business_service ?? "N.A."
+}
+
+function ownerLabel(finding: FindingPublic) {
+  return finding.owner ?? finding.business_service ?? "Unassigned"
+}
+
+function findingWhyNow(finding: FindingPublic) {
+  return (
+    optionalText(finding.rationale) ??
+    optionalText(finding.recommended_action) ??
+    "No priority rationale has been recorded yet."
+  )
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "N.A."
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return "N.A."
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+function formatShortDate(value: string | null | undefined) {
+  if (!value) return "N.A."
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return "N.A."
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "2-digit",
+  }).format(date)
+}
+
+type SortHeaderProps = {
+  currentDirection: FindingsDirection
+  currentSort: QueueSort
+  label: string
+  onSort: (sort: QueueSort) => void
+  sort: QueueSort
+}
+
+function sortAriaState(
+  currentDirection: FindingsDirection,
+  currentSort: QueueSort,
+  sort: QueueSort,
+) {
+  if (currentSort !== sort) return undefined
+  return currentDirection === "asc" ? "ascending" : "descending"
+}
+
+function SortHeader({
+  currentDirection,
+  currentSort,
+  label,
+  onSort,
+  sort,
+}: SortHeaderProps) {
+  const active = currentSort === sort
+  const nextDirection: FindingsDirection = active
+    ? currentDirection === "asc"
+      ? "desc"
+      : "asc"
+    : defaultSortDirections[sort]
+  const Icon = active
+    ? currentDirection === "asc"
+      ? ArrowUp
+      : ArrowDown
+    : ArrowUpDown
+
+  return (
+    <button
+      aria-label={`Sort by ${label} (${active ? `${currentDirection} active` : `${nextDirection} first`})`}
+      aria-pressed={active}
+      className={cn(
+        "-ml-1 inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-[0.72rem] font-extrabold uppercase text-inherit transition hover:bg-slate-100 hover:text-slate-900",
+        active ? "text-teal-700" : "text-slate-500",
+      )}
+      onClick={() => onSort(sort)}
+      type="button"
+    >
+      <Icon
+        aria-hidden="true"
+        className={cn(
+          "size-3.5 shrink-0",
+          active ? "opacity-100" : "opacity-50",
+        )}
+      />
+      <span className="text-left leading-tight">{label}</span>
+    </button>
+  )
+}
+
+function StaticHeader({
+  align = "left",
+  label,
+}: {
+  align?: "left" | "right"
+  label: string
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-7 items-center text-[0.72rem] font-extrabold uppercase text-slate-500",
+        align === "right" ? "justify-end" : "justify-start",
+      )}
+    >
+      {label}
+    </span>
+  )
+}
+
+type FindingsDataTableProps = {
+  findings: readonly FindingPublic[]
+  findingDirection: FindingsDirection
+  onOpenSheet: (finding: FindingPublic) => void
+  onOpenWhy: (finding: FindingPublic) => void
+  onSort: (sort: QueueSort) => void
+  queueSort: QueueSort
+}
+
+type FindingsDataTableColumn = {
+  id: string
+  header: ReactNode
+  cell: (finding: FindingPublic) => ReactNode
+  ariaSort?: "ascending" | "descending"
+  className?: string
+  headerClassName?: string
+}
+
+export function FindingsDataTable({
+  findings,
+  findingDirection,
+  onOpenSheet,
+  onOpenWhy,
+  onSort,
+  queueSort,
+}: FindingsDataTableProps) {
+  const columns: readonly FindingsDataTableColumn[] = [
+    {
+      id: "priority",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="Priority"
+          onSort={onSort}
+          sort="priority"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "priority"),
+      cell: (finding) => <PriorityBadge priority={finding.priority} />,
+      className: "w-[6%]",
+      headerClassName: "w-[6%]",
+    },
+    {
+      id: "score",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="Score"
+          onSort={onSort}
+          sort="score"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "score"),
+      cell: (finding) => <RiskScore value={finding.risk_score} />,
+      className: "w-[5%]",
+      headerClassName: "w-[5%]",
+    },
+    {
+      id: "cve",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="CVE"
+          onSort={onSort}
+          sort="cve"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "cve"),
+      cell: (finding) => (
+        <>
+          <Link
+            className="finding-cve-link"
+            params={{ findingId: finding.id }}
+            title={`Open finding ${finding.cve_id}`}
+            to="/findings/$findingId"
+          >
+            {finding.cve_id}
+          </Link>
+          {finding.attack_mapped ? (
+            <span className="remediation-subtext">ATT&amp;CK mapped</span>
+          ) : null}
+        </>
+      ),
+      className: "w-[8%]",
+      headerClassName: "w-[8%]",
+    },
+    {
+      id: "component",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="Component / Service"
+          onSort={onSort}
+          sort="component"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "component"),
+      cell: (finding) => (
+        <div className="min-w-0">
+          <strong className="block truncate" title={componentLabel(finding)}>
+            {componentLabel(finding)}
+          </strong>
+          <span
+            className="remediation-subtext truncate"
+            title={`${serviceLabel(finding)} / ${assetLabel(finding)}`}
+          >
+            {serviceLabel(finding)} / {assetLabel(finding)}
+          </span>
+        </div>
+      ),
+      className: "w-[19%] min-w-0",
+      headerClassName: "w-[19%]",
+    },
+    {
+      id: "owner",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="Owner"
+          onSort={onSort}
+          sort="owner"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "owner"),
+      cell: (finding) => (
+        <>
+          <strong>{ownerLabel(finding)}</strong>
+          {finding.exposure ? (
+            <span className="remediation-subtext">
+              {labelize(finding.exposure)}
+            </span>
+          ) : null}
+        </>
+      ),
+      className: "w-[10%]",
+      headerClassName: "w-[10%]",
+    },
+    {
+      id: "status",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="Status"
+          onSort={onSort}
+          sort="status"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "status"),
+      cell: (finding) => (
+        <div className="grid justify-items-start gap-1.5">
+          <FindingStatusBadge status={finding.status} />
+          <span
+            className="remediation-subtext"
+            title={`Last seen ${formatDateTime(finding.last_seen_at)}`}
+          >
+            {formatShortDate(finding.last_seen_at)}
+          </span>
+        </div>
+      ),
+      className: "w-[8%]",
+      headerClassName: "w-[8%]",
+    },
+    {
+      id: "signals",
+      header: (
+        <SortHeader
+          currentDirection={findingDirection}
+          currentSort={queueSort}
+          label="Signals"
+          onSort={onSort}
+          sort="epss"
+        />
+      ),
+      ariaSort: sortAriaState(findingDirection, queueSort, "epss"),
+      cell: (finding) => (
+        <div className="flex flex-wrap items-center gap-1.5 min-[1500px]:flex-nowrap">
+          <span className="inline-flex min-h-6 items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2 text-[0.72rem] font-extrabold leading-none text-slate-600">
+            <span>EPSS</span>
+            <strong className="font-black text-slate-950">
+              <EpssBadge value={finding.epss} />
+            </strong>
+          </span>
+          <span className="inline-flex min-h-6 items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2 text-[0.72rem] font-extrabold leading-none text-slate-600">
+            <span>CVSS</span>
+            <strong className="font-black text-slate-950">
+              <CvssBadge value={finding.cvss_base_score} />
+            </strong>
+          </span>
+          <KevBadge matched={finding.in_kev} />
+        </div>
+      ),
+      className: "w-[13%]",
+      headerClassName: "w-[13%]",
+    },
+    {
+      id: "why",
+      header: <StaticHeader label="Why now" />,
+      cell: (finding) => (
+        <>
+          <span className="remediation-why-now">{findingWhyNow(finding)}</span>
+          <button
+            className="mt-1 border-0 bg-transparent p-0 text-[0.78rem] font-extrabold text-slate-900 hover:text-teal-700"
+            onClick={() => onOpenWhy(finding)}
+            type="button"
+          >
+            Why now
+          </button>
+        </>
+      ),
+      className: "w-[25%]",
+      headerClassName: "w-[25%]",
+    },
+    {
+      id: "view",
+      header: <StaticHeader align="right" label="View" />,
+      cell: (finding) => (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={`Quick view ${finding.cve_id}`}
+              className="finding-view-action"
+              onClick={() => onOpenSheet(finding)}
+              type="button"
+              variant="ghost"
+            >
+              <Eye aria-hidden="true" size={16} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">Quick view</TooltipContent>
+        </Tooltip>
+      ),
+      className:
+        "sticky right-0 z-10 w-16 min-w-16 bg-[var(--vpw-bg-card)] pr-4 text-right",
+      headerClassName:
+        "sticky right-0 z-20 w-16 min-w-16 bg-[var(--vpw-bg-panel)] pr-4 text-right",
+    },
+  ]
+
+  return (
+    <div className="vpw-table-wrap remediation-table-wrap shadow-none">
+      <table className="vpw-table min-w-[1240px] table-fixed [&_td]:py-3 [&_th]:py-3">
+        <caption className="sr-only">Findings remediation queue</caption>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th
+                aria-sort={column.ariaSort}
+                className={cn("vpw-table-header-cell", column.headerClassName)}
+                key={column.id}
+                scope="col"
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {findings.map((finding) => (
+            <tr
+              className="vpw-table-row transition-colors hover:[&>td]:bg-[var(--vpw-bg-panel)]"
+              key={finding.id}
+            >
+              {columns.map((column) => (
+                <td
+                  className={cn("vpw-table-cell", column.className)}
+                  key={column.id}
+                >
+                  {column.cell(finding)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/findings/RemediationQueue.tsx
+++ b/frontend/src/components/findings/RemediationQueue.tsx
@@ -1,9 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import {
   AlertTriangle,
-  ArrowDown,
   ArrowUp,
-  ArrowUpDown,
   ChevronLeft,
   ChevronRight,
   Eye,
@@ -29,7 +27,6 @@ import {
   FindingStatusBadge,
   KevBadge,
   PriorityBadge,
-  RiskScore,
 } from "@/components/risk"
 import { Button } from "@/components/ui/button"
 import {
@@ -52,12 +49,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import {
   VpwBadge,
   VpwDemoBanner,
@@ -73,6 +65,7 @@ import {
 import { DEMO_FINDINGS, DEMO_PROJECT, DEMO_SUMMARY } from "@/lib/demo-data"
 import { formatLabel as labelize, optionalText } from "@/lib/ui-copy"
 import { cn } from "@/lib/utils"
+import { FindingsDataTable, type QueueSort } from "./FindingsDataTable"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -82,7 +75,6 @@ type FindingsSort = NonNullable<FindingsReadProjectFindingsData["sort"]>
 type FindingsDirection = NonNullable<
   FindingsReadProjectFindingsData["direction"]
 >
-type QueueSort = FindingsSort | "component" | "owner"
 
 type KevFilter = "" | "true" | "false"
 
@@ -196,6 +188,10 @@ const statusSortRank: Record<string, number> = {
 // Helpers
 // ---------------------------------------------------------------------------
 
+function isApiSort(sort: QueueSort): sort is FindingsSort {
+  return (apiSortValues as readonly string[]).includes(sort)
+}
+
 function componentLabel(f: FindingPublic) {
   const name = optionalText(f.component_name)
   return f.component_version ? `${name} ${f.component_version}` : name
@@ -205,16 +201,8 @@ function serviceLabel(f: FindingPublic) {
   return f.business_service ?? f.component_purl ?? "Service not linked"
 }
 
-function assetLabel(f: FindingPublic) {
-  return f.asset_name ?? f.asset_key ?? f.business_service ?? "N.A."
-}
-
 function ownerLabel(f: FindingPublic) {
   return f.owner ?? f.business_service ?? "Unassigned"
-}
-
-function isApiSort(sort: QueueSort): sort is FindingsSort {
-  return (apiSortValues as readonly string[]).includes(sort)
 }
 
 function findingWhyNow(f: FindingPublic) {
@@ -223,31 +211,6 @@ function findingWhyNow(f: FindingPublic) {
     optionalText(f.recommended_action) ??
     "No priority rationale has been recorded yet."
   )
-}
-
-function formatDateTime(value: string | null | undefined) {
-  if (!value) return "N.A."
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return "N.A."
-  }
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date)
-}
-
-function formatShortDate(value: string | null | undefined) {
-  if (!value) return "N.A."
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return "N.A."
-  }
-  return new Intl.DateTimeFormat(undefined, {
-    day: "2-digit",
-    month: "2-digit",
-    year: "2-digit",
-  }).format(date)
 }
 
 function dateSortValue(value: string | null | undefined) {
@@ -583,86 +546,6 @@ function QuickViewSheet({ finding, open, onClose }: QuickViewSheetProps) {
         </div>
       </SheetContent>
     </Sheet>
-  )
-}
-
-type SortHeaderProps = {
-  currentDirection: FindingsDirection
-  currentSort: QueueSort
-  label: string
-  onSort: (sort: QueueSort) => void
-  sort: QueueSort
-}
-
-function SortHeader({
-  currentDirection,
-  currentSort,
-  label,
-  onSort,
-  sort,
-}: SortHeaderProps) {
-  const active = currentSort === sort
-  const nextDirection: FindingsDirection = active
-    ? currentDirection === "asc"
-      ? "desc"
-      : "asc"
-    : defaultSortDirections[sort]
-  const Icon = active
-    ? currentDirection === "asc"
-      ? ArrowUp
-      : ArrowDown
-    : ArrowUpDown
-
-  return (
-    <th
-      aria-sort={
-        active
-          ? currentDirection === "asc"
-            ? "ascending"
-            : "descending"
-          : undefined
-      }
-    >
-      <button
-        aria-label={`Sort by ${label} (${active ? `${currentDirection} active` : `${nextDirection} first`})`}
-        className={cn(
-          "-ml-1 inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-[0.72rem] font-extrabold uppercase text-inherit transition hover:bg-slate-100 hover:text-slate-900",
-          active ? "text-teal-700" : "text-slate-500",
-        )}
-        onClick={() => onSort(sort)}
-        type="button"
-      >
-        <Icon
-          aria-hidden="true"
-          className={cn(
-            "size-3.5 shrink-0",
-            active ? "opacity-100" : "opacity-50",
-          )}
-        />
-        <span className="text-left leading-tight">{label}</span>
-      </button>
-    </th>
-  )
-}
-
-function StaticHeader({
-  align = "left",
-  label,
-}: {
-  align?: "left" | "right"
-  label: string
-}) {
-  return (
-    <th>
-      <span
-        className={cn(
-          "inline-flex h-7 items-center text-[0.72rem] font-extrabold uppercase text-slate-500",
-          align === "right" ? "justify-end" : "justify-start",
-        )}
-      >
-        {label}
-      </span>
-    </th>
   )
 }
 
@@ -1246,172 +1129,14 @@ export function RemediationQueue({
                 ) : null}
               </div>
 
-              <div className="remediation-table-wrap findings-remediation-table-wrap">
-                <table
-                  aria-label="Findings remediation queue"
-                  className="remediation-table findings-remediation-table"
-                >
-                  <thead>
-                    <tr>
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="Priority"
-                        onSort={updateColumnSort}
-                        sort="priority"
-                      />
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="Score"
-                        onSort={updateColumnSort}
-                        sort="score"
-                      />
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="CVE"
-                        onSort={updateColumnSort}
-                        sort="cve"
-                      />
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="Component / Service"
-                        onSort={updateColumnSort}
-                        sort="component"
-                      />
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="Owner"
-                        onSort={updateColumnSort}
-                        sort="owner"
-                      />
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="Status"
-                        onSort={updateColumnSort}
-                        sort="status"
-                      />
-                      <SortHeader
-                        currentDirection={findingDirection}
-                        currentSort={queueSort}
-                        label="Signals"
-                        onSort={updateColumnSort}
-                        sort="epss"
-                      />
-                      <StaticHeader label="Why now" />
-                      <StaticHeader align="right" label="View" />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {displayFindings.map((finding) => (
-                      <tr key={finding.id}>
-                        <td>
-                          <PriorityBadge priority={finding.priority} />
-                        </td>
-                        <td>
-                          <RiskScore value={finding.risk_score} />
-                        </td>
-                        <td>
-                          <Link
-                            className="finding-cve-link"
-                            params={{ findingId: finding.id }}
-                            title={`Open finding ${finding.cve_id}`}
-                            to="/findings/$findingId"
-                          >
-                            {finding.cve_id}
-                          </Link>
-                          {finding.attack_mapped ? (
-                            <span className="remediation-subtext">
-                              ATT&amp;CK mapped
-                            </span>
-                          ) : null}
-                        </td>
-                        <td className="remediation-component-cell">
-                          <strong title={componentLabel(finding)}>
-                            {componentLabel(finding)}
-                          </strong>
-                          <span
-                            className="remediation-subtext"
-                            title={`${serviceLabel(finding)} / ${assetLabel(finding)}`}
-                          >
-                            {serviceLabel(finding)} / {assetLabel(finding)}
-                          </span>
-                        </td>
-                        <td>
-                          <strong>{ownerLabel(finding)}</strong>
-                          {finding.exposure ? (
-                            <span className="remediation-subtext">
-                              {labelize(finding.exposure)}
-                            </span>
-                          ) : null}
-                        </td>
-                        <td>
-                          <div className="remediation-status-cell">
-                            <FindingStatusBadge status={finding.status} />
-                            <span
-                              className="remediation-subtext"
-                              title={`Last seen ${formatDateTime(finding.last_seen_at)}`}
-                            >
-                              {formatShortDate(finding.last_seen_at)}
-                            </span>
-                          </div>
-                        </td>
-                        <td>
-                          <div className="remediation-signal-stack">
-                            <span className="remediation-signal-item">
-                              <span>EPSS</span>
-                              <strong>
-                                <EpssBadge value={finding.epss} />
-                              </strong>
-                            </span>
-                            <span className="remediation-signal-item">
-                              <span>CVSS</span>
-                              <strong>
-                                <CvssBadge value={finding.cvss_base_score} />
-                              </strong>
-                            </span>
-                            <KevBadge matched={finding.in_kev} />
-                          </div>
-                        </td>
-                        <td>
-                          <span className="remediation-why-now">
-                            {findingWhyNow(finding)}
-                          </span>
-                          <button
-                            className="remediation-why-action"
-                            onClick={() => openWhy(finding)}
-                            type="button"
-                          >
-                            Why now
-                          </button>
-                        </td>
-                        <td>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                aria-label={`Quick view ${finding.cve_id}`}
-                                className="finding-view-action"
-                                onClick={() => openSheet(finding)}
-                                type="button"
-                                variant="ghost"
-                              >
-                                <Eye aria-hidden="true" size={16} />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="left">
-                              Quick view
-                            </TooltipContent>
-                          </Tooltip>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <FindingsDataTable
+                findingDirection={findingDirection}
+                findings={displayFindings}
+                onOpenSheet={openSheet}
+                onOpenWhy={openWhy}
+                onSort={updateColumnSort}
+                queueSort={queueSort}
+              />
             </section>
 
             {/* Pagination */}

--- a/frontend/src/components/findings/index.ts
+++ b/frontend/src/components/findings/index.ts
@@ -1,3 +1,5 @@
+export { FindingsDataTable } from "./FindingsDataTable"
+export type { QueueSort } from "./FindingsDataTable"
 export { RemediationQueue } from "./RemediationQueue"
 export type { RemediationQueueProps } from "./RemediationQueue"
 export { useFindingsRouteState } from "./useFindingsRouteState"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -943,12 +943,6 @@ textarea:focus-visible,
   padding: 18px;
 }
 
-.findings-remediation-table-wrap {
-  border-color: #e2e8f0;
-  border-radius: 10px;
-  background: #ffffff;
-}
-
 .risk-score-pill {
   display: inline-flex;
   align-items: center;
@@ -985,39 +979,6 @@ textarea:focus-visible,
   font-weight: 800;
 }
 
-.remediation-status-cell {
-  display: grid;
-  gap: 5px;
-  justify-items: start;
-}
-
-.remediation-signal-stack {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-}
-
-.remediation-signal-item {
-  display: inline-flex;
-  min-height: 24px;
-  align-items: center;
-  gap: 5px;
-  border: 1px solid #dbe5ee;
-  border-radius: 999px;
-  padding: 0 8px;
-  background: #f8fafc;
-  color: #475569;
-  font-size: 0.72rem;
-  font-weight: 800;
-  line-height: 1;
-}
-
-.remediation-signal-item strong {
-  color: #0f172a;
-  font-weight: 900;
-}
-
 .remediation-why-now {
   display: block;
   overflow: hidden;
@@ -1025,21 +986,6 @@ textarea:focus-visible,
   font-size: 0.8rem;
   line-height: 1.4;
   max-width: 28ch;
-}
-
-.remediation-why-action {
-  border: 0;
-  margin-top: 5px;
-  padding: 0;
-  background: transparent;
-  color: #111827;
-  cursor: pointer;
-  font-size: 0.78rem;
-  font-weight: 800;
-}
-
-.remediation-why-action:hover {
-  color: #0f766e;
 }
 
 .finding-view-action {
@@ -3364,28 +3310,12 @@ td {
   border-collapse: collapse;
 }
 
-.findings-remediation-table {
-  min-width: 1240px;
-  table-layout: fixed;
-}
-
-@media (min-width: 1800px) {
-  .findings-remediation-table {
-    min-width: 100%;
-  }
-}
-
 .remediation-table th,
 .remediation-table td {
   border-bottom: 1px solid #edf1ef;
   padding: 10px 12px;
   text-align: left;
   vertical-align: top;
-}
-
-.findings-remediation-table th,
-.findings-remediation-table td {
-  padding: 12px;
 }
 
 .remediation-table th {
@@ -3396,22 +3326,6 @@ td {
   text-transform: uppercase;
 }
 
-.findings-remediation-table th {
-  height: 44px;
-  background: #fbfdff;
-  box-shadow: inset 0 -1px 0 #e2e8f0;
-}
-
-.findings-remediation-table tbody tr {
-  transition:
-    background-color 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.findings-remediation-table tbody tr:hover td {
-  background: #fbfdff;
-}
-
 .remediation-table tr:last-child td {
   border-bottom: 0;
 }
@@ -3419,98 +3333,6 @@ td {
 .remediation-table td {
   color: #111827;
   font-size: 0.88rem;
-}
-
-.findings-remediation-table th:last-child,
-.findings-remediation-table td:last-child {
-  position: sticky;
-  right: 0;
-  z-index: 1;
-  width: 64px;
-  min-width: 64px;
-  padding-right: 16px;
-  text-align: right;
-  white-space: nowrap;
-}
-
-.findings-remediation-table th:last-child {
-  z-index: 2;
-  background: #fbfdff;
-}
-
-.findings-remediation-table td:last-child {
-  background: #ffffff;
-  box-shadow: -12px 0 18px -18px rgb(15 23 42 / 0.55);
-}
-
-.findings-remediation-table tbody tr:hover td:last-child {
-  background: #fbfdff;
-}
-
-.findings-remediation-table th:nth-child(1),
-.findings-remediation-table td:nth-child(1) {
-  width: 6%;
-}
-
-.findings-remediation-table th:nth-child(2),
-.findings-remediation-table td:nth-child(2) {
-  width: 5%;
-}
-
-.findings-remediation-table th:nth-child(3),
-.findings-remediation-table td:nth-child(3) {
-  width: 8%;
-}
-
-.findings-remediation-table th:nth-child(4),
-.findings-remediation-table td:nth-child(4) {
-  width: 19%;
-}
-
-.findings-remediation-table th:nth-child(5),
-.findings-remediation-table td:nth-child(5) {
-  width: 10%;
-}
-
-.findings-remediation-table th:nth-child(6),
-.findings-remediation-table td:nth-child(6) {
-  width: 8%;
-}
-
-.findings-remediation-table th:nth-child(7),
-.findings-remediation-table td:nth-child(7) {
-  width: 13%;
-}
-
-.findings-remediation-table th:nth-child(8),
-.findings-remediation-table td:nth-child(8) {
-  width: 25%;
-}
-
-@media (min-width: 1500px) {
-  .findings-remediation-table .remediation-signal-stack {
-    flex-wrap: nowrap;
-  }
-}
-
-.remediation-component-cell {
-  min-width: 0;
-}
-
-.remediation-component-cell strong,
-.remediation-component-cell .remediation-subtext {
-  display: block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.findings-remediation-table .remediation-why-now {
-  display: -webkit-box;
-  max-width: 42ch;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
 }
 
 .parse-errors table {


### PR DESCRIPTION
## What changed
- Extracted the Findings table rendering from `RemediationQueue` into a dedicated `FindingsDataTable`.
- Preserved all existing table behavior, including sortable headers, `aria-sort`, row actions, Why Now dialog trigger, quick-view sheet trigger, CVE/detail links, badges, signals, sticky View column, and pagination outside the table.
- Removed proven-unused Findings-only table CSS.
- Left shared Dashboard/remediation CSS untouched.

## Why
`VpwDataTable` could not be used directly without losing the current `aria-sort` behavior required by the Findings integration tests. This PR uses VPW table structure/classes while keeping accessibility and behavior intact.

## Scope
- Frontend Findings table consolidation only.
- No backend changes.
- No generated API client changes.
- No docs/evidence changes.
- No data/attack changes.
- No Dashboard changes.
- No route-state/fetch/auth/project/detail changes.

## Impact
- `RemediationQueue.tsx`: 1,490 -> 1,215 lines.
- Added `FindingsDataTable.tsx`.
- `index.css`: 4,126 -> 3,948 lines.
- No intended user-facing behavior changes.

## Validation
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] npm --prefix frontend run test -- tests/ui-smoke.spec.ts
- [x] npm --prefix frontend run test
- [x] git diff --check
- [x] Visual smoke for Findings table, sorting, Why Now dialog, quick-view sheet, links and pagination

## Notes
- Future work could enhance `VpwDataTable` to support the exact sortable header/aria-sort pattern, then migrate `FindingsDataTable` further.
- Dashboard remediation table was intentionally left unchanged.