### PR TITLE
[VPW-AUD-104] Remove FastAPI coupling from import services

### DIFF
--- a/backend/app/api/routes/imports.py
+++ b/backend/app/api/routes/imports.py
@@ -4,13 +4,86 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, File, Form, Request, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 
 from app.api.deps import ScopedImportUser, SessionDep
+from app.api.routes.workbench_access import require_visible_project
+from app.core.app_state import workbench_settings
+from app.core.config import Settings
 from app.models import AnalysisRun, AnalysisRunPublic
-from app.services.import_execution import execute_project_import_upload
+from app.services.import_errors import ImportServiceError
+from app.services.import_execution import (
+    ImportUploadContent,
+    ProjectImportUploadRequest,
+    execute_project_import_upload,
+)
+from app.services.import_uploads import has_optional_upload, read_bounded_upload
 
 router = APIRouter(tags=["imports"])
+
+
+async def _read_optional_upload(
+    upload: UploadFile | None,
+    *,
+    settings: Settings,
+    remaining_bytes: int,
+) -> ImportUploadContent | None:
+    if upload is None or not has_optional_upload(upload.filename):
+        return None
+    content = await read_bounded_upload(
+        upload,
+        settings=settings,
+        max_bytes=remaining_bytes,
+    )
+    return ImportUploadContent(
+        filename=upload.filename,
+        content_type=upload.content_type,
+        content=content,
+    )
+
+
+async def _build_project_import_upload_request(
+    *,
+    settings: Settings,
+    input_type: str,
+    file: UploadFile,
+    asset_context_file: UploadFile | None,
+    vex_file: UploadFile | None,
+    provider_snapshot_file: str | None,
+    locked_provider_data: bool,
+    attack_source: str,
+    attack_mapping_file: str | None,
+    attack_technique_metadata_file: str | None,
+) -> ProjectImportUploadRequest:
+    primary_content = await read_bounded_upload(file, settings=settings)
+    remaining_bytes = settings.max_upload_bytes - len(primary_content)
+    asset_context_content = await _read_optional_upload(
+        asset_context_file,
+        settings=settings,
+        remaining_bytes=remaining_bytes,
+    )
+    if asset_context_content is not None:
+        remaining_bytes -= len(asset_context_content.content)
+    vex_content = await _read_optional_upload(
+        vex_file,
+        settings=settings,
+        remaining_bytes=remaining_bytes,
+    )
+    return ProjectImportUploadRequest(
+        input_type=input_type,
+        file=ImportUploadContent(
+            filename=file.filename,
+            content_type=file.content_type,
+            content=primary_content,
+        ),
+        asset_context_file=asset_context_content,
+        vex_file=vex_content,
+        provider_snapshot_file=provider_snapshot_file,
+        locked_provider_data=locked_provider_data,
+        attack_source=attack_source,
+        attack_mapping_file=attack_mapping_file,
+        attack_technique_metadata_file=attack_technique_metadata_file,
+    )
 
 
 @router.post("/projects/{project_id}/imports", response_model=AnalysisRunPublic)
@@ -30,18 +103,27 @@ async def import_project_upload(
     attack_technique_metadata_file: str | None = Form(None),
 ) -> AnalysisRun:
     """Accept one upload request and delegate import execution to the service layer."""
-    return await execute_project_import_upload(
-        project_id=project_id,
-        request=request,
-        session=session,
-        current_user=current_user,
-        input_type=input_type,
-        file=file,
-        asset_context_file=asset_context_file,
-        vex_file=vex_file,
-        provider_snapshot_file=provider_snapshot_file,
-        locked_provider_data=locked_provider_data,
-        attack_source=attack_source,
-        attack_mapping_file=attack_mapping_file,
-        attack_technique_metadata_file=attack_technique_metadata_file,
-    )
+    require_visible_project(session, current_user, project_id)
+    settings = workbench_settings(request)
+    try:
+        upload = await _build_project_import_upload_request(
+            settings=settings,
+            input_type=input_type,
+            file=file,
+            asset_context_file=asset_context_file,
+            vex_file=vex_file,
+            provider_snapshot_file=provider_snapshot_file,
+            locked_provider_data=locked_provider_data,
+            attack_source=attack_source,
+            attack_mapping_file=attack_mapping_file,
+            attack_technique_metadata_file=attack_technique_metadata_file,
+        )
+        return await execute_project_import_upload(
+            project_id=project_id,
+            session=session,
+            current_user=current_user,
+            settings=settings,
+            upload=upload,
+        )
+    except ImportServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc

--- a/backend/app/services/import_artifacts.py
+++ b/backend/app/services/import_artifacts.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from fastapi import HTTPException, Request
-
-from app.services.import_uploads import workbench_settings
+from app.core.config import Settings
+from app.services.import_errors import ImportServiceError
 from vuln_prioritizer.cli_options import AttackSource
 
 SAFE_ATTACK_FILENAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -17,7 +16,7 @@ SAFE_SNAPSHOT_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*[.]json$")
 def resolve_workbench_provider_snapshot_path(
     provider_snapshot_file: str | None,
     *,
-    request: Request,
+    settings: Settings,
 ) -> Path | None:
     value = provider_snapshot_file.strip() if provider_snapshot_file else ""
     if not value:
@@ -28,20 +27,20 @@ def resolve_workbench_provider_snapshot_path(
         or "\\" in value
         or Path(value).name != value
     ):
-        raise HTTPException(status_code=422, detail="Provider snapshot path is not allowed.")
-    snapshot_root = workbench_settings(request).provider_snapshot_dir_path.resolve(strict=False)
+        raise ImportServiceError(status_code=422, detail="Provider snapshot path is not allowed.")
+    snapshot_root = settings.provider_snapshot_dir_path.resolve(strict=False)
     candidate = (snapshot_root / value).resolve(strict=False)
     if not candidate.is_relative_to(snapshot_root):
-        raise HTTPException(status_code=422, detail="Provider snapshot path is not allowed.")
+        raise ImportServiceError(status_code=422, detail="Provider snapshot path is not allowed.")
     if not candidate.exists() or not candidate.is_file():
-        raise HTTPException(status_code=422, detail="Provider snapshot file does not exist.")
+        raise ImportServiceError(status_code=422, detail="Provider snapshot file does not exist.")
     return candidate
 
 
 def resolve_workbench_attack_artifact_path(
     value: str | None,
     *,
-    request: Request,
+    settings: Settings,
 ) -> Path | None:
     filename = value.strip() if value else ""
     if not filename:
@@ -52,13 +51,13 @@ def resolve_workbench_attack_artifact_path(
         or "\\" in filename
         or Path(filename).name != filename
     ):
-        raise HTTPException(status_code=422, detail="ATT&CK artifact path is not allowed.")
-    artifact_root = workbench_settings(request).attack_artifact_dir_path.resolve(strict=False)
+        raise ImportServiceError(status_code=422, detail="ATT&CK artifact path is not allowed.")
+    artifact_root = settings.attack_artifact_dir_path.resolve(strict=False)
     candidate = (artifact_root / filename).resolve(strict=False)
     if not candidate.is_relative_to(artifact_root):
-        raise HTTPException(status_code=422, detail="ATT&CK artifact path is not allowed.")
+        raise ImportServiceError(status_code=422, detail="ATT&CK artifact path is not allowed.")
     if not candidate.exists() or not candidate.is_file():
-        raise HTTPException(status_code=422, detail="ATT&CK artifact file does not exist.")
+        raise ImportServiceError(status_code=422, detail="ATT&CK artifact file does not exist.")
     return candidate
 
 
@@ -72,24 +71,24 @@ def validate_attack_import_options(
     try:
         normalized_source = AttackSource(raw_source)
     except ValueError as exc:
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422,
             detail=f"Unsupported ATT&CK source: {raw_source}.",
         ) from exc
     if normalized_source == AttackSource.none:
         if attack_mapping_path is not None or attack_metadata_path is not None:
-            raise HTTPException(
+            raise ImportServiceError(
                 status_code=422,
                 detail="ATT&CK mapping files require attack_source=ctid-json.",
             )
         return normalized_source
     if normalized_source not in {AttackSource.ctid_json, AttackSource.local_curated}:
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422,
             detail="Workbench ATT&CK imports only support ctid-json or local-curated.",
         )
     if attack_mapping_path is None:
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422,
             detail="ATT&CK imports require a mapping file.",
         )

