### PR TITLE
Add current product documentation package

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,103 @@
+# Product Architecture
+
+This page summarizes the current VPW product architecture for reviewers and
+maintainers. It describes the implemented Workbench state after the frontend
+route, design-system, evidence, and CI cleanup work.
+
+## Runtime Shape
+
+VPW is a local-first application for prioritizing already-known CVEs from
+uploaded inputs. It is not a scanner and it does not actively probe systems.
+
+The repository now follows the FastAPI Full Stack Template shape for the active
+Workbench surface:
+
+- `backend/app/`: FastAPI application, API routes, SQL models, services,
+  repositories, auth/session support, and Alembic migrations.
+- `frontend/`: React, Vite, TanStack Router, TypeScript, and the generated API
+  client consumed by the browser app.
+- `frontend/src/client/**` and `frontend/src/api-client.ts`: generated API
+  client boundary. Product code imports the generated services and types, but
+  generated files are not manually edited.
+- `backend/src/vuln_prioritizer/**`: retained CLI and domain implementation
+  used by maintainer workflows and compatibility surfaces.
+
+The frontend and backend communicate through the generated API client. UI
+component structure, route extraction, CSS organization, and VPW design-system
+implementation details are intentionally outside the backend/API contract.
+
+## Frontend Route Ownership
+
+TanStack Router file routes remain small entrypoints. Most product rendering is
+owned by route-level Workbench components:
+
+| Route | Main owner | Notes |
+| --- | --- | --- |
+| Dashboard | `components/dashboard/RiskOperationsDashboard.tsx` | Subcomponents own hero, metrics, charts, queue, side panel. Recharts is lazy-loaded through `DashboardSignalOverview`. |
+| Projects | `components/projects/ProjectsWorkbench.tsx` | Project CRUD UI; data and handlers are still supplied by `WorkbenchShell`. |
+| Imports | `components/imports/ImportsWorkbench.tsx` | Import wizard, run selection, parse errors, and run detail UI; API timing remains in `WorkbenchShell`. |
+| Findings | `components/findings/RemediationQueue.tsx` | Uses `useFindingsRouteState` for filters/sort/pagination and `FindingsDataTable` for the table surface. |
+| Finding Detail | `components/finding-detail/FindingDetailRoute.tsx` | Hero, priority explanation, evidence, TTP Context, and history are extracted from `WorkbenchShell`. |
+| Waivers | `components/waivers/WaiversWorkbench.tsx` | VPW-based waiver register and governance workflow; handlers remain shell-owned. |
+| Assets | `routes/_layout/assets.tsx` | Largest remaining route-local implementation; already uses VPW primitives but still owns route state directly. |
+| Providers | `components/providers/ProvidersRouteContainer.tsx` | Typed container over `ProvidersWorkbench`; provider status remains shared state. |
+| Reports | `components/reports/EvidenceCenter.tsx` | Evidence Center for report generation, download, verification, and bundle metadata. |
+| Settings | `components/settings/SettingsRouteContainer.tsx` | Typed wrapper over `SettingsWorkbench`; token/session data remains shell-owned. |
+| Login | `routes/login.tsx` | Standalone login route using local template auth defaults and API status. |
+
+## WorkbenchShell Role
+
+`frontend/src/workbench/WorkbenchShell.tsx` is still the app-level Workbench
+composition root. It intentionally owns cross-route concerns:
+
+- current user/session loading and sign-out
+- generated API client setup through the auth token
+- selected project state and project list refresh
+- provider status and Workbench status
+- dashboard, findings, finding detail, import, report, project, waiver, and
+  settings API effects that are still shared or navigation-sensitive
+- route-level lazy component boundaries
+- status strip and app shell props
+
+Recent refactors moved large route rendering surfaces out of the shell without
+moving high-risk global state. Future state extraction should stay route-by-route
+and preserve API timing, selected project behavior, and auth/session redirects.
+
+## VPW Design System Role
+
+The VPW design system lives under `frontend/src/components/vpw`. It provides
+shared surfaces, panels, badges, tables, filter bars, metric cards, skeletons,
+status banners, key-value lists, timeline, toolbar, evidence cards, and
+selection cards.
+
+The design system is a frontend implementation layer. It does not define API
+contracts, scoring semantics, evidence manifests, or report schemas. Public VPW
+component APIs should be changed cautiously because many routes now depend on
+them, but those APIs are still internal frontend code.
+
+## Shared State and Provider Status
+
+Provider and status state is intentionally shared:
+
+- Dashboard displays provider freshness and stale/degraded states.
+- Providers route exposes source status and refresh controls.
+- Reports and Evidence Center use provider/run readiness for report generation.
+- Settings shows session, provider, and Workbench status.
+- AppShell uses health/status context for top-level status indicators.
+
+Keeping this state in `WorkbenchShell` avoids duplicate provider requests and
+keeps refresh behavior consistent across routes.
+
+## Explicit Non-Contracts
+
+The following are intentionally not backend or API contracts:
+
+- route component file names and frontend folder structure
+- CSS bucket names under `frontend/src/styles`
+- lazy-loading and bundle boundaries
+- VPW component composition inside routes
+- Dashboard chart chunking and Recharts placement
+- demo-only frontend data used when no project exists
+
+Backend/API contracts are the generated OpenAPI surface, persisted models,
+report/evidence artifacts, schemas, and tested response behavior.

