### PR TITLE
[VPW-AUD-201] Fix Findings table scroll containment

### DIFF
--- a/frontend/src/components/findings/FindingsDataTable.tsx
+++ b/frontend/src/components/findings/FindingsDataTable.tsx
@@ -424,8 +424,13 @@ export function FindingsDataTable({
   ]
 
   return (
-    <div className="vpw-table-wrap remediation-table-wrap shadow-none">
-      <table className="vpw-table min-w-[1240px] table-fixed [&_td]:py-3 [&_th]:py-3">
+    <section
+      aria-label="Findings table scroll region"
+      className="vpw-table-wrap remediation-table-wrap shadow-none"
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: The table overflow container must be keyboard-focusable for horizontal scroll access.
+      tabIndex={0}
+    >
+      <table className="vpw-table table-fixed [&_td]:py-3 [&_th]:py-3">
         <caption className="sr-only">Findings remediation queue</caption>
         <thead>
           <tr>
@@ -459,6 +464,6 @@ export function FindingsDataTable({
           ))}
         </tbody>
       </table>
-    </div>
+    </section>
   )
 }

--- a/frontend/src/components/vpw/VpwDataTable.tsx
+++ b/frontend/src/components/vpw/VpwDataTable.tsx
@@ -45,6 +45,8 @@ export function VpwDataTable<TData>({
     <section
       aria-label={caption ?? "Data table"}
       className={cn("vpw-table-wrap", className)}
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: Data table wrappers can scroll horizontally and need keyboard access.
+      tabIndex={0}
     >
       <table className={cn("vpw-table", densityClass[density])}>
         {caption ? <caption className="sr-only">{caption}</caption> : null}

--- a/frontend/src/components/vpw/VpwSectionHeader.tsx
+++ b/frontend/src/components/vpw/VpwSectionHeader.tsx
@@ -28,7 +28,11 @@ export function VpwSectionHeader({
           </p>
         ) : null}
       </div>
-      {actions ? <div className="flex shrink-0 gap-2">{actions}</div> : null}
+      {actions ? (
+        <div className="flex min-w-0 flex-wrap gap-2 sm:shrink-0 sm:justify-end">
+          {actions}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/styles/findings.css
+++ b/frontend/src/styles/findings.css
@@ -135,3 +135,8 @@
   color: #111827;
   font-size: 0.88rem;
 }
+
+.findings-queue-panel .remediation-table-wrap .vpw-table {
+  width: max(100%, 1240px);
+  min-width: 1240px;
+}

--- a/frontend/src/styles/vpw-components.css
+++ b/frontend/src/styles/vpw-components.css
@@ -1,6 +1,7 @@
 @layer components {
   .vpw-page-container {
     width: 100%;
+    min-width: 0;
     max-width: var(--vpw-container-max);
     margin-inline: auto;
     padding-inline: var(--vpw-container-padding);
@@ -89,17 +90,21 @@
   }
 
   .vpw-table-wrap {
-    overflow-x: visible;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-gutter: stable;
     border: 1px solid var(--vpw-border-default);
     border-radius: var(--vpw-radius-xl);
     background: var(--vpw-bg-card);
     box-shadow: var(--vpw-shadow-1);
+    -webkit-overflow-scrolling: touch;
   }
 
-  @media (width < 768px) {
-    .vpw-table-wrap {
-      overflow-x: auto;
-    }
+  .vpw-table-wrap:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--vpw-teal) 70%, white);
+    outline-offset: 3px;
   }
 
   .vpw-table {

--- a/frontend/tests/findings-route-integration.spec.ts
+++ b/frontend/tests/findings-route-integration.spec.ts
@@ -1,75 +1,5 @@
-import { expect, type Page, test } from "@playwright/test"
-
-async function routeWorkbenchShell(page: Page) {
-  await page.addInitScript(() => {
-    // biome-ignore lint/suspicious/noDocumentCookie: Playwright sets a mock readable CSRF cookie before app boot.
-    document.cookie = "vpw_csrf_token=mock-csrf; Path=/; SameSite=Strict"
-  })
-
-  await page.route("**/api/v1/users/me", (route) =>
-    route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: "demo-user",
-        email: "admin@example.com",
-        full_name: "Admin",
-        is_active: true,
-        is_superuser: true,
-        created_at: "2025-01-01T00:00:00Z",
-      }),
-    }),
-  )
-  await page.route("**/api/v1/workbench/status", (route) =>
-    route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({
-        app: "Vuln Prioritizer Workbench",
-        status: "ready",
-        core_package: "vuln_prioritizer",
-        core_version: "demo",
-        database_status: "ready",
-        schema_status: "ready",
-      }),
-    }),
-  )
-  await page.route("**/api/v1/providers/status", (route) =>
-    route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({
-        status: "ok",
-        snapshot_mode: "demo",
-        cache_age_seconds: 0,
-        last_sync: "2025-04-30T10:00:00Z",
-        warnings: [],
-        snapshot: {
-          id: "demo",
-          mode: "demo",
-          missing: false,
-          selected_sources: ["epss", "kev"],
-        },
-        sources: [],
-      }),
-    }),
-  )
-  await page.route("**/api/v1/utils/health-check/", (route) =>
-    route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({ status: "ok" }),
-    }),
-  )
-  await page.route("**/api/v1/projects/", (route) =>
-    route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({ data: [], count: 0 }),
-    }),
-  )
-  await page.route("**/api/v1/projects/?*", (route) =>
-    route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({ data: [], count: 0 }),
-    }),
-  )
-}
+import { expect, test } from "@playwright/test"
+import { mockFinding, mockProject, routeWorkbenchShell } from "./workbench-route-mocks"
 
 test("findings route renders the empty live queue without demo data", async ({
   page,
@@ -130,4 +60,47 @@ test("finding detail API errors do not fall back to demo findings", async ({
   await expect(page.getByText("Finding detail unavailable")).toBeVisible()
   await expect(page.getByText("Demo preview")).toHaveCount(0)
   await expect(page.getByText("CVE-2024-3094")).toHaveCount(0)
+})
+
+test("findings table owns horizontal scroll without page overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 768, height: 1024 })
+  await routeWorkbenchShell(page, {
+    findings: [mockFinding],
+    projects: [mockProject],
+  })
+
+  await page.goto("/findings")
+
+  await expect(
+    page.getByRole("table", { name: "Findings remediation queue" }),
+  ).toContainText("CVE-2024-3094")
+  const scrollRegion = page.getByRole("region", {
+    name: "Findings table scroll region",
+  })
+  const metrics = await scrollRegion.evaluate((region) => {
+    const documentElement = document.documentElement
+    region.scrollLeft = region.scrollWidth
+    return {
+      bodyScrollWidth: document.body.scrollWidth,
+      documentScrollWidth: documentElement.scrollWidth,
+      regionClientWidth: region.clientWidth,
+      regionScrollLeft: region.scrollLeft,
+      regionScrollWidth: region.scrollWidth,
+      viewportWidth: documentElement.clientWidth,
+    }
+  })
+
+  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(metrics.regionClientWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(metrics.regionScrollWidth).toBeGreaterThan(metrics.regionClientWidth)
+  expect(metrics.regionScrollLeft).toBeGreaterThan(0)
 })

--- a/frontend/tests/responsive-shell.spec.ts
+++ b/frontend/tests/responsive-shell.spec.ts
@@ -1,5 +1,7 @@
 import { expect, type Page, test } from "@playwright/test"
 import { login } from "./auth-helpers"
+import { evidenceScreenshotPath } from "./evidence-paths"
+import { mockFinding, mockProject, routeWorkbenchShell } from "./workbench-route-mocks"
 
 async function expectNoPageOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({
@@ -10,6 +12,66 @@ async function expectNoPageOverflow(page: Page) {
   expect(dimensions.bodyScrollWidth).toBeLessThanOrEqual(
     dimensions.viewportWidth + 1,
   )
+}
+
+async function expectFindingsTableScrollContainment(
+  page: Page,
+  viewport: { width: number; height: number },
+) {
+  const scrollRegion = page.getByRole("region", {
+    name: "Findings table scroll region",
+  })
+  await expect(scrollRegion).toBeVisible()
+  await expect(
+    page.getByRole("table", { name: "Findings remediation queue" }),
+  ).toBeVisible()
+
+  const metrics = await scrollRegion.evaluate((region) => {
+    const table = region.querySelector("table")
+    const documentElement = document.documentElement
+    const style = window.getComputedStyle(region)
+    const tableStyle = table ? window.getComputedStyle(table) : null
+    region.scrollLeft = region.scrollWidth
+    return {
+      bodyScrollWidth: document.body.scrollWidth,
+      computedTableMinWidth: tableStyle?.minWidth ?? "",
+      computedTableWidth: tableStyle?.width ?? "",
+      documentScrollWidth: documentElement.scrollWidth,
+      overflowX: style.overflowX,
+      regionClientWidth: region.clientWidth,
+      regionScrollLeft: region.scrollLeft,
+      regionScrollWidth: region.scrollWidth,
+      tableScrollWidth: table?.scrollWidth ?? 0,
+      viewportWidth: documentElement.clientWidth,
+    }
+  })
+
+  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(["auto", "scroll"]).toContain(metrics.overflowX)
+  expect(metrics.regionClientWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(metrics.tableScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
+    metrics.regionClientWidth,
+  )
+  expect(metrics.regionScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
+    metrics.regionClientWidth,
+  )
+  expect(metrics.regionScrollLeft, JSON.stringify(metrics)).toBeGreaterThan(0)
+
+  await page.screenshot({
+    fullPage: true,
+    path: evidenceScreenshotPath(
+      "ui-productization",
+      "screenshots",
+      `vpw-aud-201-findings-${viewport.width}.png`,
+    ),
+  })
 }
 
 const authenticatedRoutes = [
@@ -62,5 +124,25 @@ test("authenticated routes keep content within desktop, tablet, and mobile viewp
       await expect(page.locator(":focus")).toBeVisible()
       await expectNoPageOverflow(page)
     }
+  }
+})
+
+test("findings table keeps horizontal scroll contained at desktop, tablet, and mobile widths", async ({
+  page,
+}) => {
+  await routeWorkbenchShell(page, {
+    findings: [mockFinding],
+    projects: [mockProject],
+  })
+
+  for (const viewport of [
+    { height: 900, width: 1440 },
+    { height: 1024, width: 768 },
+    { height: 844, width: 390 },
+  ]) {
+    await page.setViewportSize(viewport)
+    await page.goto("/findings")
+    await expect(page.getByRole("main")).toBeVisible()
+    await expectFindingsTableScrollContainment(page, viewport)
   }
 })

--- a/frontend/tests/workbench-route-mocks.ts
+++ b/frontend/tests/workbench-route-mocks.ts
@@ -1,0 +1,185 @@
+import type { Page } from "@playwright/test"
+
+type MockProject = {
+  created_at: string
+  description: string
+  id: string
+  name: string
+  owner_id: string
+  updated_at: string
+}
+
+type MockFinding = {
+  asset_id: string
+  asset_key: string
+  asset_name: string
+  business_service: string
+  component_id: string | null
+  component_name: string
+  component_purl: string
+  component_version: string
+  created_at: string
+  cve_id: string
+  cvss_base_score: number
+  epss: number
+  exposure: string
+  first_seen_at: string
+  id: string
+  in_kev: boolean
+  last_seen_at: string
+  owner: string
+  priority: string
+  project_id: string
+  rationale: string
+  recommended_action: string
+  risk_score: number
+  status: string
+  updated_at: string
+  vulnerability_id: string
+}
+
+type RouteWorkbenchShellOptions = {
+  findings?: MockFinding[]
+  projects?: MockProject[]
+}
+
+export const mockProject: MockProject = {
+  created_at: "2025-01-01T00:00:00Z",
+  description: "Critical payment processing workloads.",
+  id: "project-1",
+  name: "Payments Platform",
+  owner_id: "demo-user",
+  updated_at: "2025-01-02T00:00:00Z",
+}
+
+export const mockFinding: MockFinding = {
+  asset_id: "asset-1",
+  asset_key: "build-host-1",
+  asset_name: "build-host-1",
+  business_service: "payments",
+  component_id: null,
+  component_name: "xz",
+  component_purl: "pkg:apk/alpine/xz@5.6.0-r0",
+  component_version: "5.6.0",
+  created_at: "2025-01-01T00:00:00Z",
+  cve_id: "CVE-2024-3094",
+  cvss_base_score: 10,
+  epss: 0.92,
+  exposure: "internet_facing",
+  first_seen_at: "2025-01-01T00:00:00Z",
+  id: "finding-1",
+  in_kev: true,
+  last_seen_at: "2025-01-02T00:00:00Z",
+  owner: "platform",
+  priority: "critical",
+  project_id: mockProject.id,
+  rationale: "Known exploited dependency in a critical runtime.",
+  recommended_action: "Patch xz.",
+  risk_score: 9.8,
+  status: "open",
+  updated_at: "2025-01-02T00:00:00Z",
+  vulnerability_id: "CVE-2024-3094",
+}
+
+export async function routeWorkbenchShell(
+  page: Page,
+  options: RouteWorkbenchShellOptions = {},
+) {
+  const projects = options.projects ?? []
+  const findings = options.findings ?? []
+  await page.addInitScript(() => {
+    // biome-ignore lint/suspicious/noDocumentCookie: Playwright sets a mock readable CSRF cookie before app boot.
+    document.cookie = "vpw_csrf_token=mock-csrf; Path=/; SameSite=Strict"
+  })
+
+  await page.route("**/api/v1/users/me", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "demo-user",
+        email: "admin@example.com",
+        full_name: "Admin",
+        is_active: true,
+        is_superuser: true,
+        created_at: "2025-01-01T00:00:00Z",
+      }),
+    }),
+  )
+  await page.route("**/api/v1/workbench/status", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        app: "Vuln Prioritizer Workbench",
+        status: "ready",
+        core_package: "vuln_prioritizer",
+        core_version: "demo",
+        database_status: "ready",
+        schema_status: "ready",
+      }),
+    }),
+  )
+  await page.route("**/api/v1/providers/status", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "ok",
+        snapshot_mode: "demo",
+        cache_age_seconds: 0,
+        last_sync: "2025-04-30T10:00:00Z",
+        warnings: [],
+        snapshot: {
+          id: "demo",
+          mode: "demo",
+          missing: false,
+          selected_sources: ["epss", "kev"],
+        },
+        sources: [],
+      }),
+    }),
+  )
+  await page.route("**/api/v1/utils/health-check/", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ status: "ok" }),
+    }),
+  )
+  await page.route("**/api/v1/projects/", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ data: projects, count: projects.length }),
+    }),
+  )
+  await page.route("**/api/v1/projects/?*", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ data: projects, count: projects.length }),
+    }),
+  )
+  for (const project of projects) {
+    await page.route(`**/api/v1/projects/${project.id}/summary`, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          counts_by_priority: { critical: findings.length },
+          counts_by_status: { open: findings.length },
+          cvss_known_count: findings.length,
+          epss_hits: findings.filter((finding) => finding.epss > 0).length,
+          finding_count: findings.length,
+          kev_hits: findings.filter((finding) => finding.in_kev).length,
+          latest_run_id: null,
+          latest_run_status: null,
+          latest_run_summary: {},
+          open_finding_count: findings.length,
+          project_id: project.id,
+          provider_degraded: false,
+        }),
+      }),
+    )
+    await page.route(`**/api/v1/projects/${project.id}/findings/?*`, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ data: findings, count: findings.length }),
+      }),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- make VPW table wrappers own horizontal overflow without page-level overflow
- convert the Findings queue table wrapper to a named, keyboard-focusable scroll region
- move the Findings table width contract into scoped Findings CSS so legacy global table CSS cannot shrink it
- add deterministic mocked Workbench routes and responsive/integration regressions for 1440, 768, and 390 widths

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test -- tests/responsive-shell.spec.ts --project=mobile-chromium`
- `npm --prefix frontend run test -- tests/findings-route-integration.spec.ts --project=chromium`
- `npm --prefix frontend run build`
- `make playwright-check`

## Evidence
- `frontend/test-results/evidence/ui-productization/screenshots/vpw-aud-201-findings-1440.png`
- `frontend/test-results/evidence/ui-productization/screenshots/vpw-aud-201-findings-768.png`
- `frontend/test-results/evidence/ui-productization/screenshots/vpw-aud-201-findings-390.png`

## Residual Risk
- No known residual risk for the Findings table scroll contract. The generic `VpwDataTable` wrapper is now keyboard-focusable because horizontal overflow can apply across reusable tables.

Closes #404