--- a/backend/app/services/import_errors.py
+++ b/backend/app/services/import_errors.py
@@ -1,0 +1,14 @@
+"""Domain errors for Workbench import services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ImportServiceError(RuntimeError):
+    """Raised by import services when the route layer should return an error."""
+
+    def __init__(self, *, status_code: int, detail: str | dict[str, Any]) -> None:
+        super().__init__(str(detail))
+        self.status_code = status_code
+        self.detail = detail

--- a/backend/app/services/import_execution.py
+++ b/backend/app/services/import_execution.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
-from fastapi import HTTPException, Request, UploadFile
 from sqlmodel import Session
 
-from app.api.routes.workbench_access import require_visible_project
+from app.core.config import Settings
 from app.domain.import_asset_context import (
     canonicalize_occurrence_asset_context as _canonicalize_occurrence_asset_context,
 )
@@ -30,6 +30,7 @@ from app.services.import_artifacts import (
 from app.services.import_artifacts import (
     validate_attack_import_options as _validate_attack_import_options,
 )
+from app.services.import_errors import ImportServiceError
 from app.services.import_execution_context import (
     _apply_workbench_asset_context,
     _apply_workbench_vex,
@@ -55,9 +56,6 @@ from app.services.import_uploads import (
 )
 from app.services.import_uploads import (
     optional_upload_summary as _optional_upload_summary,
-)
-from app.services.import_uploads import (
-    read_bounded_upload as _read_bounded_upload,
 )
 from app.services.import_uploads import (
     reject_unsafe_upload_filename as _reject_unsafe_upload_filename,
@@ -104,37 +102,56 @@ from app.services.import_uploads import (
 from app.services.import_uploads import (
     validate_vex_upload as _validate_vex_upload,
 )
-from app.services.import_uploads import (
-    workbench_settings as _workbench_settings,
-)
+
+
+@dataclass(frozen=True, slots=True)
+class ImportUploadContent:
+    """HTTP-independent upload payload accepted by the import service."""
+
+    filename: str | None
+    content_type: str | None
+    content: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectImportUploadRequest:
+    """Workbench import request normalized at the route boundary."""
+
+    input_type: str
+    file: ImportUploadContent
+    asset_context_file: ImportUploadContent | None = None
+    vex_file: ImportUploadContent | None = None
+    provider_snapshot_file: str | None = None
+    locked_provider_data: bool = False
+    attack_source: str = "none"
+    attack_mapping_file: str | None = None
+    attack_technique_metadata_file: str | None = None
 
 
 async def execute_project_import_upload(
     *,
     project_id: uuid.UUID,
-    request: Request,
     session: Session,
     current_user: User,
-    input_type: str,
-    file: UploadFile,
-    asset_context_file: UploadFile | None = None,
-    vex_file: UploadFile | None = None,
-    provider_snapshot_file: str | None = None,
-    locked_provider_data: bool = False,
-    attack_source: str = "none",
-    attack_mapping_file: str | None = None,
-    attack_technique_metadata_file: str | None = None,
+    settings: Settings,
+    upload: ProjectImportUploadRequest,
 ) -> AnalysisRun:
     """Securely upload, normalize, and persist one Workbench import file."""
-    require_visible_project(session, current_user, project_id)
-    normalized_input_type = _normalize_input_type(input_type)
+    normalized_input_type = _normalize_input_type(upload.input_type)
     _validate_input_type(normalized_input_type)
+    file = upload.file
     original_filename = file.filename or "upload"
     _reject_unsafe_upload_filename(original_filename)
     stored_filename = _sanitize_filename(original_filename)
     _validate_upload_suffix(stored_filename, input_type=normalized_input_type)
     _validate_mime_hint(file.content_type, input_type=normalized_input_type)
-    asset_context_upload = asset_context_file if _has_optional_upload(asset_context_file) else None
+    asset_context_upload = (
+        upload.asset_context_file
+        if _has_optional_upload(
+            upload.asset_context_file.filename if upload.asset_context_file is not None else None
+        )
+        else None
+    )
     asset_context_original_filename = (
         asset_context_upload.filename if asset_context_upload is not None else None
     )
@@ -145,8 +162,15 @@ async def execute_project_import_upload(
             asset_context_original_filename,
             reserved_filename=stored_filename,
         )
-        _validate_asset_context_upload(asset_context_stored_filename, asset_context_upload)
-    vex_upload = vex_file if _has_optional_upload(vex_file) else None
+        _validate_asset_context_upload(
+            asset_context_stored_filename,
+            asset_context_upload.content_type,
+        )
+    vex_upload = (
+        upload.vex_file
+        if _has_optional_upload(upload.vex_file.filename if upload.vex_file is not None else None)
+        else None
+    )
     vex_original_filename = vex_upload.filename if vex_upload is not None else None
     vex_stored_filename: str | None = None
     if vex_upload is not None and vex_original_filename is not None:
@@ -155,52 +179,36 @@ async def execute_project_import_upload(
             vex_original_filename,
             reserved_filenames={stored_filename, asset_context_stored_filename},
         )
-        _validate_vex_upload(vex_stored_filename, vex_upload)
+        _validate_vex_upload(vex_stored_filename, vex_upload.content_type)
     provider_snapshot_path = _resolve_workbench_provider_snapshot_path(
-        provider_snapshot_file,
-        request=request,
+        upload.provider_snapshot_file,
+        settings=settings,
     )
     attack_mapping_path = _resolve_workbench_attack_artifact_path(
-        attack_mapping_file,
-        request=request,
+        upload.attack_mapping_file,
+        settings=settings,
     )
     attack_metadata_path = _resolve_workbench_attack_artifact_path(
-        attack_technique_metadata_file,
-        request=request,
+        upload.attack_technique_metadata_file,
+        settings=settings,
     )
     normalized_attack_source = _validate_attack_import_options(
-        attack_source=attack_source,
+        attack_source=upload.attack_source,
         attack_mapping_path=attack_mapping_path,
         attack_metadata_path=attack_metadata_path,
     )
 
-    active_settings = _workbench_settings(request)
-    upload_bytes = await _read_bounded_upload(file, settings=active_settings)
-    remaining_upload_bytes = active_settings.max_upload_bytes - len(upload_bytes)
-    asset_context_bytes = (
-        await _read_bounded_upload(
-            asset_context_upload,
-            settings=active_settings,
-            max_bytes=remaining_upload_bytes,
-        )
-        if asset_context_upload is not None
-        else None
-    )
-    if asset_context_bytes is not None:
-        remaining_upload_bytes -= len(asset_context_bytes)
-    vex_bytes = (
-        await _read_bounded_upload(
-            vex_upload,
-            settings=active_settings,
-            max_bytes=remaining_upload_bytes,
-        )
-        if vex_upload is not None
-        else None
-    )
     _validate_aggregate_upload_size(
-        settings=active_settings,
-        payloads=[upload_bytes, asset_context_bytes, vex_bytes],
+        settings=settings,
+        payloads=[
+            file.content,
+            asset_context_upload.content if asset_context_upload is not None else None,
+            vex_upload.content if vex_upload is not None else None,
+        ],
     )
+    upload_bytes = file.content
+    asset_context_bytes = asset_context_upload.content if asset_context_upload is not None else None
+    vex_bytes = vex_upload.content if vex_upload is not None else None
     upload_sha256 = hashlib.sha256(upload_bytes).hexdigest()
     asset_context_sha256 = (
         hashlib.sha256(asset_context_bytes).hexdigest() if asset_context_bytes is not None else None
@@ -257,7 +265,7 @@ async def execute_project_import_upload(
         },
     )
     upload_path = _store_upload(
-        request,
+        settings,
         project_id=project_id,
         run_id=run.id,
         filename=stored_filename,
@@ -265,7 +273,7 @@ async def execute_project_import_upload(
     )
     asset_context_path = (
         _store_upload(
-            request,
+            settings,
             project_id=project_id,
             run_id=run.id,
             filename=asset_context_stored_filename or "asset_context.csv",
@@ -276,7 +284,7 @@ async def execute_project_import_upload(
     )
     vex_path = (
         _store_upload(
-            request,
+            settings,
             project_id=project_id,
             run_id=run.id,
             filename=vex_stored_filename or "openvex.json",
@@ -383,7 +391,7 @@ async def execute_project_import_upload(
             input_type=normalized_input_type,
         )
         session.commit()
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422,
             detail={
                 "message": "Import parsing failed.",
@@ -448,7 +456,7 @@ async def execute_project_import_upload(
                 input_type=normalized_input_type,
             )
             session.commit()
-            raise HTTPException(
+            raise ImportServiceError(
                 status_code=422,
                 detail={
                     "message": "Asset context parsing failed.",
@@ -512,7 +520,7 @@ async def execute_project_import_upload(
                 input_type=normalized_input_type,
             )
             session.commit()
-            raise HTTPException(
+            raise ImportServiceError(
                 status_code=422,
                 detail={
                     "message": "VEX parsing failed.",
@@ -522,12 +530,12 @@ async def execute_project_import_upload(
             ) from exc
 
     try:
-        analysis_result = AnalysisService(session, _workbench_settings(request)).analyze_import(
+        analysis_result = AnalysisService(session, settings).analyze_import(
             input_path=upload_path,
             input_type=normalized_input_type,
             asset_context_file=asset_context_path,
             provider_snapshot_file=provider_snapshot_path,
-            locked_provider_data=locked_provider_data,
+            locked_provider_data=upload.locked_provider_data,
             attack_source=normalized_attack_source,
             attack_mapping_file=attack_mapping_path,
             attack_technique_metadata_file=attack_metadata_path,

--- a/backend/app/services/import_execution_failures.py
+++ b/backend/app/services/import_execution_failures.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import uuid
 from typing import NoReturn
 
-from fastapi import HTTPException
 from sqlmodel import Session
 
 from app.models import AnalysisRun, AnalysisRunStatus, User
 from app.repositories import RunRepository
+from app.services.import_errors import ImportServiceError
 from app.services.import_execution_summary import (
     _job_payload,
     _job_status_entry,
@@ -79,7 +79,7 @@ def raise_analysis_failure(
         input_type=input_type,
     )
     session.commit()
-    raise HTTPException(
+    raise ImportServiceError(
         status_code=422,
         detail={
             "message": "Import analysis failed.",

--- a/backend/app/services/import_uploads.py
+++ b/backend/app/services/import_uploads.py
@@ -41,7 +41,8 @@ ALLOWED_UPLOAD_MIME_HINTS = {
 class ReadableUpload(Protocol):
     """Async readable upload-like stream used at the HTTP boundary."""
 
-    async def read(self, size: int = -1) -> bytes: ...
+    async def read(self, size: int = -1) -> bytes:
+        raise NotImplementedError
 
 
 async def read_bounded_upload(

--- a/backend/app/services/import_uploads.py
+++ b/backend/app/services/import_uploads.py
@@ -6,13 +6,11 @@ import re
 import shutil
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
-from fastapi import HTTPException, Request, UploadFile
-
-from app.core.app_state import workbench_settings as _request_workbench_settings
 from app.core.config import Settings
 from app.importers import UnsupportedInputTypeError, build_importer_registry
+from app.services.import_errors import ImportServiceError
 
 ALLOWED_UPLOAD_SUFFIXES = {
     "cve-list": {".txt", ".csv"},
@@ -40,17 +38,14 @@ ALLOWED_UPLOAD_MIME_HINTS = {
 }
 
 
-def workbench_settings(request: Request) -> Settings:
-    return _request_workbench_settings(request)
+class ReadableUpload(Protocol):
+    """Async readable upload-like stream used at the HTTP boundary."""
 
-
-def template_settings(request: Request) -> Settings:
-    """Backward-compatible alias for older local tests and scripts."""
-    return workbench_settings(request)
+    async def read(self, size: int = -1) -> bytes: ...
 
 
 async def read_bounded_upload(
-    file: UploadFile,
+    file: ReadableUpload,
     *,
     settings: Settings,
     max_bytes: int | None = None,
@@ -65,7 +60,7 @@ async def read_bounded_upload(
     while chunk := await file.read(1024 * 1024):
         total += len(chunk)
         if total > limit:
-            raise HTTPException(
+            raise ImportServiceError(
                 status_code=413,
                 detail="Upload exceeds configured limit.",
             )
@@ -79,37 +74,37 @@ def validate_aggregate_upload_size(
     payloads: list[bytes | None],
 ) -> None:
     if sum(len(payload) for payload in payloads if payload is not None) > settings.max_upload_bytes:
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=413,
             detail="Upload exceeds configured limit.",
         )
 
 
-def has_optional_upload(file: UploadFile | None) -> bool:
-    return bool(file is not None and file.filename and file.filename.strip())
+def has_optional_upload(filename: str | None) -> bool:
+    return bool(filename and filename.strip())
 
 
-def validate_asset_context_upload(filename: str, file: UploadFile) -> None:
+def validate_asset_context_upload(filename: str, content_type: str | None) -> None:
     if Path(filename).suffix.lower() != ".csv":
-        raise HTTPException(status_code=422, detail="Asset context file must be a CSV.")
-    normalized = (file.content_type or "").split(";", maxsplit=1)[0].strip().lower()
+        raise ImportServiceError(status_code=422, detail="Asset context file must be a CSV.")
+    normalized = (content_type or "").split(";", maxsplit=1)[0].strip().lower()
     if normalized in {"", "application/octet-stream"}:
         return
     if normalized not in {"text/csv", "text/plain", "application/vnd.ms-excel"}:
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422,
             detail="Asset context content type must be text/csv.",
         )
 
 
-def validate_vex_upload(filename: str, file: UploadFile) -> None:
+def validate_vex_upload(filename: str, content_type: str | None) -> None:
     if Path(filename).suffix.lower() != ".json":
-        raise HTTPException(status_code=422, detail="VEX file must be a JSON document.")
-    normalized = (file.content_type or "").split(";", maxsplit=1)[0].strip().lower()
+        raise ImportServiceError(status_code=422, detail="VEX file must be a JSON document.")
+    normalized = (content_type or "").split(";", maxsplit=1)[0].strip().lower()
     if normalized in {"", "application/octet-stream"}:
         return
     if normalized not in {"application/json", "text/json"}:
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422,
             detail="VEX content type must be application/json.",
         )
@@ -173,19 +168,19 @@ def upload_storage_ref(
 
 
 def store_upload(
-    request: Request,
+    settings: Settings,
     *,
     project_id: uuid.UUID,
     run_id: uuid.UUID,
     filename: str,
     content: bytes,
 ) -> Path:
-    upload_root = workbench_settings(request).import_upload_dir_path.resolve(strict=False)
+    upload_root = settings.import_upload_dir_path.resolve(strict=False)
     target_dir = upload_root / str(project_id) / str(run_id)
     target_dir.mkdir(parents=True, exist_ok=True)
     target_path = (target_dir / filename).resolve(strict=False)
     if not target_path.is_relative_to(upload_root):
-        raise HTTPException(status_code=422, detail="Upload path is not allowed.")
+        raise ImportServiceError(status_code=422, detail="Upload path is not allowed.")
     try:
         with target_path.open("wb") as output:
             output.write(content)
@@ -238,13 +233,16 @@ def validate_input_type(input_type: str) -> None:
     try:
         build_importer_registry().get(input_type)
     except UnsupportedInputTypeError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise ImportServiceError(status_code=422, detail=str(exc)) from exc
 
 
 def validate_upload_suffix(filename: str, *, input_type: str) -> None:
     suffix = Path(filename).suffix.lower()
     if suffix not in ALLOWED_UPLOAD_SUFFIXES.get(input_type, set()):
-        raise HTTPException(status_code=422, detail="File extension does not match input type.")
+        raise ImportServiceError(
+            status_code=422,
+            detail="File extension does not match input type.",
+        )
 
 
 def validate_mime_hint(content_type: str | None, *, input_type: str) -> None:
@@ -252,16 +250,16 @@ def validate_mime_hint(content_type: str | None, *, input_type: str) -> None:
     if normalized in {"", "application/octet-stream"}:
         return
     if normalized not in ALLOWED_UPLOAD_MIME_HINTS.get(input_type, set()):
-        raise HTTPException(
+        raise ImportServiceError(
             status_code=422, detail="Upload content type does not match input type."
         )
 
 
 def reject_unsafe_upload_filename(filename: str) -> None:
     if "/" in filename or "\\" in filename or Path(filename).name != filename:
-        raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+        raise ImportServiceError(status_code=422, detail="Upload filename is not allowed.")
     if any(ord(character) < 32 for character in filename):
-        raise HTTPException(status_code=422, detail="Upload filename is not allowed.")
+        raise ImportServiceError(status_code=422, detail="Upload filename is not allowed.")
 
 
 def sanitize_filename(filename: str) -> str:
@@ -273,7 +271,7 @@ def sanitize_filename(filename: str) -> str:
 def normalize_input_type(input_type: str) -> str:
     normalized = input_type.strip().lower()
     if not normalized:
-        raise HTTPException(status_code=422, detail="input_type is required.")
+        raise ImportServiceError(status_code=422, detail="input_type is required.")
     return normalized
 
 

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -154,6 +154,25 @@ def test_template_backend_import_graph_does_not_reach_legacy_runtime() -> None:
     assert legacy_runtime_modules == []
 
 
+def test_import_service_modules_do_not_import_http_or_route_boundaries() -> None:
+    violations: dict[str, list[str]] = {}
+    blocked_prefixes = ("fastapi", "starlette", "app.api")
+
+    for path in sorted((APP_ROOT / "services").glob("import*.py")):
+        imports = sorted(
+            imported
+            for imported in _raw_imports(path)
+            if any(
+                imported == prefix or imported.startswith(f"{prefix}.")
+                for prefix in blocked_prefixes
+            )
+        )
+        if imports:
+            violations[str(path.relative_to(BACKEND_ROOT))] = imports
+
+    assert violations == {}
+
+
 def test_default_compose_services_start_only_active_backend_runtime() -> None:
     compose = yaml.safe_load((REPO_ROOT / "compose.yml").read_text(encoding="utf-8"))
     services = compose["services"]

--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -25,6 +25,7 @@ TEXT_SUFFIXES = {
 }
 MEDIA_SUFFIXES = {".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
 CANONICAL_EVIDENCE_CONTRACT_ARTIFACTS = {
+    Path("docs/evidence/backend-service-layer-boundary.md"),
     Path("docs/evidence/vpw-050-analysis-result.v1.json"),
     Path("docs/evidence/vpw-050-findings.csv"),
     Path("docs/evidence/vpw-051-analysis.json"),
@@ -35,7 +36,7 @@ CANONICAL_EVIDENCE_CONTRACT_ARTIFACTS = {
     Path("docs/evidence/vpw-060-attack-navigator-layer.json"),
 }
 # docs/evidence is intentionally kept only for contract artifacts validated by
-# backend report tests. Public and historical evidence belongs in
+# backend contract tests. Public and historical evidence belongs in
 # archive/vpw-evidence so broad evidence sprawl cannot return unnoticed.
 NON_PUBLIC_CONTRACT_MARKDOWN = {
     path for path in CANONICAL_EVIDENCE_CONTRACT_ARTIFACTS if path.suffix.lower() == ".md"

--- a/backend/tests/test_refactor_hygiene.py
+++ b/backend/tests/test_refactor_hygiene.py
@@ -145,7 +145,7 @@ def test_import_upload_route_delegates_to_application_service() -> None:
     service_source = (ROOT / "app/services/import_execution.py").read_text(encoding="utf-8")
     route_imports = _imported_modules("app/api/routes/imports.py")
 
-    assert len(route_source.splitlines()) <= 80
+    assert len(route_source.splitlines()) <= 140
     assert "app.services.import_execution" in route_imports
     assert "AnalysisService" not in route_source
     assert "build_importer_registry" not in route_source
@@ -233,12 +233,12 @@ def test_template_import_validation_and_storage_are_split_from_route_facade() ->
     artifact_source = (ROOT / "app/services/import_artifacts.py").read_text(encoding="utf-8")
 
     assert "app.services.import_execution" in imports
-    assert "app.services.import_uploads" not in imports
+    assert "app.services.import_uploads" in imports
     assert "app.services.import_artifacts" not in imports
     assert "ALLOWED_UPLOAD_SUFFIXES = " not in source
-    assert "def _read_bounded_upload" not in source
-    assert "def _store_upload" not in source
-    assert "def _resolve_template_provider_snapshot_path" not in source
+    assert "def read_bounded_upload" not in source
+    assert "def store_upload" not in source
+    assert "def resolve_workbench_provider_snapshot_path" not in source
     assert "app.services.import_uploads" in execution_source
     assert "app.services.import_artifacts" in execution_source
     assert "ALLOWED_UPLOAD_SUFFIXES = " in upload_source

--- a/docs/evidence/backend-service-layer-boundary.md
+++ b/docs/evidence/backend-service-layer-boundary.md
@@ -1,0 +1,31 @@
+# Backend Service Layer Boundary Evidence
+
+Audit item: VPW-AUD-104
+Date: 2026-05-07
+
+## Boundary
+
+The Workbench import route is the only HTTP adapter for multipart upload input. It resolves the active request settings, checks project visibility, reads bounded upload streams, and translates `ImportServiceError` into the existing FastAPI `HTTPException` response contract.
+
+Import service modules accept domain data only:
+
+- `ProjectImportUploadRequest`
+- `ImportUploadContent`
+- `Settings`
+
+They do not import FastAPI, Starlette, or route modules.
+
+## Regression Guard
+
+`backend/tests/test_backend_runtime_boundary.py::test_import_service_modules_do_not_import_http_or_route_boundaries` scans every `backend/app/services/import*.py` module and fails if it imports `fastapi`, `starlette`, or `app.api`.
+
+## Validation
+
+Required commands for this item:
+
+- `python3 -m pytest -q backend/tests/api/test_template_service_layer.py backend/tests/api/test_template_import_upload_api.py backend/tests/test_backend_runtime_boundary.py --no-cov`
+- `make check`
+
+## Evidence Hygiene
+
+This artifact contains only architecture evidence and validation commands. It does not include secrets, tokens, cookies, customer data, local usernames, or private absolute paths.


### PR DESCRIPTION
## Summary
- Move project visibility, request settings, upload stream reads, and FastAPI exception translation into the import route boundary.
- Convert import services to domain DTOs plus `ImportServiceError`, preserving existing public error details and run/audit failure persistence.
- Add a regression guard that blocks `fastapi`, `starlette`, and `app.api` imports from `backend/app/services/import*.py`, plus boundary evidence.

VPW ID: VPW-AUD-104
Disposition: gap
Closes #402

## Validation
- `python3 -m pytest -q backend/tests/api/test_template_service_layer.py backend/tests/api/test_template_import_upload_api.py backend/tests/test_backend_runtime_boundary.py --no-cov` -> 62 passed
- `python3 -m pytest -q backend/tests/test_refactor_hygiene.py backend/tests/test_docs_hygiene.py --no-cov` -> 32 passed
- `python3 -m ruff check backend/app/services/import_errors.py backend/app/services/import_uploads.py backend/app/services/import_artifacts.py backend/app/services/import_execution_failures.py backend/app/services/import_execution.py backend/app/api/routes/imports.py backend/tests/test_backend_runtime_boundary.py backend/tests/test_refactor_hygiene.py backend/tests/test_docs_hygiene.py` -> passed
- `python3 -m ruff format --check backend/app/services/import_errors.py backend/app/services/import_uploads.py backend/app/services/import_artifacts.py backend/app/services/import_execution_failures.py backend/app/services/import_execution.py backend/app/api/routes/imports.py backend/tests/test_backend_runtime_boundary.py backend/tests/test_refactor_hygiene.py backend/tests/test_docs_hygiene.py` -> passed
- `make check` -> 959 passed, 4 skipped; coverage 90.91%

## Evidence
- `docs/evidence/backend-service-layer-boundary.md`

## Residual Risk
- No known residual risk for VPW-AUD-104. The route remains the HTTP adapter by design; service modules are guarded against reintroducing HTTP/route imports.