--- a/docs/attack-ttp-methodology.md
+++ b/docs/attack-ttp-methodology.md
@@ -97,6 +97,23 @@ Current limitations:
   authored notes and reports must avoid exploit payloads, commands, reproduction
   steps, and procedure guidance.
 
+## Current Workbench Demo Proof
+
+The current Workbench demo intentionally shows both mapped and unmapped TTP
+states.
+
+- Unmapped CVEs remain explicitly unmapped. VPW does not fill gaps from CVE
+  descriptions, vendor names, products, exploit keywords, EPSS rank, or LLM
+  output.
+- The curated demo proof for `CVE-2024-4577` is used only to show how a reviewed
+  mapping appears in the TTP Context UI. The mapped state can show technique,
+  tactic, confidence, source, detection coverage, and safety wording.
+- The archived demo proof is indexed in
+  `archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md`.
+
+The mapped demo state is defensive context for prioritization and detection
+planning. It does not prove that a local environment was exploited.
+
 ## Mapping Review Checklist
 
 Use this checklist for each local curated mapping and for report surfaces that

--- a/docs/demo-readiness.md
+++ b/docs/demo-readiness.md
@@ -1,0 +1,85 @@
+# Demo Readiness
+
+This page summarizes the current VPW demo story and the evidence files that
+support it. It is intended for maintainers, technical reviewers, and Applied
+Security Project review.
+
+## Primary Demo Flow
+
+Use the Workbench as the first-screen experience:
+
+1. **Projects**: create or select a project.
+2. **Imports**: import CVE, scanner, SBOM, generic occurrence CSV, and optional
+   VEX or asset-context inputs.
+3. **Findings**: review the remediation queue, filters, sort, priority, EPSS,
+   CVSS, KEV, status, and "Why now" context.
+4. **Finding Detail**: inspect hero metrics, priority explanation, evidence,
+   TTP Context, and history.
+5. **TTP Context**: show the no-inference state for unmapped findings and the
+   curated mapped demo proof when available.
+6. **Waivers**: create and review accepted-risk decisions with owner, scope,
+   expiry, review date, and waiver debt.
+7. **Evidence Center**: generate reports and inspect checksum metadata.
+8. **Evidence Bundle**: download and verify the ZIP bundle manifest.
+
+The flow demonstrates prioritization of known CVEs. It does not scan targets or
+prove exploitability.
+
+## Evidence References
+
+Use these archived entrypoints for proof and presentation planning:
+
+| Flow area | Evidence reference |
+| --- | --- |
+| End-to-end demo screenshots and notes | `archive/vpw-evidence/final-demo-flow/demo-flow-summary.md` |
+| Curated mapped TTP proof | `archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md` |
+| Presentation package overview | `archive/vpw-evidence/presentation-pack/README.md` |
+| Presentation evidence index | `archive/vpw-evidence/presentation-pack/evidence-index.md` |
+| Historical milestone manifest | `archive/vpw-evidence/MANIFEST.md` |
+| Contract report snapshots | `docs/evidence/vpw-054-report-snapshots.md` |
+| Evidence bundle manifest contract | `docs/evidence/vpw-051-manifest.json` |
+| Positive verification contract | `docs/evidence/vpw-052-positive-verification.json` |
+| Tamper verification contract | `docs/evidence/vpw-052-tampered-verification.json` |
+| ATT&CK Navigator contract | `docs/evidence/vpw-060-attack-navigator-layer.json` |
+
+These references are deliberately split: current contract artifacts stay in
+`docs/evidence/`, while broad screenshots and milestone proof stay in
+`archive/vpw-evidence/`.
+
+## Demo TTP States
+
+Two TTP states should be shown:
+
+- **No inference**: unmapped CVEs remain unmapped. The UI should make it clear
+  that VPW did not guess tactics or techniques.
+- **Mapped proof**: the curated demo mapping for `CVE-2024-4577` can show
+  technique, tactic, confidence, source, coverage, and safety wording.
+
+Both states should keep the defensive boundary visible. A mapped ATT&CK
+technique is not proof of local exploitation, and an unmapped finding is not
+safe by default.
+
+## Readiness Checks
+
+Before a final demo or review, use a small stability sample:
+
+- frontend build, lint, unit tests, and UI smoke
+- backend Workbench/API smoke subset
+- backend report contract tests
+- docs hygiene and MkDocs build
+- evidence bundle verification for any newly generated bundle
+
+Avoid adding fresh screenshots during routine documentation work unless a visual
+regression needs diagnosis. Screenshots used for final presentation should be
+captured intentionally and indexed in the archive or presentation pack.
+
+## Known Limitations
+
+- Demo data is sample data and must be labeled as such.
+- Provider freshness depends on selected local or live provider data.
+- ATT&CK mapping is explicit and source-backed; VPW does not infer missing
+  mappings.
+- Detection coverage is defensive review context, not proof that controls are
+  effective against a real intrusion.
+- The built-in Workbench is self-hosted/local-first; public deployment still
+  needs separate hardening and operational review.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,11 @@ The site includes the `v1.1.0` release notes, Workbench milestone evidence, and 
 - [Release notes: Workbench v1.0.0](releases/workbench-v1.0.0.md)
 - [Workbench v1.0 release checklist](workbench-v1-release-checklist.md)
 - [External user documentation guide](user_documentation.md)
