### PR TITLE
Fix archived presentation evidence paths

### DIFF
--- a/archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md
+++ b/archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md
@@ -25,7 +25,7 @@ This follow-up adds one local curated demo mapping fixture for the final demo fl
 
 ## Evidence
 
-- Screenshot: `docs/evidence/final-demo-flow/06-ttp-context-mapped-demo.png`
+- Screenshot: `archive/vpw-evidence/final-demo-flow/06-ttp-context-mapped-demo.png`
 - Mapping fixture: `data/attack/local_curated_demo_mappings.yml`
 
 ## Safety Notes

--- a/archive/vpw-evidence/presentation-pack/README.md
+++ b/archive/vpw-evidence/presentation-pack/README.md
@@ -1,6 +1,6 @@
 # Presentation Evidence Pack
 
-This folder is an index for the final Vuln Prioritizer Workbench evidence set. It does not duplicate large screenshots; it points to the canonical proof files already committed under `docs/evidence/final-demo-flow/` and `docs/evidence/vpw-design-system-foundation/`.
+This folder is an index for the final Vuln Prioritizer Workbench evidence set. It does not duplicate large screenshots; it points to the archived proof files already committed under `archive/vpw-evidence/final-demo-flow/` and `archive/vpw-evidence/vpw-design-system-foundation/`.
 
 ## What Was Built
 

--- a/archive/vpw-evidence/presentation-pack/evidence-index.md
+++ b/archive/vpw-evidence/presentation-pack/evidence-index.md
@@ -4,51 +4,51 @@ This index lists the canonical evidence files for the final presentation. Prefer
 
 ## Primary Proof
 
-- `docs/evidence/final-demo-flow/01-dashboard-final.png`
-- `docs/evidence/final-demo-flow/02-projects-final.png`
-- `docs/evidence/final-demo-flow/03-imports-final.png`
-- `docs/evidence/final-demo-flow/04-findings-final.png`
-- `docs/evidence/final-demo-flow/05-finding-detail-final.png`
-- `docs/evidence/final-demo-flow/06-ttp-context-final.png`
-- `docs/evidence/final-demo-flow/06-ttp-context-mapped-demo.png`
-- `docs/evidence/final-demo-flow/07-waivers-final.png`
-- `docs/evidence/final-demo-flow/08-evidence-center-final.png`
-- `docs/evidence/final-demo-flow/09-report-or-bundle-generated-final.png`
-- `docs/evidence/final-demo-flow/demo-flow-summary.md`
-- `docs/evidence/final-demo-flow/attack-demo-mapping-summary.md`
+- `archive/vpw-evidence/final-demo-flow/01-dashboard-final.png`
+- `archive/vpw-evidence/final-demo-flow/02-projects-final.png`
+- `archive/vpw-evidence/final-demo-flow/03-imports-final.png`
+- `archive/vpw-evidence/final-demo-flow/04-findings-final.png`
+- `archive/vpw-evidence/final-demo-flow/05-finding-detail-final.png`
+- `archive/vpw-evidence/final-demo-flow/06-ttp-context-final.png`
+- `archive/vpw-evidence/final-demo-flow/06-ttp-context-mapped-demo.png`
+- `archive/vpw-evidence/final-demo-flow/07-waivers-final.png`
+- `archive/vpw-evidence/final-demo-flow/08-evidence-center-final.png`
+- `archive/vpw-evidence/final-demo-flow/09-report-or-bundle-generated-final.png`
+- `archive/vpw-evidence/final-demo-flow/demo-flow-summary.md`
+- `archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md`
 
 ## Design-System Proof
 
