### PR TITLE
[VPW-AUD-199] Close Backend/API 10/10 scorecard

### DIFF
--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -25,6 +25,7 @@ TEXT_SUFFIXES = {
 }
 MEDIA_SUFFIXES = {".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"}
 CANONICAL_EVIDENCE_CONTRACT_ARTIFACTS = {
+    Path("docs/evidence/backend-api-scorecard.md"),
     Path("docs/evidence/backend-service-layer-boundary.md"),
     Path("docs/evidence/vpw-050-analysis-result.v1.json"),
     Path("docs/evidence/vpw-050-findings.csv"),

--- a/docs/evidence/backend-api-scorecard.md
+++ b/docs/evidence/backend-api-scorecard.md
@@ -1,0 +1,41 @@
+# Backend/API 10/10 Category Scorecard
+
+Audit item: VPW-AUD-199
+Date: 2026-05-07
+
+## Decision
+
+Backend/API is ready to score 10/10 for the VPW audit remediation category after the PP8 child issues closed with fresh implementation evidence, local validation, GitHub checks, and residual-risk decisions.
+
+This is a Backend/API category decision only. It does not make a final project-wide 10/10 or public-production readiness claim; those remain gated by the remaining category scorecards and VPW-AUD-999.
+
+## Closed Child Issues
+
+| VPW ID | Issue | PR | Result |
+| --- | --- | --- | --- |
+| VPW-AUD-101 | https://github.com/Noetheon/vuln-prioritizer-workbench/issues/399 | https://github.com/Noetheon/vuln-prioritizer-workbench/pull/432 | Same-batch import dedupe gap fixed and shipped. |
+| VPW-AUD-102 | https://github.com/Noetheon/vuln-prioritizer-workbench/issues/400 | https://github.com/Noetheon/vuln-prioritizer-workbench/pull/433 | API and CLI parser normalization contract unified for positive fixtures. |
+| VPW-AUD-103 | https://github.com/Noetheon/vuln-prioritizer-workbench/issues/401 | https://github.com/Noetheon/vuln-prioritizer-workbench/pull/434 | API and CLI SARIF/report fingerprint contract unified. |
+| VPW-AUD-104 | https://github.com/Noetheon/vuln-prioritizer-workbench/issues/402 | https://github.com/Noetheon/vuln-prioritizer-workbench/pull/435 | Import services decoupled from FastAPI and route modules. |
+
+## Validation Baseline
+
+Fresh category validation required by VPW-AUD-199:
+
+- `make check`
+- `make api-client-drift-check`
+
+Supporting child validation includes targeted backend/API tests for import upload behavior, service boundaries, parser fixture parity, input-loader contracts, benchmark regressions, SARIF/report contracts, GitHub Action contracts, report APIs, CLI report output, docs checks, demo sync checks, and GitHub PR checks.
+
+## Residual Risk
+
+No known Backend/API blocker remains after VPW-AUD-101 through VPW-AUD-104.
+
+Accepted compatibility notes:
+
+- VPW-AUD-102 keeps mixed invalid-row handling intentionally different: Workbench imports fail closed, while CLI/input-loader compatibility warns and skips invalid mixed rows. This is documented and tested.
+- VPW-AUD-103 keeps the legacy Workbench SARIF fingerprint alias emitted with the canonical value for compatibility.
+
+## Evidence Hygiene
+
+Evidence comments and artifacts were reviewed for the scorecard. No secrets, tokens, cookies, customer data, or private absolute paths are intentionally included in this scorecard artifact.


### PR DESCRIPTION
## Summary
- Add the Backend/API category scorecard evidence for VPW-AUD-199.
- Link closed child issues VPW-AUD-101 through VPW-AUD-104 and their remediation PRs.
- Keep the scorecard scoped to Backend/API; final project-wide 10/10 remains gated by remaining category scorecards and VPW-AUD-999.

VPW ID: VPW-AUD-199
Disposition: gap
Closes #403

## Validation
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed
- `make api-client-drift-check` -> client regenerated; no `frontend/src/client` diff
- `make check` -> 959 passed, 4 skipped; coverage 90.91%

## Evidence
- `docs/evidence/backend-api-scorecard.md`
- Child closeout evidence: #399, #400, #401, #402

## Residual Risk
- No known Backend/API blocker remains after VPW-AUD-101 through VPW-AUD-104.
- Accepted compatibility notes are recorded in `docs/evidence/backend-api-scorecard.md`.
