### PR TITLE
[VPW-AUD-301] Fail closed inactive API token principals

### DIFF
--- a/archive/vpw-evidence/vpw-aud-301-api-token-inactive-user.md
+++ b/archive/vpw-evidence/vpw-aud-301-api-token-inactive-user.md
@@ -52,8 +52,8 @@ make docs-check
 ```
 
 Result: release evidence hygiene passed and MkDocs built successfully. MkDocs
-reported that this evidence file is not included in the public nav, which is
-expected for repo-local evidence artifacts under `docs/evidence`.
+builds the public documentation tree while this audit evidence remains archived
+outside `docs/evidence`.
 
 ## Evidence Hygiene
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -20,6 +20,7 @@ from app.core.rate_limit import InMemoryRateLimiter, rate_limit_client_host
 from app.models import ApiToken, ApiTokenScope, TokenPayload, User
 from app.models.api_tokens import attach_api_token_context, scope_set
 from app.repositories import ApiTokenRepository, AuthSessionRepository
+from app.services.audit import record_audit_event
 from vuln_prioritizer.security_tokens import api_token_digest
 
 reusable_oauth2 = OAuth2PasswordBearer(
@@ -160,9 +161,6 @@ def require_api_scope(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail=f"API token requires {required_scope} scope.",
                 )
-            repo = ApiTokenRepository(session)
-            repo.mark_api_token_used(token_record)
-            session.commit()
             principal = ensure_configured_superuser(
                 session,
                 active_settings=active_settings,
@@ -173,6 +171,25 @@ def require_api_scope(
                 project_id=token_record.project_id,
                 scopes=scopes,
             )
+            if not principal.is_active:
+                record_audit_event(
+                    session,
+                    action="api_token.auth.failure",
+                    resource_type="api_token",
+                    resource_id=token_record.id,
+                    status="failure",
+                    actor=principal,
+                    project_id=token_record.project_id,
+                    detail={"reason": "inactive_user", "scopes": sorted(scopes)},
+                )
+                session.commit()
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Inactive user",
+                )
+            repo = ApiTokenRepository(session)
+            repo.mark_api_token_used(token_record)
+            session.commit()
             return principal
         if jwt_needs_superuser and not user.is_superuser:
             raise HTTPException(

--- a/backend/tests/api/test_template_api_tokens.py
+++ b/backend/tests/api/test_template_api_tokens.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 from utils.template_workbench import (
     TemplateApiEnv,
     auth_headers,
@@ -266,6 +266,132 @@ def test_template_scoped_service_tokens_gate_import_report_admin_and_revoke(
         headers=_bearer_headers(read_token["token"]),
     )
     assert read_list_tokens.status_code == 403
+
+
+def test_template_service_tokens_fail_closed_for_inactive_configured_user(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_template_dirs(template_api_env, tmp_path)
+    client = template_api_env.client
+    jwt_headers = auth_headers(client)
+    project = create_project_via_api(client, jwt_headers)
+
+    imported = client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=jwt_headers,
+        data={"input_type": "cve-list"},
+        files={"file": ("known-cves.txt", b"CVE-2024-3094\n", "text/plain")},
+    )
+    assert imported.status_code == 200, imported.text
+    run_id = imported.json()["id"]
+
+    service_tokens = {
+        "read": _create_token(
+            client,
+            jwt_headers,
+            name="inactive-read",
+            scopes=["read"],
+            project_id=project["id"],
+        ),
+        "write": _create_token(
+            client,
+            jwt_headers,
+            name="inactive-write",
+            scopes=["write"],
+            project_id=project["id"],
+        ),
+        "import": _create_token(
+            client,
+            jwt_headers,
+            name="inactive-import",
+            scopes=["import"],
+            project_id=project["id"],
+        ),
+        "report": _create_token(
+            client,
+            jwt_headers,
+            name="inactive-report",
+            scopes=["report"],
+            project_id=project["id"],
+        ),
+        "admin": _create_token(
+            client,
+            jwt_headers,
+            name="inactive-admin",
+            scopes=["admin"],
+        ),
+    }
+
+    with Session(template_api_env.engine) as session:
+        active_settings = template_api_env.client.app.state.workbench_settings
+        user = session.exec(
+            select(app_models.User).where(app_models.User.email == active_settings.FIRST_SUPERUSER)
+        ).one()
+        user.is_active = False
+        session.add(user)
+        session.commit()
+
+    responses = {
+        "read": client.get(
+            "/api/v1/projects/",
+            headers=_bearer_headers(str(service_tokens["read"]["token"])),
+        ),
+        "write": client.patch(
+            f"/api/v1/projects/{project['id']}",
+            headers=_bearer_headers(str(service_tokens["write"]["token"])),
+            json={"description": "inactive service token must not mutate"},
+        ),
+        "import": _upload_cve_list(
+            client,
+            project["id"],
+            token=str(service_tokens["import"]["token"]),
+        ),
+        "report": client.post(
+            f"/api/v1/runs/{run_id}/reports",
+            headers=_bearer_headers(str(service_tokens["report"]["token"])),
+            json={"format": "json"},
+        ),
+        "admin": client.get(
+            "/api/v1/api-tokens/",
+            headers=_bearer_headers(str(service_tokens["admin"]["token"])),
+        ),
+    }
+
+    for scope, response in responses.items():
+        assert response.status_code == 403, (scope, response.text)
+        assert "Inactive user" in response.text
+        assert str(service_tokens[scope]["token"]) not in response.text
+
+    with Session(template_api_env.engine) as session:
+        token_records = session.exec(select(app_models.ApiToken)).all()
+        inactive_token_ids = {UUID(str(token["id"])) for token in service_tokens.values()}
+        inactive_records = [token for token in token_records if token.id in inactive_token_ids]
+        failure_events = session.exec(
+            select(app_models.AuditEvent).where(
+                app_models.AuditEvent.action == "api_token.auth.failure"
+            )
+        ).all()
+
+    assert {record.name for record in inactive_records} == {
+        "inactive-read",
+        "inactive-write",
+        "inactive-import",
+        "inactive-report",
+        "inactive-admin",
+    }
+    assert all(record.last_used_at is None for record in inactive_records)
+    assert len(failure_events) == len(service_tokens)
+    assert {event.resource_id for event in failure_events} == {
+        str(token["id"]) for token in service_tokens.values()
+    }
+    assert {event.status for event in failure_events} == {"failure"}
+    assert all(event.detail_json["reason"] == "inactive_user" for event in failure_events)
+    assert all(
+        str(token["token"]) not in str(event.detail_json)
+        for token in service_tokens.values()
+        for event in failure_events
+    )
 
 
 def test_template_api_token_creation_rejects_empty_or_unknown_scopes(

--- a/docs/evidence/security-auth-api-token-inactive-user.md
+++ b/docs/evidence/security-auth-api-token-inactive-user.md
@@ -1,0 +1,76 @@
+# VPW-AUD-301 API Token Inactive User Evidence
+
+Issue: VPW-AUD-301 / #412
+Category: Security/Deployment
+Date: 2026-05-07
+Disposition: gap
+
+## Scope
+
+This evidence covers service-token authentication when the configured API-token
+principal has been deactivated. The change is limited to fail-closed handling for
+inactive principals on existing project-scoped and admin service-token paths.
+
+Out of scope: any work outside inactive-principal service-token handling.
+
+## Behavior Verified
+
+- Service tokens for `read`, `write`, `import`, `report`, and `admin` scopes are
+  denied with HTTP 403 when the configured principal is inactive.
+- Denied API-token attempts return `Inactive user` without echoing the raw token.
+- Denied API-token attempts do not update `last_used_at`.
+- Each denied token attempt records an `api_token.auth.failure` audit event with
+  `status=failure`, `reason=inactive_user`, and the token record id as the
+  resource id.
+- Audit event details include scopes and the failure reason, but not raw token
+  values.
+
+## Validation Commands
+
+```text
+python3 -m pytest -q backend/tests/api/test_template_api_tokens.py::test_template_service_tokens_fail_closed_for_inactive_configured_user --no-cov
+```
+
+Result: `1 passed in 0.46s`
+
+```text
+python3 -m pytest -q backend/tests/api/test_template_api_tokens.py backend/tests/api/test_template_auth_smoke.py --no-cov
+```
+
+Result: `22 passed in 4.64s`
+
+```text
+make check
+```
+
+Result: Ruff format/check clean, mypy clean for 211 source files, and backend
+tests passed with `937 passed, 4 skipped in 46.28s`. Coverage remained above the
+required 90% threshold at `90.84%`.
+
+```text
+make docs-check
+```
+
+Result: release evidence hygiene passed and MkDocs built successfully. MkDocs
+reported that this evidence file is not included in the public nav, which is
+expected for repo-local evidence artifacts under `docs/evidence`.
+
+## Evidence Hygiene
+
+The evidence above contains no secrets, service-token values, cookies, customer
+data, or private filesystem paths.
+
+## Residual Risk
+
+None for inactive-principal API-token handling.
+
+## Scorecard Impact
+
+Before: Security/Deployment retained a P0 fail-open service-token gap for
+inactive principals.
+
+After: The inactive-principal service-token path fails closed, preserves token
+usage metadata, and leaves an audit trail for denied attempts.
+
+Decision: This issue is ready for PR review after the evidence file, code, tests,
+and GitHub Project #9 fields are linked.


### PR DESCRIPTION
## Summary
- fail closed service-token authentication when the configured principal is inactive
- preserve token `last_used_at` on denied inactive-principal attempts
- audit denied inactive-principal service-token attempts as `api_token.auth.failure`
- add archived VPW-AUD-301 evidence artifact without expanding the public `docs/evidence` contract-artifact tree

Closes #412

## Disposition
`gap`

## Validation
- `python3 -m pytest -q backend/tests/api/test_template_api_tokens.py::test_template_service_tokens_fail_closed_for_inactive_configured_user --no-cov` -> 1 passed
- `python3 -m pytest -q backend/tests/api/test_template_api_tokens.py backend/tests/api/test_template_auth_smoke.py --no-cov` -> 22 passed
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed
- `make check` -> Ruff clean, mypy clean, backend tests 937 passed / 4 skipped, coverage 90.84%
- `make docs-check` -> release evidence hygiene OK, MkDocs build OK

## Evidence
- `archive/vpw-evidence/vpw-aud-301-api-token-inactive-user.md`
- independent Explorer security review: no blockers found

## CI Follow-up
- First CI run failed on `check (3.12)` because the evidence artifact was initially placed under `docs/evidence`, which is intentionally limited to contract artifacts.
- Moved the artifact to `archive/vpw-evidence` and re-ran docs hygiene plus `make check` locally.

## Residual Risk
None for inactive-principal API-token handling.
