### PR TITLE
Reduce PR CI cost with scoped checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Branch protection currently requires both matrix check contexts. Pull
+      # requests run the full workflow gate only on the primary Python version;
+      # the secondary PR context exits successfully after a clear skip message.
+      # Pushes to main and manual runs keep the full supported matrix.
       matrix:
         python-version: ["3.11", "3.12"]
 
@@ -30,7 +34,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Skip expensive Python gate for draft PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft
+        run: echo "Draft pull request; skipping expensive Python workflow gate."
+
+      - name: Skip secondary Python PR version
+        if: github.event_name == 'pull_request' && !github.event.pull_request.draft && matrix.python-version != '3.12'
+        run: echo "Pull request Python gate runs on 3.12 only; full matrix runs on main and manual dispatch."
+
       - name: Set up Python
+        if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && matrix.python-version == '3.12')
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -41,13 +54,16 @@ jobs:
             .pre-commit-config.yaml
 
       - name: Install project and dev dependencies
+        if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && matrix.python-version == '3.12')
         run: python -m pip install -e "backend[dev]"
 
       - name: Run local-equivalent workflow gate
+        if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && matrix.python-version == '3.12')
         run: make workflow-check
 
   action-smoke:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Check out repository
@@ -125,8 +141,42 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether frontend gate is needed
+        id: frontend-scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run-frontend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo "Draft pull request; skipping expensive frontend gate."
+            echo "run-frontend=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed_files="$(git diff --name-only "$base_sha"...HEAD)"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Ev '^($|docs/|archive/|\.github/|.*\.md$)' >/dev/null; then
+            echo "run-frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Documentation, archive, or workflow-only PR; skipping expensive frontend gate."
+            echo "run-frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip frontend gate
+        if: steps.frontend-scope.outputs.run-frontend != 'true'
+        run: echo "Frontend gate skipped; no frontend/runtime-impacting files changed."
 
       - name: Set up Python
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -136,41 +186,50 @@ jobs:
             backend/pyproject.toml
 
       - name: Set up Node
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
 
       - name: Install backend package
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: python -m pip install -e "backend[dev]"
 
       - name: Install frontend dependencies
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: npm --prefix frontend install --no-package-lock
 
       - name: Lint frontend
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: make frontend-lint
 
       - name: Check frontend lint drift
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: git diff --exit-code -- frontend
 
       - name: Build frontend
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: make frontend-build
 
       - name: Regenerate frontend client
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: make frontend-generate-client
 
       - name: Check generated frontend client drift
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         run: git diff --exit-code -- frontend/src/client
 
       - name: Install Playwright browser
+        if: steps.frontend-scope.outputs.run-frontend == 'true'
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
       - name: Run frontend Playwright smoke
-        if: github.event_name == 'pull_request'
+        if: steps.frontend-scope.outputs.run-frontend == 'true' && github.event_name == 'pull_request'
         run: npm --prefix frontend run test -- tests/ui-smoke.spec.ts
 
       - name: Run full frontend Playwright suite
-        if: github.event_name != 'pull_request'
+        if: steps.frontend-scope.outputs.run-frontend == 'true' && github.event_name != 'pull_request'
         run: npm --prefix frontend run test
 
       - name: Upload frontend Playwright failure evidence

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,7 @@ jobs:
   analyze:
     name: Analyze Python
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Check out repository

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,16 +40,33 @@ jobs:
             exit 0
           fi
 
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo "Draft pull request; Docker compose smoke skipped."
+            echo "run-docker=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           base_sha="${{ github.event.pull_request.base.sha }}"
           changed_files="$(git diff --name-only "$base_sha"...HEAD)"
           printf '%s\n' "$changed_files"
 