+- [Current product architecture](architecture.md)
+- [Scoring methodology](scoring-methodology.md)
+- [ATT&CK/TTP methodology](attack-ttp-methodology.md)
+- [Reports and evidence](reports-and-evidence.md)
+- [Demo readiness](demo-readiness.md)
 - [Example HTML report](examples/example_report.html)
 - [Template report demo artifacts](examples/vpw-054-template-technical-report.md)
 - [Operational use cases](use_cases.md)
@@ -91,6 +96,11 @@ for single-upload and multi-upload flows.
 - Start with [user_documentation.md](user_documentation.md) when you need the full external-user path.
 - Start with [concept.md](concept.md) for positioning and scope.
 - Read [methodology.md](methodology.md) for scoring, ATT&CK, Asset Context, and VEX semantics.
+- Read [architecture.md](architecture.md) for the current FastAPI/React route architecture, generated client boundary, VPW design-system role, and shared state ownership.
+- Read [scoring-methodology.md](scoring-methodology.md) for the rule-based CVSS, EPSS, KEV, lifecycle, provider freshness, asset-context, and waiver methodology.
+- Read [attack-ttp-methodology.md](attack-ttp-methodology.md) for curated ATT&CK/TTP mapping rules, no-inference boundaries, and the current mapped demo proof.
+- Read [reports-and-evidence.md](reports-and-evidence.md) for Evidence Center formats, ZIP bundle verification, canonical contract artifacts, and archive layout.
+- Read [demo-readiness.md](demo-readiness.md) for the Project -> Import -> Findings -> Finding Detail -> TTP Context -> Waivers -> Evidence Center demo flow.
 - Use [support_matrix.md](support_matrix.md) and [contracts.md](contracts.md) for stable consumer-facing surfaces.
 - Use [architecture/index.md](architecture/index.md), [architecture/core-workbench-schema.md](architecture/core-workbench-schema.md), and [architecture/analysis-run-provider-schema.md](architecture/analysis-run-provider-schema.md) for architecture and data-model details.
 - Use [asset-context-csv.md](asset-context-csv.md) for the local asset-context CSV schema, match modes, precedence, and re-score semantics.