-- `docs/evidence/vpw-design-system-foundation/assets-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/evidence-center-vpw-integrated-clean.png`
-- `docs/evidence/vpw-design-system-foundation/evidence-center-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/imports-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/projects-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/providers-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/settings-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/waivers-vpw-integrated.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-complete-set-desktop.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-complete-set-mobile.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-foundation-dashboard.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-foundation-evidence-center.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-foundation-finding-detail.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-foundation-findings.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-foundation-showcase.png`
-- `docs/evidence/vpw-design-system-foundation/vpw-design-system-showcase.html`
+- `archive/vpw-evidence/vpw-design-system-foundation/assets-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/evidence-center-vpw-integrated-clean.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/evidence-center-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/imports-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/projects-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/providers-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/settings-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/waivers-vpw-integrated.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-complete-set-desktop.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-complete-set-mobile.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-dashboard.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-evidence-center.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-finding-detail.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-findings.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-showcase.png`
+- `archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-showcase.html`
 
 ## Optional Supporting Historical Screenshots
 
 These screenshots are useful for presentation context when the story needs historical ATT&CK, asset, waiver, VEX, governance, or service-risk evidence. They are secondary to the final demo flow.
 
-- `docs/evidence/vpw-058-ttp-context-tab.png`
-- `docs/evidence/vpw-059-attack-summary-dashboard.png`
-- `docs/evidence/vpw-060-attack-navigator-layer.png`
-- `docs/evidence/vpw-063-asset-recalculate.png`
-- `docs/evidence/vpw-064-waiver-risk-acceptance.png`
-- `docs/evidence/vpw-065-openvex-status-application.png`
-- `docs/evidence/vpw-066-cyclonedx-vex-parser.png`
-- `docs/evidence/vpw-067-governance-rollups-waiver-debt.png`
-- `docs/evidence/vpw-067-top-services-by-risk.png`
+- `archive/vpw-evidence/vpw-058-ttp-context-tab.png`
+- `archive/vpw-evidence/vpw-059-attack-summary-dashboard.png`
+- `archive/vpw-evidence/vpw-060-attack-navigator-layer.png`
+- `archive/vpw-evidence/vpw-063-asset-recalculate.png`
+- `archive/vpw-evidence/vpw-064-waiver-risk-acceptance.png`
+- `archive/vpw-evidence/vpw-065-openvex-status-application.png`
+- `archive/vpw-evidence/vpw-066-cyclonedx-vex-parser.png`
+- `archive/vpw-evidence/vpw-067-governance-rollups-waiver-debt.png`
+- `archive/vpw-evidence/vpw-067-top-services-by-risk.png`
 
 ## Evidence Story
 
@@ -61,6 +61,6 @@ These screenshots are useful for presentation context when the story needs histo
 
 ## Proof Notes
 
-- Evidence ZIP, manifest, and checksum proof are documented in `docs/evidence/final-demo-flow/demo-flow-summary.md`.
-- Curated ATT&CK demo mapping proof is documented in `docs/evidence/final-demo-flow/attack-demo-mapping-summary.md`.
+- Evidence ZIP, manifest, and checksum proof are documented in `archive/vpw-evidence/final-demo-flow/demo-flow-summary.md`.
+- Curated ATT&CK demo mapping proof is documented in `archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md`.
 - The curated ATT&CK mapping does not prove exploitation and contains no offensive guidance.


### PR DESCRIPTION
## What changed
- Fixed stale archived presentation-pack references that still pointed to old `docs/evidence/...` paths.
- Updated the archived ATT&CK demo mapping summary to point to the archived mapped TTP screenshot.
- Verified there are no remaining stale `docs/evidence/final-demo-flow`, `docs/evidence/vpw-design-system-foundation`, or `docs/evidence/presentation-pack` references under `archive/vpw-evidence`.

## Scope
- Archive documentation path cleanup only.
- No product code changes.
- No frontend source changes.
- No backend source changes.
- No generated API client changes.
- No `data/attack` changes.
- No `docs/evidence` contract artifact changes.
- No screenshots added or moved.

## Validation
- [x] python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
- [x] python3 -m mkdocs build --clean
- [x] make docs-check
- [x] git diff --check