-          # Docs/archive-only PRs still get a successful Docker workflow, but
-          # skip the expensive compose build because runtime behavior cannot
-          # change from those paths.
-          if printf '%s\n' "$changed_files" | grep -Ev '^(docs/|archive/|.*\.md$)' >/dev/null; then
+          # The compose smoke remains a required check, so it runs as a job and
+          # skips internally unless a PR touches runtime/build inputs. Frontend
+          # route, component, and CSS changes are covered by the CI frontend
+          # job and do not need a Docker rebuild on every PR.
+          run_docker=false
+          while IFS= read -r path; do
+            case "$path" in
+              backend/*|compose*.yml|backend/Dockerfile|frontend/Dockerfile|frontend/Dockerfile.playwright|docker/*|pyproject.toml|backend/pyproject.toml|backend/requirements.txt|uv.lock|scripts/start*|package.json|bun.lock|frontend/package.json|frontend/nginx.conf|frontend/nginx-backend-not-found.conf|frontend/vite.config.*|frontend/tsconfig*.json)
+                run_docker=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [[ "$run_docker" == "true" ]]; then
             echo "run-docker=true" >> "$GITHUB_OUTPUT"
           else
+            echo "No runtime-impacting Docker inputs changed; compose smoke skipped."
             echo "run-docker=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -58,7 +75,7 @@ jobs:
     needs: changes
 
     steps:
-      - name: Skip Docker smoke for docs/archive-only PR
+      - name: Skip Docker smoke for non-runtime PR
         if: needs.changes.outputs.run-docker != 'true'
         run: echo "No runtime-impacting files changed; Docker compose smoke skipped."
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
           run_docker=false
           while IFS= read -r path; do
             case "$path" in
-              backend/*|compose*.yml|backend/Dockerfile|frontend/Dockerfile|frontend/Dockerfile.playwright|docker/*|pyproject.toml|backend/pyproject.toml|backend/requirements.txt|uv.lock|scripts/start*|package.json|bun.lock|frontend/package.json|frontend/nginx.conf|frontend/nginx-backend-not-found.conf|frontend/vite.config.*|frontend/tsconfig*.json)
+              backend/*|compose*.yml|frontend/Dockerfile*|docker/*|pyproject.toml|uv.lock|scripts/start*|package.json|bun.lock|frontend/package.json|frontend/nginx.conf|frontend/nginx-backend-not-found.conf|frontend/vite.config.*|frontend/tsconfig*.json)
                 run_docker=true
                 ;;
             esac

--- a/docs/ci-cost-optimization.md
+++ b/docs/ci-cost-optimization.md
@@ -49,6 +49,11 @@ expensive work:
 
 When the PR is marked ready, normal ready-PR checks run.
 
+The required PR workflows explicitly listen for the `ready_for_review` activity.
+That makes GitHub start a fresh ready-state check run when a draft PR becomes
+ready. Rerunning an older draft workflow is not equivalent because GitHub
+reuses the original draft event payload for that rerun.
+
 ## Documentation and archive changes
 
 Documentation, archive, Markdown-only, and workflow-only PRs keep required check

--- a/docs/ci-cost-optimization.md
+++ b/docs/ci-cost-optimization.md
@@ -1,0 +1,82 @@
+# CI cost optimization
+
+This repository keeps required GitHub checks present on pull requests and skips
+expensive work inside jobs when the change scope does not need it. Avoid
+workflow-level path filters for required checks because a filtered workflow can
+leave branch protection waiting for a check that never starts.
+
+## Pull request checks
+
+Ready pull requests keep the merge-safety checks that are required on `main`:
+
+- `check (3.12)` runs the local-equivalent Python workflow gate.
+- `check (3.11)` remains as a required context and exits with a clear skip
+  message on pull requests. The full 3.11 gate runs on `main` and manual
+  dispatch.
+- `frontend` runs frontend lint, build, generated-client drift, and Playwright
+  smoke unless the PR is documentation, archive, or workflow-only.
+- `compose-smoke` runs as a required Docker workflow job, but skips Compose when
+  no runtime-impacting Docker inputs changed.
+- `Analyze Python` CodeQL remains enabled on ready PRs because it is a required
+  branch-protection context.
+
+## Main checks
+
+Pushes to `main` run the full merge validation:
+
+- Python workflow gate on 3.11 and 3.12.
+- Full frontend Playwright suite.
+- Docker compose smoke.
+- CodeQL analysis.
+
+## Manual checks
+
+`workflow_dispatch` remains the full validation escape hatch:
+
+- CI runs the full Python matrix and full frontend Playwright suite.
+- Docker runs Compose regardless of changed paths.
+- CodeQL can be started manually.
+
+## Draft pull requests
+
+Draft PRs keep lightweight successful required contexts where possible and skip
+expensive work:
+
+- Python matrix jobs exit after skip messages.
+- Frontend exits after the scope decision.
+- Docker Compose is skipped.
+- CodeQL is skipped until the PR is ready.
+
+When the PR is marked ready, normal ready-PR checks run.
+
+## Documentation and archive changes
+
+Documentation, archive, Markdown-only, and workflow-only PRs keep required check
+contexts visible but avoid frontend browser work and Docker Compose. The Python
+workflow gate still runs on the primary PR Python version so docs hygiene,
+actionlint, packaging guardrails, and pre-commit checks remain covered.
+
+## Frontend-only changes
+
+Frontend route, component, and CSS changes run the frontend job with lint, build,
+generated-client drift, and Playwright smoke. They do not run Docker Compose
+unless Docker build inputs such as frontend package files, Dockerfiles, nginx
+config, or build config changed.
+
+## Backend and runtime-impacting changes
+
+Backend, compose, Dockerfile, dependency, runtime script, frontend package, and
+frontend build-config changes run Docker Compose. This keeps runtime/deployment
+coverage for changes that can alter container startup, image contents, backend
+API behavior, or frontend image construction.
+
+## Tradeoffs
+
+The main tradeoff is that pull requests no longer run the expensive Python gate
+on every supported Python version. The 3.11 required context remains present,
+but the full 3.11 gate runs after merge on `main` and can be run manually before
+merge when a dependency or compatibility-sensitive change warrants it.
+
+CodeQL stays conservative on ready PRs because branch protection currently
+requires `Analyze Python`. If branch protection changes later, CodeQL can move
+to `main`, schedule, and manual-only runs for additional savings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Integrations: integrations/reporting_and_ci.md
   - Gap Analysis: reference_cve_prioritizer_gap_analysis.md
   - Community Setup: community_repository_setup.md
+  - CI Cost Optimization: ci-cost-optimization.md
   - Release Operations: release_operations.md
   - Roadmap: roadmap.md
   - Workbench History:


### PR DESCRIPTION
## What changed
- Reduced PR CI cost while keeping required check contexts visible.
- Ready PRs run the full Python workflow gate on 3.12, while the required 3.11 context exits with a clear skip message on PRs.
- Full Python 3.11 and 3.12 validation still runs on `main` and manual dispatch.
- Draft PRs skip expensive Python, frontend, Docker and CodeQL work where safe.
- Frontend jobs skip expensive work for documentation, archive and workflow-only PRs.
- Docker Compose runs only for runtime-impacting PR changes.
- CodeQL remains enabled on ready PRs because `Analyze Python` is currently branch-protection required.
- Updated CI cost documentation and mkdocs navigation.

## Scope
- GitHub Actions and CI documentation only.
- No frontend source changes.
- No backend implementation changes.
- No generated API client changes.
- No docs/evidence changes.
- No data/attack changes.

## Validation
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] npm --prefix frontend run test -- tests/ui-smoke.spec.ts
- [x] backend smoke subset
- [x] docs hygiene test
- [x] YAML parse fallback for workflow files
- [x] git diff --check

## Expected cost reduction
- Draft PRs should be much cheaper.
- Frontend-only route/component/CSS PRs should skip Docker Compose.
- Docs/archive/workflow-only PRs should avoid frontend browser work and Docker Compose.
- Pull requests no longer run the full Python gate on both 3.11 and 3.12.
- Main and manual runs still provide full validation.

## Tradeoffs
- Full 3.11 Python validation no longer runs on every PR, but still runs on `main` and manual dispatch.
- Full validation should be manually triggered for dependency-sensitive or compatibility-sensitive PRs.
- CodeQL remains on ready PRs because it is currently branch-protection required.