--- a/docs/reports-and-evidence.md
+++ b/docs/reports-and-evidence.md
@@ -1,0 +1,88 @@
+# Reports and Evidence
+
+The Evidence Center turns selected project runs into reviewable artifacts. The
+goal is audit-ready defensive evidence, not exploit proof.
+
+## Evidence Center
+
+The current React Evidence Center lives in
+`frontend/src/components/reports/EvidenceCenter.tsx`. It shows:
+
+- selected project and run readiness
+- provider and report-input context
+- report format cards
+- generated report list
+- checksum and manifest metadata
+- evidence bundle status and verification actions
+
+Report generation, download, and verification are still handled through the
+Workbench backend API. The frontend does not invent report content or bypass
+checksum validation.
+
+## Report Formats
+
+The current report surface supports:
+
+| Format | Purpose |
+| --- | --- |
+| HTML | Executive browser report with priority summary and evidence links. |
+| Markdown | Technical handoff for analysts, PR notes, and audit review. |
+| JSON | Machine-readable analysis and report data. |
+| CSV | Finding table export for spreadsheets and ticket routing. |
+| SARIF | Code-scanning and CI evidence workflows. |
+| ATT&CK Navigator | Defensive layer for mapped techniques when ATT&CK context exists. |
+| Evidence ZIP Bundle | Bundle containing reports, source artifacts, manifest, and SHA256 checksums. |
+
+Available formats depend on the selected run and report action state. Demo data
+is labeled as demo-only and should not be presented as production evidence.
+
+## Evidence ZIP Bundle
+
+The Evidence ZIP Bundle is the strongest audit artifact. It is expected to
+contain generated reports plus a manifest that records file names, sizes, and
+SHA256 checksums.
+
+Verification checks that bundle contents still match the manifest. Tampered or
+missing artifacts should fail verification instead of being treated as usable
+evidence.
+
+## Canonical Contract Artifacts
+
+`docs/evidence/` intentionally remains small. It contains only committed
+contract artifacts used by backend report/evidence tests:
+
+- `docs/evidence/vpw-050-analysis-result.v1.json`
+- `docs/evidence/vpw-050-findings.csv`
+- `docs/evidence/vpw-051-analysis.json`
+- `docs/evidence/vpw-051-manifest.json`
+- `docs/evidence/vpw-052-positive-verification.json`
+- `docs/evidence/vpw-052-tampered-verification.json`
+- `docs/evidence/vpw-054-report-snapshots.md`
+- `docs/evidence/vpw-060-attack-navigator-layer.json`
+
+Do not add screenshots, broad historical evidence, or ad hoc demo artifacts
+under `docs/evidence/`. The docs hygiene test enforces this boundary.
+
+## Historical Evidence Archive
+
+Historical VPW evidence now lives under `archive/vpw-evidence/`. Important
+entrypoints:
+
+- `archive/vpw-evidence/README.md`
+- `archive/vpw-evidence/MANIFEST.md`
+- `archive/vpw-evidence/final-demo-flow/demo-flow-summary.md`
+- `archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md`
+- `archive/vpw-evidence/presentation-pack/README.md`
+- `archive/vpw-evidence/presentation-pack/evidence-index.md`
+
+The archive preserves screenshots, issue closeout notes, validation logs,
+presentation-pack references, and old milestone evidence without making the
+public `docs/evidence/` tree sprawl again.
+
+## Safety Boundary
+
+Reports and evidence may describe CVSS, EPSS, KEV, provider freshness, asset
+context, waivers, ATT&CK mappings, and detection coverage. They must not claim
+that a local environment was exploited unless a cited source explicitly supports
+that statement. ATT&CK context is defensive triage context and does not prove
+exploitation.

