### PR TITLE
[VPW-AUD-101] Handle same-batch import dedupe

### DIFF
--- a/archive/vpw-evidence/vpw-aud-101-backend-bulk-import-dedupe.md
+++ b/archive/vpw-evidence/vpw-aud-101-backend-bulk-import-dedupe.md
@@ -1,0 +1,82 @@
+# VPW-AUD-101 Backend Bulk Import Dedupe Evidence
+
+Issue: VPW-AUD-101 / #399
+Category: Backend/API
+Date: 2026-05-07
+Disposition: gap
+
+## Scope
+
+This evidence covers same-batch duplicate finding dedup keys in the Workbench
+bulk import persistence path. The change is limited to detecting duplicate
+incoming dedup keys before the large all-new bulk insert path is used.
+
+Out of scope: importer redesign, parser contract changes, and generated client
+changes.
+
+## Behavior Verified
+
+- A 1000-row generic occurrence CSV batch with the same CVE and asset identity
+  succeeds without violating the `project_id` plus `dedup_key` uniqueness
+  constraint.
+- The import persists one Finding and 1000 FindingOccurrence rows.
+- Summary semantics are preserved:
+  - `occurrence_count=1000`
+  - `finding_count=1`
+  - `created_findings=1`
+  - `updated_findings=999`
+  - `reused_findings=999`
+- Dedup decision sampling still records 500 sampled decisions and reports 500
+  omitted decisions.
+- Existing DB-to-import dedupe behavior remains covered by the import API test
+  suite.
+
+## Validation Commands
+
+```text
+python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py::test_same_batch_duplicate_bulk_import_reuses_finding_and_appends_occurrences --no-cov
+```
+
+Result: `1 passed in 2.18s`
+
+```text
+python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py backend/tests/api/test_template_service_layer.py --no-cov
+```
+
+Result: `46 passed in 7.70s`
+
+```text
+make docs-check
+```
+
+Result: release evidence hygiene passed and MkDocs built successfully.
+
+```text
+make check
+```
+
+Result: Ruff format/check clean, mypy clean for 211 source files, and backend
+tests passed with `938 passed, 4 skipped in 47.18s`. Coverage remained above the
+required 90% threshold at `90.86%`.
+
+## Evidence Hygiene
+
+The evidence above contains no secrets, tokens, cookies, customer data, or
+private filesystem paths. The artifact is archived under `archive/vpw-evidence`
+because `docs/evidence` is reserved for canonical report/evidence contract
+artifacts.
+
+## Residual Risk
+
+None for same-batch duplicate dedup keys in the bulk import eligibility path.
+
+## Scorecard Impact
+
+Before: Backend/API retained a same-batch duplicate dedup-key gap that could
+abort large imports through a unique-constraint failure.
+
+After: Large imports with same-batch duplicate dedup keys avoid the unsafe bulk
+insert path and use the existing dedupe-safe persistence flow.
+
+Decision: This issue is ready for PR review after the evidence file, code,
+tests, and GitHub Project #9 fields are linked.

--- a/backend/app/services/import_execution_persistence.py
+++ b/backend/app/services/import_execution_persistence.py
@@ -283,6 +283,8 @@ def _persist_workbench_occurrences_bulk_insert(
 
     dedup_parts_by_index = [_dedup_key_parts(project_id, occurrence) for occurrence in occurrences]
     dedup_keys = [_finding_dedup_key(parts) for parts in dedup_parts_by_index]
+    if len(set(dedup_keys)) != len(dedup_keys):
+        return None
     if _existing_findings_by_dedup_key(
         session=session,
         project_id=project_id,

--- a/backend/tests/api/test_template_import_upload_api.py
+++ b/backend/tests/api/test_template_import_upload_api.py
@@ -524,6 +524,61 @@ def test_double_import_deduplicates_findings_and_appends_occurrences(
     )
 
 
+def test_same_batch_duplicate_bulk_import_reuses_finding_and_appends_occurrences(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    project_id = uuid.UUID(project["id"])
+    duplicate_rows = [
+        "CVE-2024-3094,duplicate-host,CRITICAL,team-platform,payments,public" for _ in range(1000)
+    ]
+    content = "\n".join(
+        [
+            "cve_id,asset_ref,severity,owner,business_service,exposure",
+            *duplicate_rows,
+            "",
+        ]
+    ).encode()
+
+    response = template_api_env.client.post(
+        f"/api/v1/projects/{project['id']}/imports",
+        headers=headers,
+        data={"input_type": "generic-occurrence-csv"},
+        files={"file": ("duplicate-occurrences.csv", content, "text/csv")},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    dedup_summary = payload["summary_json"]["dedup_summary"]
+    assert payload["summary_json"]["occurrence_count"] == 1000
+    assert payload["summary_json"]["finding_count"] == 1
+    assert payload["summary_json"]["created_findings"] == 1
+    assert payload["summary_json"]["updated_findings"] == 999
+    assert dedup_summary["created_findings"] == 1
+    assert dedup_summary["updated_findings"] == 999
+    assert dedup_summary["reused_findings"] == 999
+    assert dedup_summary["decision_count"] == 1000
+    assert dedup_summary["omitted_decisions"] == 500
+    assert {item["action"] for item in dedup_summary["decisions"]} == {
+        "created",
+        "reused",
+    }
+    assert len({item["dedup_key"] for item in dedup_summary["decisions"]}) == 1
+
+    findings, occurrence_count = _finding_state(template_api_env, project_id)
+    assert len(findings) == 1
+    assert occurrence_count == 1000
+    assert findings[0].cve_id == "CVE-2024-3094"
+    assert findings[0].asset_id is not None
+    with Session(template_api_env.engine) as session:
+        asset = session.get(app_models.Asset, findings[0].asset_id)
+    assert asset is not None
+    assert asset.asset_key == "duplicate-host"
+
+
 def test_import_upload_applies_asset_context_sidecar_to_template_findings(
     template_api_env: TemplateApiEnv,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- detect duplicate incoming finding dedup keys before the large all-new bulk insert path
- fall back to the existing dedupe-safe persistence flow for same-batch duplicates
- add a 1000-row API regression that persists one Finding and 1000 FindingOccurrence rows
- archive VPW-AUD-101 evidence under `archive/vpw-evidence`

Closes #399

## Disposition
`gap`

## Validation
- `python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py::test_same_batch_duplicate_bulk_import_reuses_finding_and_appends_occurrences --no-cov` -> 1 passed
- `python3 -m pytest -q backend/tests/api/test_template_import_upload_api.py backend/tests/api/test_template_service_layer.py --no-cov` -> 46 passed
- `make docs-check` -> release evidence hygiene OK, MkDocs build OK
- `make check` -> Ruff clean, mypy clean, backend tests 938 passed / 4 skipped, coverage 90.86%

## Evidence
- `archive/vpw-evidence/vpw-aud-101-backend-bulk-import-dedupe.md`
- independent Explorer review of failure path and count semantics completed

## Residual Risk
None for same-batch duplicate dedup keys in the bulk import eligibility path.
