### PR TITLE
Fix public-production accessibility gate

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--vpw-radius-md)] text-sm font-medium outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--vpw-radius-md)] text-sm font-medium outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-100 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- remove disabled button opacity reduction so disabled controls keep WCAG contrast
- restores the public-production Playwright/Axe gate that failed on the Projects route

## Evidence
- `cd frontend && npm run test -- tests/accessibility.spec.ts` -> 3 passed
- `make playwright-check` -> 12 passed
- `make release-readiness-check` -> passed end-to-end; backend 896 passed / 4 skipped, coverage 91.13%; frontend lint/build/unit passed; dependency audit found 0 vulnerabilities; docker demo smoke passed; evidence bundle verification passed; production-like Docker smoke passed

Closes #338
Closes #350
Closes #320