### PR TITLE
Public production remediation hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,8 +18,8 @@ affected?
 ## Affected Surface
 
 - [ ] CLI
-- [ ] Template backend API
-- [ ] Legacy Workbench API/UI
+- [ ] Workbench backend API
+- [ ] Active Workbench UI/API
 - [ ] React frontend
 - [ ] Docker/Compose
 - [ ] Docs/release/packaging
@@ -70,6 +70,8 @@ What should have happened instead?
 - [ ] Commands run and results are posted before closure.
 - [ ] No secrets, customer scanner exports, tokens, cookies, or private paths are
       included in public evidence.
+- [ ] Public-production readiness is not claimed unless PP5 release-readiness
+      evidence and the final scorecard issue support it.
 
 ## Evidence
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,7 +23,7 @@ Describe the smallest useful version of the feature.
 Target surface:
 
 - [ ] CLI/core
-- [ ] Template backend API
+- [ ] Workbench backend API
 - [ ] SQLModel/Alembic persistence
 - [ ] React frontend
 - [ ] Import/parser
@@ -38,7 +38,7 @@ Target surface:
       probing, credential testing, autopatching, or offensive guidance
 - [ ] this does not require heuristic or LLM-generated CVE-to-ATT&CK mapping
 - [ ] this does not claim public/shared Workbench readiness without explicit
-      threat-model and deployment-hardening work
+      threat-model, deployment, release-readiness, and residual-risk evidence
 
 ## Tests
 
@@ -60,6 +60,8 @@ What simpler approaches were considered?
 - [ ] Tests or evidence artifacts are named before implementation.
 - [ ] API, DB, generated-client, UI, docs, and security impacts are identified.
 - [ ] Residual risk and follow-up work are documented.
+- [ ] Public-production readiness is not claimed unless PP5 release-readiness
+      evidence and the final scorecard issue support it.
 
 ## Evidence
 

--- a/.github/ISSUE_TEMPLATE/security_hardening.md
+++ b/.github/ISSUE_TEMPLATE/security_hardening.md
@@ -42,7 +42,8 @@ Describe the smallest safe change.
 
 ## Safety Checklist
 
-- [ ] No public internet readiness is claimed without explicit hardening docs.
+- [ ] No public-production readiness is claimed without explicit threat-model,
+      deployment, release-readiness, and PP5 scorecard evidence.
 - [ ] No secrets, token values, cookies, API keys, customer exports, or private
       paths are exposed.
 - [ ] No scanner, exploit, PoC, active probing, credential testing, or

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,8 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
-      - "frontend"
+      - "type:frontend"
+      - "area:ui"
     groups:
       frontend-dependencies:
         patterns:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,10 @@
 ## Scope
 
 - [ ] CLI/core
-- [ ] Template backend API
+- [ ] Workbench backend API
 - [ ] DB/migrations
 - [ ] Generated OpenAPI client
+- [ ] Manual frontend API wrapper
 - [ ] React frontend
 - [ ] Docker/Compose
 - [ ] Docs/governance/security
@@ -62,13 +63,14 @@ paste command output summary here
       exposed in code, logs, screenshots, reports, or docs
 - [ ] upload limits, rooted artifact paths, safe parsing, CSRF-sensitive forms,
       security headers, and token hashing are not weakened
-- [ ] public/shared Workbench readiness is not claimed without threat-model and
-      deployment-hardening updates
+- [ ] public-production Workbench readiness is not claimed before the PP5
+      scorecard closes with threat-model, deployment, release, and residual-risk
+      evidence
 
 ## Docs / Release Notes
 
 - [ ] README and changelog were updated if user-visible behavior changed
 - [ ] SECURITY/threat model/deployment docs were updated if a security boundary
       changed
-- [ ] removed Workbench runtime behavior is not used as automatic closure
-      evidence for active React/JWT/SQLModel work
+- [ ] historical template-era or removed Workbench runtime behavior is not used
+      as automatic closure evidence for active `backend/app` work

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DEMO_EVIDENCE_ANALYSIS_FILE := build/v1.0-demo-analysis.json
 DEMO_EVIDENCE_BUNDLE_FILE := build/v1.0-demo-evidence-bundle.zip
 DEMO_EVIDENCE_VERIFICATION_FILE := build/v1.0-demo-evidence-bundle-verification.json
 
-.PHONY: install test lint format fix typecheck check benchmark-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-unit frontend-generate-client frontend-audit frontend-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke dependency-audit clean-local clean-deps provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-check package-check-temp pipx-source-smoke release-check release-readiness-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
+.PHONY: install test lint format fix typecheck check benchmark-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-unit frontend-generate-client api-client-drift-check frontend-audit frontend-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke dependency-audit clean-local clean-deps provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-contents-check package-check package-check-temp pipx-source-smoke release-check release-readiness-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
 
 install:
 	$(PYTHON) -m pip install -e "$(BACKEND_DIR)[dev]"
@@ -68,6 +68,9 @@ frontend-test-unit:
 frontend-generate-client:
 	bash scripts/generate-client.sh
 
+api-client-drift-check: frontend-generate-client
+	git diff --exit-code -- frontend/src/client
+
 frontend-audit:
 	cd frontend && npm --workspaces=false audit --omit=dev
 
@@ -114,11 +117,11 @@ docker-demo-smoke:
 		sleep 2; \
 	done; \
 	if [ "$$backend_ready" != "1" ]; then \
-		echo "Template Workbench backend health check failed." >&2; \
+		echo "Workbench backend health check failed." >&2; \
 		exit 1; \
 	fi; \
 	if ! $(PYTHON) -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:8000/api/v1/utils/health-check/', timeout=2).read().decode())" 2>/dev/null; then \
-		echo "Template Workbench utility health check failed." >&2; \
+		echo "Workbench utility health check failed." >&2; \
 		exit 1; \
 	fi; \
 	frontend_ready=0; \
@@ -130,15 +133,15 @@ docker-demo-smoke:
 		sleep 2; \
 	done; \
 	if [ "$$frontend_ready" != "1" ]; then \