--- a/docs/scoring-methodology.md
+++ b/docs/scoring-methodology.md
@@ -1,0 +1,91 @@
+# Scoring Methodology
+
+VPW prioritizes already-known CVEs using deterministic, explainable rules. It
+does not use opaque machine-learning scoring and it does not infer exploitability
+from unreviewed text.
+
+## Base Priority
+
+The base priority is rule-based from CVSS, FIRST EPSS, and CISA KEV:
+
+| Priority | Rule |
+| --- | --- |
+| Critical | CISA KEV match, or EPSS >= 0.70 with CVSS >= 7.0 |
+| High | EPSS >= 0.40, or CVSS >= 9.0 |
+| Medium | CVSS >= 7.0, or EPSS >= 0.10 |
+| Low | Everything else |
+
+The base rule stays transparent so a finding can be explained in reports, API
+responses, the Findings table, and Finding Detail.
+
+## Signal Inputs
+
+| Signal | Role |
+| --- | --- |
+| CVSS | Severity baseline from NVD/provider records. VPW records the selected CVSS family where available. |
+| EPSS | Probability signal from FIRST EPSS. High EPSS can raise urgency even when CVSS alone is lower. |
+| KEV | Known exploited vulnerability signal from CISA KEV. KEV makes a finding Critical in the base priority model. |
+| Lifecycle status | Workbench state such as open, in review, remediating, resolved, accepted, and false positive keeps operational status visible. |
+| Provider freshness | Stale, missing, or degraded provider data does not silently mark a finding safe; freshness is surfaced as data quality context. |
+| Asset context | Owner, business service, exposure, environment, criticality, and asset identity help route remediation and governance rollups. |
+| Waivers | Accepted-risk decisions are scoped, time-bound, and visible in lifecycle/governance context instead of deleting the finding. |
+| VEX/applicability | Applicable, not affected, fixed, or under-investigation statements are handled as contextual evidence. Under-investigation stays visible. |
+
+## Explanation Model
+
+VPW produces human-readable priority reasons from the visible signal set. The
+Finding Detail "Why this priority" view separates:
+
+- base priority drivers: CVSS, EPSS, KEV
+- occurrence and source provenance
+- lifecycle and waiver context
+- asset and service context
+- ATT&CK/TTP context when explicitly mapped
+- recommended action and SLA-oriented decision language
+
+The UI and reports should show readable text, not internal keys such as
+`priority.*`.
+
+## Asset Context and Waivers
+
+Asset context and waivers are governance context, not hidden scoring magic.
+
+- Asset fields help identify owner, service, exposure, environment, and
+  business criticality.
+- Governance rollups group risk by owner, service, asset, and waiver debt.
+- Waivers preserve accepted-risk decisions with owner, scope, approval,
+  expiration, review date, and matching finding counts.
+- Expired or review-due waivers remain visible as debt.
+
+These signals can change operational ordering and decision language, but the
+base CVSS/EPSS/KEV priority remains explainable.
+
+## Data Quality and Gaps
+
+VPW treats missing data as uncertainty:
+
+- Missing CVSS means severity is unknown, not safe.
+- Missing EPSS means probability is unavailable, not low.
+- Missing KEV data means no KEV match was observed from the selected provider
+  data, not proof that exploitation is impossible.
+- Missing asset context means ownership and exposure need validation.
+- Missing ATT&CK mapping means unmapped, not inferred.
+- Stale provider data is shown as degraded freshness.
+
+Reports and the Workbench should keep these limitations visible so a reviewer
+can decide whether to refresh providers, add asset context, review waivers, or
+collect better input evidence.
+
+## Safety Boundary
+
+The methodology is defensive prioritization. It does not:
+
+- scan systems
+- prove exploitation
+- generate payloads or exploit steps
+- autopatch assets
+- claim ML-derived risk
+- infer ATT&CK mappings from CVE text or vendor names
+
+Human review remains required for final remediation, accepted-risk, and business
+impact decisions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,12 @@ nav:
   - User Documentation Guide: user_documentation.md
   - Concept: concept.md
   - Executive Summary: executive_summary.md
+  - Current Product State:
+      - Product Architecture: architecture.md
+      - Scoring Methodology: scoring-methodology.md
+      - ATT&CK/TTP Methodology: attack-ttp-methodology.md
+      - Reports and Evidence: reports-and-evidence.md
+      - Demo Readiness: demo-readiness.md
   - Methodology: methodology.md
   - Benchmarking: benchmarking.md
   - Architecture:
@@ -37,7 +43,6 @@ nav:
       - Infrastructure Scan Triage: playbooks/infrastructure_scan_triage.md
   - Contracts: contracts.md
   - Asset Context CSV: asset-context-csv.md
-  - ATT&CK Curated Mapping Schema: attack-ttp-methodology.md
   - Support Matrix: support_matrix.md
   - Integrations: integrations/reporting_and_ci.md
   - Gap Analysis: reference_cve_prioritizer_gap_analysis.md


### PR DESCRIPTION
## What changed
- Added current product architecture documentation for the FastAPI, React, TanStack Router and generated client based Workbench.
- Added scoring methodology documentation for CVSS, EPSS, KEV, lifecycle, provider freshness, asset context, waivers and data quality gaps.
- Updated ATT&CK/TTP methodology documentation with no inference rules, curated mapping boundaries and defensive safety guidance.
- Added Reports and Evidence documentation for Evidence Center, report formats, Evidence ZIP, manifest, checksum verification and canonical contract artifacts.
- Added Demo Readiness documentation for the Project to Evidence Bundle workflow.
- Updated docs index and MkDocs navigation.

## Scope
- Documentation only.
- No frontend source changes.
- No backend source changes.
- No generated API client changes.
- No data/attack changes.
- No docs/evidence contract artifact changes.
- No screenshots or slides.

## Validation
- [x] python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
- [x] python3 -m mkdocs build --clean
- [x] make docs-check
- [x] npm --prefix frontend run build
- [x] npm --prefix frontend run lint
- [x] npm --prefix frontend run test:unit
- [x] git diff --check

## Notes
- Final README screenshots and presentation slides remain intentionally out of scope.
- Public deployment hardening documentation can be expanded later if the project moves beyond local/self-hosted assumptions.