-		echo "Template Workbench frontend health check failed." >&2; \
+		echo "Workbench frontend health check failed." >&2; \
 		exit 1; \
 	fi; \
 	if ! $(PYTHON) -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:5173/login', timeout=2).status)" 2>/dev/null; then \
-		echo "Template Workbench login route check failed." >&2; \
+		echo "Workbench login route check failed." >&2; \
 		exit 1; \
 	fi; \
 	$(PYTHON) scripts/docker_quickstart_api_smoke.py; \
-	echo "Template Workbench Docker smoke passed."
+	echo "Workbench Docker smoke passed."
 
 dependency-audit:
 	@$(PYTHON) -c "import pip_audit" >/dev/null 2>&1 || { \
@@ -197,7 +200,10 @@ package:
 	rm -rf dist
 	$(PYTHON) -m build $(BACKEND_DIR) --outdir dist
 
-package-check: package
+package-contents-check: package
+	$(PYTHON) scripts/check_package_contents.py dist
+
+package-check: package-contents-check
 	$(PYTHON) -m twine check dist/*
 
 package-check-temp:
@@ -219,7 +225,7 @@ release-check:
 	$(MAKE) pipx-source-smoke
 	$(MAKE) demo-sync-check
 
-release-readiness-check: release-check demo-evidence-bundle-check playwright-check
+release-readiness-check: release-check api-client-drift-check demo-evidence-bundle-check playwright-check
 
 demo-report:
 	$(DEMO_ENV) $(PYTHON) -m vuln_prioritizer.cli analyze --input data/sample_cves.txt --output docs/example_report.md --format markdown $(DEMO_PROVIDER_FLAGS)

--- a/README.md
+++ b/README.md
@@ -86,12 +86,15 @@ for decisions.
   `/api/v1` routes, services, repositories, models, and Alembic migrations.
 - Frontend: React, Vite, TypeScript, TanStack Router, and VPW design-system
   components.
-- API boundary: generated client files under `frontend/src/client/**` and
-  `frontend/src/api-client.ts`; these are generated artifacts and are not
-  manually edited.
+- API boundary: generated client files under `frontend/src/client/**`; the
+  `frontend/src/api-client.ts` wrapper is manual integration code over that
+  generated client.
 - CLI/domain layer: retained under `backend/src/vuln_prioritizer/**` for
   automation, reporting, and neutral domain helpers shared with the active
   backend.
+- Python package boundary: the backend distribution intentionally ships both
+  the CLI/core package and the active Workbench FastAPI app under `app/*`; it is
+  not a CLI-only package.
 
 See [Product Architecture](docs/architecture.md) for route ownership,
 WorkbenchShell responsibilities, shared provider/status state, and explicit
@@ -153,6 +156,7 @@ Public docs:
 - [Documentation home](docs/index.md)
 - [User Documentation Guide](docs/user_documentation.md)
 - [Product Architecture](docs/architecture.md)
+- [Dependency and Package Policy](docs/dependency-and-package-policy.md)
 - [Scoring Methodology](docs/scoring-methodology.md)
 - [ATT&CK/TTP Methodology](docs/attack-ttp-methodology.md)
 - [Reports and Evidence](docs/reports-and-evidence.md)
@@ -160,6 +164,7 @@ Public docs:
 - [Contracts](docs/contracts.md)
 - [Support Matrix](docs/support_matrix.md)
 - [Workbench Threat Model](docs/workbench-threat-model.md)
+- [Public-Production Release Evidence Ledger](docs/public-production-release-evidence-ledger.md)
 
 Submission and reviewer docs:
 
@@ -217,6 +222,8 @@ python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov
 python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
 python3 -m mkdocs build --clean
 make docs-check
+make package-check
+make api-client-drift-check
 ```
 
 For broader contributor guidance, see [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -224,17 +231,15 @@ Security reporting and deployment-scope caveats are in [SECURITY.md](SECURITY.md
 
 ## Project Status
 
-Implementation is complete for the current phase. The current repository state
-includes the VPW design system, route integrations, ATT&CK demo mapping proof,
-presentation evidence pack, product documentation, CI cost optimization, route
-extractions, CSS organization, Dashboard chart lazy loading, Assets extraction,
-and the final submission package.
+The current repository state includes the active `backend/app` Workbench
+runtime, React frontend, retained CLI/domain package, VPW design system,
+evidence/reporting surfaces, public docs, CI cost controls, and package release
+automation.
 
-Remaining follow-ups are documentation or presentation oriented:
-
-- refresh README screenshots later if new current-state images are desired
-- expand public deployment hardening docs before any internet-facing deployment
-- continue engineering refactors only if a concrete maintenance need appears
+Public-production readiness is still tracked as explicit PP5 evidence work.
+Do not treat this README, the local Workbench quickstart, or local release gates
+as a final internet-facing certification until the public-production scorecard
+issue closes with evidence.
 
 ## License, Security, And Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,11 @@
 # Vuln Prioritizer Workbench Roadmap
 
 This top-level roadmap summarizes the current delivery direction. Detailed
-release-line history remains in [docs/roadmap.md](docs/roadmap.md). The active
-template-first execution plan is tracked in
+release-line history remains in [docs/roadmap.md](docs/roadmap.md). Historical
+template migration planning is preserved in
 [docs/vpw_template_execution_sequence.md](docs/vpw_template_execution_sequence.md)
-and [docs/full_stack_fastapi_template_migration.md](docs/full_stack_fastapi_template_migration.md).
+and [docs/full_stack_fastapi_template_migration.md](docs/full_stack_fastapi_template_migration.md);
+those pages are reference material, not active acceptance evidence.
 
 ## Product Direction
 
@@ -20,45 +21,39 @@ CVE-to-ATT&CK mappings with heuristics or AI.
 
 ## Current Execution Track
 
-The current VPW cycle rebuilds the Workbench on the official
-`fastapi/full-stack-fastapi-template` shape without discarding the existing
-CLI/core domain value.
+The current VPW cycle hardens the implemented `backend/app` Workbench, retained
+CLI/core package, React frontend, generated-client boundary, docs, packaging,
+and release gates for public-production review.
 
-1. Baseline and governance: prove the official template baseline, product
-   identity, auth smoke, governance docs, issue templates, milestones, and
-   strict evidence flow.
-2. Backend domain foundation: replace template demo Items with Workbench
-   Projects, Findings, Assets, Components, Vulnerabilities, Analysis Runs,
-   Provider Snapshots, and SQLModel/Alembic persistence.
-3. Core package extraction: keep parser, provider, scoring, reporting, ATT&CK,
-   VEX, and governance logic framework-neutral so the template backend can call
-   it through service boundaries.
-4. Import MVP: persist imported scanner/SBOM/advisory data as findings and
-   occurrences with provenance.
-5. Enrichment and prioritization: attach provider context, risk reasons,
-   operational ranking, waivers, and explanations.
-6. React Workbench workflow: replace demo frontend pages with dashboard,
-   projects, imports, findings, detail, reports, providers, settings, and
-   browser-tested user flows.
-7. Evidence, reporting, ATT&CK, asset, VEX, governance, deployment, release, and
-   integration hardening: land each capability with tests and evidence before
-   closure.
+1. Security/auth/deployment baseline: document and verify the implemented
+   session, token, upload/report, CSP/routing, health/readiness, dependency, and
+   public deployment controls.
+2. Migration/package/docs coherence: keep issue templates, package boundaries,
+   generated-client ownership, archive boundaries, and current-state docs
+   aligned with the implemented runtime.
+3. Public-production release evidence: collect package contents, source-tag
+   install smoke, docs build, client drift, evidence bundle verification, Docker
+   smoke, and residual-risk decisions in the release evidence ledger.
+4. PP5 certification: run the final quality gate and close the 10/10 scorecard
+   only when every category has current evidence and no unresolved P1/P2 blocker.
 
 ## Roadmap Guardrails
 
 - Keep one roadmap issue per PR unless a dependency group is explicitly stated.
 - Close issues only after fresh evidence is posted: changed scope, commands run,
   artifacts, residual risk, and follow-up links.
-- Treat the old FastAPI/Jinja2/SQLAlchemy Workbench as reference material, not
-  automatic completion evidence for template React/JWT/SQLModel work.
-- Preserve the local-first posture until public/shared deployment hardening is
-  explicitly implemented and documented.
+- Treat historical template-era and removed-runtime notes as reference material,
+  not automatic completion evidence for current `backend/app` work.
+- Preserve the local-first posture until public-production deployment hardening
+  and PP5 evidence explicitly support a stronger claim.
 - Keep ATT&CK defensive and evidence-based. Do not infer mappings.
 
 ## Key References
 
-- [VPW Template Execution Sequence](docs/vpw_template_execution_sequence.md)
-- [Full Stack FastAPI Template Migration Plan](docs/full_stack_fastapi_template_migration.md)
+- [Public-Production Release Evidence Ledger](docs/public-production-release-evidence-ledger.md)
+- [Dependency and Package Policy](docs/dependency-and-package-policy.md)
+- [VPW Template Execution Sequence](docs/vpw_template_execution_sequence.md) (historical)
+- [Full Stack FastAPI Template Migration Plan](docs/full_stack_fastapi_template_migration.md) (historical)
 - [Template Replacement Strategy](docs/architecture/template-replacement.md)
 - [Workbench Threat Model](docs/workbench-threat-model.md)
 - [Current Release Roadmap](docs/roadmap.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,10 @@ Workbench for known CVEs and imported findings. It is not a scanning engine,
 exploit framework, or asset discovery platform.
 
 The Workbench is local-first and self-hosted by default. Treat it as a trusted
-single-workspace operator tool unless a specific deployment hardening review has
-covered TLS/proxy configuration, backup and restore, audit retention, token
-handling, role boundaries, upload/download storage, and the published threat
-model.
+single-workspace operator tool unless the public deployment runbook, threat
+model, release evidence ledger, and PP5 scorecard all cover the target
+deployment's TLS/proxy configuration, backup and restore, audit retention, token
+handling, role boundaries, upload/download storage, and residual risks.
 
 The project does not accept changes that turn the tool into an exploit runner,
 PoC generator, credential tester, active network probe, attack simulator,
@@ -70,5 +70,7 @@ Include, when possible:
 - Optional ATT&CK support must stay offline-mapping-based unless the project explicitly adopts a reviewed live approach.
 - XML, SBOM, scanner, and advisory inputs are treated as local exported evidence
   files. The tool must not scan remote systems to create those files.
-- Public internet deployment is out of scope until the threat model and
-  operational hardening documents explicitly say otherwise.
+- Public internet deployment remains gated by the threat model, public
+  deployment runbook, release evidence ledger, and PP5 scorecard. Do not claim
+  public-production readiness from local quickstart or package-release evidence
+  alone.

--- a/archive/historical-planning/README.md
+++ b/archive/historical-planning/README.md
@@ -7,9 +7,15 @@ Current planning and release status lives in:
 
 - `ROADMAP.md`
 - `docs/roadmap.md`
+- `docs/public-production-release-evidence-ledger.md`
+- `docs/dependency-and-package-policy.md`
+- `docs/releases/`
+
+Template migration reference pages remain in `docs/` for public navigation, but
+they are marked historical/current-state reference material:
+
 - `docs/vpw_template_execution_sequence.md`
 - `docs/full_stack_fastapi_template_migration.md`
-- `docs/releases/`
 
 Archived files here are retained for context only. They should not be treated as
 current scope, acceptance criteria, or release commitments.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,9 +1,12 @@
 # Vuln Prioritizer Backend
 
 This backend workspace packages the `vuln_prioritizer` Python CLI, FastAPI
-Workbench API, Jinja2 Workbench views, database migrations, and supporting
-services while the repository migrates toward the full-stack FastAPI template
-layout.
+Workbench API, database migrations, and supporting services for the active
+`backend/app` runtime.
+
+The published backend distribution intentionally includes both
+`src/vuln_prioritizer/**` and `app/**`. It is not a CLI-only package; package
+checks validate that the wheel and sdist match this boundary.
 
 Repository-level docs, fixtures, demo artifacts, and maintainer commands remain
 at the repository root.

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import secrets
 from collections.abc import Callable, Generator
 from hashlib import sha256
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
@@ -21,9 +21,14 @@ from app.models.api_tokens import attach_api_token_context, scope_set
 from app.repositories import ApiTokenRepository, AuthSessionRepository
 from vuln_prioritizer.security_tokens import api_token_digest
 
-reusable_oauth2 = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/login/access-token")
+reusable_oauth2 = OAuth2PasswordBearer(
+    tokenUrl=f"{settings.API_V1_STR}/login/access-token",
+    auto_error=False,
+)
 
-TokenDep = Annotated[str, Depends(reusable_oauth2)]
+TokenDep = Annotated[str | None, Depends(reusable_oauth2)]
+AuthTokenSource = Literal["bearer", "cookie"]
+UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -35,7 +40,13 @@ def get_db() -> Generator[Session, None, None]:
 SessionDep = Annotated[Session, Depends(get_db)]
 
 
-def _current_user_from_jwt(session: Session, token: str) -> User:
+def _current_user_from_jwt(
+    session: Session,
+    token: str,
+    *,
+    request: Request | None = None,
+    token_source: AuthTokenSource = "bearer",
+) -> User:
     """Validate a JWT and resolve the configured active-runtime user."""
     try:
         payload = security.decode_access_token(token)
@@ -62,17 +73,29 @@ def _current_user_from_jwt(session: Session, token: str) -> User:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Session is expired or revoked",
         )
+    if request is not None and token_source == "cookie":
+        _enforce_cookie_csrf(request, token_data.jti)
     auth_session_repo.mark_auth_session_seen(auth_session)
     session.commit()
+    if request is not None:
+        request.state.auth_token = token
+        request.state.auth_token_source = token_source
+        request.state.auth_jti = token_data.jti
     user = ensure_configured_superuser(session)
     if not user.is_active:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Inactive user")
     return user
 
 
-def get_current_user(session: SessionDep, token: TokenDep) -> User:
+def get_current_user(request: Request, session: SessionDep, token: TokenDep) -> User:
     """Require a configured-user JWT for active UI/session routes."""
-    return _current_user_from_jwt(session, token)
+    raw_token, token_source = _resolve_request_token(request, token)
+    return _current_user_from_jwt(
+        session,
+        raw_token,
+        request=request,
+        token_source=token_source,
+    )
 
 
 CurrentUser = Annotated[User, Depends(get_current_user)]
@@ -89,12 +112,20 @@ def require_api_scope(required_scope: ApiTokenScope) -> Callable[..., User]:
     """Accept a user JWT or a service token with the requested scope."""
 
     def dependency(request: Request, session: SessionDep, token: TokenDep) -> User:
+        raw_token, token_source = _resolve_request_token(request, token)
         try:
-            user = _current_user_from_jwt(session, token)
+            user = _current_user_from_jwt(
+                session,
+                raw_token,
+                request=request,
+                token_source=token_source,
+            )
         except HTTPException as jwt_error:
-            token_record = _active_service_token(session, token)
+            if token_source != "bearer":
+                raise jwt_error
+            token_record = _active_service_token(session, raw_token)
             if token_record is None:
-                _enforce_token_failure_rate_limit(request, token)
+                _enforce_token_failure_rate_limit(request, raw_token)
                 raise jwt_error
             scopes = scope_set(token_record)
             if required_scope not in scopes and "admin" not in scopes:
@@ -121,6 +152,39 @@ def require_api_scope(required_scope: ApiTokenScope) -> Callable[..., User]:
         return user
 
     return dependency
+
+
+def _resolve_request_token(
+    request: Request,
+    bearer_token: str | None,
+) -> tuple[str, AuthTokenSource]:
+    if bearer_token:
+        return bearer_token, "bearer"
+    cookie_token = request.cookies.get(security.SESSION_COOKIE_NAME)
+    if cookie_token:
+        return cookie_token, "cookie"
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _enforce_cookie_csrf(request: Request, jti: str) -> None:
+    if request.method.upper() not in UNSAFE_METHODS:
+        return
+    header_token = request.headers.get(security.CSRF_HEADER_NAME)
+    cookie_token = request.cookies.get(security.CSRF_COOKIE_NAME)
+    if (
+        not header_token
+        or not cookie_token
+        or not secrets.compare_digest(header_token, cookie_token)
+        or not security.verify_csrf_token(jti, header_token)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token missing or invalid",
+        )
 
 
 def _enforce_token_failure_rate_limit(request: Request, raw_token: str) -> None:

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -1,0 +1,209 @@
+"""Request-safe API error envelope and public payload redaction helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import JSONResponse
+
+from app.core.config import Settings
+from vuln_prioritizer.security_redaction import redact_text, redact_value
+
+DEFAULT_ERROR_MESSAGES = {
+    400: "Bad request.",
+    401: "Authentication required.",
+    403: "Not enough permissions.",
+    404: "Resource not found.",
+    409: "Request conflict.",
+    413: "Upload exceeds configured limit.",
+    422: "Request validation failed.",
+    429: "Too many requests.",
+}
+
+EXACT_MESSAGE_CODES = {
+    "Asset context parsing failed.": "import_asset_context_parse_failed",
+    "Import analysis failed.": "import_analysis_failed",
+    "Import parsing failed.": "import_parse_failed",
+    "Report artifact checksum mismatch": "report_artifact_checksum_mismatch",
+    "Report artifact not found": "report_artifact_not_found",
+    "Report is not an evidence bundle": "report_not_evidence_bundle",
+    "Too many requests.": "rate_limited",
+    "Upload exceeds configured limit.": "upload_too_large",
+    "VEX parsing failed.": "import_vex_parse_failed",
+}
+
+STATUS_CODES = {
+    400: "bad_request",
+    401: "authentication_required",
+    403: "permission_denied",
+    404: "not_found",
+    409: "conflict",
+    413: "payload_too_large",
+    422: "validation_error",
+    429: "rate_limited",
+}
+
+
+def error_response_content(
+    *,
+    status_code: int,
+    detail: Any = None,
+    code: str | None = None,
+    message: str | None = None,
+    request: Request | None = None,
+) -> dict[str, Any]:
+    """Build the stable API error envelope plus legacy ``detail`` compatibility."""
+    safe_detail = redact_request_safe_value(detail)
+    resolved_message = _resolve_message(status_code, safe_detail, message)
+    resolved_details = _resolve_details(safe_detail)
+    resolved_code = code or _resolve_code(status_code, safe_detail, resolved_message)
+
+    content: dict[str, Any] = {
+        "code": resolved_code,
+        "message": resolved_message,
+        "details": resolved_details,
+        "detail": _legacy_detail(
+            safe_detail,
+            code=resolved_code,
+            details=resolved_details,
+            message=resolved_message,
+        ),
+    }
+    trace_id = _trace_id(request)
+    if trace_id:
+        content["trace_id"] = trace_id
+    return content
+
+
+def redact_request_safe_value(value: Any) -> Any:
+    """Redact secrets and absolute local paths from request-facing payloads."""
+    if isinstance(value, str):
+        return redact_text(value)
+    redacted, _paths = redact_value(jsonable_encoder(value))
+    return redacted
+
+
+def redact_public_payload(value: Any) -> Any:
+    """Redact secrets and local absolute paths from public API payload fragments."""
+    redacted, _paths = redact_value(jsonable_encoder(value))
+    return redacted
+
+
+def production_safe_settings(active_settings: object) -> bool:
+    """Return whether diagnostics should use the production-safe projection."""
+    return isinstance(active_settings, Settings) and active_settings.ENVIRONMENT != "local"
+
+
+async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Return a stable JSON envelope for FastAPI/Starlette HTTP exceptions."""
+    if not isinstance(exc, StarletteHTTPException):
+        return internal_error_response(request)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=error_response_content(
+            status_code=exc.status_code,
+            detail=exc.detail,
+            request=request,
+        ),
+        headers=exc.headers,
+    )
+
+
+async def validation_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Return a stable JSON envelope for request validation failures."""
+    if not isinstance(exc, RequestValidationError):
+        return internal_error_response(request)
+    return JSONResponse(
+        status_code=422,
+        content=error_response_content(
+            status_code=422,
+            code="request_validation_failed",
+            message="Request validation failed.",
+            detail={"errors": jsonable_encoder(exc.errors())},
+            request=request,
+        ),
+    )
+
+
+async def unhandled_exception_handler(request: Request, _exc: Exception) -> JSONResponse:
+    """Hide implementation details for uncaught backend failures."""
+    return internal_error_response(request)
+
+
+def internal_error_response(request: Request | None = None) -> JSONResponse:
+    """Return a generic 500 error envelope."""
+    return JSONResponse(
+        status_code=500,
+        content=error_response_content(
+            status_code=500,
+            code="internal_server_error",
+            message="Internal server error.",
+            detail={},
+            request=request,
+        ),
+    )
+
+
+def _resolve_message(status_code: int, detail: Any, explicit: str | None) -> str:
+    if explicit:
+        return redact_text(explicit)
+    if isinstance(detail, Mapping):
+        candidate = detail.get("message")
+        if isinstance(candidate, str) and candidate.strip():
+            return redact_text(candidate)
+    if isinstance(detail, str) and detail.strip():
+        return redact_text(detail)
+    return DEFAULT_ERROR_MESSAGES.get(status_code, "Internal server error.")
+
+
+def _resolve_details(detail: Any) -> dict[str, Any]:
+    if isinstance(detail, Mapping):
+        nested = detail.get("details")
+        if isinstance(nested, Mapping):
+            return dict(nested)
+        return {str(key): value for key, value in detail.items() if key not in {"code", "message"}}
+    if isinstance(detail, list):
+        return {"errors": detail}
+    return {}
+
+
+def _resolve_code(status_code: int, detail: Any, message: str) -> str:
+    if isinstance(detail, Mapping):
+        candidate = detail.get("code")
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    if message in EXACT_MESSAGE_CODES:
+        return EXACT_MESSAGE_CODES[message]
+    if "not found" in message.lower():
+        return "not_found"
+    return STATUS_CODES.get(status_code, "internal_server_error")
+
+
+def _legacy_detail(
+    detail: Any,
+    *,
+    code: str,
+    details: dict[str, Any],
+    message: str,
+) -> Any:
+    if isinstance(detail, Mapping):
+        legacy = dict(detail)
+        legacy.setdefault("message", message)
+        legacy.setdefault("code", code)
+        legacy.setdefault("details", details)
+        return legacy
+    return detail if detail not in (None, "") else message
+
+
+def _trace_id(request: Request | None) -> str | None:
+    if request is None:
+        return None
+    value = request.headers.get("x-request-id") or request.headers.get("x-correlation-id")
+    if not value:
+        return None
+    return redact_text(value.strip())[:128] or None

--- a/backend/app/api/routes/imports.py
+++ b/backend/app/api/routes/imports.py
@@ -101,6 +101,9 @@ from app.services.import_uploads import (
     template_settings as _template_settings,
 )
 from app.services.import_uploads import (
+    upload_storage_ref as _upload_storage_ref,
+)
+from app.services.import_uploads import (
     upload_summary as _upload_summary,
 )
 from app.services.import_uploads import (
@@ -312,6 +315,29 @@ async def import_project_upload(
     )
     run.status = AnalysisRunStatus.RUNNING
     job_history = [*job_history, _job_status_entry("running")]
+    upload_ref = _upload_storage_ref(
+        project_id=project_id,
+        run_id=run.id,
+        filename=stored_filename,
+    )
+    asset_context_ref = (
+        _upload_storage_ref(
+            project_id=project_id,
+            run_id=run.id,
+            filename=asset_context_stored_filename or "asset_context.csv",
+        )
+        if asset_context_path is not None
+        else None
+    )
+    vex_ref = (
+        _upload_storage_ref(
+            project_id=project_id,
+            run_id=run.id,
+            filename=vex_stored_filename or "openvex.json",
+        )
+        if vex_path is not None
+        else None
+    )
     run.summary_json = {
         **run.summary_json,
         "import_job": _job_payload(
@@ -321,15 +347,16 @@ async def import_project_upload(
         ),
         "input_upload": {
             **run.summary_json["input_upload"],
-            "path": str(upload_path),
+            "path": upload_ref,
+            "storage_ref": upload_ref,
         },
         "asset_context_upload": _upload_summary_with_path(
             run.summary_json.get("asset_context_upload"),
-            path=str(asset_context_path) if asset_context_path is not None else None,
+            path=asset_context_ref,
         ),
         "vex_upload": _upload_summary_with_path(
             run.summary_json.get("vex_upload"),
-            path=str(vex_path) if vex_path is not None else None,
+            path=vex_ref,
         ),
     }
     session.flush()
@@ -941,6 +968,10 @@ def _persist_template_occurrences(
         "finding_count": len(touched_finding_ids),
         "created_findings": created_count,
         "updated_findings": reused_count,
+        "analysis_semantics": _analysis_semantics_summary(
+            occurrences=occurrences,
+            finding_count=len(touched_finding_ids),
+        ),
         "dedup_summary": {
             "key_version": "vpw019-v1",
             "created_findings": created_count,
@@ -1186,6 +1217,10 @@ def _persist_template_occurrences_bulk_insert(
         "finding_count": len(touched_finding_ids),
         "created_findings": len(touched_finding_ids),
         "updated_findings": 0,
+        "analysis_semantics": _analysis_semantics_summary(
+            occurrences=occurrences,
+            finding_count=len(touched_finding_ids),
+        ),
         "dedup_summary": {
             "key_version": "vpw019-v1",
             "created_findings": len(touched_finding_ids),
@@ -1204,6 +1239,22 @@ def _attack_context_enabled(
     decision: PrioritizedFinding,
 ) -> bool:
     return analysis_result.context.attack_source != "none" or decision.attack_context.mapped
+
+
+def _analysis_semantics_summary(
+    *,
+    occurrences: list[NormalizedOccurrence],
+    finding_count: int,
+) -> dict[str, Any]:
+    return {
+        "analysis_decision_scope": "cve",
+        "persistence_scope": "asset_component_occurrence",
+        "finding_dedup_key_version": "vpw019-v1",
+        "cve_count": len({occurrence.cve for occurrence in occurrences}),
+        "occurrence_count": len(occurrences),
+        "finding_count": finding_count,
+        "same_cve_can_create_distinct_asset_findings": True,
+    }
 
 
 def _compact_decision_payload(decision: PrioritizedFinding) -> dict[str, Any]:

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import secrets
 from datetime import timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.security import OAuth2PasswordRequestForm
 
-from app.api.deps import CurrentUser, SessionDep, TokenDep
+from app.api.deps import CurrentUser, SessionDep
 from app.core import security
 from app.core.config import Settings, settings
 from app.core.db import ensure_configured_superuser
@@ -23,15 +24,14 @@ router = APIRouter(tags=["login"])
 @router.post("/login/access-token")
 def login_access_token(
     request: Request,
+    response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     session: SessionDep,
 ) -> Token:
     """OAuth2 compatible token login for the configured template-shell user."""
     _enforce_login_rate_limit(request, form_data.username)
-    if (
-        form_data.username != settings.FIRST_SUPERUSER
-        or form_data.password != settings.FIRST_SUPERUSER_PASSWORD
-    ):
+    user = ensure_configured_superuser(session)
+    if not _credentials_are_valid(user, form_data.username, form_data.password):
         record_audit_event(
             session,
             action="login.failure",
@@ -45,7 +45,6 @@ def login_access_token(
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     expires_at = security.access_token_expires_at(access_token_expires)
     jti = security.new_token_jti()
-    user = ensure_configured_superuser(session)
     auth_session = AuthSessionRepository(session).create_auth_session(
         user_id=user.id,
         jti_hash=security.token_jti_digest(jti),
@@ -59,13 +58,23 @@ def login_access_token(
         actor=user,
     )
     session.commit()
+    access_token = security.create_access_token(
+        user.email,
+        expires_delta=access_token_expires,
+        expires_at=expires_at,
+        jti=jti,
+    )
+    csrf_token = security.create_csrf_token(jti)
+    _set_session_cookies(
+        request,
+        response,
+        access_token=access_token,
+        csrf_token=csrf_token,
+        max_age_seconds=int(access_token_expires.total_seconds()),
+    )
     return Token(
-        access_token=security.create_access_token(
-            settings.FIRST_SUPERUSER,
-            expires_delta=access_token_expires,
-            expires_at=expires_at,
-            jti=jti,
-        )
+        access_token=access_token,
+        csrf_token=csrf_token,
     )
 
 
@@ -98,13 +107,13 @@ def _enforce_login_rate_limit(request: Request, username: str) -> None:
 
 @router.post("/login/logout", response_model=UserPublic)
 def logout_current_token(
+    request: Request,
+    response: Response,
     session: SessionDep,
-    token: TokenDep,
     current_user: CurrentUser,
 ) -> User:
     """Revoke the active browser session token."""
-    payload = security.decode_access_token(token)
-    jti = payload.get("jti")
+    jti = getattr(request.state, "auth_jti", None)
     if isinstance(jti, str):
         auth_session = AuthSessionRepository(session).get_active_auth_session_by_hash(
             security.token_jti_digest(jti)
@@ -119,4 +128,55 @@ def logout_current_token(
                 actor=current_user,
             )
             session.commit()
+    _clear_session_cookies(response)
     return current_user
+
+
+def _credentials_are_valid(user: User, username: str, password: str) -> bool:
+    normalized_username = username.strip().lower()
+    normalized_email = user.email.strip().lower()
+    return secrets.compare_digest(
+        normalized_username.encode(),
+        normalized_email.encode(),
+    ) and security.verify_password(password, user.hashed_password)
+
+
+def _set_session_cookies(
+    request: Request,
+    response: Response,
+    *,
+    access_token: str,
+    csrf_token: str,
+    max_age_seconds: int,
+) -> None:
+    cookie_secure = _session_cookie_secure(request)
+    response.set_cookie(
+        security.SESSION_COOKIE_NAME,
+        access_token,
+        max_age=max_age_seconds,
+        path="/",
+        httponly=True,
+        secure=cookie_secure,
+        samesite="lax",
+    )
+    response.set_cookie(
+        security.CSRF_COOKIE_NAME,
+        csrf_token,
+        max_age=max_age_seconds,
+        path="/",
+        httponly=False,
+        secure=cookie_secure,
+        samesite="lax",
+    )
+
+
+def _clear_session_cookies(response: Response) -> None:
+    response.delete_cookie(security.SESSION_COOKIE_NAME, path="/")
+    response.delete_cookie(security.CSRF_COOKIE_NAME, path="/")
+
+
+def _session_cookie_secure(request: Request) -> bool:
+    active_settings = getattr(request.app.state, "template_settings", settings)
+    if isinstance(active_settings, Settings) and active_settings.ENVIRONMENT != "local":
+        return True
+    return request.url.scheme == "https"

--- a/backend/app/api/routes/providers.py
+++ b/backend/app/api/routes/providers.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request, status
 
 from app.api.deps import ScopedAdminUser, ScopedReadUser, SessionDep
+from app.api.errors import production_safe_settings, redact_public_payload
 from app.core.config import Settings, settings
 from app.models import (
     AnalysisRun,
@@ -38,14 +39,16 @@ NO_PROVIDER_SNAPSHOT_WARNING = "No provider snapshot has been recorded yet."
 
 @router.get("/update-jobs", response_model=ProviderUpdateJobsPublic)
 def list_provider_update_jobs(
+    request: Request,
     session: SessionDep,
     _current_user: ScopedReadUser,
 ) -> ProviderUpdateJobsPublic:
     """Return provider update jobs newest first."""
+    production_safe = production_safe_settings(_request_settings(request))
     jobs = [
         job
         for run in RunRepository(session).list_provider_update_runs()
-        if (job := _provider_update_job(run)) is not None
+        if (job := _provider_update_job(run, production_safe=production_safe)) is not None
     ]
     return ProviderUpdateJobsPublic(data=jobs, count=len(jobs))
 
@@ -83,7 +86,10 @@ def create_template_provider_update_job(
     )
     session.commit()
     session.refresh(run)
-    job = _provider_update_job(run)
+    job = _provider_update_job(
+        run,
+        production_safe=production_safe_settings(_request_settings(request)),
+    )
     if job is None:  # Defensive; the service always returns a provider_update run.
         raise HTTPException(status_code=500, detail="Provider update job could not be read.")
     return job
@@ -113,30 +119,51 @@ def _provider_status_payload(
     active_settings: object,
 ) -> ProviderStatusPublic:
     metadata = _snapshot_metadata(snapshot)
-    warnings = _string_list(metadata.get("warnings"))
+    production_safe = production_safe_settings(active_settings)
+    public_metadata = _provider_public_metadata(metadata, production_safe=production_safe)
+    warnings = [_public_text(item) for item in _string_list(metadata.get("warnings"))]
     failed_update_error = _failed_update_error(latest_update_run)
-    last_error = failed_update_error or _last_error(metadata)
+    raw_last_error = failed_update_error or _last_error(metadata)
+    last_error = _public_text(raw_last_error) if raw_last_error is not None else None
     snapshot_status = _snapshot_status(snapshot, metadata)
     if snapshot is None:
         warnings.append(NO_PROVIDER_SNAPSHOT_WARNING)
     if failed_update_error is not None:
-        warnings.append(f"Latest provider update failed: {failed_update_error}")
+        warnings.append(f"Latest provider update failed: {_public_text(failed_update_error)}")
 
-    degraded = snapshot_status.missing or last_error is not None
+    degraded = snapshot_status.missing or raw_last_error is not None
     return ProviderStatusPublic(
         status="degraded" if degraded else "ok",
-        snapshot=snapshot_status,
-        sources=_source_statuses(snapshot, snapshot_status.selected_sources, last_error=last_error),
-        latest_update_job=_provider_update_job(latest_update_run),
-        cache_dir=(
-            _string_or_none(metadata.get("cache_dir"))
-            or _settings_path(active_settings, "provider_cache_dir", "PROVIDER_CACHE_DIR")
+        snapshot=_snapshot_status(
+            snapshot,
+            metadata,
+            public_metadata=public_metadata,
+            production_safe=production_safe,
         ),
-        snapshot_dir=_string_or_none(metadata.get("snapshot_dir"))
-        or _settings_path(
-            active_settings,
-            "provider_snapshot_dir",
-            "PROVIDER_SNAPSHOT_DIR",
+        sources=_source_statuses(snapshot, snapshot_status.selected_sources, last_error=last_error),
+        latest_update_job=_provider_update_job(
+            latest_update_run,
+            production_safe=production_safe,
+        ),
+        cache_dir=(
+            None
+            if production_safe
+            else _public_path(
+                _string_or_none(public_metadata.get("cache_dir"))
+                or _settings_path(active_settings, "provider_cache_dir", "PROVIDER_CACHE_DIR")
+            )
+        ),
+        snapshot_dir=(
+            None
+            if production_safe
+            else _public_path(
+                _string_or_none(public_metadata.get("snapshot_dir"))
+                or _settings_path(
+                    active_settings,
+                    "provider_snapshot_dir",
+                    "PROVIDER_SNAPSHOT_DIR",
+                )
+            )
         ),
         warnings=warnings,
         last_sync=_last_sync(snapshot, metadata),
@@ -149,6 +176,9 @@ def _provider_status_payload(
 def _snapshot_status(
     snapshot: ProviderSnapshot | None,
     metadata: dict[str, Any],
+    *,
+    public_metadata: dict[str, Any] | None = None,
+    production_safe: bool = False,
 ) -> ProviderSnapshotStatusPublic:
     if snapshot is None:
         return ProviderSnapshotStatusPublic()
@@ -156,6 +186,10 @@ def _snapshot_status(
     source_hashes = _dict_value(snapshot.source_hashes_json)
     selected_sources = _selected_sources(snapshot, metadata, source_hashes)
     snapshot_mode = _snapshot_mode(snapshot, metadata)
+    safe_metadata = public_metadata or _provider_public_metadata(
+        metadata,
+        production_safe=production_safe,
+    )
     return ProviderSnapshotStatusPublic(
         id=str(snapshot.id),
         created_at=_iso_datetime(snapshot.created_at),
@@ -166,9 +200,9 @@ def _snapshot_status(
         generated_at=_string_or_none(metadata.get("generated_at")),
         selected_sources=selected_sources,
         requested_cves=_int_value(metadata.get("requested_cves")),
-        source_hashes=source_hashes,
-        source_metadata=metadata,
-        source_path=_source_path(metadata),
+        source_hashes={} if production_safe else _dict_value(redact_public_payload(source_hashes)),
+        source_metadata=safe_metadata,
+        source_path=None if production_safe else _source_path(safe_metadata),
         locked_provider_data=_bool_value(metadata.get("locked_provider_data")),
         missing=_bool_value(metadata.get("missing"), default=False),
         mode=snapshot_mode,
@@ -219,10 +253,15 @@ def _source_statuses(
     ]
 
 
-def _provider_update_job(run: AnalysisRun | None) -> ProviderUpdateJobPublic | None:
+def _provider_update_job(
+    run: AnalysisRun | None,
+    *,
+    production_safe: bool = False,
+) -> ProviderUpdateJobPublic | None:
     if run is None:
         return None
     metadata = _dict_value(run.summary_json) or _dict_value(run.error_json)
+    public_metadata = _provider_public_metadata(metadata, production_safe=production_safe)
     return ProviderUpdateJobPublic(
         id=str(run.id),
         status=str(run.status),
@@ -231,8 +270,8 @@ def _provider_update_job(run: AnalysisRun | None) -> ProviderUpdateJobPublic | N
         ),
         started_at=_iso_datetime(run.started_at),
         finished_at=_iso_datetime(run.finished_at),
-        error_message=_failed_update_error(run),
-        metadata_=metadata,
+        error_message=_public_text(_failed_update_error(run)),
+        metadata_=public_metadata,
     )
 
 
@@ -407,3 +446,61 @@ def _aware_datetime(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value
+
+
+def _provider_public_metadata(
+    metadata: dict[str, Any],
+    *,
+    production_safe: bool,
+) -> dict[str, Any]:
+    redacted = redact_public_payload(metadata)
+    public = dict(redacted) if isinstance(redacted, dict) else {}
+    if not production_safe:
+        return public
+
+    for key in (
+        "cache_dir",
+        "input_path",
+        "input_paths",
+        "output_path",
+        "provider_cache_dir",
+        "snapshot_dir",
+        "snapshot_file",
+        "snapshot_path",
+        "source_path",
+    ):
+        public.pop(key, None)
+    source_metadata = public.get("source_metadata")
+    if isinstance(source_metadata, dict):
+        public["source_metadata"] = _production_source_metadata(source_metadata)
+    return public
+
+
+def _production_source_metadata(value: dict[str, Any]) -> dict[str, Any]:
+    allowed_keys = {
+        "cache_only",
+        "fallback_from_previous_snapshot",
+        "fetched_count",
+        "missing_count",
+        "record_count",
+        "source",
+    }
+    public: dict[str, Any] = {}
+    for source, metadata in value.items():
+        if isinstance(metadata, dict):
+            public[source] = {key: item for key, item in metadata.items() if key in allowed_keys}
+    return public
+
+
+def _public_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    redacted = redact_public_payload(value)
+    return redacted if isinstance(redacted, str) else None
+
+
+def _public_path(value: str | None) -> str | None:
+    if value is None:
+        return None
+    redacted = redact_public_payload(value)
+    return redacted if isinstance(redacted, str) else None

--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import hashlib
 import uuid
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from starlette.responses import FileResponse
 
 from app.api.deps import ScopedReportUser, SessionDep
+from app.api.errors import redact_public_payload
 from app.api.routes.workbench_access import require_visible_project
 from app.core.config import Settings
 from app.models import (
@@ -188,7 +190,7 @@ def _report_public(report: Report, request: Request) -> ReportPublic:
         content_type=report.content_type,
         sha256=report.sha256,
         size_bytes=report.size_bytes,
-        metadata_json=report.metadata_json,
+        metadata_json=_dict_value(redact_public_payload(report.metadata_json or {})),
         created_at=report.created_at,
         download_url=f"{settings.API_V1_STR}/reports/{report.id}/download",
     )
@@ -215,3 +217,7 @@ def _template_settings(request: Request) -> Settings:
     if isinstance(candidate, Settings):
         return candidate
     raise HTTPException(status_code=500, detail="Template settings are not configured.")
+
+
+def _dict_value(value: object) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}

--- a/backend/app/api/routes/runs.py
+++ b/backend/app/api/routes/runs.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 
 from app.api.deps import ScopedReadUser, SessionDep
+from app.api.errors import redact_public_payload
 from app.api.routes.workbench_access import require_visible_project
 from app.models import (
     AnalysisRun,
@@ -40,19 +41,23 @@ def read_project_runs(
     require_visible_project(session, current_user, project_id)
     runs = RunRepository(session).list_analysis_runs(project_id)
     return AnalysisRunsPublic(
-        data=[AnalysisRunPublic.model_validate(run) for run in runs],
+        data=[_analysis_run_public(run) for run in runs],
         count=len(runs),
     )
 
 
 @router.get("/runs/{run_id}", response_model=AnalysisRunPublic)
-def read_run(run_id: uuid.UUID, session: SessionDep, current_user: ScopedReadUser) -> AnalysisRun:
+def read_run(
+    run_id: uuid.UUID,
+    session: SessionDep,
+    current_user: ScopedReadUser,
+) -> AnalysisRunPublic:
     """Read one analysis run if its project is visible."""
     run = RunRepository(session).get_analysis_run(run_id)
     if run is None:
         raise HTTPException(status_code=404, detail="Analysis run not found")
     require_visible_project(session, current_user, run.project_id)
-    return run
+    return _analysis_run_public(run)
 
 
 @router.get("/runs/{run_id}/summary", response_model=AnalysisRunSummaryPublic)
@@ -70,8 +75,8 @@ def read_run_summary(
 
 
 def _analysis_run_summary(run: AnalysisRun) -> AnalysisRunSummaryPublic:
-    summary_json = dict(run.summary_json or {})
-    error_json = dict(run.error_json or {})
+    summary_json = _dict_value(redact_public_payload(run.summary_json or {}))
+    error_json = _dict_value(redact_public_payload(run.error_json or {}))
     dedup_summary = _dict_value(summary_json.get("dedup_summary"))
     parse_errors = _parse_errors(summary_json, error_json)
     return AnalysisRunSummaryPublic(
@@ -104,6 +109,17 @@ def _analysis_run_summary(run: AnalysisRun) -> AnalysisRunSummaryPublic:
         dedup_summary=dedup_summary,
         summary_json=summary_json,
         error_json=error_json,
+    )
+
+
+def _analysis_run_public(run: AnalysisRun) -> AnalysisRunPublic:
+    public = AnalysisRunPublic.model_validate(run)
+    return public.model_copy(
+        update={
+            "summary_json": _dict_value(redact_public_payload(run.summary_json or {})),
+            "error_json": _dict_value(redact_public_payload(run.error_json or {})),
+            "error_message": redact_public_payload(run.error_message),
+        }
     )
 
 

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -7,6 +7,7 @@ import uuid
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from app.core import security
 from app.core.config import settings
 from app.models import User
 
@@ -42,6 +43,10 @@ def ensure_configured_superuser(session: Session) -> User:
     statement = select(User).where(User.email == settings.FIRST_SUPERUSER)
     user = session.exec(statement).first()
     if user:
+        if security.password_hash_needs_bootstrap(user.hashed_password):
+            user.hashed_password = security.get_password_hash(settings.FIRST_SUPERUSER_PASSWORD)
+            session.add(user)
+            session.flush()
         return user
 
     user = User(
@@ -49,7 +54,7 @@ def ensure_configured_superuser(session: Session) -> User:
         email=settings.FIRST_SUPERUSER,
         is_active=True,
         is_superuser=True,
-        hashed_password="configured-superuser-password-placeholder",
+        hashed_password=security.get_password_hash(settings.FIRST_SUPERUSER_PASSWORD),
     )
     session.add(user)
     try:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -13,6 +14,18 @@ from typing import Any
 from app.core.config import settings
 
 ALGORITHM = "HS256"
+PASSWORD_HASH_ALGORITHM = "pbkdf2_sha256"
+PASSWORD_HASH_ITERATIONS = 600_000
+PASSWORD_SALT_BYTES = 16
+LEGACY_CONFIGURED_PASSWORD_PLACEHOLDERS = frozenset(
+    {
+        "configured-superuser",
+        "configured-superuser-password-placeholder",
+    }
+)
+SESSION_COOKIE_NAME = "vpw_session"
+CSRF_COOKIE_NAME = "vpw_csrf"
+CSRF_HEADER_NAME = "x-csrf-token"
 
 
 class TokenDecodeError(ValueError):
@@ -26,6 +39,51 @@ def _base64url_encode(payload: bytes) -> str:
 def _base64url_decode(payload: str) -> bytes:
     padding = "=" * (-len(payload) % 4)
     return base64.urlsafe_b64decode(f"{payload}{padding}")
+
+
+def get_password_hash(password: str) -> str:
+    """Hash a password with stdlib PBKDF2-HMAC-SHA256."""
+    salt = secrets.token_bytes(PASSWORD_SALT_BYTES)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        PASSWORD_HASH_ITERATIONS,
+    )
+    return "$".join(
+        [
+            PASSWORD_HASH_ALGORITHM,
+            str(PASSWORD_HASH_ITERATIONS),
+            _base64url_encode(salt),
+            _base64url_encode(digest),
+        ]
+    )
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Verify a password against the persisted stdlib PBKDF2 hash."""
+    try:
+        algorithm, iterations_raw, salt_raw, digest_raw = hashed_password.split("$", 3)
+        if algorithm != PASSWORD_HASH_ALGORITHM:
+            return False
+        iterations = int(iterations_raw)
+        if iterations <= 0:
+            return False
+        expected_digest = _base64url_decode(digest_raw)
+        actual_digest = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode("utf-8"),
+            _base64url_decode(salt_raw),
+            iterations,
+        )
+    except (ValueError, binascii.Error):
+        return False
+    return hmac.compare_digest(actual_digest, expected_digest)
+
+
+def password_hash_needs_bootstrap(hashed_password: str) -> bool:
+    """Return whether a configured user's placeholder hash should be replaced."""
+    return hashed_password in LEGACY_CONFIGURED_PASSWORD_PLACEHOLDERS
 
 
 def access_token_expires_at(expires_delta: timedelta | None = None) -> datetime:
@@ -43,6 +101,37 @@ def new_token_jti() -> str:
 def token_jti_digest(jti: str) -> str:
     """Return a stable digest for storing JWT IDs without token material."""
     return hashlib.sha256(jti.encode("utf-8")).hexdigest()
+
+
+def create_csrf_token(jti: str) -> str:
+    """Create a signed CSRF token bound to one JWT ID."""
+    nonce = secrets.token_urlsafe(32)
+    signature = _csrf_signature(jti, nonce)
+    return f"{nonce}.{_base64url_encode(signature)}"
+
+
+def verify_csrf_token(jti: str, token: str) -> bool:
+    """Validate a signed CSRF token for one JWT ID."""
+    try:
+        nonce, signature_raw = token.split(".", 1)
+    except ValueError:
+        return False
+    if not nonce or not signature_raw:
+        return False
+    try:
+        actual_signature = _base64url_decode(signature_raw)
+    except (ValueError, binascii.Error):
+        return False
+    expected_signature = _csrf_signature(jti, nonce)
+    return hmac.compare_digest(actual_signature, expected_signature)
+
+
+def _csrf_signature(jti: str, nonce: str) -> bytes:
+    return hmac.new(
+        settings.SECRET_KEY.encode("utf-8"),
+        f"csrf:{jti}:{nonce}".encode(),
+        hashlib.sha256,
+    ).digest()
 
 
 def create_access_token(
@@ -97,5 +186,5 @@ def decode_access_token(token: str) -> dict[str, Any]:
         if datetime.now(UTC).timestamp() >= expires_at:
             raise TokenDecodeError("Expired token")
         return dict(claims)
-    except (ValueError, json.JSONDecodeError) as exc:
+    except (ValueError, json.JSONDecodeError, binascii.Error) as exc:
         raise TokenDecodeError("Could not decode token") from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request
-from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import JSONResponse, Response
 
+from app.api.errors import (
+    error_response_content,
+    http_exception_handler,
+    unhandled_exception_handler,
+    validation_error_handler,
+)
 from app.api.main import api_router
 from app.core.config import Settings, settings
 from app.core.rate_limit import InMemoryRateLimiter, rate_limit_key
-from vuln_prioritizer.security_redaction import redact_value
 
 SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
@@ -65,21 +70,16 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
             allow_origins=list(selected_settings.all_cors_origins),
             allow_credentials=True,
             allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-            allow_headers=["Authorization", "Content-Type", "Accept"],
+            allow_headers=["Authorization", "Content-Type", "Accept", "X-CSRF-Token"],
         )
     app.middleware("http")(_rate_limit_guard)
     app.middleware("http")(_upload_size_guard)
     app.middleware("http")(_security_headers)
     app.include_router(api_router, prefix=selected_settings.API_V1_STR)
-    app.add_exception_handler(RequestValidationError, _validation_error_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_error_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)
     return app
-
-
-async def _validation_error_handler(_request: Request, exc: Exception) -> JSONResponse:
-    if not isinstance(exc, RequestValidationError):
-        return JSONResponse(status_code=500, content={"detail": "Internal server error."})
-    detail, _redacted_paths = redact_value(jsonable_encoder(exc.errors()))
-    return JSONResponse(status_code=422, content={"detail": detail})
 
 
 async def _security_headers(
@@ -106,7 +106,11 @@ async def _rate_limit_guard(
             if not decision.allowed:
                 return JSONResponse(
                     status_code=429,
-                    content={"detail": "Too many requests."},
+                    content=error_response_content(
+                        status_code=429,
+                        detail="Too many requests.",
+                        request=request,
+                    ),
                     headers={"Retry-After": str(decision.retry_after_seconds)},
                 )
     return await call_next(request)
@@ -129,7 +133,11 @@ async def _upload_size_guard(
                 if content_length > active_settings.max_upload_bytes + multipart_overhead:
                     return JSONResponse(
                         status_code=413,
-                        content={"detail": "Upload exceeds configured limit."},
+                        content=error_response_content(
+                            status_code=413,
+                            detail="Upload exceeds configured limit.",
+                            request=request,
+                        ),
                     )
     return await call_next(request)
 

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -8,6 +8,7 @@ class Token(SQLModel):
 
     access_token: str
     token_type: str = "bearer"
+    csrf_token: str | None = None
 
 
 class TokenPayload(SQLModel):

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -18,6 +18,7 @@ from vuln_prioritizer.config import DEFAULT_CACHE_TTL_HOURS
 from vuln_prioritizer.inputs.loader import InputSpec
 from vuln_prioritizer.models import AnalysisContext, PrioritizedFinding, PriorityPolicy
 from vuln_prioritizer.provider_snapshot import load_provider_snapshot
+from vuln_prioritizer.security_redaction import redact_value
 from vuln_prioritizer.services.analysis import (
     AnalysisInputError,
     AnalysisNoFindingsError,
@@ -48,7 +49,7 @@ class TemplateAnalysisResult:
     @property
     def summary_json(self) -> dict[str, Any]:
         """Return run-summary fields that prove enrichment, scoring, and explanation."""
-        return {
+        summary = {
             "analysis_service": {
                 "pipeline": "parse-persist-enrich-score-explain",
                 "engine": "vuln_prioritizer.prepare_analysis",
@@ -57,7 +58,7 @@ class TemplateAnalysisResult:
             if self.provider_snapshot_id is not None
             else None,
             "provider_snapshot_hash": self.provider_snapshot_hash,
-            "provider_snapshot_file": self.provider_snapshot_file,
+            "provider_snapshot_file": _public_path_label(self.provider_snapshot_file),
             "locked_provider_data": self.locked_provider_data,
             "findings_count": self.context.findings_count,
             "counts_by_priority": _counts_by_priority(self.context.counts_by_priority),
@@ -68,9 +69,11 @@ class TemplateAnalysisResult:
             "attack_enabled": self.context.attack_enabled,
             "attack_source": self.context.attack_source,
             "attack_mapped_cves": self.context.attack_hits,
-            "attack_mapping_file": self.context.attack_mapping_file,
+            "attack_mapping_file": _public_path_label(self.context.attack_mapping_file),
             "attack_mapping_file_sha256": self.context.attack_mapping_file_sha256,
-            "attack_technique_metadata_file": self.context.attack_technique_metadata_file,
+            "attack_technique_metadata_file": _public_path_label(
+                self.context.attack_technique_metadata_file
+            ),
             "attack_technique_metadata_file_sha256": (
                 self.context.attack_technique_metadata_file_sha256
             ),
@@ -82,6 +85,8 @@ class TemplateAnalysisResult:
             "under_investigation_count": self.context.under_investigation_count,
             "vex_conflict_count": self.context.vex_conflict_count,
         }
+        redacted, _paths = redact_value(summary)
+        return redacted if isinstance(redacted, dict) else summary
 
 
 class AnalysisService:
@@ -258,6 +263,12 @@ class AnalysisService:
 
 def _file_sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _public_path_label(value: str | Path | None) -> str | None:
+    if value is None:
+        return None
+    return Path(value).name
 
 
 def _counts_by_priority(raw_counts: dict[str, int]) -> dict[str, int]:

--- a/backend/app/services/import_uploads.py
+++ b/backend/app/services/import_uploads.py
@@ -156,7 +156,17 @@ def optional_upload_summary(
 def upload_summary_with_path(value: Any, *, path: str | None) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    return {**value, "path": path}
+    return {**value, "path": path, "storage_ref": path}
+
+
+def upload_storage_ref(
+    *,
+    project_id: uuid.UUID,
+    run_id: uuid.UUID,
+    filename: str,
+) -> str:
+    """Return the public managed upload reference without exposing server roots."""
+    return f"{project_id}/{run_id}/{sanitize_filename(filename)}"
 
 
 def store_upload(
@@ -200,6 +210,7 @@ def upload_summary(
         "size_bytes": size_bytes,
         "sha256": sha256,
         "path": path,
+        "storage_ref": path,
     }
 
 

--- a/backend/tests/api/test_template_auth_smoke.py
+++ b/backend/tests/api/test_template_auth_smoke.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 from sqlalchemy.pool import StaticPool
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.core import security
 from app.core.config import Settings, settings
@@ -34,28 +34,110 @@ def _client(active_app: Any = app) -> TestClient:
     return TestClient(active_app)
 
 
-def _login(client: TestClient) -> str:
+def _login_response(client: TestClient, *, password: str | None = None) -> Any:
     response = client.post(
         "/api/v1/login/access-token",
         data={
             "username": settings.FIRST_SUPERUSER,
-            "password": settings.FIRST_SUPERUSER_PASSWORD,
+            "password": password or settings.FIRST_SUPERUSER_PASSWORD,
         },
     )
     assert response.status_code == 200
     payload = response.json()
     assert payload["token_type"] == "bearer"
+    return response
+
+
+def _login(client: TestClient) -> str:
+    response = _login_response(client)
+    payload = response.json()
     return str(payload["access_token"])
 
 
 def test_template_login_access_token_accepts_configured_superuser() -> None:
     client = _client()
 
-    token = _login(client)
+    response = _login_response(client)
+    token = str(response.json()["access_token"])
 
     decoded = security.decode_access_token(token)
     assert decoded["sub"] == settings.FIRST_SUPERUSER
     assert decoded["jti"]
+    assert response.json()["csrf_token"]
+
+
+def test_template_login_verifies_db_stored_password_hash(template_api_env: Any) -> None:
+    client = template_api_env.client
+    db_only_password = "db-only-password"
+    with Session(template_api_env.engine) as db_session:
+        statement = select(template_api_env.app_models.User).where(
+            template_api_env.app_models.User.email == settings.FIRST_SUPERUSER
+        )
+        user = db_session.exec(statement).one()
+        user.hashed_password = security.get_password_hash(db_only_password)
+        db_session.add(user)
+        db_session.commit()
+
+    env_password = client.post(
+        "/api/v1/login/access-token",
+        data={
+            "username": settings.FIRST_SUPERUSER,
+            "password": settings.FIRST_SUPERUSER_PASSWORD,
+        },
+    )
+    db_password = _login_response(client, password=db_only_password)
+
+    assert env_password.status_code == 400
+    assert db_password.status_code == 200
+
+
+def test_template_login_sets_session_and_csrf_cookies() -> None:
+    client = _client()
+
+    response = _login_response(client)
+    payload = response.json()
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    session_cookie = next(
+        header
+        for header in set_cookie_headers
+        if header.startswith(f"{security.SESSION_COOKIE_NAME}=")
+    )
+
+    assert response.cookies.get(security.SESSION_COOKIE_NAME) == payload["access_token"]
+    assert response.cookies.get(security.CSRF_COOKIE_NAME) == payload["csrf_token"]
+    assert "HttpOnly" in session_cookie
+    assert "SameSite=lax" in session_cookie
+
+
+def test_template_cookie_session_authenticates_safe_browser_requests() -> None:
+    client = _client()
+    _login_response(client)
+
+    response = client.get("/api/v1/users/me")
+
+    assert response.status_code == 200
+    assert response.json()["email"] == settings.FIRST_SUPERUSER
+
+
+def test_template_cookie_session_requires_csrf_for_unsafe_methods() -> None:
+    client = _client()
+    login = _login_response(client)
+    csrf_token = str(login.json()["csrf_token"])
+
+    missing_csrf = client.post(
+        "/api/v1/projects/",
+        json={"name": "Missing CSRF", "description": None},
+    )
+    valid_csrf = client.post(
+        "/api/v1/projects/",
+        headers={security.CSRF_HEADER_NAME: csrf_token},
+        json={"name": "Valid CSRF", "description": None},
+    )
+
+    assert missing_csrf.status_code == 403
+    assert missing_csrf.json()["detail"] == "CSRF token missing or invalid"
+    assert valid_csrf.status_code == 200
+    assert valid_csrf.json()["name"] == "Valid CSRF"
 
 
 def test_template_login_access_token_rejects_wrong_password() -> None:
@@ -105,6 +187,31 @@ def test_template_logout_revokes_browser_session() -> None:
     assert logout.status_code == 200
     assert after_logout.status_code == 403
     assert after_logout.json()["detail"] == "Session is expired or revoked"
+
+
+def test_template_logout_revokes_cookie_session_and_clears_cookies() -> None:
+    client = _client()
+    login = _login_response(client)
+    payload = login.json()
+    csrf_token = str(payload["csrf_token"])
+    token = str(payload["access_token"])
+
+    logout = client.post(
+        "/api/v1/login/logout",
+        headers={security.CSRF_HEADER_NAME: csrf_token},
+    )
+    cookie_after_logout = client.get("/api/v1/users/me")
+    bearer_after_logout = client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert logout.status_code == 200
+    assert security.SESSION_COOKIE_NAME not in client.cookies
+    assert security.CSRF_COOKIE_NAME not in client.cookies
+    assert cookie_after_logout.status_code == 401
+    assert bearer_after_logout.status_code == 403
+    assert bearer_after_logout.json()["detail"] == "Session is expired or revoked"
 
 
 def test_template_login_rate_limit_blocks_repeated_attempts() -> None:

--- a/backend/tests/api/test_template_backend_adapter.py
+++ b/backend/tests/api/test_template_backend_adapter.py
@@ -85,6 +85,39 @@ def test_template_backend_health_check_matches_template_utility_route() -> None:
     assert response.json() is True
 
 
+def test_template_backend_http_errors_include_stable_envelope() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/v1/items/")
+
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload["code"] == "not_found"
+    assert payload["message"] == "Not Found"
+    assert payload["details"] == {}
+    assert payload["detail"] == "Not Found"
+
+
+def test_template_backend_validation_errors_include_redacted_envelope() -> None:
+    selected_app = create_app(Settings(ENVIRONMENT="local"))
+
+    @selected_app.get("/debug/{item_id}")
+    def _debug_item(item_id: int) -> dict[str, int]:
+        return {"item_id": item_id}
+
+    client = TestClient(selected_app)
+
+    response = client.get("/debug/not-a-number")
+
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["code"] == "request_validation_failed"
+    assert payload["message"] == "Request validation failed."
+    assert "errors" in payload["details"]
+    assert "/Users/" not in response.text
+    assert "token" not in response.text.lower()
+
+
 def test_template_backend_allows_configured_frontend_cors_origin() -> None:
     client = TestClient(app)
 

--- a/backend/tests/api/test_template_import_upload_api.py
+++ b/backend/tests/api/test_template_import_upload_api.py
@@ -85,7 +85,11 @@ def test_valid_cve_list_upload_creates_analysis_run_and_stores_sha256(
     assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
     assert payload["summary_json"]["input_upload"]["original_filename"] == "Team Scan (prod).txt"
     assert payload["summary_json"]["input_upload"]["stored_filename"] == "Team_Scan__prod_.txt"
-    stored_path = Path(payload["summary_json"]["input_upload"]["path"])
+    stored_ref = payload["summary_json"]["input_upload"]["path"]
+    assert stored_ref == f"{project['id']}/{payload['id']}/Team_Scan__prod_.txt"
+    assert payload["summary_json"]["input_upload"]["storage_ref"] == stored_ref
+    assert not Path(stored_ref).is_absolute()
+    stored_path = upload_dir / stored_ref
     assert stored_path == upload_dir / project["id"] / payload["id"] / "Team_Scan__prod_.txt"
     assert stored_path.read_bytes() == content
     assert payload["summary_json"]["import_job"]["status"] == "succeeded"
@@ -171,7 +175,7 @@ def test_template_import_uses_demo_snapshot_without_network_or_keys(
     summary = payload["summary_json"]
     assert payload["status"] == "succeeded"
     assert summary["locked_provider_data"] is True
-    assert summary["provider_snapshot_file"].endswith("data/demo_provider_snapshot.json")
+    assert summary["provider_snapshot_file"] == "demo_provider_snapshot.json"
     assert summary["provider_snapshot_id"] == payload["provider_snapshot_id"]
     assert summary["finding_count"] > 0
     assert summary["kev_hits"] > 0
@@ -301,7 +305,7 @@ def test_decision_api_endpoints_expose_explain_summary_and_cvss_comparison(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
 ) -> None:
-    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    _configure_upload_dir(template_api_env, tmp_path)
     headers = auth_headers(template_api_env.client)
     project = create_project_via_api(template_api_env.client, headers)
     content = b"CVE-2021-44228\nCVE-2024-3094\n"
@@ -314,7 +318,7 @@ def test_decision_api_endpoints_expose_explain_summary_and_cvss_comparison(
     )
     assert import_response.status_code == 200
     run_payload = import_response.json()
-    assert Path(run_payload["summary_json"]["input_upload"]["path"]).is_relative_to(upload_dir)
+    assert not Path(run_payload["summary_json"]["input_upload"]["path"]).is_absolute()
 
     findings_response = template_api_env.client.get(
         f"/api/v1/projects/{project['id']}/findings/",
@@ -550,8 +554,8 @@ def test_import_upload_applies_asset_context_sidecar_to_template_findings(
     sidecar_upload = payload["summary_json"]["asset_context_upload"]
     assert sidecar_upload["sha256"] == expected_sidecar_sha256
     assert sidecar_upload["stored_filename"] == "asset-context.csv"
-    assert Path(sidecar_upload["path"]).is_relative_to(upload_dir)
-    assert Path(sidecar_upload["path"]).read_bytes() == asset_context_csv
+    assert not Path(sidecar_upload["path"]).is_absolute()
+    assert (upload_dir / sidecar_upload["path"]).read_bytes() == asset_context_csv
     assert payload["summary_json"]["asset_context"]["loaded_rows"] == 1
     assert payload["summary_json"]["asset_context"]["matched_occurrences"] == 1
     assert payload["summary_json"]["dedup_summary"]["decisions"][0]["asset_ref"] == "asset-web-1"
@@ -681,8 +685,8 @@ def test_import_upload_applies_openvex_sidecar_to_template_findings(
     vex_upload = payload["summary_json"]["vex_upload"]
     assert vex_upload["sha256"] == expected_vex_sha256
     assert vex_upload["stored_filename"] == "openvex.json"
-    assert Path(vex_upload["path"]).is_relative_to(upload_dir)
-    assert Path(vex_upload["path"]).read_bytes() == vex_bytes
+    assert not Path(vex_upload["path"]).is_absolute()
+    assert (upload_dir / vex_upload["path"]).read_bytes() == vex_bytes
     assert payload["summary_json"]["vex"]["statement_count"] == 4
     assert payload["summary_json"]["vex"]["matched_occurrences"] == 1
     assert payload["summary_json"]["suppressed_by_vex"] == 1
@@ -721,7 +725,7 @@ def test_import_upload_applies_cyclonedx_vex_sidecar_to_template_findings(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
 ) -> None:
-    upload_dir = _configure_upload_dir(template_api_env, tmp_path)
+    _configure_upload_dir(template_api_env, tmp_path)
     headers = auth_headers(template_api_env.client)
     project = create_project_via_api(template_api_env.client, headers)
     occurrence_csv = "\n".join(
@@ -752,7 +756,7 @@ def test_import_upload_applies_cyclonedx_vex_sidecar_to_template_findings(
     vex_upload = payload["summary_json"]["vex_upload"]
     assert vex_upload["input_type"] == "vex-json"
     assert vex_upload["stored_filename"] == "cyclonedx-vex.json"
-    assert Path(vex_upload["path"]).is_relative_to(upload_dir)
+    assert not Path(vex_upload["path"]).is_absolute()
     assert payload["summary_json"]["vex"]["statement_count"] == 3
     assert payload["summary_json"]["vex"]["matched_occurrences"] == 2
     assert payload["summary_json"]["suppressed_by_vex"] == 2
@@ -806,6 +810,8 @@ def test_import_upload_rejects_invalid_vex_sidecar_with_clear_error(
     )
 
     assert response.status_code == 422, response.text
+    assert response.json()["code"] == "import_vex_parse_failed"
+    assert response.json()["details"]["analysis_run_id"]
     detail = response.json()["detail"]
     assert detail["message"] == "VEX parsing failed."
     assert detail["analysis_run_id"]
@@ -862,6 +868,8 @@ def test_import_upload_rejects_invalid_asset_context_sidecar_with_clear_error(
     )
 
     assert response.status_code == 422, response.text
+    assert response.json()["code"] == "import_asset_context_parse_failed"
+    assert response.json()["details"]["analysis_run_id"]
     detail = response.json()["detail"]
     assert detail["message"] == "Asset context parsing failed."
     assert detail["analysis_run_id"]
@@ -923,6 +931,8 @@ def test_analysis_failure_persists_failed_run_without_partial_findings(
     )
 
     assert response.status_code == 422
+    assert response.json()["code"] == "import_analysis_failed"
+    assert response.json()["details"]["analysis_run_id"]
     detail = response.json()["detail"]
     assert detail["message"] == "Import analysis failed."
     assert detail["analysis_error"]["stage"] == "enrich_score_explain"
@@ -986,6 +996,15 @@ def test_same_cve_on_different_assets_creates_distinct_findings(
     assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["summary_json"]["finding_count"] == 2
+    assert payload["summary_json"]["analysis_semantics"] == {
+        "analysis_decision_scope": "cve",
+        "persistence_scope": "asset_component_occurrence",
+        "finding_dedup_key_version": "vpw019-v1",
+        "cve_count": 1,
+        "occurrence_count": 2,
+        "finding_count": 2,
+        "same_cve_can_create_distinct_asset_findings": True,
+    }
     assert payload["summary_json"]["dedup_summary"]["created_findings"] == 2
     assert {
         item["asset_ref"] for item in payload["summary_json"]["dedup_summary"]["decisions"]
@@ -1050,6 +1069,7 @@ def test_upload_rejects_oversized_file_without_persisting_run_or_file(
     )
 
     assert response.status_code == 413
+    assert response.json()["code"] == "upload_too_large"
     assert "Upload exceeds configured limit" in response.text
     assert _run_count(template_api_env, uuid.UUID(project["id"])) == 0
     assert not upload_dir.exists()
@@ -1236,6 +1256,7 @@ def test_parse_errors_are_structured_and_failed_run_is_persisted(
     )
 
     assert response.status_code == 422
+    assert response.json()["code"] == "import_parse_failed"
     detail = response.json()["detail"]
     assert detail["message"] == "Import parsing failed."
     assert detail["analysis_run_id"]
@@ -1266,8 +1287,9 @@ def test_parse_errors_are_structured_and_failed_run_is_persisted(
     _assert_no_sensitive_path_leak(payload["error_json"]["parse_errors"], tmp_path, upload_dir)
     _assert_no_sensitive_path_leak(payload["summary_json"]["parse_errors"], tmp_path, upload_dir)
     assert payload["summary_json"]["input_upload"]["sha256"] == expected_sha256
-    assert Path(payload["summary_json"]["input_upload"]["path"]).is_relative_to(upload_dir)
-    assert Path(payload["summary_json"]["input_upload"]["path"]).read_bytes() == content
+    upload_ref = payload["summary_json"]["input_upload"]["path"]
+    assert not Path(upload_ref).is_absolute()
+    assert (upload_dir / upload_ref).read_bytes() == content
 
     summary = template_api_env.client.get(
         f"/api/v1/runs/{detail['analysis_run_id']}/summary",

--- a/backend/tests/api/test_template_provider_status_api.py
+++ b/backend/tests/api/test_template_provider_status_api.py
@@ -198,6 +198,74 @@ def test_template_provider_status_surfaces_failed_provider_update(
     )
 
 
+def test_template_provider_status_redacts_production_paths_and_cache_details(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    headers = auth_headers(template_api_env.client)
+    active_settings = template_api_env.client.app.state.template_settings
+    private_snapshot = tmp_path / "private" / "provider-snapshot.json"
+    private_cache = tmp_path / "private" / "cache"
+    with Session(template_api_env.engine) as session:
+        session.add(
+            template_api_env.app_models.ProviderSnapshot(
+                id=uuid.uuid4(),
+                created_at=datetime(2026, 4, 28, 10, 0, tzinfo=UTC),
+                content_hash="sha256:provider-production-redaction",
+                nvd_last_sync="2026-04-28T10:15:00Z",
+                source_hashes_json={"nvd": "sha256:nvd-cache-namespace"},
+                source_metadata_json={
+                    "selected_sources": ["nvd"],
+                    "generated_at": "2026-04-28T10:30:00Z",
+                    "cache_dir": str(private_cache),
+                    "snapshot_dir": str(private_snapshot.parent),
+                    "source_path": str(private_snapshot),
+                    "warnings": [f"using cache from {private_cache}"],
+                    "source_metadata": {
+                        "nvd": {
+                            "source": "NVD CVE API 2.0",
+                            "record_count": 1,
+                            "cache_namespace_hash": "sha256:nvd-cache-namespace",
+                        }
+                    },
+                },
+            )
+        )
+        session.commit()
+
+    template_api_env.client.app.state.template_settings = replace(
+        active_settings,
+        ENVIRONMENT="production",
+        SECRET_KEY="template-shell-secret",
+        FIRST_SUPERUSER_PASSWORD="template-shell-password",
+        FRONTEND_HOST="https://workbench.example.com",
+        ALLOWED_HOSTS=("workbench.example.com",),
+        PROVIDER_CACHE_DIR=str(private_cache),
+        PROVIDER_SNAPSHOT_DIR=str(private_snapshot.parent),
+    )
+    try:
+        response = template_api_env.client.get("/api/v1/providers/status", headers=headers)
+    finally:
+        template_api_env.client.app.state.template_settings = active_settings
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["cache_dir"] is None
+    assert payload["snapshot_dir"] is None
+    assert payload["snapshot"]["source_path"] is None
+    assert payload["snapshot"]["source_hashes"] == {}
+    assert "cache_dir" not in payload["snapshot"]["source_metadata"]
+    assert "snapshot_dir" not in payload["snapshot"]["source_metadata"]
+    assert "source_path" not in payload["snapshot"]["source_metadata"]
+    assert payload["snapshot"]["source_metadata"]["source_metadata"]["nvd"] == {
+        "source": "NVD CVE API 2.0",
+        "record_count": 1,
+    }
+    assert str(tmp_path) not in response.text
+    assert "cache_namespace_hash" not in response.text
+
+
 def test_template_provider_update_job_create_list_and_status(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,
@@ -382,6 +450,7 @@ def test_template_provider_update_job_rejects_active_job(
         )
 
         assert response.status_code == 409
+        assert response.json()["code"] == "conflict"
         assert "Provider update already running" in response.json()["detail"]
     finally:
         template_api_env.client.app.state.template_settings = active_settings

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -242,7 +242,8 @@ def test_public_deployment_runbook_documents_backup_retention_and_tls() -> None:
     assert "scripts/workbench-backup.sh" in runbook
     assert "scripts/workbench-restore.sh" in runbook
     assert "WORKBENCH_ARTIFACT_MODE=compose" in runbook
-    assert "/app/template-import-uploads" in runbook
+    assert "import-upload, report, provider-snapshot, and\nprovider-cache" in runbook
+    assert "/app/template-import-uploads" not in runbook
     assert "python -m app.core.retention --dry-run" in runbook
     assert "TRAEFIK_APP_ENABLED=true" in runbook
     assert "BACKEND_CORS_ORIGINS=https://workbench.example.com" in runbook

--- a/backend/tests/test_refactor_hygiene.py
+++ b/backend/tests/test_refactor_hygiene.py
@@ -447,3 +447,17 @@ def test_sdist_manifest_excludes_partial_test_tree() -> None:
     manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
 
     assert "prune tests" in manifest
+
+
+def test_backend_package_boundary_intentionally_ships_workbench_app() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    package_check = (ROOT.parent / "scripts" / "check_package_contents.py").read_text(
+        encoding="utf-8"
+    )
+    makefile = (ROOT.parent / "Makefile").read_text(encoding="utf-8")
+
+    assert 'include = ["vuln_prioritizer*", "app*"]' in pyproject
+    assert "app/main.py" in package_check
+    assert "vuln_prioritizer/cli.py" in package_check
+    assert "package-contents-check: package" in makefile
+    assert "package-check: package-contents-check" in makefile

--- a/backend/tests/test_repository_templates.py
+++ b/backend/tests/test_repository_templates.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ISSUE_TEMPLATE_DIR = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+DEPENDABOT_FILE = REPO_ROOT / ".github" / "dependabot.yml"
+
+CURRENT_TRACKER_LABELS = {
+    "area:api",
+    "area:attack",
+    "area:ci",
+    "area:core",
+    "area:docs",
+    "area:governance",
+    "area:parser",
+    "area:provider",
+    "area:report",
+    "area:security",
+    "area:ui",
+    "bug",
+    "dependencies",
+    "documentation",
+    "duplicate",
+    "enhancement",
+    "github-actions",
+    "good first issue",
+    "help wanted",
+    "invalid",
+    "maintenance",
+    "priority:critical",
+    "priority:high",
+    "priority:low",
+    "priority:medium",
+    "priority:p0",
+    "priority:p1",
+    "priority:p2",
+    "python",
+    "question",
+    "risk:data-quality",
+    "risk:demo",
+    "risk:provider-api",
+    "risk:scope",
+    "risk:security",
+    "status:blocked",
+    "status:needs-docs",
+    "status:needs-revalidation",
+    "status:needs-review",
+    "status:needs-tests",
+    "status:strict-dod",
+    "status:template-gap",
+    "type:api",
+    "type:attack",
+    "type:backend",
+    "type:db",
+    "type:docs",
+    "type:epic",
+    "type:feature",
+    "type:frontend",
+    "type:governance",
+    "type:parser",
+    "type:provider",
+    "type:refactor",
+    "type:release",
+    "type:report",
+    "type:security",
+    "type:task",
+    "type:test",
+    "wontfix",
+}
+
+
+def _front_matter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), path
+    _, payload, _ = text.split("---", 2)
+    return yaml.safe_load(payload)
+
+
+def _labels(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    return {label.strip() for label in value.split(",") if label.strip()}
+
+
+def test_issue_template_default_labels_exist_in_current_taxonomy() -> None:
+    missing: dict[str, set[str]] = {}
+
+    for path in sorted(ISSUE_TEMPLATE_DIR.glob("*.md")):
+        labels = _labels(_front_matter(path).get("labels"))
+        unknown = labels - CURRENT_TRACKER_LABELS
+        if unknown:
+            missing[path.name] = unknown
+
+    assert missing == {}
+
+
+def test_issue_templates_keep_strict_evidence_sections() -> None:
+    missing: list[str] = []
+
+    for path in sorted(ISSUE_TEMPLATE_DIR.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        if "## Definition Of Done" not in text or "## Evidence" not in text:
+            missing.append(path.name)
+
+    assert missing == []
+
+
+def test_dependabot_labels_exist_and_use_current_frontend_taxonomy() -> None:
+    payload = yaml.safe_load(DEPENDABOT_FILE.read_text(encoding="utf-8"))
+    labels_by_ecosystem = {
+        update["package-ecosystem"]: set(update.get("labels", [])) for update in payload["updates"]
+    }
+    all_labels = set().union(*labels_by_ecosystem.values())
+
+    assert all_labels - CURRENT_TRACKER_LABELS == set()
+    assert "frontend" not in all_labels
+    assert labels_by_ecosystem["npm"] >= {"maintenance", "dependencies", "type:frontend", "area:ui"}

--- a/backend/tests/test_v11_output_contracts.py
+++ b/backend/tests/test_v11_output_contracts.py
@@ -836,9 +836,11 @@ def test_release_check_keeps_demo_sync_manual_and_deterministic() -> None:
     assert "$(MAKE) docker-demo-smoke" in release_block
     assert "$(MAKE) pipx-source-smoke" in release_block
     assert "$(MAKE) demo-sync-check" in release_block
+    assert "api-client-drift-check: frontend-generate-client" in makefile
+    assert "git diff --exit-code -- frontend/src/client" in makefile
     assert (
-        "release-readiness-check: release-check demo-evidence-bundle-check playwright-check"
-        in makefile
+        "release-readiness-check: release-check api-client-drift-check "
+        "demo-evidence-bundle-check playwright-check" in makefile
     )
     assert "VULN_PRIORITIZER_FIXED_NOW" in makefile
     assert "git diff --binary -- docs" in makefile

--- a/backend/tests/test_workbench_integration_contracts.py
+++ b/backend/tests/test_workbench_integration_contracts.py
@@ -83,7 +83,7 @@ def test_docker_demo_smoke_runs_quickstart_api_import() -> None:
     assert "providers/update-jobs" in script
 
 
-def test_frontend_nginx_serves_security_headers_for_static_and_404_routes() -> None:
+def test_frontend_nginx_serves_security_headers_and_same_origin_api_proxy() -> None:
     nginx_conf = Path("frontend/nginx.conf").read_text(encoding="utf-8")
     blocked_routes = Path("frontend/nginx-backend-not-found.conf").read_text(encoding="utf-8")
 
@@ -92,7 +92,9 @@ def test_frontend_nginx_serves_security_headers_for_static_and_404_routes() -> N
     assert "default-src 'self'" in nginx_conf
     assert "object-src 'none'" in nginx_conf
     assert "frame-ancestors 'none'" in nginx_conf
-    assert "connect-src 'self' http://localhost:8000 http://127.0.0.1:8000" in nginx_conf
+    assert "connect-src 'self';" in nginx_conf
+    assert "http://localhost:8000" not in nginx_conf
+    assert "http://127.0.0.1:8000" not in nginx_conf
     assert 'add_header X-Content-Type-Options "nosniff" always;' in nginx_conf
     assert 'add_header X-Frame-Options "DENY" always;' in nginx_conf
     assert 'add_header Referrer-Policy "same-origin" always;' in nginx_conf
@@ -103,4 +105,6 @@ def test_frontend_nginx_serves_security_headers_for_static_and_404_routes() -> N
     ) in nginx_conf
     assert "include /etc/nginx/extra-conf.d/*.conf;" in nginx_conf
     assert "location /api" in blocked_routes
+    assert "proxy_pass http://backend:8000;" in blocked_routes
+    assert "location /docs" in blocked_routes
     assert "return 404;" in blocked_routes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,11 +16,15 @@ Workbench surface:
   repositories, auth/session support, and Alembic migrations.
 - `frontend/`: React, Vite, TanStack Router, TypeScript, and the generated API
   client consumed by the browser app.
-- `frontend/src/client/**` and `frontend/src/api-client.ts`: generated API
-  client boundary. Product code imports the generated services and types, but
-  generated files are not manually edited.
+- `frontend/src/client/**`: generated OpenAPI client. Generated files are not
+  manually edited.
+- `frontend/src/api-client.ts`: manual wrapper and integration layer over the
+  generated client.
 - `backend/src/vuln_prioritizer/**`: retained CLI and domain implementation
   used by maintainer workflows and shared analysis/reporting helpers.
+- Python package boundary: `backend/pyproject.toml` intentionally includes both
+  `vuln_prioritizer*` and `app*`, so the backend distribution ships the CLI/core
+  package and the active Workbench FastAPI app.
 
 The frontend and backend communicate through the generated API client. UI
 component structure, route extraction, CSS organization, and VPW design-system
@@ -31,11 +35,10 @@ implementation details are intentionally outside the backend/API contract.
 The active browser Workbench runtime is `backend/app`. Docker, the local Compose
 quickstart, Playwright backend startup, and OpenAPI client generation must point
 to `app.main:app` or import `app.main.app`. The generated browser API boundary is
-`frontend/src/client/**` plus `frontend/src/api-client.ts`; generated client files
-are not manually edited.
+`frontend/src/client/**`; `frontend/src/api-client.ts` is manual wrapper code.
 
 `backend/src/vuln_prioritizer/**` remains the retained CLI and domain
-implementation. The active template backend may import neutral, framework-light
+implementation. The active Workbench backend may import neutral, framework-light
 domain helpers from this package, such as input normalization, provider clients,
 scoring, report/evidence helpers, redaction, and token hashing. Reusable logic
 needed by the CLI and browser runtime must live in these neutral modules.
@@ -63,7 +66,7 @@ owned by route-level Workbench components:
 | Providers | `components/providers/ProvidersRouteContainer.tsx` | Typed container over `ProvidersWorkbench`; provider status remains shared state. |
 | Reports | `components/reports/EvidenceCenter.tsx` | Evidence Center for report generation, download, verification, and bundle metadata. |
 | Settings | `components/settings/SettingsRouteContainer.tsx` | Typed wrapper over `SettingsWorkbench`; token/session data remains shell-owned. |
-| Login | `routes/login.tsx` | Standalone login route using local template auth defaults and API status. |
+| Login | `routes/login.tsx` | Standalone login route using local auth defaults and API status. |
 
 ## WorkbenchShell Role
 

--- a/docs/community_repository_setup.md
+++ b/docs/community_repository_setup.md
@@ -61,7 +61,8 @@ Avoid adding adjacent-but-misleading topics such as `scanner`, `siem`, `edr`, or
 
 ## Recommended Label Taxonomy
 
-Keep the label set small. The goal is routing and contributor clarity, not process theater.
+Keep the label set current with the GitHub repository taxonomy. The goal is
+routing and contributor clarity, not process theater.
 
 ### Core Type Labels
 
@@ -70,8 +71,10 @@ These should exist before opening the repo to wider contribution:
 | Label | Use when | Notes |
 | --- | --- | --- |
 | `bug` | behavior is incorrect, regressed, or broken | Already used by the bug issue template. |
-| `enhancement` | a scoped product improvement is requested | Already used by the feature request template. |
-| `documentation` | the main work is docs, examples, or guidance | Good candidate for low-risk external contributions. |
+| `type:feature` | a scoped product improvement is requested | Used by the feature request template. |
+| `type:docs` | the main work is docs, examples, or guidance | Good candidate for low-risk external contributions. |
+| `type:task` | engineering work without standalone user-facing value | Useful for roadmap and release-readiness tracking. |
+| `type:security` | security hardening, threat modeling, or secure defaults | Public disclosures still use `SECURITY.md`, not public issue details. |
 | `maintenance` | dependency, CI, release, packaging, or cleanup work | Use for repo upkeep that is not user-facing behavior. |
 
 ### Community Labels
@@ -83,28 +86,41 @@ These help contributors self-select:
 | `good first issue` | a newcomer can complete the work with clear file pointers and a local verification path | Do not use for provider, scoring, or ATT&CK design work unless the change is tightly bounded. |
 | `help wanted` | maintainers actively want outside help and expect to review a contribution | Remove it if the issue is blocked or already assigned. |
 
-### Minimal Triage Labels
+### Status Labels
 
-Add only the few status labels that reduce back-and-forth:
+Use `status:*` labels for tracker state:
 
 | Label | Use when | Notes |
 | --- | --- | --- |
-| `needs-repro` | a bug report is missing a concrete command, input shape, or output evidence | Prefer this over long clarification threads. |
-| `needs-decision` | the issue is valid, but a maintainer scope or product decision is still needed | Useful for roadmap-bound feature requests. |
-| `blocked` | work depends on an upstream change, external data issue, or another issue/PR | Remove it as soon as the blocker clears. |
+| `status:needs-revalidation` | reopened or duplicated work needs fresh evidence | Do not close from historical notes alone. |
+| `status:needs-review` | implementation or decision evidence needs review | Use after a PR or evidence comment is ready. |
+| `status:needs-tests` | implementation exists but test coverage is incomplete | Keep the issue open with a named test target. |
+| `status:needs-docs` | implementation exists but documentation is incomplete | Link the required docs path. |
+| `status:blocked` | work depends on an upstream change, external data issue, or another issue/PR | Remove it as soon as the blocker clears. |
+| `status:strict-dod` | explicit Definition of Done and evidence are required before closure | Use for public-production, release, and roadmap closeout work. |
+| `status:template-gap` | full-stack-template assumptions still need implementation or an approved decision | Use only where exact template alignment is still the issue. |
 | `duplicate` | another open or closed issue already tracks the same work | Close with a link to the canonical issue. |
 
 ### Area Labels
 
-This repository already uses a small `area:*` set. Keep that convention instead of introducing a second, competing scope taxonomy:
+This repository uses a scoped `area:*` set. Keep that convention instead of
+introducing a second, competing scope taxonomy:
 
-- `area:benchmarking`
-- `area:workflow`
-- `area:governance`
-- `area:release`
+- `area:core`
+- `area:parser`
+- `area:api`
+- `area:provider`
+- `area:ui`
+- `area:attack`
+- `area:report`
 - `area:docs`
+- `area:governance`
+- `area:ci`
+- `area:security`
 
-Do not create a public `security` issue label for vulnerability disclosures. Public issues should be rerouted to `SECURITY.md` instead of encouraging security reports in the issue tracker.
+Do not use public issue labels as a substitute for private vulnerability
+reporting. Public issues should be rerouted to `SECURITY.md` when they contain
+vulnerability disclosure detail.
 
 ### Automation Labels
 
@@ -115,6 +131,7 @@ If dependency automation is enabled, keep the bot-facing label set small and exp
 | `dependencies` | a PR updates one or more project dependencies | Use for both Python package updates and workflow/action bumps. |
 | `python` | a dependency or packaging change is Python-specific | Useful for pip / build / tooling updates. |
 | `github-actions` | a change only affects GitHub Actions workflows or referenced actions | Useful for workflow dependency bumps and runner-related maintenance. |
+| `type:frontend` plus `area:ui` | a dependency change affects the frontend npm workspace | Use for Dependabot npm updates; do not use the stale `frontend` label. |
 
 These are not a second issue-triage taxonomy. They mainly exist so Dependabot or maintainers can label automation PRs without overloading the public issue tracker.
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -495,7 +495,7 @@ Important boundary:
 - `table` is a terminal view and must not be combined with `--output`
 - `sarif` is a documented export for `analyze` and saved analysis JSON rendered
   through `report workbench`
-- Template Workbench report creation also exposes SARIF as `results.sarif`
+- Workbench report creation also exposes SARIF as `results.sarif`
   through `POST /api/v1/runs/{run_id}/reports`
 - `analyze --summary-output` is a Markdown sidecar derived from the same in-memory analysis payload and does not replace the JSON contract
 

--- a/docs/dependency-and-package-policy.md
+++ b/docs/dependency-and-package-policy.md
@@ -1,0 +1,96 @@
+# Dependency and Package Policy
+
+This page defines the current dependency, lockfile, and Python package boundary
+for release and security hygiene work.
+
+## Backend Package Boundary
+
+The `vuln-prioritizer` backend distribution intentionally ships both:
+
+- the CLI/core package under `backend/src/vuln_prioritizer/**`
+- the active Workbench FastAPI runtime under `backend/app/**`
+
+This is the selected package story for the current tree. The package is not
+CLI-only, and README/release wording should not imply that `app/*` is an
+accidental inclusion.
+
+The package boundary is enforced by:
+
+- `backend/pyproject.toml`, where `tool.setuptools.packages.find.include`
+  includes both `vuln_prioritizer*` and `app*`
+- `make package-check`, which builds the backend distributions, validates their
+  content with `scripts/check_package_contents.py`, and runs `twine check`
+- `build/package-contents.json`, generated locally by the package-content check
+
+The sdist and wheel must contain `app/main.py`, `app/api/main.py`, and
+`vuln_prioritizer` CLI entrypoints. They must not include the backend test tree.
+
+## Python Dependencies
+
+Python dependency metadata is owned by `backend/pyproject.toml`. Direct runtime
+requirements use bounded ranges so the package can receive compatible security
+updates without a source release for every transitive patch.
+
+`backend/requirements.txt` is the audited backend dependency input for the
+repository release gate. It includes runtime and maintainer gate tools needed by
+`make dependency-audit`, `make docs-check`, `make package-check`, and the local
+workflow gate.
+
+Current audit command:
+
+```bash
+python3 -m pip_audit --requirement backend/requirements.txt
+```
+
+The repository does not currently publish a separate fully pinned Python
+production lockfile. Release evidence must state this explicitly if a release
+owner requires byte-for-byte environment reproduction beyond the package
+artifacts and checked-in dependency bounds.
+
+## Frontend Dependencies
+
+`frontend/package-lock.json` is the frontend source of truth for reproducible
+npm installs. CI, Docker, local frontend gates, and dependency audit use npm
+against that lockfile:
+
+```bash
+cd frontend && npm ci --workspaces=false
+cd frontend && npm --workspaces=false audit --omit=dev
+```
+
+The root `bun.lock` is intentional because the root workspace keeps
+Bun-compatible convenience scripts in `package.json`. It is not the audited
+frontend install source. Do not use Bun lock updates as release evidence unless
+a future issue changes the frontend package-manager policy.
+
+## Dependabot Labels
+
+Dependabot PR labels must use labels that exist in the repository taxonomy.
+The current automation label policy is:
+
+| Ecosystem | Labels |
+| --- | --- |
+| Python backend | `maintenance`, `dependencies`, `python` |
+| GitHub Actions | `maintenance`, `dependencies`, `github-actions` |
+| Frontend npm | `maintenance`, `dependencies`, `type:frontend`, `area:ui` |
+
+Dependabot PR
+[#287](https://github.com/Noetheon/vuln-prioritizer-workbench/pull/287)
+remains the linked GitHub Actions dependency-update follow-up for this policy.
+It should be merged, closed, or explicitly carried forward by a maintainer after
+the release gate confirms the `actions/upload-artifact` upgrade is compatible
+with the current artifact upload usage.
+
+## Release Evidence Commands
+
+Use these commands when dependency or package policy changes:
+
+```bash
+make dependency-audit
+make package-check
+make pipx-source-smoke
+cd frontend && npm ci --workspaces=false && npm audit --omit=dev
+```
+
+Evidence must not include secrets, token values, cookies, customer exports,
+private absolute paths, or shell history.

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -18,6 +18,8 @@ normal `docs/` navigation.
 
 - Current roadmap: [docs/roadmap.md](./roadmap.md)
 - Release notes: [docs/releases/](./releases/v1.1.0.md)
+- Public-production release evidence ledger:
+  [docs/public-production-release-evidence-ledger.md](./public-production-release-evidence-ledger.md)
 - Report and evidence contracts: [docs/contracts.md](./contracts.md)
 - Support matrix: [docs/support_matrix.md](./support_matrix.md)
 - Release operations: [docs/release_operations.md](./release_operations.md)

--- a/docs/extension_strategy.md
+++ b/docs/extension_strategy.md
@@ -18,12 +18,12 @@ The extension policy is intentionally conservative:
 
 There are two parser-facing contracts:
 
-- Template Workbench upload importers implement
+- Workbench upload importers implement
   `app.importers.contracts.Importer`.
 - CLI/input-loader extensions use
   `vuln_prioritizer.inputs.sdk.InputParserDefinition`.
 
-Template Workbench importers must expose:
+Workbench importers must expose:
 
 - `input_type`: a stable, lowercase Workbench input type
 - `parse(payload, *, filename=None)`: deterministic parsing from bytes or text

--- a/docs/full_stack_fastapi_template_migration.md
+++ b/docs/full_stack_fastapi_template_migration.md
@@ -1,14 +1,19 @@
 # Full Stack FastAPI Template Migration Plan
 
-## Decision
+Status: historical migration plan and current-state reference. The active
+Workbench runtime is now `backend/app`; this document is retained to explain why
+the migration happened and which boundaries must stay preserved. Do not use this
+page by itself as completion evidence for reopened roadmap issues.
 
-The Workbench migration should restart from the official
+## Historical Decision
+
+The Workbench migration restarted from the official
 `fastapi/full-stack-fastapi-template` baseline instead of continuing to reshape
 the previous second Workbench runtime in place.
 
-The current repository remains valuable as the domain engine. The migration target
-is a template-based full-stack application that reuses the existing
-`vuln_prioritizer` CLI/core logic behind a new backend and frontend.
+The retained repository domain engine remains valuable. The implemented runtime
+now reuses the existing `vuln_prioritizer` CLI/core logic through the active
+`backend/app` backend and React frontend.
 
 ## Why This Direction
 
@@ -24,9 +29,10 @@ bundles, but not the actual template shape:
 - no SQLModel domain model layer
 - no generated frontend client workflow on `main`
 
-Trying to mutate that tree directly would mix two application architectures. The
-cleaner path is to preserve the domain code and build the Workbench shell from
-the template. Current implementation progress is tracked below.
+Trying to mutate that tree directly would have mixed two application
+architectures. The cleaner path was to preserve the domain code and build the
+Workbench shell from the template. The current implementation state is tracked
+below.
 
 ## Target Architecture
 
@@ -77,9 +83,9 @@ Runtime-specific web/API/database packages are not part of the retained core.
 New shared logic should be extracted into the neutral modules above before it is
 used by both the CLI and active backend.
 
-## Branch Strategy
+## Historical Branch Strategy
 
-Use stacked PRs from clean `main`.
+The migration used stacked PRs from clean `main`.
 
 - `template/full-stack-fastapi-template-13652b5`: pinned local reference branch
   for the official template snapshot
@@ -97,10 +103,8 @@ Do not merge the official template history into `main` as one giant
 unrelated-history merge. Keep the template snapshot reproducible and move the app
 in small reviewable PRs.
 
-## Migration Rules
+## Migration Rules Preserved As Current Guardrails
 
-- Keep the current `main` branch intact until the template branch passes baseline
-  checks.
 - One roadmap issue per PR unless a dependency group is explicitly documented.
 - Treat historical implementation notes as source material, not as automatic
   completion evidence.
@@ -111,7 +115,7 @@ in small reviewable PRs.
 - Keep provider tests offline and fixture-based.
 - Do not regress CLI/core contracts while moving code.
 
-## First Implementation PRs
+## Historical First Implementation PRs
 
 1. `VPW-001`: create a template baseline branch from the official template and
    record baseline evidence.

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,9 @@ Workbench remains local-first and uses the import-format matrix documented in
   Security Project submission package.
 - Read [methodology.md](methodology.md) for scoring, ATT&CK, Asset Context, and VEX semantics.
 - Read [architecture.md](architecture.md) for the current FastAPI/React route architecture, generated client boundary, VPW design-system role, and shared state ownership.
+- Read [dependency-and-package-policy.md](dependency-and-package-policy.md) for
+  backend package contents, frontend lockfile ownership, Dependabot labels, and
+  dependency-audit policy.
 - Read [scoring-methodology.md](scoring-methodology.md) for the rule-based CVSS, EPSS, KEV, lifecycle, provider freshness, asset-context, and waiver methodology.
 - Read [attack-ttp-methodology.md](attack-ttp-methodology.md) for curated ATT&CK/TTP mapping rules, no-inference boundaries, and the current mapped demo proof.
 - Read [reports-and-evidence.md](reports-and-evidence.md) for Evidence Center formats, ZIP bundle verification, canonical contract artifacts, and archive layout.
@@ -119,6 +122,9 @@ Workbench remains local-first and uses the import-format matrix documented in
 - Use [user_documentation.md#known-limitations](user_documentation.md#known-limitations) for the consolidated external-user limitations list.
 - Use [roadmap.md](roadmap.md) for shipped scope and deliberate non-goals.
 - Use [release_operations.md](release_operations.md) for maintainer-only release, GitHub Release recovery, and PyPI/TestPyPI operations.
+- Use [public-production-release-evidence-ledger.md](public-production-release-evidence-ledger.md)
+  for PP4/PP5 release-readiness targets, evidence boundaries, and residual-risk
+  tracking.
 - Use [community_repository_setup.md](community_repository_setup.md) for maintainer-facing public repo topics, labels, and triage defaults.
 - Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current package release.
 

--- a/docs/public-production-release-evidence-ledger.md
+++ b/docs/public-production-release-evidence-ledger.md
@@ -1,0 +1,80 @@
+# Public-Production Release Evidence Ledger
+
+This ledger tracks the public-production readiness evidence story without
+claiming final readiness before PP5 acceptance. It is a public-safe index for
+commands, generated artifacts, package boundaries, and residual risks.
+
+## Acceptance Boundary
+
+Public-production readiness is not claimed until
+[#350](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/350)
+closes with a final scorecard and evidence links. Until then, this document is
+a readiness ledger and release-target checklist, not a certification.
+
+Evidence added to public docs must avoid secrets, tokens, cookies, customer
+exports, private absolute paths, and shell history. Current contract artifacts
+belong in `docs/evidence/`; screenshots, historical issue proof, and broader
+validation logs belong under `archive/vpw-evidence/` or external CI artifacts
+linked from an issue or PR.
+
+## Selected Package and Runtime Story
+
+- The active browser Workbench runtime is `backend/app`.
+- The Python distribution intentionally ships both `backend/app/**` and
+  `backend/src/vuln_prioritizer/**`.
+- The frontend generated OpenAPI client is `frontend/src/client/**`.
+- `frontend/src/api-client.ts` is a manual wrapper over the generated client,
+  not generated output.
+- `frontend/package-lock.json` is the audited frontend lockfile.
+- The root `bun.lock` is retained for Bun-compatible convenience scripts, not
+  as the release audit source.
+
+## Release-Readiness Targets
+
+| Target | Purpose | Evidence |
+| --- | --- | --- |
+| `make dependency-audit` | Backend and frontend dependency audit | `pip-audit` on `backend/requirements.txt`; npm audit on `frontend/package-lock.json` |
+| `make package-check` | Build, package-content, and metadata validation | `dist/*`, `twine check`, `build/package-contents.json` |
+| `make pipx-source-smoke` | Source-at-tag install path compatibility | pipx smoke output and generated smoke artifacts |
+| `make api-client-drift-check` | OpenAPI/generated-client compatibility | `scripts/generate-client.sh`; clean `frontend/src/client` diff |
+| `make docs-check` | Public documentation build | clean MkDocs build |
+| `make demo-evidence-bundle-check` | Evidence bundle integrity | `build/v1.0-demo-evidence-bundle-verification.json` |
+| `make docker-demo-smoke` | Compose runtime smoke | backend/frontend health plus import/provider smoke |
+| `make playwright-check` | Browser smoke path | frontend Playwright test results |
+| `make release-readiness-check` | Full local readiness handoff | release gate, client drift, evidence bundle, and Playwright smoke |
+
+## Issue Ledger
+
+| Issue | Current docs/CI/package evidence target | Residual risk until closure |
+| --- | --- | --- |
+| [#326](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/326) | Dependency policy, `make dependency-audit`, npm audit, PR #287 disposition | No fully pinned Python production lockfile is committed. |
+| [#327](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/327) | README, `SECURITY.md`, threat model, deployment runbook, release ledger | Public-production readiness remains gated by PP5 scorecard #350. |
+| [#339](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/339) | Current issue-template labels, Dependabot labels, strict evidence language | GitHub labels/milestones still require live repository review before closeout. |
+| [#340](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/340) | Package policy, package-content check, `make package-check` | Future PyPI wording must keep the CLI-plus-Workbench package story explicit. |
+| [#341](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/341) | Current-state roadmap docs and historical migration notes | Historical template pages must not be used as active acceptance evidence. |
+| [#342](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/342) | Generated-client ownership docs and `make api-client-drift-check` | API changes still need backend/API tests owned by implementation PRs. |
+| [#343](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/343) | Workbench naming in active scripts/gates and backend/app references | Storage paths with `template-*` names remain compatibility paths until a code-level migration is approved. |
+| [#344](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/344) | `docs/evidence/` boundary and docs hygiene test | Large or historical artifacts must stay linked or archived, not duplicated in docs. |
+| [#345](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/345) | This release evidence ledger and release checklist updates | Ledger records targets; it does not replace command output from the release candidate. |
+| [#346](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/346) | Docker/Playwright readiness target references | Production-like smoke implementation and header captures are owned by runtime workers. |
+| [#347](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/347) | Client drift target in `release-readiness-check` | API error-envelope/auth contract assertions must remain covered by API tests. |
+| [#349](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/349) | Full quality-gate command list and residual-risk section | Any exception needs owner, rationale, and a follow-up issue before closure. |
+| [#350](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/350) | Final scorecard target and PP5 acceptance boundary | If any category is below target, #350 stays open with blockers. |
+
+## Residual Risk Decision Format
+
+Use this format in the final PP5 issue or PR evidence comment:
+
+```text
+Category:
+Evidence:
+Command:
+Result:
+Residual risk:
+Owner:
+Follow-up:
+Decision:
+```
+
+Accepted residual risk must have an owner and a follow-up issue unless the
+reason for no follow-up is explicit in the final scorecard.

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -42,13 +42,23 @@ Use this path for normal releases:
 make release-check
 ```
 
-3. Create or update the checked-in release notes file:
+3. For public-production readiness handoff, run and record the broader gate:
+
+```bash
+make release-readiness-check
+```
+
+This adds generated-client drift, demo evidence-bundle verification, and
+Playwright smoke evidence to the normal release gate. It does not by itself
+close the PP5 scorecard.
+
+4. Create or update the checked-in release notes file:
 
 ```text
 docs/releases/vX.Y.Z.md
 ```
 
-4. Tag the release:
+5. Tag the release:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z"
@@ -56,9 +66,9 @@ git push origin main
 git push origin vX.Y.Z
 ```
 
-5. Confirm that the GitHub Release workflow completed successfully.
-6. If PyPI publishing is enabled for the repository, verify that the package appeared on PyPI.
-7. Confirm that the workflow's hosted-index install verification step completed successfully.
+6. Confirm that the GitHub Release workflow completed successfully.
+7. If PyPI publishing is enabled for the repository, verify that the package appeared on PyPI.
+8. Confirm that the workflow's hosted-index install verification step completed successfully.
 
 ## Restoring a Missing GitHub Release Object
 
@@ -196,4 +206,6 @@ If the PyPI publish job fails, check these before anything else:
 
 - Keep this document in sync with [`release.yml`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/workflows/release.yml).
 - Keep the public install wording in [`README.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/README.md) aligned with the real supported install path.
+- Keep the package story aligned with [Dependency and Package Policy](./dependency-and-package-policy.md): the backend distribution intentionally ships both the CLI/core package and active `backend/app` Workbench runtime.
+- Keep public-production release evidence aligned with [Public-Production Release Evidence Ledger](./public-production-release-evidence-ledger.md).
 - If PyPI goes live, update the README and release docs immediately so GitHub-tag install is no longer described as the only verified public path.

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -39,6 +39,8 @@ Current post-release documentation and security-hygiene status is tracked on `ma
 
 - [docs/workbench-v1-release-checklist.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/workbench-v1-release-checklist.md)
 - [docs/roadmap.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/roadmap.md)
+- [docs/dependency-and-package-policy.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/dependency-and-package-policy.md)
+- [docs/public-production-release-evidence-ledger.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/public-production-release-evidence-ledger.md)
 
 ## Validation
 
@@ -68,3 +70,5 @@ The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIX
 - Use [docs/releases/v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/v1.0.0.md) for the first stable baseline release notes.
 - Use [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md) for Workbench milestone scope and evidence details. The package tag for this tree must be `v1.1.0` because `pyproject.toml` is versioned `1.1.0`.
 - Public PyPI/TestPyPI publication remains gated until trusted-publisher setup is explicitly enabled in the repository.
+- The backend distribution intentionally ships both the CLI/core package and the
+  active Workbench FastAPI app. It should not be described as CLI-only.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,15 +4,15 @@ This roadmap records the release line implemented from the ATT&CK-focused `v0.3.
 
 The product remains a CLI and local Workbench for prioritizing known CVEs and imported findings. It is not a scanner and does not use heuristic or AI-generated CVE-to-ATT&CK mappings.
 
-## Current VPW Template Roadmap
+## Current VPW Public-Production Track
 
-The active duplicate VPW cycle is now tracked as a template-first execution
-track, summarized in the repository-root `ROADMAP.md`. It starts with
-FastAPI Full Stack Template baseline and governance work, then replaces demo
-Items with Workbench Projects and Findings, rebuilds import/enrichment/scoring
-APIs behind SQLModel/Alembic, and finally restores the React Workbench workflow,
-evidence, reporting, ATT&CK, asset, VEX, governance, deployment, release, and
-integration slices.
+The active duplicate VPW cycle is now tracked as a public-production remediation
+track, summarized in the repository-root `ROADMAP.md`. It starts from the
+implemented `backend/app` FastAPI runtime, retained CLI/core package, React
+frontend, generated-client boundary, and release automation. Current work aligns
+security/deployment docs, package and dependency policy, issue-template
+taxonomy, evidence/archive boundaries, generated-client ownership, release
+readiness gates, and the final PP5 scorecard.
 
 Strict DoD evidence remains required for every VPW issue: scoped PR, commands
 run, artifacts or screenshots where relevant, residual risks, and follow-up

--- a/docs/submission/evidence-sheet.md
+++ b/docs/submission/evidence-sheet.md
@@ -9,7 +9,8 @@ files. It does not duplicate screenshots.
 | --- | --- |
 | VPW is a workbench for known CVEs, not a scanner. | [README](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/README.md), [Security Policy](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/SECURITY.md), [Architecture](../architecture.md) |
 | The architecture uses FastAPI, React/Vite/TanStack Router, and a generated API client. | [Product Architecture](../architecture.md) |
-| The generated client remains the contract boundary. | [Product Architecture](../architecture.md) |
+| The generated client remains the contract boundary, and `api-client.ts` is manual wrapper source. | [Product Architecture](../architecture.md) |
+| The backend package intentionally ships both CLI/core and active Workbench app code. | [Dependency and Package Policy](../dependency-and-package-policy.md) |
 | Prioritization is transparent and rule-based, not ML/AI-based. | [Scoring Methodology](../scoring-methodology.md) |
 | CVSS, EPSS, KEV, asset context, provider freshness, lifecycle, VEX, and waivers are visible. | [Scoring Methodology](../scoring-methodology.md), [Technical Documentation](technical-documentation.md) |
 | ATT&CK/TTP is defensive context and does not prove exploitation. | [ATT&CK/TTP Methodology](../attack-ttp-methodology.md), [Curated Mapping Summary](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/archive/vpw-evidence/final-demo-flow/attack-demo-mapping-summary.md) |

--- a/docs/submission/reviewer-checklist.md
+++ b/docs/submission/reviewer-checklist.md
@@ -19,8 +19,9 @@ reproducibly.
 
 ## Scope And Integrity
 
-- [ ] No manual edits in `frontend/src/client/**`.
-- [ ] No manual edits in `frontend/src/api-client.ts`.
+- [ ] No manual edits in generated files under `frontend/src/client/**`.
+- [ ] Any `frontend/src/api-client.ts` changes are reviewed as manual wrapper
+      source, not generated-client drift.
 - [ ] No unintended backend implementation changes.
 - [ ] No changes to `data/attack/**`.
 - [ ] No changes to contract artifacts under `docs/evidence/`.
@@ -54,7 +55,8 @@ reproducibly.
 ## Limitations
 
 - [ ] Demo data is clearly marked as sample/evidence data.
-- [ ] Public deployment hardening remains marked as a later topic.
+- [ ] Public-production readiness is not claimed unless PP5 evidence and the
+      final scorecard support it.
 - [ ] Detection coverage is not overstated as proof of effectiveness.
 - [ ] Waivers are described as governance context, not as risk deletion.
 

--- a/docs/submission/technical-documentation.md
+++ b/docs/submission/technical-documentation.md
@@ -11,8 +11,9 @@ reports, and maintainer workflows.
 | --- | --- |
 | Backend | FastAPI, auth/session, SQL models, services, repositories, Alembic. |
 | Frontend | React, Vite, TypeScript, TanStack Router, VPW Design System. |
-| API Boundary | `frontend/src/client/**` and `frontend/src/api-client.ts` are generated. |
-| Product Logic | Components import services/types from the generated client but do not edit it manually. |
+| API Boundary | `frontend/src/client/**` is generated from OpenAPI. |
+| Product Logic | `frontend/src/api-client.ts` is manual wrapper code; components import services/types from the generated client but do not edit generated files manually. |
+| Package Boundary | The backend distribution intentionally ships both `app/**` and `src/vuln_prioritizer/**`. |
 | Evidence | Reports, evidence ZIP bundle, manifest, checksums, and contract artifacts. |
 
 Further details are available in [Product Architecture](../architecture.md).
@@ -22,7 +23,8 @@ Further details are available in [Product Architecture](../architecture.md).
 `backend/app` is the active browser Workbench runtime. Docker, Compose,
 Playwright backend startup, and OpenAPI client generation use `app.main:app` or
 `app.main.app`. The browser calls the generated `/api/v1` client under
-`frontend/src/client/**` and `frontend/src/api-client.ts`.
+`frontend/src/client/**` through manual frontend integration code such as
+`frontend/src/api-client.ts`.
 
 `backend/src/vuln_prioritizer/**` remains available for CLI, domain logic, and
 reports. Neutral modules such as input normalization, providers, scoring,

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -22,7 +22,7 @@
 | `rollup` | analysis JSON or snapshot JSON | `markdown`, `json` | JSON schema | Aggregates findings by `asset_id` or `asset_business_service`, keeps waiver lifecycle debt visible, and ranks buckets for remediation planning without rerunning enrichment. |
 | `attack validate` | ATT&CK local files | `markdown`, `json` | JSON schema | Validates local mapping and metadata artifacts; `ctid-json` is the preferred workflow. |
 | `attack coverage` | `--input PATH` | `markdown`, `json` | JSON schema | Uses the same input loader for CVE extraction. |
-| `attack navigator-layer` | `--input PATH` | Navigator layer JSON | Navigator JSON, no local schema here | Exports a frequency-based ATT&CK Navigator layer. The template Workbench also exposes `attack-navigator` and `sarif` as run report artifacts. |
+| `attack navigator-layer` | `--input PATH` | Navigator layer JSON | Navigator JSON, no local schema here | Exports a frequency-based ATT&CK Navigator layer. The Workbench also exposes `attack-navigator` and `sarif` as run report artifacts. |
 | `data status` | none | `json` | JSON schema | Cache namespace inspection plus optional local ATT&CK metadata validation. |
 | `data update` | optional repeatable `--input PATH` / `--cve` | `json` | JSON schema | Cache refresh for `nvd`, `epss`, and `kev`; `table` remains the default terminal view. |
 | `data verify` | optional repeatable `--input PATH` / `--cve` | `json` | JSON schema | Cache coverage, checksum, and pinned local file verification; `table` remains the default terminal view. |
@@ -95,7 +95,7 @@ Without a matching target, the explain flow still works, but asset-context and V
 - Prefer `report verify-evidence-bundle` before shipping or archiving an evidence ZIP outside the repository or CI workspace.
 - `report html` expects an analysis JSON export, not compare JSON or explain JSON.
 - `sarif` is part of the documented contract for `analyze`, `report workbench`,
-  and template Workbench run reports.
+  and Workbench run reports.
 - `data status`, `data update`, `data verify`, and `data export-provider-snapshot` publish JSON contracts; their Rich table layout remains human-facing where applicable.
 - The optional SQLite state store is separate from the existing file cache and does not change `analyze`, `snapshot`, or `report` output semantics.
 - Workbench imports now accept the same input-format matrix as the CLI for single-upload and multi-upload import flows.

--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -56,7 +56,7 @@ runbook covers import, locked provider replay, findings review, provider
 freshness, reports, evidence bundles, screenshot capture, fallback artifacts,
 and no-secret rules.
 
-The active browser Workbench uses the template backend under `backend/app` and
+The active browser Workbench uses the backend runtime under `backend/app` and
 the generated `/api/v1` browser client:
 
 ```bash

--- a/docs/vpw_template_execution_sequence.md
+++ b/docs/vpw_template_execution_sequence.md
@@ -1,9 +1,15 @@
 # VPW Template Execution Sequence
 
-This file maps the reopened duplicate VPW roadmap to a safer template-first
-execution order. The reopened GitHub issues remain authoritative. This document is
-the engineering sequence for working through them without repeating the previous
-false closeout.
+Status: historical execution sequence and current-state reference. The active
+runtime is now `backend/app`; current public-production readiness work is tracked
+through the root `ROADMAP.md` and
+[Public-Production Release Evidence Ledger](public-production-release-evidence-ledger.md).
+This file should not be used as standalone closure evidence for reopened issues.
+
+This file mapped the reopened duplicate VPW roadmap to a safer template-first
+execution order. The reopened GitHub issues remain authoritative. This document
+is retained to explain sequencing and guardrails without repeating previous false
+closeout patterns.
 
 ## Phase 0: Baseline And Governance
 

--- a/docs/workbench-public-deployment.md
+++ b/docs/workbench-public-deployment.md
@@ -3,6 +3,10 @@
 This runbook covers the additional controls required before exposing the
 Workbench beyond a local or private single-workspace environment.
 
+Status: deployment-control runbook, not final certification. Public-production
+readiness remains gated by the PP5 scorecard and the
+[Public-Production Release Evidence Ledger](./public-production-release-evidence-ledger.md).
+
 ## Required Environment
 
 Use non-default secrets and exact public origins:
@@ -124,9 +128,13 @@ scripts/workbench-backup.sh
 `WORKBENCH_DATABASE_MODE=compose` runs `pg_dump` inside the Compose `db`
 container, so the default stack does not need to publish Postgres on the host.
 `WORKBENCH_ARTIFACT_MODE=compose` copies artifacts from the running backend
-container, including the Compose volumes mounted at `/app/template-import-uploads`,
-`/app/template-reports`, `/app/provider-snapshots`, and
-`/app/template-provider-cache`.
+container, including the import-upload, report, provider-snapshot, and
+provider-cache Compose volumes.
+
+Some historical artifact directory names are retained as storage-path
+compatibility names for the active `backend/app` runtime. They do not indicate a
+separate template-era Workbench runtime, and API responses expose managed
+artifact IDs or relative references rather than container filesystem paths.
 
 The script writes a timestamped directory under `./backups` unless `BACKUP_DIR`
 is set. Artifact paths are packed into `artifacts.tar`.
@@ -170,3 +178,21 @@ python -c "import urllib.request; print(urllib.request.urlopen('https://api.${DO
 
 The status response should report `database_status=ready` and
 `schema_status=ready`.
+
+## Release Evidence
+
+Before a public-production release claim, record these public-safe results in
+the release evidence ledger or linked issue evidence:
+
+- `make release-readiness-check`
+- `make package-check`
+- `make dependency-audit`
+- `make api-client-drift-check`
+- `make docker-demo-smoke`
+- `make playwright-check`
+- header captures for the public frontend and API routes
+- residual-risk decision with owner and follow-up issue for every exception
+
+Do not include secrets, token values, cookies, customer exports, private
+absolute paths, shell history, or unredacted environment dumps in public
+evidence.

--- a/docs/workbench-threat-model.md
+++ b/docs/workbench-threat-model.md
@@ -8,7 +8,7 @@ This page defines the defensive threat model and operational readiness assumptio
 
 The current local-first Workbench threat model covers:
 
-- active browser Workbench use through the template backend in `backend/app` and
+- active browser Workbench use through the backend runtime in `backend/app` and
   the React frontend
 - retained local CLI and domain flows under `backend/src/vuln_prioritizer/**`
 - import of existing CVE lists and selected scanner export files
@@ -102,7 +102,7 @@ Primary boundaries:
 | Ticket token misuse or over-privileged credentials | Unauthorized issue/ticket creation or broader external account compromise | Read tokens only at request time from explicit environment variables such as `GITHUB_TOKEN`, `JIRA_API_TOKEN`, or `SERVICENOW_API_TOKEN`; use narrowly scoped external tokens; do not store token values in the Workbench database; include only counts and non-secret metadata in audit events. |
 | Oversized reports or evidence bundles | Disk exhaustion, slow UI, failed downloads | Enforce upload limits, keep generated artifacts in configured report directories, document cleanup responsibility, and surface generation errors. |
 | Supply-chain or dependency compromise | Compromised runtime or generated artifacts | Prefer pinned release installs, local checks, virtual environments, and reproducible docs/build commands. Do not load remote code through ATT&CK metadata or provider data. |
-| Internet-exposed Workbench deployment | Unauthorized access to imports, reports, and local state | Treat the current Workbench as local-first and not hardened for public exposure. API tokens are a local automation guard, not a complete internet-facing authentication, authorization, TLS, session, or multi-user isolation model. |
+| Internet-exposed Workbench deployment | Unauthorized access to imports, reports, and local state | Treat the current Workbench as local-first and not certified for public-production exposure until PP5 evidence closes. API tokens are a local automation guard, not a complete internet-facing authentication, authorization, TLS, session, or multi-user isolation model. |
 
 ## Operational Assumptions
 
@@ -127,6 +127,12 @@ Primary boundaries:
 
 ## Shared Deployment Prerequisites
 
+Public-production readiness is not certified by this page alone. The final
+acceptance boundary is the PP5 scorecard tracked in
+[Public-Production Release Evidence Ledger](./public-production-release-evidence-ledger.md).
+Until that scorecard closes, the controls below are prerequisites and evidence
+targets, not a blanket production-readiness claim.
+
 Shared or internet-exposed Workbench deployment is only acceptable after the
 public-deployment controls in
 [Workbench Public Deployment Runbook](./workbench-public-deployment.md) are
@@ -149,7 +155,10 @@ requirements:
 - operational monitoring for job failures, stale provider data, failed migrations, artifact-integrity failures, and storage pressure
 - documented incident response for leaked API tokens, exposed reports, tampered evidence bundles, and compromised provider snapshot directories
 
-These prerequisites are intentionally listed as blockers rather than implied support. API tokens remain a local automation control, not a complete shared-deployment auth model.
+These prerequisites are intentionally listed as blockers rather than implied
+support. API tokens remain a local automation control, not a complete
+shared-deployment auth model unless the final PP5 evidence explicitly accepts
+that boundary.
 
 ## Readiness Checklist
 
@@ -204,7 +213,7 @@ Maintain v1.2 readiness with local, repeatable checks:
 - Grep/no-real-key review to confirm docs, examples, screenshots, snapshots, and
   generated artifacts contain placeholders or redacted state only.
 - `make workflow-check` before merge or release branches when Docker and pre-commit tooling are available.
-- `make docker-demo-smoke` for the Compose quickstart path; it starts the template shell, polls `/api/v1/workbench/status`, verifies a locked provider-data import, triggers `/api/v1/providers/update-jobs`, and removes the demo stack.
+- `make docker-demo-smoke` for the Compose quickstart path; it starts the Workbench stack, polls `/api/v1/workbench/status`, verifies a locked provider-data import, triggers `/api/v1/providers/update-jobs`, and removes the demo stack.
 - `make demo-sync-check-temp` before release when output changes affect checked-in examples, reports, SARIF, HTML, or evidence artifacts.
 - `make release-readiness-check` before release handoff when the local release gate and demo evidence bundle verification should be recorded together.
 - `make dependency-audit` for maintainer dependency review when `pip-audit`, npm, and advisory data are reachable.

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -6,6 +6,11 @@ Use this checklist before tagging or publishing a Workbench-capable package rele
 
 The Workbench v1.0 milestone evidence is preserved here, but the current package tree is versioned `1.1.0`. A tag cut from this tree must therefore be `v1.1.0`; the release workflow rejects tags that do not match `pyproject.toml`.
 
+For public-production remediation and PP5 certification, use
+[Public-Production Release Evidence Ledger](public-production-release-evidence-ledger.md).
+This historical checklist remains useful release context, but it is not the
+final public-production scorecard.
+
 ## Current Closeout Evidence
 
 - Historical implementation baseline before the first docs closeout: `f5db33f58aa14eba23daa47b38def71b243466a3`.
@@ -144,6 +149,13 @@ make dependency-audit
 make release-check
 ```
 
+- [ ] For public-production readiness handoff, run the broader gate and record
+  the result with residual risk:
+
+```bash
+make release-readiness-check
+```
+
 - [x] Run the documentation gate:
 
 ```bash
@@ -185,7 +197,8 @@ The v1.0 release must keep these boundaries visible in docs, UI copy, examples, 
 
 ## Residual Risks to State
 
-- [x] The Workbench is local-first and is not hardened for public internet exposure.
+- [x] The Workbench v1.0 evidence was local-first; public-production certification
+  requires the separate PP5 evidence ledger and scorecard.
 - [x] SSO, multi-user isolation, audit logging, and ticket sync remain outside the v1.0 local Workbench scope unless explicitly shipped; the later local API-token gate is documented as a v1.2 automation control, not a full internet-facing auth model.
 - [x] SQLite backup, retention, filesystem permissions, and local disk protection remain operator responsibilities.
 - [x] Evidence bundles provide integrity checks but not encryption.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci --workspaces=false
 
 COPY frontend ./
 
-ARG VITE_API_URL=http://localhost:8000
+ARG VITE_API_URL=
 ARG NODE_ENV=production
 ENV VITE_API_URL=$VITE_API_URL
 ENV NODE_ENV=$NODE_ENV

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,8 +3,10 @@
 This is the React/Vite/TanStack Router workspace for the active Workbench.
 
 The browser app talks to the active FastAPI backend through the generated
-`/api/v1` client in `frontend/src/client/**` and the wrapper in
-`frontend/src/api-client.ts`.
+`/api/v1` client in `frontend/src/client/**`.
+
+`frontend/src/api-client.ts` is a manual wrapper over the generated client. It is
+owned like normal frontend source and should not be treated as generated drift.
 
 ## Local Commands
 
@@ -12,6 +14,7 @@ The browser app talks to the active FastAPI backend through the generated
 cd frontend && npm ci --workspaces=false
 cd frontend && npm run build
 bash scripts/generate-client.sh
+git diff --exit-code -- frontend/src/client
 ```
 
 The official template uses Bun. This repository keeps Bun-compatible scripts in

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -5,12 +5,19 @@
     "indentStyle": "space",
     "indentWidth": 2
   },
+  "files": {
+    "includes": [
+      "**",
+      "!src/client/**",
+      "!src/routeTree.gen.ts"
+    ]
+  },
   "linter": {
     "enabled": true,
     "rules": {
       "recommended": true,
       "correctness": {
-        "useExhaustiveDependencies": "off"
+        "useExhaustiveDependencies": "warn"
       },
       "style": {
         "noNonNullAssertion": "off"

--- a/frontend/nginx-backend-not-found.conf
+++ b/frontend/nginx-backend-not-found.conf
@@ -1,5 +1,15 @@
-location /api {
-  return 404;
+location = /api {
+  return 308 /api/;
+}
+
+location /api/ {
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_pass http://backend:8000;
 }
 
 location /docs {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,7 +1,7 @@
 server {
   listen 80;
 
-  add_header Content-Security-Policy "default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' http://localhost:8000 http://127.0.0.1:8000; frame-ancestors 'none'" always;
+  add_header Content-Security-Policy "default-src 'self'; base-uri 'none'; object-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'" always;
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "DENY" always;
   add_header Referrer-Policy "same-origin" always;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc -p tsconfig.build.json && vite build",
-    "lint": "biome check --no-errors-on-unmatched --files-ignore-unknown=true index.html src/auth.ts src/main.tsx src/index.css src/routes vite.config.ts openapi-ts.config.ts playwright.config.ts tests package.json tsconfig.json tsconfig.build.json tsconfig.node.json components.json",
-    "lint:fix": "biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true index.html src/auth.ts src/main.tsx src/index.css src/routes vite.config.ts openapi-ts.config.ts playwright.config.ts tests package.json tsconfig.json tsconfig.build.json tsconfig.node.json components.json",
+    "lint": "biome lint --no-errors-on-unmatched --files-ignore-unknown=true index.html src tests vite.config.ts openapi-ts.config.ts playwright.config.ts package.json tsconfig.json tsconfig.build.json tsconfig.node.json components.json",
+    "lint:fix": "biome lint --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true index.html src tests vite.config.ts openapi-ts.config.ts playwright.config.ts package.json tsconfig.json tsconfig.build.json tsconfig.node.json components.json",
     "preview": "vite preview --host 127.0.0.1",
     "generate-client": "openapi-ts",
     "test": "playwright test",
-    "test:unit": "node --test --experimental-strip-types tests/chart-data.test.ts tests/report-download.test.ts",
+    "test:unit": "node --test --experimental-strip-types tests/auth.test.ts tests/chart-data.test.ts tests/report-download.test.ts tests/runtime-config.test.ts",
     "test:ui": "playwright test --ui"
   },
   "dependencies": {

--- a/frontend/src/api-client.ts
+++ b/frontend/src/api-client.ts
@@ -1,4 +1,5 @@
 import { client } from "./client/client.gen"
+import { withCsrfHeader } from "./auth"
 
 export * from "./client"
 export { client } from "./client/client.gen"
@@ -24,6 +25,16 @@ export class ApiError extends Error {
 }
 
 let hasErrorInterceptor = false
+let hasRequestInterceptor = false
+
+function installRequestInterceptor() {
+  if (hasRequestInterceptor) {
+    return
+  }
+
+  client.interceptors.request.use((request) => withCsrfHeader(request))
+  hasRequestInterceptor = true
+}
 
 function installErrorInterceptor() {
   if (hasErrorInterceptor) {
@@ -43,8 +54,10 @@ function installErrorInterceptor() {
 }
 
 function configureClient(config: Parameters<typeof client.setConfig>[0]) {
+  installRequestInterceptor()
   installErrorInterceptor()
   client.setConfig({
+    credentials: "include",
     responseStyle: "data",
     throwOnError: true,
     ...config,

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,17 +1,175 @@
-const accessTokenKey = "access_token"
+declare const __VPW_LEGACY_SESSION_TOKEN_STORAGE__: boolean | undefined
+
+const legacySessionTokenStorage =
+  typeof __VPW_LEGACY_SESSION_TOKEN_STORAGE__ === "boolean"
+    ? __VPW_LEGACY_SESSION_TOKEN_STORAGE__
+    : false
+const legacySessionTokenKey = "vpw.legacySessionToken"
+const csrfCookieNames = [
+  "vpw_csrf_token",
+  "vpw_csrf",
+  "csrf_token",
+  "csrftoken",
+  "XSRF-TOKEN",
+]
+const csrfMetaNames = ["csrf-token", "vpw-csrf-token"]
+const csrfHeaderName = "X-CSRF-Token"
+const unsafeMethods = new Set(["DELETE", "PATCH", "POST", "PUT"])
+
+let inMemoryAccessToken = readLegacySessionToken()
+let authenticatedInCurrentTab = false
 
 export function getAccessToken(): string {
-  return localStorage.getItem(accessTokenKey) ?? ""
+  if (!legacySessionTokenStorage) {
+    return ""
+  }
+  if (!inMemoryAccessToken) {
+    inMemoryAccessToken = readLegacySessionToken()
+  }
+  return inMemoryAccessToken
 }
 
 export function isLoggedIn(): boolean {
-  return getAccessToken().length > 0
+  return (
+    authenticatedInCurrentTab ||
+    getAccessToken().length > 0 ||
+    getCsrfToken().length > 0
+  )
 }
 
-export function setAccessToken(token: string): void {
-  localStorage.setItem(accessTokenKey, token)
+export function setAccessToken(token?: string): void {
+  inMemoryAccessToken = legacySessionTokenStorage ? (token ?? "") : ""
+  authenticatedInCurrentTab = true
+  writeLegacySessionToken(inMemoryAccessToken)
 }
 
 export function clearAccessToken(): void {
-  localStorage.removeItem(accessTokenKey)
+  inMemoryAccessToken = ""
+  authenticatedInCurrentTab = false
+  clearLegacySessionToken()
+  expireReadableAuthCookies()
+}
+
+export function getCsrfToken(cookie = browserCookie()): string {
+  const cookieToken = readFirstCookieValue(cookie, csrfCookieNames)
+  if (cookieToken) {
+    return cookieToken
+  }
+  return readCsrfMetaToken()
+}
+
+export function csrfHeaderForMethod(method: string): HeadersInit | undefined {
+  if (!unsafeMethods.has(method.toUpperCase())) {
+    return undefined
+  }
+  const token = getCsrfToken()
+  return token ? { [csrfHeaderName]: token } : undefined
+}
+
+export function withCsrfHeader(request: Request): Request {
+  if (!unsafeMethods.has(request.method.toUpperCase())) {
+    return request
+  }
+  if (request.headers.has(csrfHeaderName)) {
+    return request
+  }
+
+  const token = getCsrfToken()
+  if (!token) {
+    return request
+  }
+
+  const headers = new Headers(request.headers)
+  headers.set(csrfHeaderName, token)
+  return new Request(request, { headers })
+}
+
+function browserCookie() {
+  return typeof document === "undefined" ? "" : document.cookie
+}
+
+function readLegacySessionToken() {
+  if (!legacySessionTokenStorage || typeof sessionStorage === "undefined") {
+    return ""
+  }
+  try {
+    return sessionStorage.getItem(legacySessionTokenKey) ?? ""
+  } catch {
+    return ""
+  }
+}
+
+function writeLegacySessionToken(token: string) {
+  if (!legacySessionTokenStorage || typeof sessionStorage === "undefined") {
+    return
+  }
+  try {
+    if (token) {
+      sessionStorage.setItem(legacySessionTokenKey, token)
+    } else {
+      sessionStorage.removeItem(legacySessionTokenKey)
+    }
+  } catch {
+    // Session storage can be blocked; cookie sessions remain the primary path.
+  }
+}
+
+function clearLegacySessionToken() {
+  if (!legacySessionTokenStorage || typeof sessionStorage === "undefined") {
+    return
+  }
+  try {
+    sessionStorage.removeItem(legacySessionTokenKey)
+  } catch {
+    // Session storage can be blocked; cookie sessions remain the primary path.
+  }
+}
+
+function readFirstCookieValue(cookie: string, names: readonly string[]) {
+  const pairs = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  for (const name of names) {
+    const prefix = `${encodeURIComponent(name)}=`
+    const pair = pairs.find((entry) => entry.startsWith(prefix))
+    if (!pair) {
+      continue
+    }
+    const value = pair.slice(prefix.length)
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+  return ""
+}
+
+function readCsrfMetaToken() {
+  if (typeof document === "undefined") {
+    return ""
+  }
+  for (const name of csrfMetaNames) {
+    const token = document
+      .querySelector<HTMLMetaElement>(`meta[name="${name}"]`)
+      ?.content.trim()
+    if (token) {
+      return token
+    }
+  }
+  return ""
+}
+
+function expireReadableAuthCookies() {
+  if (typeof document === "undefined") {
+    return
+  }
+  for (const name of csrfCookieNames) {
+    // biome-ignore lint/suspicious/noDocumentCookie: logout must expire client-readable CSRF cookies on browsers without Cookie Store support.
+    document.cookie = `${encodeURIComponent(
+      name,
+    )}=; Max-Age=0; Path=/; SameSite=Strict`
+  }
 }

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4715,6 +4715,17 @@ export const TokenSchema = {
             title: 'Access Token',
             type: 'string'
         },
+        csrf_token: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Csrf Token'
+        },
         token_type: {
             default: 'bearer',
             title: 'Token Type',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2652,6 +2652,10 @@ export type Token = {
      */
     access_token: string;
     /**
+     * Csrf Token
+     */
+    csrf_token?: string | null;
+    /**
      * Token Type
      */
     token_type?: string;

--- a/frontend/src/components/assets/useAssetsRouteState.ts
+++ b/frontend/src/components/assets/useAssetsRouteState.ts
@@ -1,5 +1,11 @@
 import { useNavigate } from "@tanstack/react-router"
-import { type FormEvent, useEffect, useMemo, useState } from "react"
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 
 import {
   ApiError,
@@ -67,84 +73,100 @@ export function useAssetsRouteState() {
     [assets, selectedAssetId],
   )
 
-  async function handleUnauthorized(caught: unknown) {
-    if (caught instanceof ApiError && [401, 403].includes(caught.status)) {
-      clearAccessToken()
-      await navigate({ to: "/login" })
-      return true
-    }
-    return false
-  }
+  const handleUnauthorized = useCallback(
+    async function handleUnauthorized(caught: unknown) {
+      if (caught instanceof ApiError && [401, 403].includes(caught.status)) {
+        clearAccessToken()
+        await navigate({ to: "/login" })
+        return true
+      }
+      return false
+    },
+    [navigate],
+  )
 
-  async function refreshProjects(preferredProjectId?: string) {
-    setProjectLoading(true)
-    try {
-      const projectPage = await ProjectsService.readProjects()
-      setProjects(projectPage.data)
-      setSelectedProjectId((currentProjectId) => {
-        if (
-          preferredProjectId &&
-          projectPage.data.some((project) => project.id === preferredProjectId)
-        ) {
-          return preferredProjectId
+  const refreshProjects = useCallback(
+    async function refreshProjects(preferredProjectId?: string) {
+      setProjectLoading(true)
+      try {
+        const projectPage = await ProjectsService.readProjects()
+        setProjects(projectPage.data)
+        setSelectedProjectId((currentProjectId) => {
+          if (
+            preferredProjectId &&
+            projectPage.data.some(
+              (project) => project.id === preferredProjectId,
+            )
+          ) {
+            return preferredProjectId
+          }
+          if (
+            projectPage.data.some((project) => project.id === currentProjectId)
+          ) {
+            return currentProjectId
+          }
+          return projectPage.data[0]?.id ?? ""
+        })
+      } catch (caught) {
+        if (await handleUnauthorized(caught)) {
+          return
         }
-        if (
-          projectPage.data.some((project) => project.id === currentProjectId)
-        ) {
-          return currentProjectId
-        }
-        return projectPage.data[0]?.id ?? ""
-      })
-    } catch (caught) {
-      if (await handleUnauthorized(caught)) {
+        setProjects([])
+        setSelectedProjectId("")
+        setAssetsError(apiErrorMessage("Project list unavailable", caught))
+      } finally {
+        setProjectLoading(false)
+      }
+    },
+    [handleUnauthorized],
+  )
+
+  const refreshAssets = useCallback(
+    async function refreshAssets(preferredAssetId?: string) {
+      if (!selectedProjectId) {
+        setAssets([])
+        setSelectedAssetId("")
         return
       }
-      setProjects([])
-      setSelectedProjectId("")
-      setAssetsError(apiErrorMessage("Project list unavailable", caught))
-    } finally {
-      setProjectLoading(false)
-    }
-  }
-
-  async function refreshAssets(preferredAssetId?: string) {
-    if (!selectedProjectId) {
-      setAssets([])
-      setSelectedAssetId("")
-      return
-    }
-    setAssetsLoading(true)
-    setAssetsError("")
-    try {
-      const assetPage = await AssetsService.readProjectAssets({
-        owner: assetOwnerFilter.trim() || undefined,
-        project_id: selectedProjectId,
-        service: assetServiceFilter.trim() || undefined,
-      })
-      setAssets(assetPage.data)
-      setSelectedAssetId((currentAssetId) => {
-        if (
-          preferredAssetId &&
-          assetPage.data.some((asset) => asset.id === preferredAssetId)
-        ) {
-          return preferredAssetId
+      setAssetsLoading(true)
+      setAssetsError("")
+      try {
+        const assetPage = await AssetsService.readProjectAssets({
+          owner: assetOwnerFilter.trim() || undefined,
+          project_id: selectedProjectId,
+          service: assetServiceFilter.trim() || undefined,
+        })
+        setAssets(assetPage.data)
+        setSelectedAssetId((currentAssetId) => {
+          if (
+            preferredAssetId &&
+            assetPage.data.some((asset) => asset.id === preferredAssetId)
+          ) {
+            return preferredAssetId
+          }
+          if (assetPage.data.some((asset) => asset.id === currentAssetId)) {
+            return currentAssetId
+          }
+          return assetPage.data[0]?.id ?? ""
+        })
+      } catch (caught) {
+        if (await handleUnauthorized(caught)) {
+          return
         }
-        if (assetPage.data.some((asset) => asset.id === currentAssetId)) {
-          return currentAssetId
-        }
-        return assetPage.data[0]?.id ?? ""
-      })
-    } catch (caught) {
-      if (await handleUnauthorized(caught)) {
-        return
+        setAssets([])
+        setSelectedAssetId("")
+        setAssetsError(apiErrorMessage("Assets unavailable", caught))
+      } finally {
+        setAssetsLoading(false)
       }
-      setAssets([])
-      setSelectedAssetId("")
-      setAssetsError(apiErrorMessage("Assets unavailable", caught))
-    } finally {
-      setAssetsLoading(false)
-    }
-  }
+    },
+    [
+      assetOwnerFilter,
+      assetServiceFilter,
+      handleUnauthorized,
+      selectedProjectId,
+    ],
+  )
 
   useEffect(() => {
     let isMounted = true
@@ -178,11 +200,11 @@ export function useAssetsRouteState() {
     return () => {
       isMounted = false
     }
-  }, [])
+  }, [handleUnauthorized, refreshProjects])
 
   useEffect(() => {
     void refreshAssets()
-  }, [assetOwnerFilter, assetServiceFilter, selectedProjectId])
+  }, [refreshAssets])
 
   useEffect(() => {
     let isMounted = true
@@ -230,7 +252,7 @@ export function useAssetsRouteState() {
     return () => {
       isMounted = false
     }
-  }, [selectedAsset, selectedProjectId])
+  }, [handleUnauthorized, selectedAsset, selectedProjectId])
 
   async function createAsset(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/frontend/src/components/charts/RiskTrendChart.tsx
+++ b/frontend/src/components/charts/RiskTrendChart.tsx
@@ -39,7 +39,13 @@ export function RiskTrendChart({ items }: RiskTrendChartProps) {
       title="Run Activity"
     >
       <figure className="trend-chart" aria-label="Run activity trend">
-        <svg role="img" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <svg
+          aria-labelledby="run-activity-trend-title"
+          role="img"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+        >
+          <title id="run-activity-trend-title">Run activity trend</title>
           <path className="trend-line" d={path} />
           {points.map((point) => (
             <circle

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -33,6 +33,7 @@ import {
   DEMO_TOP_SERVICES,
 } from "@/lib/demo-data"
 import { formatProviderFreshness } from "@/lib/provider-format"
+import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { ErrorState } from "../states"
 import { DashboardDemoBanner, DashboardSetupEmptyState } from "./DashboardEmptyState"
 import { DashboardHero } from "./DashboardHero"
@@ -115,10 +116,11 @@ export function RiskOperationsDashboard({
     selectedRunRange: "10",
   })
 
-  // ── Demo preview mode ────────────────────────────────────────────────────
-  // Active only when no real project is connected. A labeled banner is shown.
   const isDemoMode =
-    !projectListLoading && projects.length === 0 && !dashboardError
+    DEMO_MODE_ENABLED &&
+    !projectListLoading &&
+    projects.length === 0 &&
+    !dashboardError
 
   const effectiveProjects = isDemoMode ? [DEMO_PROJECT] : projects
   const effectiveSelectedProject = isDemoMode ? DEMO_PROJECT : selectedProject

--- a/frontend/src/components/findings/FindingsDataTable.tsx
+++ b/frontend/src/components/findings/FindingsDataTable.tsx
@@ -1,10 +1,5 @@
 import { Link } from "@tanstack/react-router"
-import {
-  ArrowDown,
-  ArrowUp,
-  ArrowUpDown,
-  Eye,
-} from "lucide-react"
+import { ArrowDown, ArrowUp, ArrowUpDown, Eye } from "lucide-react"
 import type {
   FindingPublic,
   FindingsReadProjectFindingsData,
@@ -23,9 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import {
-  type ReactNode,
-} from "react"
+import type { ReactNode } from "react"
 import { formatLabel as labelize, optionalText } from "@/lib/ui-copy"
 import { cn } from "@/lib/utils"
 
@@ -51,15 +44,24 @@ const defaultSortDirections: Record<QueueSort, FindingsDirection> = {
 
 function componentLabel(finding: FindingPublic) {
   const name = optionalText(finding.component_name)
-  return finding.component_version ? `${name} ${finding.component_version}` : name
+  return finding.component_version
+    ? `${name} ${finding.component_version}`
+    : name
 }
 
 function serviceLabel(finding: FindingPublic) {
-  return finding.business_service ?? finding.component_purl ?? "Service not linked"
+  return (
+    finding.business_service ?? finding.component_purl ?? "Service not linked"
+  )
 }
 
 function assetLabel(finding: FindingPublic) {
-  return finding.asset_name ?? finding.asset_key ?? finding.business_service ?? "N.A."
+  return (
+    finding.asset_name ??
+    finding.asset_key ??
+    finding.business_service ??
+    "N.A."
+  )
 }
 
 function ownerLabel(finding: FindingPublic) {

--- a/frontend/src/components/findings/RemediationQueue.tsx
+++ b/frontend/src/components/findings/RemediationQueue.tsx
@@ -63,6 +63,7 @@ import {
   VpwStatusBanner,
 } from "@/components/vpw"
 import { DEMO_FINDINGS, DEMO_PROJECT, DEMO_SUMMARY } from "@/lib/demo-data"
+import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { formatLabel as labelize, optionalText } from "@/lib/ui-copy"
 import { cn } from "@/lib/utils"
 import { FindingsDataTable, type QueueSort } from "./FindingsDataTable"
@@ -203,14 +204,6 @@ function serviceLabel(f: FindingPublic) {
 
 function ownerLabel(f: FindingPublic) {
   return f.owner ?? f.business_service ?? "Unassigned"
-}
-
-function findingWhyNow(f: FindingPublic) {
-  return (
-    optionalText(f.rationale) ??
-    optionalText(f.recommended_action) ??
-    "No priority rationale has been recorded yet."
-  )
 }
 
 function dateSortValue(value: string | null | undefined) {
@@ -587,7 +580,8 @@ export function RemediationQueue({
   const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false)
   const [queueSort, setQueueSort] = useState<QueueSort>(findingSort)
 
-  const isDemo = projects.length === 0 && !projectListLoading
+  const isDemo =
+    DEMO_MODE_ENABLED && projects.length === 0 && !projectListLoading
   const sourceFindings = isDemo ? DEMO_FINDINGS : findings
   const displayFindings =
     isDemo || !isApiSort(queueSort)

--- a/frontend/src/components/imports/ImportsWorkbench.tsx
+++ b/frontend/src/components/imports/ImportsWorkbench.tsx
@@ -1,14 +1,6 @@
 import { Link } from "@tanstack/react-router"
-import {
-  AlertTriangle,
-  CheckCircle2,
-  FileJson,
-  FileText,
-  History,
-  PackageCheck,
-  Upload,
-} from "lucide-react"
-import type { FormEventHandler, ReactNode } from "react"
+import { CheckCircle2, History, PackageCheck, Upload } from "lucide-react"
+import type { FormEventHandler } from "react"
 import type {
   AnalysisRunPublic,
   AnalysisRunSummaryPublic,
@@ -48,6 +40,7 @@ import {
   VpwToolbarGroup,
 } from "@/components/vpw"
 import { formatProviderFreshness } from "@/lib/provider-format"
+import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { runStatusLabel, runStatusTone } from "@/lib/risk-format"
 
 export type SupportedImportFormat = {
@@ -121,7 +114,9 @@ function runFileLabel(run: {
   input_upload?: Record<string, unknown>
   summary_json?: Record<string, unknown>
 }) {
-  const upload = objectRecord(run.input_upload ?? run.summary_json?.input_upload)
+  const upload = objectRecord(
+    run.input_upload ?? run.summary_json?.input_upload,
+  )
   const uploadFilename = stringValue(upload.filename)
   return run.filename ?? uploadFilename ?? `${run.input_type} upload`
 }
@@ -210,7 +205,7 @@ function ImportHero({
   const providerSummary = providerStatus
     ? formatProviderFreshness(providerStatus)
     : null
-  const isDemo = !selectedProject
+  const isDemo = DEMO_MODE_ENABLED && !selectedProject
 
   return (
     <VpwSection>
@@ -314,7 +309,8 @@ function ImportWizard({
     },
     {
       title: "Validate and import",
-      description: "The backend validates format, parses input, and records run evidence.",
+      description:
+        "The backend validates format, parses input, and records run evidence.",
       status: importLoading ? "Running" : "Ready",
       statusTone: importLoading ? "info" : "neutral",
     },
@@ -489,7 +485,8 @@ function ImportWizard({
               {
                 label: "Unsupported formats",
                 value: "Rejected",
-                description: "Uploads must match the selected format and extension.",
+                description:
+                  "Uploads must match the selected format and extension.",
                 tone: "warning",
               },
               {
@@ -502,7 +499,8 @@ function ImportWizard({
               {
                 label: "Network activity",
                 value: "No scanning",
-                description: "The import wizard does not run probes or scanners.",
+                description:
+                  "The import wizard does not run probes or scanners.",
                 tone: "success",
               },
             ]}
@@ -550,10 +548,12 @@ function SupportedFormats({
           title="OpenVEX / VEX sidecar"
         >
           <div className="space-y-2">
-            <p>Optional VEX JSON sidecar attached to occurrence or SBOM imports.</p>
+            <p>
+              Optional VEX JSON sidecar attached to occurrence or SBOM imports.
+            </p>
             <p className="text-xs">
-              Expected: OpenVEX statements or CycloneDX VEX vulnerability
-              status data.
+              Expected: OpenVEX statements or CycloneDX VEX vulnerability status
+              data.
             </p>
           </div>
         </VpwSelectionCard>
@@ -575,7 +575,9 @@ function ImportResult({
   return (
     <VpwSection>
       <VpwSectionHeader
-        actions={<VpwBadge tone={runTone(status)}>{runStatusLabel(status)}</VpwBadge>}
+        actions={
+          <VpwBadge tone={runTone(status)}>{runStatusLabel(status)}</VpwBadge>
+        }
         description="Latest completed import result from the current session."
         title="Import Result"
       />
@@ -620,11 +622,7 @@ function ImportResult({
   )
 }
 
-function ParserErrors({
-  errors,
-}: {
-  errors: ImportParseErrorPublic[]
-}) {
+function ParserErrors({ errors }: { errors: ImportParseErrorPublic[] }) {
   if (errors.length === 0) return null
 
   const columns: VpwDataTableColumn<ImportParseErrorPublic>[] = [
@@ -646,7 +644,9 @@ function ParserErrors({
         columns={columns}
         data={errors}
         getRowKey={(error, index) =>
-          [error.filename, error.line, error.field, error.value, index].join(":")
+          [error.filename, error.line, error.field, error.value, index].join(
+            ":",
+          )
         }
       />
     </VpwSection>
@@ -697,12 +697,18 @@ function RecentImports({
     {
       id: "type",
       header: "Input type",
-      cell: (run) => <VpwBadge tone="info">{formatDisplayType(run.input_type)}</VpwBadge>,
+      cell: (run) => (
+        <VpwBadge tone="info">{formatDisplayType(run.input_type)}</VpwBadge>
+      ),
     },
     {
       id: "status",
       header: "Status",
-      cell: (run) => <VpwBadge tone={runTone(run.status)}>{runStatusLabel(run.status)}</VpwBadge>,
+      cell: (run) => (
+        <VpwBadge tone={runTone(run.status)}>
+          {runStatusLabel(run.status)}
+        </VpwBadge>
+      ),
     },
     {
       id: "findings",

--- a/frontend/src/components/reports/EvidenceCenter.tsx
+++ b/frontend/src/components/reports/EvidenceCenter.tsx
@@ -1,6 +1,5 @@
 import {
   AlertTriangle,
-  CheckCircle2,
   Clock,
   Download,
   FileArchive,
@@ -12,9 +11,8 @@ import {
   Layers,
   ShieldCheck,
   Table2,
-  XCircle,
 } from "lucide-react"
-import type { ComponentType, ReactNode } from "react"
+import type { ComponentType } from "react"
 import type {
   AnalysisRunPublic,
   AnalysisRunSummaryPublic,
@@ -74,6 +72,7 @@ import {
   reportFormatLabel,
   reportSizeLabel,
 } from "@/lib/report-format"
+import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { runStatusLabel, runStatusTone } from "@/lib/risk-format"
 
 export type EvidenceCenterProps = {
@@ -201,9 +200,7 @@ function priorityCount(
   key: "critical" | "high",
 ): number {
   return (summary?.counts_by_priority?.[key] ??
-    summary?.counts_by_priority?.[
-      key.charAt(0).toUpperCase() + key.slice(1)
-    ] ??
+    summary?.counts_by_priority?.[key.charAt(0).toUpperCase() + key.slice(1)] ??
     0) as number
 }
 
@@ -274,7 +271,9 @@ function RunContext({
   return (
     <VpwSection>
       <VpwSectionHeader
-        actions={isDemo ? <VpwBadge tone="warning">Demo preview</VpwBadge> : null}
+        actions={
+          isDemo ? <VpwBadge tone="warning">Demo preview</VpwBadge> : null
+        }
         description="Generate audit-ready vulnerability evidence, executive summaries, and technical exports."
         eyebrow="Reports"
         title="Evidence Center"
@@ -302,9 +301,7 @@ function RunContext({
               <VpwBadge
                 tone={
                   isDemo || selectedReportRun
-                    ? runBadgeTone(
-                        (selectedReportRun ?? DEMO_RUNS[0]).status,
-                      )
+                    ? runBadgeTone((selectedReportRun ?? DEMO_RUNS[0]).status)
                     : "neutral"
                 }
               >
@@ -458,13 +455,7 @@ function EvidenceSummary({
   )
 }
 
-function ActionStatus({
-  error,
-  message,
-}: {
-  error: string
-  message: string
-}) {
+function ActionStatus({ error, message }: { error: string; message: string }) {
   if (!error && !message) return null
 
   return (
@@ -475,7 +466,10 @@ function ActionStatus({
         </VpwStatusBanner>
       ) : null}
       {message ? (
-        <VpwStatusBanner title="Report action complete" tone={statusBannerTone(message)}>
+        <VpwStatusBanner
+          title="Report action complete"
+          tone={statusBannerTone(message)}
+        >
           {message}
         </VpwStatusBanner>
       ) : null}
@@ -500,7 +494,9 @@ function ArtifactSection({
     <VpwSection>
       <VpwSectionHeader
         actions={
-          isDemo ? <VpwBadge tone="warning">Generation disabled</VpwBadge> : null
+          isDemo ? (
+            <VpwBadge tone="warning">Generation disabled</VpwBadge>
+          ) : null
         }
         description={
           reportActionsEnabled
@@ -761,7 +757,9 @@ function ManifestPreview({
         path: report.filename,
       }))}
       generatedAt={
-        zipReport ? formatReportDateTime(zipReport.created_at) : "Not generated yet"
+        zipReport
+          ? formatReportDateTime(zipReport.created_at)
+          : "Not generated yet"
       }
       onDownload={
         !isDemo && zipReport ? () => onDownload(zipReport) : undefined
@@ -803,8 +801,7 @@ function ExecutiveDecision({
     critical + high > 0
       ? "Patch critical findings within 48 hours and high-severity findings within 7 days. Prioritize KEV entries first."
       : "Maintain the standard remediation cadence and re-run after the next deployment cycle."
-  const priority =
-    critical > 0 ? "Immediate" : high > 0 ? "High" : "Routine"
+  const priority = critical > 0 ? "Immediate" : high > 0 ? "High" : "Routine"
   const priorityTone: VpwBadgeTone =
     critical > 0 ? "critical" : high > 0 ? "warning" : "success"
   const decisionStatement = isDemo
@@ -892,7 +889,7 @@ export function EvidenceCenter({
   selectedRunSummary,
 }: EvidenceCenterProps) {
   void selectedRunSummary
-  const isDemo = !selectedProject
+  const isDemo = DEMO_MODE_ENABLED && !selectedProject
   const combinedError = [
     runsError,
     runDetailError,

--- a/frontend/src/components/vpw/VpwAppFrame.tsx
+++ b/frontend/src/components/vpw/VpwAppFrame.tsx
@@ -33,7 +33,7 @@ export function VpwAppFrame({
   navItems,
   statusItems = [],
   title,
-  userLabel = "admin@example.com",
+  userLabel = "Workbench user",
 }: VpwAppFrameProps) {
   return (
     <div className="grid min-h-[34rem] overflow-hidden rounded-[var(--vpw-radius-xl)] border border-[var(--vpw-border-default)] bg-[var(--vpw-bg-app)] shadow-[var(--vpw-shadow-3)] lg:grid-cols-[248px_1fr]">

--- a/frontend/src/components/waivers/WaiversWorkbench.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbench.tsx
@@ -2,13 +2,10 @@ import { Link } from "@tanstack/react-router"
 import {
   AlertTriangle,
   CalendarClock,
-  CheckCircle2,
   ClipboardCheck,
   FileCheck2,
   RefreshCw,
-  ShieldAlert,
   ShieldCheck,
-  UserCheck,
 } from "lucide-react"
 import type { FormEventHandler } from "react"
 import type {
@@ -187,7 +184,9 @@ function reviewQueue(
         id: item.id,
         owner: item.owner,
         reason: `${statusLabel(item.status)} waiver affecting ${item.matched_findings ?? 0} finding(s).`,
-        reviewDate: item.review_at ? formatDate(item.review_at) : formatDate(item.expires_at),
+        reviewDate: item.review_at
+          ? formatDate(item.review_at)
+          : formatDate(item.expires_at),
         scope: debtScopeLabel(item),
         status: statusLabel(item.status),
         statusTone: statusTone(item.status),
@@ -196,13 +195,18 @@ function reviewQueue(
 
   return waivers
     .slice()
-    .sort((left, right) => (left.days_remaining ?? 9999) - (right.days_remaining ?? 9999))
+    .sort(
+      (left, right) =>
+        (left.days_remaining ?? 9999) - (right.days_remaining ?? 9999),
+    )
     .slice(0, 4)
     .map((waiver) => ({
       id: waiver.id,
       owner: waiver.owner,
       reason: waiver.reason,
-      reviewDate: waiver.review_at ? formatDate(waiver.review_at) : formatDate(waiver.expires_at),
+      reviewDate: waiver.review_at
+        ? formatDate(waiver.review_at)
+        : formatDate(waiver.expires_at),
       scope: waiverScopeLabel(waiver),
       status: statusLabel(waiver.status),
       statusTone: statusTone(waiver.status),
@@ -223,31 +227,36 @@ function timelineItems({
   return [
     {
       title: "Created",
-      description: "Risk acceptance starts only after scope, owner, reason and expiry are recorded.",
+      description:
+        "Risk acceptance starts only after scope, owner, reason and expiry are recorded.",
       meta: "Required",
       tone: "success",
     },
     {
       title: "Approved",
-      description: "Approval references or ticket URLs make accepted risk auditable in reports.",
+      description:
+        "Approval references or ticket URLs make accepted risk auditable in reports.",
       meta: `${acceptedFindings} accepted finding(s)`,
       tone: "success",
     },
     {
       title: "Review due",
-      description: "Owner review keeps accepted risk visible before it becomes stale.",
+      description:
+        "Owner review keeps accepted risk visible before it becomes stale.",
       meta: `${reviewDue} due`,
       tone: Number(reviewDue) > 0 ? "warning" : "neutral",
     },
     {
       title: "Expiring",
-      description: "Waivers close to expiry should be remediated, renewed, or explicitly re-approved.",
+      description:
+        "Waivers close to expiry should be remediated, renewed, or explicitly re-approved.",
       meta: `${expiringSoon} soon`,
       tone: Number(expiringSoon) > 0 ? "warning" : "neutral",
     },
     {
       title: "Expired",
-      description: "Expired accepted risk should return to normal remediation pressure.",
+      description:
+        "Expired accepted risk should return to normal remediation pressure.",
       meta: `${expired} expired`,
       tone: Number(expired) > 0 ? "critical" : "neutral",
     },
@@ -275,7 +284,9 @@ export function WaiversWorkbench({
   waiversError,
   waiversLoading,
 }: WaiversWorkbenchProps) {
-  const activeWaivers = waivers.filter((waiver) => waiver.status === "active").length
+  const activeWaivers = waivers.filter(
+    (waiver) => waiver.status === "active",
+  ).length
   const expiringSoon = summaryValue(waiverDebtSummary, "Expiring soon")
   const expired = summaryValue(waiverDebtSummary, "Expired")
   const reviewDue = summaryValue(waiverDebtSummary, "Review due")
@@ -296,7 +307,9 @@ export function WaiversWorkbench({
             {waiver.cve_id ?? "Scoped waiver"}
           </strong>
           <span className="font-mono text-xs text-[var(--vpw-text-muted)]">
-            {waiver.finding_id ? `Finding ${shortId(waiver.finding_id)}` : `Waiver ${shortId(waiver.id)}`}
+            {waiver.finding_id
+              ? `Finding ${shortId(waiver.finding_id)}`
+              : `Waiver ${shortId(waiver.id)}`}
           </span>
         </div>
       ),
@@ -330,7 +343,9 @@ export function WaiversWorkbench({
       className: "w-[9%]",
       headerClassName: "w-[9%]",
       cell: (waiver) => (
-        <VpwBadge tone={statusTone(waiver.status)}>{statusLabel(waiver.status)}</VpwBadge>
+        <VpwBadge tone={statusTone(waiver.status)}>
+          {statusLabel(waiver.status)}
+        </VpwBadge>
       ),
     },
     {
@@ -370,7 +385,10 @@ export function WaiversWorkbench({
         <div className="flex flex-wrap gap-2">
           {waiver.finding_id ? (
             <Button asChild size="sm" variant="outline">
-              <Link to="/findings/$findingId" params={{ findingId: waiver.finding_id }}>
+              <Link
+                to="/findings/$findingId"
+                params={{ findingId: waiver.finding_id }}
+              >
                 View finding
               </Link>
             </Button>
@@ -447,7 +465,9 @@ export function WaiversWorkbench({
               <VpwBadge tone={Number(expired) > 0 ? "critical" : "neutral"}>
                 Expired: {expired}
               </VpwBadge>
-              <VpwBadge tone={projectSummary?.latest_run_id ? "success" : "neutral"}>
+              <VpwBadge
+                tone={projectSummary?.latest_run_id ? "success" : "neutral"}
+              >
                 Evidence {projectSummary?.latest_run_id ? "ready" : "pending"}
               </VpwBadge>
             </VpwToolbarGroup>
@@ -678,22 +698,47 @@ export function WaiversWorkbench({
             eyebrow="Safety rules"
             title="Governance guidance"
           />
-          <VpwStatusBanner title="Owner, reason and expiry are required" tone="warning">
-            Waivers should document why risk is accepted and when it must be revisited.
+          <VpwStatusBanner
+            title="Owner, reason and expiry are required"
+            tone="warning"
+          >
+            Waivers should document why risk is accepted and when it must be
+            revisited.
           </VpwStatusBanner>
           <VpwStatusBanner title="Accepted risk stays visible" tone="info">
-            Reports should continue to show accepted findings instead of hiding them silently.
+            Reports should continue to show accepted findings instead of hiding
+            them silently.
           </VpwStatusBanner>
-          <VpwStatusBanner title="Critical findings still need review" tone="critical">
-            A waiver is an explicit decision record, not a remediation replacement.
+          <VpwStatusBanner
+            title="Critical findings still need review"
+            tone="critical"
+          >
+            A waiver is an explicit decision record, not a remediation
+            replacement.
           </VpwStatusBanner>
           <VpwKeyValueList
             columns={2}
             items={[
-              { label: "Active project", value: selectedProject?.name ?? "No project" },
-              { label: "Latest run", value: projectSummary?.latest_run_id ? shortId(projectSummary.latest_run_id) : "No run yet" },
-              { label: "Evidence completeness", value: `${completeness}%`, tone: completeness >= 80 ? "success" : "warning" },
-              { label: "Review due", value: reviewDue, tone: Number(reviewDue) > 0 ? "warning" : "neutral" },
+              {
+                label: "Active project",
+                value: selectedProject?.name ?? "No project",
+              },
+              {
+                label: "Latest run",
+                value: projectSummary?.latest_run_id
+                  ? shortId(projectSummary.latest_run_id)
+                  : "No run yet",
+              },
+              {
+                label: "Evidence completeness",
+                value: `${completeness}%`,
+                tone: completeness >= 80 ? "success" : "warning",
+              },
+              {
+                label: "Review due",
+                value: reviewDue,
+                tone: Number(reviewDue) > 0 ? "warning" : "neutral",
+              },
             ]}
           />
           <VpwProgress
@@ -707,7 +752,12 @@ export function WaiversWorkbench({
       <VpwSection>
         <VpwSectionHeader
           actions={
-            <Button onClick={onRefreshWaivers} size="sm" type="button" variant="outline">
+            <Button
+              onClick={onRefreshWaivers}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
               <RefreshCw aria-hidden="true" className="h-4 w-4" />
               Refresh
             </Button>

--- a/frontend/src/lib/demo-data.ts
+++ b/frontend/src/lib/demo-data.ts
@@ -1,5 +1,6 @@
 /**
- * Demo preview data – displayed only when no real project is connected.
+ * Demo preview data - displayed only when explicit local demo mode is enabled
+ * and no real project is connected.
  *
  * This module is CLEARLY LABELED in the UI and never silently replaces live
  * production API data. It exists solely so the Dashboard is evaluable during

--- a/frontend/src/lib/runtime-config.ts
+++ b/frontend/src/lib/runtime-config.ts
@@ -1,0 +1,66 @@
+type RuntimeEnv = {
+  MODE?: string
+  PROD?: boolean
+  VITE_DEMO_MODE?: string
+}
+
+declare const __VPW_API_URL__: string | undefined
+declare const __VPW_DEMO_MODE__: boolean | undefined
+declare const __VPW_LEGACY_SESSION_TOKEN_STORAGE__: boolean | undefined
+
+const LOCAL_API_HOSTS = new Set(["localhost", "127.0.0.1", "::1"])
+
+export function normalizeApiBaseUrl(value: string | undefined): string {
+  const trimmed = value?.trim().replace(/\/+$/, "") ?? ""
+  if (!trimmed || trimmed === "/") {
+    return ""
+  }
+
+  try {
+    const url = new URL(trimmed)
+    if (url.pathname !== "/" || url.search || url.hash) {
+      return `${url.origin}${url.pathname === "/" ? "" : url.pathname}`.replace(
+        /\/+$/,
+        "",
+      )
+    }
+    return url.origin
+  } catch {
+    return ""
+  }
+}
+
+export function isLocalApiBaseUrl(value: string | undefined): boolean {
+  const normalized = normalizeApiBaseUrl(value)
+  if (!normalized) {
+    return false
+  }
+  try {
+    return LOCAL_API_HOSTS.has(new URL(normalized).hostname)
+  } catch {
+    return false
+  }
+}
+
+export function isExplicitDemoModeEnabled(env: RuntimeEnv | undefined) {
+  return (
+    env?.VITE_DEMO_MODE?.trim().toLowerCase() === "true" &&
+    env.PROD !== true &&
+    env.MODE !== "production"
+  )
+}
+
+export const API_BASE_URL =
+  typeof __VPW_API_URL__ === "string"
+    ? normalizeApiBaseUrl(__VPW_API_URL__)
+    : ""
+
+export const DEMO_MODE_ENABLED =
+  typeof __VPW_DEMO_MODE__ === "boolean"
+    ? __VPW_DEMO_MODE__
+    : isExplicitDemoModeEnabled(import.meta.env)
+
+export const LEGACY_SESSION_TOKEN_STORAGE =
+  typeof __VPW_LEGACY_SESSION_TOKEN_STORAGE__ === "boolean"
+    ? __VPW_LEGACY_SESSION_TOKEN_STORAGE__
+    : false

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,9 +10,10 @@ import { createRoot } from "react-dom/client"
 import { ApiError, OpenAPI } from "./api-client"
 import { clearAccessToken, getAccessToken } from "./auth"
 import "./index.css"
+import { API_BASE_URL } from "./lib/runtime-config"
 import { routeTree } from "./routeTree.gen"
 
-OpenAPI.BASE = import.meta.env.VITE_API_URL ?? ""
+OpenAPI.BASE = API_BASE_URL
 OpenAPI.TOKEN = async () => getAccessToken()
 
 const handleApiError = (error: Error) => {

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -19,8 +19,8 @@ export const Route = createFileRoute("/login")({
 
 function LoginPage() {
   const navigate = useNavigate()
-  const [email, setEmail] = useState("admin@example.com")
-  const [password, setPassword] = useState("changethis")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
   const [backendReady, setBackendReady] = useState(false)
   const [error, setError] = useState("")
   const [isSubmitting, setSubmitting] = useState(false)
@@ -62,7 +62,9 @@ function LoginPage() {
           password,
         },
       })
-      setAccessToken(token.access_token)
+      setAccessToken(
+        typeof token.access_token === "string" ? token.access_token : "",
+      )
       await navigate({ to: "/" })
     } catch (caught) {
       const message =

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -93,8 +93,7 @@
   gap: 4px;
 }
 
-.chart-card-header h3,
-.chart-card-header span {
+.chart-card-header h3 {
   margin: 0;
 }
 
@@ -103,7 +102,9 @@
   font-size: 1rem;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: selector targets an unrelated chart-card block. */
 .chart-card-header span {
+  margin: 0;
   color: #64748b;
   font-size: 0.86rem;
   line-height: 1.4;
@@ -293,12 +294,14 @@
   gap: 12px;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: panel-heading selectors target unrelated dashboard blocks. */
 .dashboard-panel-heading span,
 .dashboard-panel-heading h3,
 .dashboard-panel-heading p {
   margin: 0;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: panel-heading selectors target unrelated dashboard blocks. */
 .dashboard-panel-heading span {
   color: #64748b;
   font-size: 0.74rem;
@@ -492,11 +495,13 @@
   background: #fff7ed;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: selector targets an unrelated provider-source block. */
 .dashboard-provider-source strong {
   color: #334155;
   font-size: 0.78rem;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: selector targets an unrelated provider-source block. */
 .dashboard-provider-source span {
   overflow-wrap: anywhere;
   color: #64748b;

--- a/frontend/src/styles/findings.css
+++ b/frontend/src/styles/findings.css
@@ -84,12 +84,14 @@
   gap: 10px;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: service-list selectors target a separate finding summary block. */
 .governance-service-list strong {
   overflow-wrap: anywhere;
   color: #0f766e;
   font-size: 0.95rem;
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: service-list selectors target a separate finding summary block. */
 .governance-service-list span {
   color: #111827;
   font-size: 0.84rem;

--- a/frontend/src/workbench/WorkbenchShell.tsx
+++ b/frontend/src/workbench/WorkbenchShell.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation, useNavigate } from "@tanstack/react-router"
+import { useQueryClient } from "@tanstack/react-query"
 import {
   Activity,
   AlertTriangle,
@@ -38,14 +39,9 @@ import {
   ProjectsService,
   type ProviderSourceStatusPublic,
   type ProviderStatusPublic,
-  ProvidersService,
   RunsService,
-  type UserPublic,
-  UsersService,
   type WaiverPublic,
   WaiversService,
-  WorkbenchService,
-  type WorkbenchStatus,
 } from "../api-client"
 import { clearAccessToken } from "../auth"
 import { ProductAppShell, type WorkbenchPath } from "../components/app/AppShell"
@@ -116,7 +112,12 @@ import {
   waiverRequestBody,
   waiverScopeLabel,
 } from "../lib/waiver-view"
+import { DEMO_MODE_ENABLED } from "../lib/runtime-config"
 import { useReportsRouteState } from "./useReportsRouteState"
+import {
+  useWorkbenchBootstrapQuery,
+  workbenchBootstrapQueryKey,
+} from "./useWorkbenchBootstrapQuery"
 
 const RiskOperationsDashboard = lazy(() =>
   import("../components/dashboard/RiskOperationsDashboard").then((module) => ({
@@ -166,9 +167,7 @@ const WaiversWorkbench = lazy(() =>
 
 const SELECTED_PROJECT_STORAGE_KEY = "vpw.selectedProjectId"
 
-type SelectedProjectIdUpdate =
-  | string
-  | ((previousProjectId: string) => string)
+type SelectedProjectIdUpdate = string | ((previousProjectId: string) => string)
 
 function readStoredSelectedProjectId() {
   if (typeof window === "undefined") {
@@ -627,13 +626,22 @@ export function WorkbenchShell({
     ? findingSearchParams.get("assetKey")
     : null
   const routeDetail = routeDetails[currentPath]
-  const [status, setStatus] = useState<WorkbenchStatus | null>(null)
-  const [providerStatus, setProviderStatus] =
-    useState<ProviderStatusPublic | null>(null)
-  const [providerStatusLoading, setProviderStatusLoading] = useState(true)
-  const [providerStatusError, setProviderStatusError] = useState("")
-  const [currentUser, setCurrentUser] = useState<UserPublic | null>(null)
-  const [statusError, setStatusError] = useState("")
+  const queryClient = useQueryClient()
+  const handleAuthExpired = useCallback(async () => {
+    clearAccessToken()
+    await navigate({ to: "/login" })
+  }, [navigate])
+  const bootstrapQuery = useWorkbenchBootstrapQuery()
+  const bootstrapError = bootstrapQuery.error
+  const status = bootstrapQuery.data?.status ?? null
+  const providerStatus = bootstrapQuery.data?.providerStatus ?? null
+  const currentUser = bootstrapQuery.data?.currentUser ?? null
+  const providerStatusLoading =
+    bootstrapQuery.isLoading || bootstrapQuery.isFetching
+  const statusError = bootstrapQuery.isError ? "Data services unavailable" : ""
+  const providerStatusError = bootstrapQuery.isError
+    ? apiErrorMessage("Provider status unavailable", bootstrapError)
+    : ""
   const [apiTokens, setApiTokens] = useState<ApiTokenPublic[]>([])
   const [apiTokensLoading, setApiTokensLoading] = useState(false)
   const [apiTokenActionLoading, setApiTokenActionLoading] = useState(false)
@@ -714,10 +722,6 @@ export function WorkbenchShell({
   const [runDetailError, setRunDetailError] = useState("")
   const selectedReportRun =
     projectRuns.find((run) => run.id === selectedRunId) ?? null
-  const handleAuthExpired = useCallback(async () => {
-    clearAccessToken()
-    await navigate({ to: "/login" })
-  }, [navigate])
   const {
     activeReportFormat,
     createReport,
@@ -849,48 +853,13 @@ export function WorkbenchShell({
   }, [currentPath])
 
   useEffect(() => {
-    let isMounted = true
-
-    async function loadTemplateState() {
-      setProviderStatusLoading(true)
-      try {
-        const [workbenchStatus, providerStatusResponse, user] =
-          await Promise.all([
-            WorkbenchService.templateWorkbenchStatus(),
-            ProvidersService.readProviderStatus(),
-            UsersService.readUserMe(),
-          ])
-        if (isMounted) {
-          setStatus(workbenchStatus)
-          setProviderStatus(providerStatusResponse)
-          setCurrentUser(user)
-          setStatusError("")
-          setProviderStatusError("")
-        }
-      } catch (caught) {
-        if (caught instanceof ApiError && [401, 403].includes(caught.status)) {
-          clearAccessToken()
-          await navigate({ to: "/login" })
-          return
-        }
-        if (isMounted) {
-          setStatusError("Data services unavailable")
-          setProviderStatusError(
-            apiErrorMessage("Provider status unavailable", caught),
-          )
-        }
-      } finally {
-        if (isMounted) {
-          setProviderStatusLoading(false)
-        }
-      }
+    if (
+      bootstrapError instanceof ApiError &&
+      [401, 403].includes(bootstrapError.status)
+    ) {
+      void handleAuthExpired()
     }
-
-    void loadTemplateState()
-    return () => {
-      isMounted = false
-    }
-  }, [navigate])
+  }, [bootstrapError, handleAuthExpired])
 
   useEffect(() => {
     let isMounted = true
@@ -936,7 +905,7 @@ export function WorkbenchShell({
     return () => {
       isMounted = false
     }
-  }, [navigate])
+  }, [navigate, setSelectedProjectId])
 
   useEffect(() => {
     let isMounted = true
@@ -972,6 +941,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void apiTokensReloadKey
 
     async function loadApiTokens() {
       if (currentPath !== "/settings") {
@@ -1025,6 +995,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void waiverReloadKey
 
     async function loadProjectSummary() {
       if (!selectedProjectId) {
@@ -1114,6 +1085,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void waiverReloadKey
 
     async function loadProjectGovernanceRollups() {
       if (!selectedProjectId) {
@@ -1260,6 +1232,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void waiverReloadKey
 
     async function loadProjectWaivers() {
       if (!isWaiversPage || !selectedProjectId) {
@@ -1303,6 +1276,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void findingReloadKey
 
     async function loadFindingsPage() {
       if (!isFindingsList || !selectedProjectId) {
@@ -1385,6 +1359,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void findingReloadKey
 
     async function loadDashboardFindings() {
       if (!isDashboard || !selectedProjectId) {
@@ -1434,6 +1409,7 @@ export function WorkbenchShell({
 
   useEffect(() => {
     let isMounted = true
+    void findingReloadKey
 
     async function loadDashboardSignals() {
       if (!isDashboard || !selectedProjectId) {
@@ -1563,11 +1539,9 @@ export function WorkbenchShell({
   }, [findingReloadKey, isDashboard, navigate, selectedProjectId])
 
   useEffect(() => {
-    setFindingDetailTab("evidence")
-  }, [findingDetailId])
-
-  useEffect(() => {
     let isMounted = true
+    void findingDetailReloadKey
+    setFindingDetailTab("evidence")
 
     async function loadFindingDetail() {
       if (!findingDetailId) {
@@ -1582,7 +1556,9 @@ export function WorkbenchShell({
       setFindingDetailLoading(true)
       setFindingDetailError("")
       setFindingExplanationWarning("")
-      const demoDetail = demoFindingDetailForId(findingDetailId)
+      const demoDetail = DEMO_MODE_ENABLED
+        ? demoFindingDetailForId(findingDetailId)
+        : null
       if (demoDetail) {
         if (isMounted) {
           setFindingDetail(demoDetail)
@@ -1641,7 +1617,7 @@ export function WorkbenchShell({
     return () => {
       isMounted = false
     }
-  }, [findingDetailId, findingDetailReloadKey, navigate])
+  }, [findingDetailId, findingDetailReloadKey, navigate, setSelectedProjectId])
 
   function selectProject(projectId: string) {
     setSelectedProjectId(projectId)
@@ -1677,23 +1653,9 @@ export function WorkbenchShell({
   }
 
   async function refreshProviderStatus() {
-    setProviderStatusLoading(true)
-    setProviderStatusError("")
-    try {
-      const statusResponse = await ProvidersService.readProviderStatus()
-      setProviderStatus(statusResponse)
-    } catch (caught) {
-      if (caught instanceof ApiError && [401, 403].includes(caught.status)) {
-        clearAccessToken()
-        await navigate({ to: "/login" })
-        return
-      }
-      setProviderStatusError(
-        apiErrorMessage("Provider status unavailable", caught),
-      )
-    } finally {
-      setProviderStatusLoading(false)
-    }
+    await queryClient.invalidateQueries({
+      queryKey: workbenchBootstrapQueryKey,
+    })
   }
 
   async function refreshProjectRuns(preferredRunId?: string) {

--- a/frontend/src/workbench/report-download.ts
+++ b/frontend/src/workbench/report-download.ts
@@ -13,16 +13,22 @@ export function reportDownloadUrl(
   return normalizedBaseUrl ? `${normalizedBaseUrl}${path}` : path
 }
 
-export function reportDownloadHeaders(token: string): HeadersInit | undefined {
-  return token ? { Authorization: `Bearer ${token}` } : undefined
+export function reportDownloadHeaders(token = ""): HeadersInit | undefined {
+  if (token) {
+    const headers = new Headers()
+    headers.set("Authorization", `Bearer ${token}`)
+    return headers
+  }
+  return undefined
 }
 
 export function reportDownloadRequest(
   report: Pick<ReportPublic, "id">,
-  token: string,
+  token = "",
   baseUrl = "",
 ) {
   return {
+    credentials: "include" as const,
     headers: reportDownloadHeaders(token),
     url: reportDownloadUrl(report, baseUrl),
   }

--- a/frontend/src/workbench/useReportsRouteState.ts
+++ b/frontend/src/workbench/useReportsRouteState.ts
@@ -28,7 +28,10 @@ type UseReportsRouteStateOptions = {
 
 async function downloadReportArtifact(report: ReportPublic) {
   const request = reportDownloadRequest(report, getAccessToken(), OpenAPI.BASE)
-  const response = await fetch(request.url, { headers: request.headers })
+  const response = await fetch(request.url, {
+    credentials: request.credentials,
+    headers: request.headers,
+  })
   if (!response.ok) {
     let detail = ""
     try {
@@ -77,6 +80,7 @@ export function useReportsRouteState({
 
   useEffect(() => {
     let isMounted = true
+    void reportsReloadKey
 
     async function loadRunReports() {
       if (currentPath !== "/reports" || !selectedRunId) {

--- a/frontend/src/workbench/useWorkbenchBootstrapQuery.ts
+++ b/frontend/src/workbench/useWorkbenchBootstrapQuery.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query"
+
+import {
+  ProvidersService,
+  UsersService,
+  WorkbenchService,
+} from "../api-client"
+
+export const workbenchBootstrapQueryKey = ["workbench", "bootstrap"] as const
+
+export async function loadWorkbenchBootstrap() {
+  const [status, providerStatus, currentUser] = await Promise.all([
+    WorkbenchService.templateWorkbenchStatus(),
+    ProvidersService.readProviderStatus(),
+    UsersService.readUserMe(),
+  ])
+  return { currentUser, providerStatus, status }
+}
+
+export function useWorkbenchBootstrapQuery() {
+  return useQuery({
+    queryFn: loadWorkbenchBootstrap,
+    queryKey: workbenchBootstrapQueryKey,
+    retry: false,
+    staleTime: 30_000,
+  })
+}

--- a/frontend/tests/accessibility.spec.ts
+++ b/frontend/tests/accessibility.spec.ts
@@ -1,0 +1,45 @@
+import { expect, type Page, test } from "@playwright/test"
+import { login } from "./auth-helpers"
+
+async function expectFocusedElementVisible(page: Page) {
+  await expect(page.locator(":focus")).toBeVisible()
+}
+
+test("login exposes labels, required fields, and keyboard submit", async ({
+  page,
+}) => {
+  await page.goto("/login")
+
+  await expect(page.getByRole("main")).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible()
+  await expect(page.getByLabel("Email")).toHaveValue("")
+  await expect(page.getByLabel("Password")).toHaveValue("")
+  await expect(
+    page.evaluate(() => window.localStorage.getItem("access_token")),
+  ).resolves.toBeNull()
+  await expect(page.getByLabel("Email")).toHaveAttribute("required", "")
+  await expect(page.getByLabel("Password")).toHaveAttribute("required", "")
+
+  await page.keyboard.press("Tab")
+  await expect(page.getByLabel("Email")).toBeFocused()
+})
+
+test("authenticated shell exposes landmarks and account controls", async ({
+  page,
+}) => {
+  await login(page)
+
+  await expect(page.getByRole("main")).toBeVisible()
+  await expect(
+    page.getByRole("navigation", { name: "Workbench navigation" }),
+  ).toBeVisible()
+  await expect(page.getByRole("button", { name: "Account menu" })).toBeVisible()
+  await expect(
+    page
+      .getByRole("navigation", { name: "Workbench navigation" })
+      .getByRole("link", { exact: true, name: "Findings" }),
+  ).toBeVisible()
+
+  await page.keyboard.press("Tab")
+  await expectFocusedElementVisible(page)
+})

--- a/frontend/tests/auth-helpers.ts
+++ b/frontend/tests/auth-helpers.ts
@@ -1,0 +1,35 @@
+import { expect, type Page } from "@playwright/test"
+
+export const testUserEmail =
+  process.env.VPW_E2E_EMAIL ?? process.env.FIRST_SUPERUSER ?? "admin@example.com"
+export const testUserPassword =
+  process.env.VPW_E2E_PASSWORD ??
+  process.env.FIRST_SUPERUSER_PASSWORD ??
+  "changethis"
+
+export async function login(page: Page): Promise<string> {
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1/login/access-token") &&
+      response.request().method() === "POST",
+  )
+
+  await page.goto("/login")
+  await expect(page.getByLabel("Email")).toHaveValue("")
+  await expect(page.getByLabel("Password")).toHaveValue("")
+  await page.getByLabel("Email").fill(testUserEmail)
+  await page.getByLabel("Password").fill(testUserPassword)
+  await page.getByRole("button", { name: "Sign in" }).click()
+
+  const response = await responsePromise
+  expect(response.ok(), await response.text()).toBeTruthy()
+  const body = (await response.json().catch(() => ({}))) as {
+    access_token?: unknown
+  }
+  await expect(page).toHaveURL(/\/$/)
+  return typeof body.access_token === "string" ? body.access_token : ""
+}
+
+export function authHeaders(accessToken: string): Record<string, string> {
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
+}

--- a/frontend/tests/auth.test.ts
+++ b/frontend/tests/auth.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { getCsrfToken } from "../src/auth.ts"
+
+test("reads CSRF tokens from client-readable cookies", () => {
+  assert.equal(getCsrfToken("vpw_csrf_token=abc123"), "abc123")
+  assert.equal(getCsrfToken("other=1; XSRF-TOKEN=encoded%20token"), "encoded token")
+  assert.equal(getCsrfToken("session=opaque"), "")
+})

--- a/frontend/tests/findings-route-integration.spec.ts
+++ b/frontend/tests/findings-route-integration.spec.ts
@@ -2,7 +2,8 @@ import { expect, type Page, test } from "@playwright/test"
 
 async function routeWorkbenchShell(page: Page) {
   await page.addInitScript(() => {
-    window.localStorage.setItem("access_token", "demo-token")
+    // biome-ignore lint/suspicious/noDocumentCookie: Playwright sets a mock readable CSRF cookie before app boot.
+    document.cookie = "vpw_csrf_token=mock-csrf; Path=/; SameSite=Strict"
   })
 
   await page.route("**/api/v1/users/me", (route) =>
@@ -68,13 +69,13 @@ async function routeWorkbenchShell(page: Page) {
   )
 }
 
-test("findings route renders only the polished remediation queue", async ({
+test("findings route renders the empty live queue without demo data", async ({
   page,
 }) => {
   await routeWorkbenchShell(page)
   await page.goto("/findings")
 
-  await expect(page.getByText("Demo preview").first()).toBeVisible()
+  await expect(page.getByText("Demo preview")).toHaveCount(0)
   await expect(
     page.getByRole("region", { name: "Findings filters" }),
   ).toBeVisible()
@@ -83,62 +84,14 @@ test("findings route renders only the polished remediation queue", async ({
   await expect(page.getByText("Provider Status")).toHaveCount(0)
   await expect(page.getByText("Evidence Flow")).toHaveCount(0)
 
-  const queue = page.getByRole("table", {
-    name: "Findings remediation queue",
-  })
-  await expect(queue).toBeVisible()
-
-  for (const column of [
-    /Priority/i,
-    /Score/i,
-    /CVE/i,
-    "Component / Service",
-    "Owner",
-    /Status/i,
-    /Signals/i,
-    "Why now",
-    "View",
-  ]) {
-    await expect(
-      queue.getByRole("columnheader", { name: column }),
-    ).toBeVisible()
-  }
+  await expect(page.getByText("No projects yet")).toBeVisible()
+  await expect(
+    page.getByRole("table", { name: "Findings remediation queue" }),
+  ).toHaveCount(0)
 
   await expect(
     page.getByRole("combobox", { name: "Sort direction" }),
   ).toHaveCount(0)
-  await expect(
-    page.getByRole("button", { name: /Sort by Score/i }),
-  ).toBeVisible()
-  await page.getByRole("button", { name: /Sort by Score/i }).click()
-  await expect(
-    queue.getByRole("columnheader", { name: /Sort by Score/i }),
-  ).toHaveAttribute("aria-sort", "descending")
-  await page.getByRole("button", { name: /Sort by Score/i }).click()
-  await expect(
-    queue.getByRole("columnheader", { name: /Sort by Score/i }),
-  ).toHaveAttribute("aria-sort", "ascending")
-
-  await expect(queue.getByText("EPSS").first()).toBeVisible()
-  await expect(queue.getByText("CVSS").first()).toBeVisible()
-  await expect(
-    page.getByRole("button", { name: /Quick view CVE-2024-3400/i }),
-  ).toBeVisible()
-
-  const tableWrapBefore = await page
-    .locator(".remediation-table-wrap")
-    .boundingBox()
-  const tableBox = await queue.boundingBox()
-  const actionBox = await page
-    .getByRole("button", { name: /Quick view CVE-2024-3400/i })
-    .boundingBox()
-  expect(tableBox).not.toBeNull()
-  expect(actionBox).not.toBeNull()
-  if (tableBox && actionBox) {
-    expect(actionBox.x + actionBox.width).toBeLessThanOrEqual(
-      tableBox.x + tableBox.width + 1,
-    )
-  }
 
   const sidebar = page.getByLabel("Workbench sidebar")
   await expect(sidebar).toHaveCSS("width", "248px")
@@ -156,12 +109,23 @@ test("findings route renders only the polished remediation queue", async ({
       .getByRole("navigation", { name: "Workbench navigation" })
       .getByText("Dashboard"),
   ).toHaveCount(0)
-  const tableWrapAfter = await page
-    .locator(".remediation-table-wrap")
-    .boundingBox()
-  expect(tableWrapBefore).not.toBeNull()
-  expect(tableWrapAfter).not.toBeNull()
-  if (tableWrapBefore && tableWrapAfter) {
-    expect(tableWrapAfter.width).toBeGreaterThan(tableWrapBefore.width + 100)
-  }
+})
+
+test("finding detail API errors do not fall back to demo findings", async ({
+  page,
+}) => {
+  await routeWorkbenchShell(page)
+  await page.route("**/api/v1/findings/demo-f1", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      status: 404,
+      body: JSON.stringify({ detail: "Finding not found" }),
+    }),
+  )
+
+  await page.goto("/findings/demo-f1")
+
+  await expect(page.getByText("Finding detail unavailable")).toBeVisible()
+  await expect(page.getByText("Demo preview")).toHaveCount(0)
+  await expect(page.getByText("CVE-2024-3094")).toHaveCount(0)
 })

--- a/frontend/tests/report-download.test.ts
+++ b/frontend/tests/report-download.test.ts
@@ -8,6 +8,10 @@ import {
   reportDownloadUrl,
 } from "../src/workbench/report-download.ts"
 
+function headerEntries(headers: HeadersInit | undefined) {
+  return headers instanceof Headers ? Object.fromEntries(headers) : headers
+}
+
 test("uses the generated same-origin report download API path", () => {
   assert.equal(
     reportDownloadPath({
@@ -26,7 +30,10 @@ test("does not derive report download targets from absolute metadata URLs", () =
   const request = reportDownloadRequest(report, "local-token")
 
   assert.equal(request.url, "/api/v1/reports/visible-report/download")
-  assert.deepEqual(request.headers, { Authorization: "Bearer local-token" })
+  assert.equal(request.credentials, "include")
+  assert.deepEqual(headerEntries(request.headers), {
+    authorization: "Bearer local-token",
+  })
 })
 
 test("uses the configured API base for generated report download paths", () => {
@@ -42,8 +49,8 @@ test("uses the configured API base for generated report download paths", () => {
 })
 
 test("builds bearer headers only from the local access token input", () => {
-  assert.deepEqual(reportDownloadHeaders("local-token"), {
-    Authorization: "Bearer local-token",
+  assert.deepEqual(headerEntries(reportDownloadHeaders("local-token")), {
+    authorization: "Bearer local-token",
   })
   assert.equal(reportDownloadHeaders(""), undefined)
 })

--- a/frontend/tests/responsive-shell.spec.ts
+++ b/frontend/tests/responsive-shell.spec.ts
@@ -1,12 +1,5 @@
 import { expect, type Page, test } from "@playwright/test"
-
-async function login(page: Page) {
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-}
+import { login } from "./auth-helpers"
 
 async function expectNoPageOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({

--- a/frontend/tests/runtime-config.test.ts
+++ b/frontend/tests/runtime-config.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  isExplicitDemoModeEnabled,
+  isLocalApiBaseUrl,
+  normalizeApiBaseUrl,
+} from "../src/lib/runtime-config.ts"
+
+test("normalizes same-origin API configuration to the generated /api paths", () => {
+  assert.equal(normalizeApiBaseUrl(undefined), "")
+  assert.equal(normalizeApiBaseUrl(""), "")
+  assert.equal(normalizeApiBaseUrl("/api"), "")
+  assert.equal(
+    normalizeApiBaseUrl("https://api.example.com/"),
+    "https://api.example.com",
+  )
+})
+
+test("detects localhost API origins before production bundling", () => {
+  assert.equal(isLocalApiBaseUrl("http://localhost:8000"), true)
+  assert.equal(isLocalApiBaseUrl("http://127.0.0.1:8000"), true)
+  assert.equal(isLocalApiBaseUrl("https://api.example.com"), false)
+})
+
+test("enables demo mode only from an explicit non-production flag", () => {
+  assert.equal(
+    isExplicitDemoModeEnabled({
+      MODE: "development",
+      PROD: false,
+      VITE_DEMO_MODE: "true",
+    }),
+    true,
+  )
+  assert.equal(
+    isExplicitDemoModeEnabled({
+      MODE: "production",
+      PROD: true,
+      VITE_DEMO_MODE: "true",
+    }),
+    false,
+  )
+  assert.equal(
+    isExplicitDemoModeEnabled({
+      MODE: "development",
+      PROD: false,
+      VITE_DEMO_MODE: "false",
+    }),
+    false,
+  )
+})

--- a/frontend/tests/template-login-status.spec.ts
+++ b/frontend/tests/template-login-status.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs"
 import { expect, type Locator, type Page, test } from "@playwright/test"
+import { authHeaders, login, testUserEmail } from "./auth-helpers"
 import { evidenceScreenshotPath } from "./evidence-paths"
 
 const validCveList = Buffer.from("CVE-2021-44228\nCVE-2024-3094\n")
@@ -112,17 +113,8 @@ test("template finding detail renders TTP Context tab", async ({ page }) => {
   const testRunSuffix = Date.now().toString(36)
   const projectName = `VPW TTP Context ${testRunSuffix}`
 
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-
-  const accessToken = await page.evaluate(() =>
-    window.localStorage.getItem("access_token"),
-  )
-  expect(accessToken).toBeTruthy()
-  const authHeaders = { Authorization: `Bearer ${accessToken}` }
+  const accessToken = await login(page)
+  const headers = authHeaders(accessToken)
   const projectResponse = await page.request.post(
     "http://127.0.0.1:8000/api/v1/projects/",
     {
@@ -130,7 +122,7 @@ test("template finding detail renders TTP Context tab", async ({ page }) => {
         description: "Playwright TTP Context project",
         name: projectName,
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(projectResponse.ok()).toBeTruthy()
@@ -139,7 +131,7 @@ test("template finding detail renders TTP Context tab", async ({ page }) => {
   const importResponse = await page.request.post(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/imports`,
     {
-      headers: authHeaders,
+      headers,
       multipart: {
         file: {
           buffer: validCveList,
@@ -154,7 +146,7 @@ test("template finding detail renders TTP Context tab", async ({ page }) => {
 
   const findingsResponse = await page.request.get(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/findings/?sort=cve`,
-    { headers: authHeaders },
+    { headers },
   )
   expect(findingsResponse.ok()).toBeTruthy()
   const findingsPayload = (await findingsResponse.json()) as {
@@ -200,17 +192,8 @@ test("template frontend renders CycloneDX VEX occurrence evidence", async ({
   const testRunSuffix = Date.now().toString(36)
   const projectName = `VPW CycloneDX VEX ${testRunSuffix}`
 
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-
-  const accessToken = await page.evaluate(() =>
-    window.localStorage.getItem("access_token"),
-  )
-  expect(accessToken).toBeTruthy()
-  const authHeaders = { Authorization: `Bearer ${accessToken}` }
+  const accessToken = await login(page)
+  const headers = authHeaders(accessToken)
   const projectResponse = await page.request.post(
     "http://127.0.0.1:8000/api/v1/projects/",
     {
@@ -218,7 +201,7 @@ test("template frontend renders CycloneDX VEX occurrence evidence", async ({
         description: "Playwright CycloneDX VEX project",
         name: projectName,
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(projectResponse.ok()).toBeTruthy()
@@ -227,7 +210,7 @@ test("template frontend renders CycloneDX VEX occurrence evidence", async ({
   const importResponse = await page.request.post(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/imports`,
     {
-      headers: authHeaders,
+      headers,
       multipart: {
         file: {
           buffer: cyclonedxVexOccurrenceCsv,
@@ -247,7 +230,7 @@ test("template frontend renders CycloneDX VEX occurrence evidence", async ({
 
   const findingsResponse = await page.request.get(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/findings/?sort=cve`,
-    { headers: authHeaders },
+    { headers },
   )
   expect(findingsResponse.ok()).toBeTruthy()
   const findingsPayload = (await findingsResponse.json()) as {
@@ -294,19 +277,16 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   const editedUiAssetName = `Playwright Asset Edited ${testRunSuffix}`
 
   await page.goto("/login")
-
   await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible()
   await expect(page.getByText("Vuln Prioritizer")).toBeVisible()
   await expect(page.getByText("Workbench", { exact: true })).toBeVisible()
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
 
+  const accessToken = await login(page)
   await expect(page).toHaveURL(/\/$/)
   await expect(
     page.getByRole("heading", { name: "Risk Operations" }),
   ).toBeVisible()
-  await expect(page.getByText("admin@example.com")).toBeVisible()
+  await expect(page.getByText(testUserEmail)).toBeVisible()
   const navigation = page.getByRole("navigation", {
     name: "Workbench navigation",
   })
@@ -328,11 +308,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(page.getByText("Evidence Readiness").first()).toBeVisible()
   await expect(page.getByText("Data Quality", { exact: true })).toBeVisible()
 
-  const accessToken = await page.evaluate(() =>
-    window.localStorage.getItem("access_token"),
-  )
-  expect(accessToken).toBeTruthy()
-  const authHeaders = { Authorization: `Bearer ${accessToken}` }
+  const headers = authHeaders(accessToken)
   const projectResponse = await page.request.post(
     "http://127.0.0.1:8000/api/v1/projects/",
     {
@@ -340,7 +316,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
         description: "Playwright dashboard summary project",
         name: dashboardProjectName,
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(projectResponse.ok()).toBeTruthy()
@@ -359,7 +335,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   const importResponse = await page.request.post(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/imports`,
     {
-      headers: authHeaders,
+      headers,
       multipart: {
         file: {
           buffer: validCveList,
@@ -387,7 +363,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
 
   const providerStatusResponse = await page.request.get(
     "http://127.0.0.1:8000/api/v1/providers/status",
-    { headers: authHeaders },
+    { headers },
   )
   expect(providerStatusResponse.ok()).toBeTruthy()
   const providerStatusPayload = (await providerStatusResponse.json()) as {
@@ -593,7 +569,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   await page.waitForTimeout(1000)
   const importWizardFindingsResponse = await page.request.get(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/findings/?sort=cve`,
-    { headers: authHeaders },
+    { headers },
   )
   expect(importWizardFindingsResponse.ok()).toBeTruthy()
   const importWizardFindingsPayload =
@@ -630,7 +606,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   const occurrenceImport = await page.request.post(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/imports`,
     {
-      headers: authHeaders,
+      headers,
       multipart: {
         file: {
           buffer: validOccurrenceCsv,
@@ -957,7 +933,7 @@ test("template frontend covers core Workbench E2E smoke", async ({ page }) => {
   ).toBeVisible()
   await expect(
     page.getByRole("region", { name: "User Settings" }),
-  ).toContainText("admin@example.com")
+  ).toContainText(testUserEmail)
 
   await page.getByRole("button", { name: "Account menu" }).click()
   await page.getByRole("menuitem", { name: "Sign out" }).click()
@@ -970,11 +946,7 @@ test("template settings clears one-time API token when leaving settings", async 
 }) => {
   const testRunSuffix = Date.now().toString(36)
 
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
+  await login(page)
 
   await page.goto("/settings")
   await expect(

--- a/frontend/tests/template-waivers.spec.ts
+++ b/frontend/tests/template-waivers.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page, test } from "@playwright/test"
+import { authHeaders, login } from "./auth-helpers"
 import { evidenceScreenshotPath } from "./evidence-paths"
 
 const validOccurrenceCsv = Buffer.from(
@@ -89,17 +90,8 @@ test("template waiver workflow keeps accepted risk visible", async ({
   const testRunSuffix = Date.now().toString(36)
   const projectName = `VPW Waiver Project ${testRunSuffix}`
 
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-
-  const accessToken = await page.evaluate(() =>
-    window.localStorage.getItem("access_token"),
-  )
-  expect(accessToken).toBeTruthy()
-  const authHeaders = { Authorization: `Bearer ${accessToken}` }
+  const accessToken = await login(page)
+  const headers = authHeaders(accessToken)
 
   const projectResponse = await page.request.post(
     "http://127.0.0.1:8000/api/v1/projects/",
@@ -108,7 +100,7 @@ test("template waiver workflow keeps accepted risk visible", async ({
         description: "Playwright waiver project",
         name: projectName,
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(projectResponse.ok()).toBeTruthy()
@@ -117,7 +109,7 @@ test("template waiver workflow keeps accepted risk visible", async ({
   const importResponse = await page.request.post(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/imports`,
     {
-      headers: authHeaders,
+      headers,
       multipart: {
         file: {
           buffer: validOccurrenceCsv,
@@ -154,7 +146,7 @@ test("template waiver workflow keeps accepted risk visible", async ({
 
   const findingsResponse = await page.request.get(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/findings/?sort=cve`,
-    { headers: authHeaders },
+    { headers },
   )
   expect(findingsResponse.ok()).toBeTruthy()
   const findingsPayload = (await findingsResponse.json()) as {
@@ -193,17 +185,8 @@ test("template governance rollups show service risk and waiver debt", async ({
   const testRunSuffix = Date.now().toString(36)
   const projectName = `VPW Governance Project ${testRunSuffix}`
 
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-
-  const accessToken = await page.evaluate(() =>
-    window.localStorage.getItem("access_token"),
-  )
-  expect(accessToken).toBeTruthy()
-  const authHeaders = { Authorization: `Bearer ${accessToken}` }
+  const accessToken = await login(page)
+  const headers = authHeaders(accessToken)
 
   const projectResponse = await page.request.post(
     "http://127.0.0.1:8000/api/v1/projects/",
@@ -212,7 +195,7 @@ test("template governance rollups show service risk and waiver debt", async ({
         description: "Playwright governance rollup project",
         name: projectName,
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(projectResponse.ok()).toBeTruthy()
@@ -221,7 +204,7 @@ test("template governance rollups show service risk and waiver debt", async ({
   const importResponse = await page.request.post(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/imports`,
     {
-      headers: authHeaders,
+      headers,
       multipart: {
         file: {
           buffer: governanceOccurrenceCsv,
@@ -245,7 +228,7 @@ test("template governance rollups show service risk and waiver debt", async ({
         review_at: dateValueFromOffset(0),
         service: "checkout",
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(reviewDueWaiver.ok(), await reviewDueWaiver.text()).toBeTruthy()
@@ -261,14 +244,14 @@ test("template governance rollups show service risk and waiver debt", async ({
         reason: "Expired identity waiver for VPW-067 debt evidence.",
         review_at: dateValueFromOffset(-2),
       },
-      headers: authHeaders,
+      headers,
     },
   )
   expect(expiredWaiver.ok(), await expiredWaiver.text()).toBeTruthy()
 
   const rollupsResponse = await page.request.get(
     `http://127.0.0.1:8000/api/v1/projects/${project.id}/governance/rollups/`,
-    { headers: authHeaders },
+    { headers },
   )
   expect(rollupsResponse.ok()).toBeTruthy()
   const rollups = (await rollupsResponse.json()) as {

--- a/frontend/tests/ui-evidence-screenshots.spec.ts
+++ b/frontend/tests/ui-evidence-screenshots.spec.ts
@@ -1,13 +1,6 @@
 import { expect, type Page, test } from "@playwright/test"
+import { login } from "./auth-helpers"
 import { evidenceScreenshotPath } from "./evidence-paths"
-
-async function login(page: Page) {
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-}
 
 async function captureRoute(
   page: Page,

--- a/frontend/tests/ui-smoke.spec.ts
+++ b/frontend/tests/ui-smoke.spec.ts
@@ -1,17 +1,5 @@
-import { expect, type Page, test } from "@playwright/test"
-
-async function login(page: Page): Promise<string> {
-  await page.goto("/login")
-  await page.getByLabel("Email").fill("admin@example.com")
-  await page.getByLabel("Password").fill("changethis")
-  await page.getByRole("button", { name: "Sign in" }).click()
-  await expect(page).toHaveURL(/\/$/)
-  const accessToken = await page.evaluate(() =>
-    window.localStorage.getItem("access_token"),
-  )
-  expect(accessToken).toBeTruthy()
-  return accessToken ?? ""
-}
+import { expect, test } from "@playwright/test"
+import { authHeaders, login } from "./auth-helpers"
 
 test("smoke: dashboard renders", async ({ page }) => {
   test.setTimeout(30_000)
@@ -77,7 +65,7 @@ test("smoke: sign out revokes the active session", async ({ page }) => {
   const response = await page.request.get(
     "http://127.0.0.1:8000/api/v1/users/me",
     {
-      headers: { Authorization: `Bearer ${accessToken}` },
+      headers: authHeaders(accessToken),
     },
   )
   expect(response.status()).toBe(403)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,27 +2,55 @@ import path from "node:path"
 import tailwindcss from "@tailwindcss/vite"
 import { tanstackRouter } from "@tanstack/router-plugin/vite"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig, loadEnv } from "vite"
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+function normalizedApiUrl(value: string | undefined) {
+  const trimmed = value?.trim().replace(/\/+$/, "") ?? ""
+  if (!trimmed || trimmed === "/") {
+    return ""
+  }
+  try {
+    const url = new URL(trimmed)
+    return url.origin
+  } catch {
+    return ""
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "")
+  const isProductionBuild =
+    mode === "production" || process.env.NODE_ENV === "production"
+  const configuredApiUrl = normalizedApiUrl(env.VITE_API_URL)
+  const bundledApiUrl = isProductionBuild ? "" : configuredApiUrl
+  const demoMode =
+    !isProductionBuild && env.VITE_DEMO_MODE?.trim().toLowerCase() === "true"
+
+  return {
+    define: {
+      __VPW_API_URL__: JSON.stringify(bundledApiUrl),
+      __VPW_DEMO_MODE__: JSON.stringify(demoMode),
+      __VPW_LEGACY_SESSION_TOKEN_STORAGE__: JSON.stringify(!isProductionBuild),
     },
-  },
-  server: {
-    host: "127.0.0.1",
-    port: 5173,
-    proxy: {
-      "/api": "http://127.0.0.1:8000",
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
-  plugins: [
-    tanstackRouter({
-      autoCodeSplitting: true,
-      target: "react",
-    }),
-    tailwindcss(),
-    react(),
-  ],
+    server: {
+      host: "127.0.0.1",
+      port: 5173,
+      proxy: {
+        "/api": "http://127.0.0.1:8000",
+      },
+    },
+    plugins: [
+      tanstackRouter({
+        autoCodeSplitting: true,
+        target: "react",
+      }),
+      tailwindcss(),
+      react(),
+    ],
+  }
 })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Executive Summary: executive_summary.md
   - Current Product State:
       - Product Architecture: architecture.md
+      - Dependency and Package Policy: dependency-and-package-policy.md
       - Scoring Methodology: scoring-methodology.md
       - ATT&CK/TTP Methodology: attack-ttp-methodology.md
       - Reports and Evidence: reports-and-evidence.md
@@ -41,8 +42,8 @@ nav:
       - Template Repository Layer: architecture/template-service-layer.md
       - Template Importer Contract: architecture/vpw-013-importer-contract.md
       - Parser and Provider Extension Strategy: extension_strategy.md
-  - Full Stack Template Migration: full_stack_fastapi_template_migration.md
-  - VPW Template Execution Sequence: vpw_template_execution_sequence.md
+  - Historical Full Stack Template Migration: full_stack_fastapi_template_migration.md
+  - Historical VPW Template Execution Sequence: vpw_template_execution_sequence.md
   - Use Cases: use_cases.md
   - Playbooks:
       - Overview: playbooks.md
@@ -57,6 +58,7 @@ nav:
   - Community Setup: community_repository_setup.md
   - CI Cost Optimization: ci-cost-optimization.md
   - Release Operations: release_operations.md
+  - Public-Production Release Evidence Ledger: public-production-release-evidence-ledger.md
   - Roadmap: roadmap.md
   - Workbench History:
       - v1.0 Release Checklist: workbench-v1-release-checklist.md

--- a/scripts/check_package_contents.py
+++ b/scripts/check_package_contents.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+REQUIRED_WHEEL_SUFFIXES = (
+    "app/main.py",
+    "app/api/main.py",
+    "vuln_prioritizer/cli.py",
+)
+REQUIRED_SDIST_SUFFIXES = (
+    "app/main.py",
+    "app/api/main.py",
+    "src/vuln_prioritizer/cli.py",
+    "pyproject.toml",
+)
+
+
+def _single(path: Path, pattern: str) -> Path:
+    matches = sorted(path.glob(pattern))
+    if len(matches) != 1:
+        raise SystemExit(f"Expected exactly one {pattern} in {path}, found {len(matches)}.")
+    return matches[0]
+
+
+def _wheel_entries(path: Path) -> list[str]:
+    with zipfile.ZipFile(path) as archive:
+        return sorted(info.filename for info in archive.infolist())
+
+
+def _sdist_entries(path: Path) -> list[str]:
+    with tarfile.open(path, "r:gz") as archive:
+        return sorted(member.name for member in archive.getmembers() if member.isfile())
+
+
+def _assert_suffixes(entries: list[str], required_suffixes: tuple[str, ...], artifact: str) -> None:
+    missing = [
+        suffix
+        for suffix in required_suffixes
+        if not any(entry.endswith(suffix) for entry in entries)
+    ]
+    if missing:
+        raise SystemExit(f"{artifact} is missing required package entries: {', '.join(missing)}")
+
+
+def _assert_no_tests(entries: list[str], artifact: str) -> None:
+    test_entries = [
+        entry
+        for entry in entries
+        if "/tests/" in entry or entry.startswith("tests/") or entry.endswith("/tests")
+    ]
+    if test_entries:
+        raise SystemExit(f"{artifact} unexpectedly includes tests: {test_entries[:10]}")
+
+
+def main() -> None:
+    dist_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("dist")
+    wheel = _single(dist_dir, "*.whl")
+    sdist = _single(dist_dir, "*.tar.gz")
+
+    wheel_entries = _wheel_entries(wheel)
+    sdist_entries = _sdist_entries(sdist)
+
+    _assert_suffixes(wheel_entries, REQUIRED_WHEEL_SUFFIXES, wheel.name)
+    _assert_suffixes(sdist_entries, REQUIRED_SDIST_SUFFIXES, sdist.name)
+    _assert_no_tests(wheel_entries, wheel.name)
+    _assert_no_tests(sdist_entries, sdist.name)
+
+    report = {
+        "boundary": (
+            "The backend distribution intentionally ships both the CLI/core package "
+            "and the active Workbench FastAPI app package."
+        ),
+        "wheel": {
+            "path": wheel.as_posix(),
+            "entry_count": len(wheel_entries),
+            "required_suffixes": list(REQUIRED_WHEEL_SUFFIXES),
+        },
+        "sdist": {
+            "path": sdist.as_posix(),
+            "entry_count": len(sdist_entries),
+            "required_suffixes": list(REQUIRED_SDIST_SUFFIXES),
+        },
+    }
+    output_path = Path("build/package-contents.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"{output_path}: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docker_quickstart_api_smoke.py
+++ b/scripts/docker_quickstart_api_smoke.py
@@ -30,12 +30,16 @@ def main() -> None:
         raise RuntimeError("Demo import returned no findings.")
     if summary.get("locked_provider_data") is not True:
         raise RuntimeError("Demo import did not use locked provider data.")
-    if not str(summary.get("provider_snapshot_file", "")).endswith(
-        "/app/provider-snapshots/demo_provider_snapshot.json"
-    ):
+    provider_snapshot_ref = str(summary.get("provider_snapshot_file", ""))
+    provider_snapshot_ref_normalized = provider_snapshot_ref.replace("\\", "/")
+    if provider_snapshot_ref_normalized.startswith("/") or ":/" in provider_snapshot_ref_normalized:
+        raise RuntimeError(
+            f"Demo import leaked an absolute provider snapshot path: {provider_snapshot_ref!r}"
+        )
+    if not provider_snapshot_ref_normalized.endswith("demo_provider_snapshot.json"):
         raise RuntimeError(
             "Demo import did not use the Compose-mounted provider snapshot: "
-            f"{summary.get('provider_snapshot_file')!r}"
+            f"{provider_snapshot_ref!r}"
         )
     if provider_job.get("status") not in {"succeeded", "completed"}:
         raise RuntimeError(f"Provider update job did not complete: {provider_job!r}")
@@ -48,7 +52,7 @@ def main() -> None:
         )
 
     print(
-        "Template Workbench demo import passed: "
+        "Workbench demo import passed: "
         f"project_id={project_id} run_id={run['id']} findings={len(findings)} "
         f"locked_provider_data={summary['locked_provider_data']} "
         f"provider_job_id={provider_job['id']}"

--- a/scripts/start-template-playwright-backend.sh
+++ b/scripts/start-template-playwright-backend.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-db_path="${TEMPLATE_PLAYWRIGHT_DB:-$repo_root/build/frontend-playwright-template.db}"
-report_dir="${TEMPLATE_PLAYWRIGHT_REPORT_DIR:-$repo_root/build/frontend-playwright-template-reports}"
+# Compatibility entrypoint for existing Playwright config. Prefer
+# scripts/start-workbench-playwright-backend.sh in new docs and tooling.
+db_path="${WORKBENCH_PLAYWRIGHT_DB:-${TEMPLATE_PLAYWRIGHT_DB:-$repo_root/build/frontend-playwright-workbench.db}}"
+report_dir="${WORKBENCH_PLAYWRIGHT_REPORT_DIR:-${TEMPLATE_PLAYWRIGHT_REPORT_DIR:-$repo_root/build/frontend-playwright-workbench-reports}}"
 mkdir -p "$(dirname "$db_path")"
 mkdir -p "$report_dir"
 rm -f "$db_path"

--- a/scripts/start-workbench-playwright-backend.sh
+++ b/scripts/start-workbench-playwright-backend.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec bash "$repo_root/scripts/start-template-playwright-backend.sh"


### PR DESCRIPTION
## Summary

Implements the public-production remediation track across security/auth, backend API correctness, frontend architecture/testability, docs/package coherence, and final release-readiness gates.

Key changes:
- DB-backed password hash bootstrap and cookie/CSRF browser session boundary while retaining bearer API tokens for automation.
- Safe API error envelope, path-redacted import/report/provider responses, and asset/occurrence context preservation in Workbench summaries.
- Same-origin production frontend API strategy, CSP-safe nginx proxying, empty login defaults, explicit non-production demo gating, and broadened frontend lint/test coverage.
- Package/docs/release evidence policy, generated-client ownership checks, package contents gate, and production smoke/evidence ledger updates.

## Evidence

- `make check` -> 891 passed, 4 optional skipped, coverage 91.12%.
- `make frontend-check` -> Biome lint 199 files, production build, unit tests, generated client.
- `cd frontend && npm run test` -> 21 Playwright tests passed, including A11y, route integration, screenshots, desktop and mobile.
- `make docs-check` -> mkdocs build passed.
- `make dependency-audit` -> pip-audit no known vulnerabilities, npm audit 0 vulnerabilities.
- `make package-check` -> package contents OK, `twine check` passed.
- `make docker-demo-smoke` -> Compose backend/frontend healthy, login/import/provider smoke passed.
- `make release-readiness-check` -> full release gate passed, including actionlint, pre-commit, Docker, pipx source smoke, demo sync, API client drift, evidence bundle verification, and Playwright smoke.
- Security scans: production frontend bundle contains no `admin@example.com`, `changethis`, `localhost:8000`, or `127.0.0.1:8000`; authored frontend no longer stores access tokens in localStorage; path-leak scan over backend/app, frontend/src, smoke script, and public-production docs returned no private/server path matches.

## Tracker

Closes #316
Closes #317
Closes #318
Closes #319
Closes #320
Closes #321
Closes #322
Closes #323
Closes #324
Closes #325
Closes #326
Closes #327
Closes #328
Closes #329
Closes #330
Closes #331
Closes #332
Closes #333
Closes #334
Closes #335
Closes #336
Closes #337
Closes #338
Closes #339
Closes #340
Closes #341
Closes #342
Closes #343
Closes #344
Closes #345
Closes #346
Closes #347
Closes #348
Closes #349
Closes #350

Links Dependabot PR #287 as the dependency-lock follow-up referenced by #326.