### PR TITLE
[VPW-AUD-203] Sync findings route state to URLs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview --host 127.0.0.1",
     "generate-client": "openapi-ts",
     "test": "playwright test",
-    "test:unit": "node --test --experimental-strip-types tests/auth.test.ts tests/chart-data.test.ts tests/imports-workbench-model.test.ts tests/report-download.test.ts tests/runtime-config.test.ts tests/workbench-query-keys.test.ts tests/route-organization.test.ts tests/reporting-state.test.ts",
+    "test:unit": "node --test --experimental-strip-types tests/auth.test.ts tests/chart-data.test.ts tests/findings-search-state.test.ts tests/imports-workbench-model.test.ts tests/report-download.test.ts tests/runtime-config.test.ts tests/workbench-query-keys.test.ts tests/route-organization.test.ts tests/reporting-state.test.ts",
     "test:pr-frontend": "npm run test:unit && playwright test tests/ui-smoke.spec.ts tests/accessibility.spec.ts tests/responsive-shell.spec.ts",
     "test:ui": "playwright test --ui"
   },

--- a/frontend/src/components/finding-detail/FindingDetailRoute.tsx
+++ b/frontend/src/components/finding-detail/FindingDetailRoute.tsx
@@ -5,6 +5,7 @@ import type {
   FindingDetailPublic,
   FindingExplanationPublic,
 } from "@/api-client"
+import type { FindingsUrlSearch } from "@/components/findings/findings-search-state"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { VpwSkeletonStack, VpwStatusBanner } from "@/components/vpw"
@@ -32,6 +33,7 @@ export type FindingDetailRouteProps = {
   explanation: FindingExplanationPublic | null
   explanationWarning: string
   finding: FindingDetailPublic | null
+  findingsBackSearch: FindingsUrlSearch
   loading: boolean
   tab: FindingDetailTab
   onRefresh: () => void
@@ -43,6 +45,7 @@ export function FindingDetailRoute({
   explanation,
   explanationWarning,
   finding,
+  findingsBackSearch,
   loading,
   onRefresh,
   onTabChange,
@@ -75,7 +78,7 @@ export function FindingDetailRoute({
     >
       <div className="finding-detail-backbar">
         <Button variant="outline" size="sm" asChild>
-          <Link to="/findings">
+          <Link search={findingsBackSearch} to="/findings">
             <ArrowLeft aria-hidden="true" size={16} />
             <span>Back to Findings</span>
           </Link>

--- a/frontend/src/components/findings/FindingsDataTable.tsx
+++ b/frontend/src/components/findings/FindingsDataTable.tsx
@@ -21,6 +21,7 @@ import {
 import type { ReactNode } from "react"
 import { formatLabel as labelize, optionalText } from "@/lib/ui-copy"
 import { cn } from "@/lib/utils"
+import type { FindingsUrlSearch } from "./findings-search-state"
 
 type FindingsSort = NonNullable<FindingsReadProjectFindingsData["sort"]>
 type FindingsDirection = NonNullable<
@@ -182,6 +183,7 @@ function StaticHeader({
 type FindingsDataTableProps = {
   findings: readonly FindingPublic[]
   findingDirection: FindingsDirection
+  findingSearch: FindingsUrlSearch
   onOpenSheet: (finding: FindingPublic) => void
   onOpenWhy: (finding: FindingPublic) => void
   onSort: (sort: QueueSort) => void
@@ -200,6 +202,7 @@ type FindingsDataTableColumn = {
 export function FindingsDataTable({
   findings,
   findingDirection,
+  findingSearch,
   onOpenSheet,
   onOpenWhy,
   onSort,
@@ -255,6 +258,7 @@ export function FindingsDataTable({
           <Link
             className="finding-cve-link"
             params={{ findingId: finding.id }}
+            search={findingSearch}
             title={`Open finding ${finding.cve_id}`}
             to="/findings/$findingId"
           >

--- a/frontend/src/components/findings/RemediationQueue.tsx
+++ b/frontend/src/components/findings/RemediationQueue.tsx
@@ -61,6 +61,7 @@ import {
   VpwSkeletonStack,
   VpwStatusBanner,
 } from "@/components/vpw"
+import type { FindingsUrlSearch } from "./findings-search-state"
 import { DEMO_FINDINGS, DEMO_PROJECT, DEMO_SUMMARY } from "@/lib/demo-data"
 import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { formatLabel as labelize, optionalText } from "@/lib/ui-copy"
@@ -106,12 +107,17 @@ export type RemediationQueueProps = {
   projectListLoading: boolean
   selectedProjectId: string
   projectSummary: ProjectDecisionSummaryPublic | null
+  findingSearch: FindingsUrlSearch
+  onClearAssetFilter: () => void
   onFilterChange: <K extends keyof FindingFilters>(
     key: K,
     value: FindingFilters[K],
   ) => void
   onClearFilters: () => void
-  onSortChange: (sort: FindingsSort) => void
+  onSortDirectionChange: (
+    sort: FindingsSort,
+    direction: FindingsDirection,
+  ) => void
   onDirectionChange: (direction: FindingsDirection) => void
   onPageNext: () => void
   onPagePrev: () => void
@@ -217,11 +223,17 @@ function WhyDialog({ finding, open, onClose }: WhyDialogProps) {
 
 type QuickViewSheetProps = {
   finding: FindingPublic | null
+  findingSearch: FindingsUrlSearch
   open: boolean
   onClose: () => void
 }
 
-function QuickViewSheet({ finding, open, onClose }: QuickViewSheetProps) {
+function QuickViewSheet({
+  finding,
+  findingSearch,
+  open,
+  onClose,
+}: QuickViewSheetProps) {
   if (!finding) return null
   return (
     <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
@@ -299,6 +311,7 @@ function QuickViewSheet({ finding, open, onClose }: QuickViewSheetProps) {
             <Button asChild className="w-full" size="sm" variant="outline">
               <Link
                 params={{ findingId: finding.id }}
+                search={findingSearch}
                 to="/findings/$findingId"
               >
                 Open full detail
@@ -333,9 +346,11 @@ export function RemediationQueue({
   projectListLoading,
   selectedProjectId,
   projectSummary,
+  findingSearch,
+  onClearAssetFilter,
   onFilterChange,
   onClearFilters,
-  onSortChange,
+  onSortDirectionChange,
   onDirectionChange,
   onPageNext,
   onPagePrev,
@@ -347,7 +362,7 @@ export function RemediationQueue({
   const [whyOpen, setWhyOpen] = useState(false)
   const [sheetOpen, setSheetOpen] = useState(false)
   const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false)
-  const [queueSort, setQueueSort] = useState<QueueSort>(findingSort)
+  const queueSort: QueueSort = findingSort
 
   const isDemo =
     DEMO_MODE_ENABLED && projects.length === 0 && !projectListLoading
@@ -401,9 +416,9 @@ export function RemediationQueue({
           ? "desc"
           : "asc"
         : defaultSortDirections[sort]
-    setQueueSort(sort)
     if (isApiSort(sort)) {
-      onSortChange(sort)
+      onSortDirectionChange(sort, nextDirection)
+      return
     }
     onDirectionChange(nextDirection)
   }
@@ -533,7 +548,7 @@ export function RemediationQueue({
                   <Button
                     aria-label="Clear asset filter"
                     className="ml-1 size-6"
-                    onClick={onClearFilters}
+                    onClick={onClearAssetFilter}
                     size="icon"
                     type="button"
                     variant="ghost"
@@ -893,6 +908,7 @@ export function RemediationQueue({
 
               <FindingsDataTable
                 findingDirection={findingDirection}
+                findingSearch={findingSearch}
                 findings={displayFindings}
                 onOpenSheet={openSheet}
                 onOpenWhy={openWhy}
@@ -968,6 +984,7 @@ export function RemediationQueue({
         />
         <QuickViewSheet
           finding={sheetFinding}
+          findingSearch={findingSearch}
           onClose={() => setSheetOpen(false)}
           open={sheetOpen}
         />

--- a/frontend/src/components/findings/findings-search-state.ts
+++ b/frontend/src/components/findings/findings-search-state.ts
@@ -1,0 +1,358 @@
+import type {
+  AssetExposure,
+  FindingPriority,
+  FindingStatus,
+  FindingsReadProjectFindingsData,
+} from "../../api-client"
+import type {
+  FindingFilters,
+  FindingsDirection,
+  FindingsSort,
+  KevFilter,
+} from "../../lib/app-defaults"
+
+const findingPageSizes = [1, 10, 25, 50] as const
+const findingPriorityOptions: readonly FindingPriority[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+]
+const findingStatusOptions: readonly FindingStatus[] = [
+  "open",
+  "in_review",
+  "remediating",
+  "fixed",
+  "accepted",
+  "suppressed",
+]
+const findingExposureOptions: readonly AssetExposure[] = [
+  "internet-facing",
+  "internal",
+  "private",
+  "unknown",
+]
+const sortOptions: readonly FindingsSort[] = [
+  "operational",
+  "priority",
+  "score",
+  "cve",
+  "status",
+  "epss",
+  "cvss",
+  "kev",
+  "last_seen",
+  "component",
+  "owner",
+]
+const defaultFindingFilters: FindingFilters = {
+  cvssMax: "",
+  cvssMin: "",
+  epssMax: "",
+  epssMin: "",
+  exposure: "",
+  kev: "",
+  ownerService: "",
+  priority: "",
+  status: "",
+}
+
+export type FindingPageSize = (typeof findingPageSizes)[number]
+
+export type FindingsSearchState = FindingFilters & {
+  assetId: string
+  assetKey: string
+  direction: FindingsDirection
+  limit: FindingPageSize
+  offset: number
+  sort: FindingsSort
+}
+
+export const defaultFindingsSearchState: FindingsSearchState = {
+  ...defaultFindingFilters,
+  assetId: "",
+  assetKey: "",
+  direction: "asc",
+  limit: 10,
+  offset: 0,
+  sort: "operational",
+}
+
+const directionOptions = ["asc", "desc"] as const
+const kevOptions = ["true", "false"] as const
+const searchKeys = [
+  "assetId",
+  "assetKey",
+  "cvssMax",
+  "cvssMin",
+  "direction",
+  "epssMax",
+  "epssMin",
+  "exposure",
+  "kev",
+  "limit",
+  "offset",
+  "ownerService",
+  "priority",
+  "sort",
+  "status",
+] as const
+
+type SearchRecord = Record<string, unknown>
+type SearchValue = string | number | boolean
+type UrlSearch = Record<string, SearchValue | undefined>
+export type FindingsUrlSearch = UrlSearch
+
+function searchValue(source: SearchRecord, key: string) {
+  const value = source[key]
+  const first = Array.isArray(value) ? value[0] : value
+  if (first == null) return ""
+  return String(first).trim()
+}
+
+function searchRecord(input: unknown): SearchRecord {
+  if (input instanceof URLSearchParams) {
+    return Object.fromEntries(input.entries())
+  }
+  if (typeof input === "string") {
+    return Object.fromEntries(new URLSearchParams(input).entries())
+  }
+  if (input && typeof input === "object") {
+    return input as SearchRecord
+  }
+  return {}
+}
+
+function enumValue<T extends string>(
+  value: string,
+  options: readonly T[],
+  fallback: T,
+): T {
+  return options.includes(value as T) ? (value as T) : fallback
+}
+
+function optionalEnumValue<T extends string>(
+  value: string,
+  options: readonly T[],
+): "" | T {
+  return value && options.includes(value as T) ? (value as T) : ""
+}
+
+function pageSizeValue(value: string): FindingPageSize {
+  const parsed = Number(value)
+  return findingPageSizes.includes(parsed as FindingPageSize)
+    ? (parsed as FindingPageSize)
+    : defaultFindingsSearchState.limit
+}
+
+function offsetValue(value: string) {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed >= 0
+    ? parsed
+    : defaultFindingsSearchState.offset
+}
+
+function numericFilterText(value: string, min: number, max: number) {
+  if (!value) return ""
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? value : ""
+}
+
+export function parseFindingsSearch(input: unknown): FindingsSearchState {
+  const source = searchRecord(input)
+  const assetId = searchValue(source, "assetId")
+  return {
+    ...defaultFindingsSearchState,
+    assetId,
+    assetKey: assetId ? searchValue(source, "assetKey") : "",
+    cvssMax: numericFilterText(searchValue(source, "cvssMax"), 0, 10),
+    cvssMin: numericFilterText(searchValue(source, "cvssMin"), 0, 10),
+    direction: enumValue(
+      searchValue(source, "direction"),
+      directionOptions,
+      defaultFindingsSearchState.direction,
+    ),
+    epssMax: numericFilterText(searchValue(source, "epssMax"), 0, 1),
+    epssMin: numericFilterText(searchValue(source, "epssMin"), 0, 1),
+    exposure: optionalEnumValue<AssetExposure>(
+      searchValue(source, "exposure"),
+      findingExposureOptions,
+    ),
+    kev: optionalEnumValue<KevFilter>(searchValue(source, "kev"), kevOptions),
+    limit: pageSizeValue(searchValue(source, "limit")),
+    offset: offsetValue(searchValue(source, "offset")),
+    ownerService: searchValue(source, "ownerService").slice(0, 200),
+    priority: optionalEnumValue<FindingPriority>(
+      searchValue(source, "priority"),
+      findingPriorityOptions,
+    ),
+    sort: enumValue(
+      searchValue(source, "sort"),
+      sortOptions,
+      defaultFindingsSearchState.sort,
+    ),
+    status: optionalEnumValue<FindingStatus>(
+      searchValue(source, "status"),
+      findingStatusOptions,
+    ),
+  }
+}
+
+function addIfPresent(
+  target: UrlSearch,
+  key: keyof FindingsSearchState,
+  state: FindingsSearchState,
+) {
+  const value = state[key]
+  const defaultValue = defaultFindingsSearchState[key]
+  if (value !== "" && value !== defaultValue) {
+    target[key] = value
+  }
+}
+
+export function findingsSearchToUrlSearch(
+  state: FindingsSearchState,
+): UrlSearch {
+  const normalized = parseFindingsSearch(state)
+  const search: UrlSearch = {
+    assetId: undefined,
+    assetKey: undefined,
+    cvssMax: undefined,
+    cvssMin: undefined,
+    direction: undefined,
+    epssMax: undefined,
+    epssMin: undefined,
+    exposure: undefined,
+    kev: undefined,
+    limit: undefined,
+    offset: undefined,
+    ownerService: undefined,
+    priority: undefined,
+    sort: undefined,
+    status: undefined,
+  }
+  addIfPresent(search, "assetId", normalized)
+  addIfPresent(search, "assetKey", normalized)
+  addIfPresent(search, "ownerService", normalized)
+  addIfPresent(search, "priority", normalized)
+  addIfPresent(search, "status", normalized)
+  addIfPresent(search, "kev", normalized)
+  addIfPresent(search, "exposure", normalized)
+  addIfPresent(search, "epssMin", normalized)
+  addIfPresent(search, "epssMax", normalized)
+  addIfPresent(search, "cvssMin", normalized)
+  addIfPresent(search, "cvssMax", normalized)
+  addIfPresent(search, "sort", normalized)
+  addIfPresent(search, "direction", normalized)
+  addIfPresent(search, "limit", normalized)
+  addIfPresent(search, "offset", normalized)
+  return search
+}
+
+export function findingsSearchQueryString(state: FindingsSearchState) {
+  const params = new URLSearchParams()
+  const search = findingsSearchToUrlSearch(state)
+  for (const [key, value] of Object.entries(search)) {
+    if (value !== undefined) {
+      params.set(key, String(value))
+    }
+  }
+  return params.toString()
+}
+
+export function cleanFindingsSearchQueryString(input: unknown) {
+  const source = searchRecord(input)
+  const parsed = parseFindingsSearch(source)
+  const params = new URLSearchParams()
+  for (const key of searchKeys) {
+    const rawValue = searchValue(source, key)
+    if (!rawValue) {
+      continue
+    }
+    const parsedValue = parsed[key]
+    if (key === "assetKey" && !parsed.assetId) {
+      continue
+    }
+    if (rawValue === String(parsedValue)) {
+      params.set(key, rawValue)
+    }
+  }
+  return params.toString()
+}
+
+export function findingsSearchToFilters(
+  state: FindingsSearchState,
+): FindingFilters {
+  return {
+    cvssMax: state.cvssMax,
+    cvssMin: state.cvssMin,
+    epssMax: state.epssMax,
+    epssMin: state.epssMin,
+    exposure: state.exposure,
+    kev: state.kev,
+    ownerService: state.ownerService,
+    priority: state.priority,
+    status: state.status,
+  }
+}
+
+export function findingsSearchToApiParams(
+  state: FindingsSearchState,
+  projectId: string,
+): FindingsReadProjectFindingsData {
+  const filters = findingsSearchToFilters(state)
+  return {
+    asset_id: state.assetId || undefined,
+    cvss_max: numericApiValue(filters.cvssMax),
+    cvss_min: numericApiValue(filters.cvssMin),
+    direction: state.direction,
+    epss_max: numericApiValue(filters.epssMax),
+    epss_min: numericApiValue(filters.epssMin),
+    exposure: filters.exposure || undefined,
+    kev: filters.kev === "" ? undefined : filters.kev === "true",
+    limit: state.limit,
+    offset: state.offset,
+    owner_service: filters.ownerService.trim() || undefined,
+    priority: filters.priority || undefined,
+    project_id: projectId,
+    sort: state.sort,
+    status: filters.status || undefined,
+  }
+}
+
+export function findingsSearchHasActiveFilters(state: FindingsSearchState) {
+  const filters = findingsSearchToFilters(state)
+  return (
+    Boolean(state.assetId) ||
+    Object.values(filters).some((value) => value.trim() !== "")
+  )
+}
+
+export function updateFindingsSearch(
+  current: FindingsSearchState,
+  patch: Partial<FindingsSearchState>,
+  { resetOffset = true }: { resetOffset?: boolean } = {},
+) {
+  const next = parseFindingsSearch({
+    ...current,
+    ...patch,
+  })
+  return resetOffset ? { ...next, offset: 0 } : next
+}
+
+export function clearFindingsFilters(
+  current: FindingsSearchState,
+  { includeAsset = true }: { includeAsset?: boolean } = {},
+) {
+  return updateFindingsSearch(current, {
+    ...defaultFindingFilters,
+    assetId: includeAsset ? "" : current.assetId,
+    assetKey: includeAsset ? "" : current.assetKey,
+  })
+}
+
+function numericApiValue(value: string) {
+  if (!value.trim()) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}

--- a/frontend/src/components/findings/index.ts
+++ b/frontend/src/components/findings/index.ts
@@ -1,5 +1,20 @@
 export { FindingsDataTable } from "./FindingsDataTable"
 export type { QueueSort } from "./FindingsDataTable"
+export {
+  clearFindingsFilters,
+  defaultFindingsSearchState,
+  findingsSearchHasActiveFilters,
+  findingsSearchQueryString,
+  findingsSearchToApiParams,
+  findingsSearchToFilters,
+  findingsSearchToUrlSearch,
+  parseFindingsSearch,
+  updateFindingsSearch,
+} from "./findings-search-state"
+export type {
+  FindingsSearchState,
+  FindingsUrlSearch,
+} from "./findings-search-state"
 export { RemediationQueue } from "./RemediationQueue"
 export type { RemediationQueueProps } from "./RemediationQueue"
 export { useFindingsRouteState } from "./useFindingsRouteState"

--- a/frontend/src/components/findings/useFindingsRouteState.ts
+++ b/frontend/src/components/findings/useFindingsRouteState.ts
@@ -1,95 +1,105 @@
-import { useState } from "react"
-
-import {
-  defaultFindingFilters,
-  type FindingFilters,
-  type FindingsDirection,
-  type FindingsSort,
-  findingPageSizes,
+import type {
+  FindingFilters,
+  FindingsDirection,
+  FindingsSort,
 } from "@/lib/app-defaults"
+import {
+  clearFindingsFilters,
+  findingsSearchHasActiveFilters,
+  findingsSearchToFilters,
+  type FindingsSearchState,
+  updateFindingsSearch,
+} from "./findings-search-state"
 
 export type UseFindingsRouteStateOptions = {
-  hasAssetFilter: boolean
-  onClearAssetFilter: () => void
-}
-
-function hasActiveFindingFilters(filters: FindingFilters) {
-  return Object.values(filters).some((value) => value.trim() !== "")
-}
-
-function supportedFindingPageSize(size: number) {
-  return findingPageSizes.includes(size as (typeof findingPageSizes)[number])
-    ? (size as (typeof findingPageSizes)[number])
-    : 10
+  onSearchChange: (nextSearch: FindingsSearchState) => void
+  search: FindingsSearchState
 }
 
 export function useFindingsRouteState({
-  hasAssetFilter,
-  onClearAssetFilter,
+  onSearchChange,
+  search,
 }: UseFindingsRouteStateOptions) {
-  const [findingFilters, setFindingFilters] = useState<FindingFilters>(
-    defaultFindingFilters,
-  )
-  const [findingSort, setFindingSort] = useState<FindingsSort>("operational")
-  const [findingDirection, setFindingDirection] =
-    useState<FindingsDirection>("asc")
-  const [findingPageSize, setFindingPageSize] =
-    useState<(typeof findingPageSizes)[number]>(10)
-  const [findingOffset, setFindingOffset] = useState(0)
-  const activeFindingFilters =
-    hasActiveFindingFilters(findingFilters) || hasAssetFilter
+  const findingFilters = findingsSearchToFilters(search)
 
   function updateFindingFilter<Key extends keyof FindingFilters>(
     key: Key,
     value: FindingFilters[Key],
   ) {
-    setFindingOffset(0)
-    setFindingFilters((filters) => ({ ...filters, [key]: value }))
+    onSearchChange(updateFindingsSearch(search, { [key]: value }))
   }
 
   function clearFindingFilters() {
-    setFindingOffset(0)
-    setFindingFilters(defaultFindingFilters)
-    if (hasAssetFilter) {
-      onClearAssetFilter()
-    }
+    onSearchChange(clearFindingsFilters(search))
+  }
+
+  function clearFindingAssetFilter() {
+    onSearchChange(
+      updateFindingsSearch(search, {
+        assetId: "",
+        assetKey: "",
+      }),
+    )
   }
 
   function updateFindingSort(sort: FindingsSort) {
-    setFindingOffset(0)
-    setFindingSort(sort)
+    onSearchChange(updateFindingsSearch(search, { sort }))
   }
 
   function updateFindingDirection(direction: FindingsDirection) {
-    setFindingOffset(0)
-    setFindingDirection(direction)
+    onSearchChange(updateFindingsSearch(search, { direction }))
+  }
+
+  function updateFindingSortDirection(
+    sort: FindingsSort,
+    direction: FindingsDirection,
+  ) {
+    onSearchChange(updateFindingsSearch(search, { direction, sort }))
   }
 
   function updateFindingPageSize(size: number) {
-    setFindingOffset(0)
-    setFindingPageSize(supportedFindingPageSize(size))
+    onSearchChange(
+      updateFindingsSearch(search, {
+        limit: size as FindingsSearchState["limit"],
+      }),
+    )
   }
 
   function nextFindingPage() {
-    setFindingOffset((offset) => offset + findingPageSize)
+    onSearchChange(
+      updateFindingsSearch(
+        search,
+        { offset: search.offset + search.limit },
+        { resetOffset: false },
+      ),
+    )
   }
 
   function previousFindingPage() {
-    setFindingOffset((offset) => Math.max(0, offset - findingPageSize))
+    onSearchChange(
+      updateFindingsSearch(
+        search,
+        { offset: Math.max(0, search.offset - search.limit) },
+        { resetOffset: false },
+      ),
+    )
   }
 
   function resetFindingOffset() {
-    setFindingOffset(0)
+    onSearchChange(
+      updateFindingsSearch(search, { offset: 0 }, { resetOffset: false }),
+    )
   }
 
   return {
-    activeFindingFilters,
+    activeFindingFilters: findingsSearchHasActiveFilters(search),
+    clearFindingAssetFilter,
     clearFindingFilters,
-    findingDirection,
+    findingDirection: search.direction,
     findingFilters,
-    findingOffset,
-    findingPageSize,
-    findingSort,
+    findingOffset: search.offset,
+    findingPageSize: search.limit,
+    findingSort: search.sort,
     nextFindingPage,
     previousFindingPage,
     resetFindingOffset,
@@ -97,6 +107,7 @@ export function useFindingsRouteState({
     updateFindingFilter,
     updateFindingPageSize,
     updateFindingSort,
+    updateFindingSortDirection,
   }
 }
 

--- a/frontend/src/workbench/routes/FindingDetailRoute.tsx
+++ b/frontend/src/workbench/routes/FindingDetailRoute.tsx
@@ -1,16 +1,22 @@
-import { useParams } from "@tanstack/react-router"
+import { useLocation, useParams } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { FindingDetailRoute as FindingDetailPanel } from "../../components/finding-detail/FindingDetailRoute"
 import { apiErrorMessage } from "../../lib/app-errors"
 import type { FindingDetailTab } from "../../lib/app-defaults"
+import {
+  findingsSearchToUrlSearch,
+  parseFindingsSearch,
+} from "../../components/findings/findings-search-state"
 import { useWorkbenchContext } from "../WorkbenchContext"
 import { useFindingDetailQuery } from "../useWorkbenchQueries"
 import { workbenchQueryKeys } from "../workbench-query-keys"
 
 function FindingDetailRouteContainer({ findingId }: { findingId: string }) {
   const queryClient = useQueryClient()
+  const location = useLocation()
   const { setSelectedProjectId } = useWorkbenchContext()
+  const findingsSearch = parseFindingsSearch(location.searchStr)
   const findingDetailQuery = useFindingDetailQuery(findingId)
   const [findingDetailTab, setFindingDetailTab] =
     useState<FindingDetailTab>("evidence")
@@ -43,6 +49,7 @@ function FindingDetailRouteContainer({ findingId }: { findingId: string }) {
         explanation={findingDetailQuery.data?.explanation ?? null}
         explanationWarning={findingDetailQuery.data?.explanationWarning ?? ""}
         finding={findingDetail}
+        findingsBackSearch={findingsSearchToUrlSearch(findingsSearch)}
         loading={findingDetailQuery.isLoading || findingDetailQuery.isFetching}
         onRefresh={refreshFindingDetail}
         onTabChange={setFindingDetailTab}

--- a/frontend/src/workbench/routes/FindingsRoute.tsx
+++ b/frontend/src/workbench/routes/FindingsRoute.tsx
@@ -1,10 +1,16 @@
 import { Outlet, useLocation, useNavigate } from "@tanstack/react-router"
-import type { FindingsReadProjectFindingsData } from "../../api-client"
+import { useEffect } from "react"
 import { RemediationQueue } from "../../components/findings/RemediationQueue"
 import { useFindingsRouteState } from "../../components/findings/useFindingsRouteState"
 import { apiErrorMessage } from "../../lib/app-errors"
 import { useWorkbenchContext } from "../WorkbenchContext"
-import { numericFilterValue } from "../route-utils"
+import {
+  cleanFindingsSearchQueryString,
+  findingsSearchToApiParams,
+  findingsSearchToUrlSearch,
+  parseFindingsSearch,
+  type FindingsSearchState,
+} from "../../components/findings/findings-search-state"
 import {
   useFindingsQuery,
   useProjectSummaryQuery,
@@ -20,11 +26,32 @@ function FindingsRouteContainer() {
     selectedProjectId,
     setSelectedProjectId,
   } = useWorkbenchContext()
-  const findingSearchParams = new URLSearchParams(location.search)
-  const findingAssetId = findingSearchParams.get("assetId")
-  const findingAssetKey = findingSearchParams.get("assetKey")
+  const findingsSearch = parseFindingsSearch(location.searchStr)
+  const cleanedSearch = cleanFindingsSearchQueryString(location.searchStr)
+  const currentSearch = location.searchStr.startsWith("?")
+    ? location.searchStr.slice(1)
+    : location.searchStr
+
+  function updateFindingsSearch(nextSearch: FindingsSearchState) {
+    void navigate({
+      search: findingsSearchToUrlSearch(nextSearch),
+      to: "/findings",
+    })
+  }
+
+  useEffect(() => {
+    if (currentSearch === cleanedSearch) {
+      return
+    }
+    const nextUrl = `${location.pathname}${cleanedSearch ? `?${cleanedSearch}` : ""}${
+      location.hash ? `#${location.hash}` : ""
+    }`
+    window.history.replaceState(window.history.state, "", nextUrl)
+  }, [cleanedSearch, currentSearch, location.hash, location.pathname])
+
   const {
     activeFindingFilters,
+    clearFindingAssetFilter,
     clearFindingFilters,
     findingDirection,
     findingFilters,
@@ -37,32 +64,16 @@ function FindingsRouteContainer() {
     updateFindingDirection,
     updateFindingFilter,
     updateFindingPageSize,
-    updateFindingSort,
+    updateFindingSortDirection,
   } = useFindingsRouteState({
-    hasAssetFilter: Boolean(findingAssetId),
-    onClearAssetFilter: () => {
-      void navigate({ to: "/findings" })
-    },
+    onSearchChange: updateFindingsSearch,
+    search: findingsSearch,
   })
   const projectSummaryQuery = useProjectSummaryQuery(selectedProjectId)
-  const findingsQueryParams: FindingsReadProjectFindingsData = {
-    asset_id: findingAssetId || undefined,
-    cvss_max: numericFilterValue(findingFilters.cvssMax),
-    cvss_min: numericFilterValue(findingFilters.cvssMin),
-    direction: findingDirection,
-    epss_max: numericFilterValue(findingFilters.epssMax),
-    epss_min: numericFilterValue(findingFilters.epssMin),
-    exposure: findingFilters.exposure || undefined,
-    kev:
-      findingFilters.kev === "" ? undefined : findingFilters.kev === "true",
-    limit: findingPageSize,
-    offset: findingOffset,
-    owner_service: findingFilters.ownerService.trim() || undefined,
-    priority: findingFilters.priority || undefined,
-    project_id: selectedProjectId,
-    sort: findingSort,
-    status: findingFilters.status || undefined,
-  }
+  const findingsQueryParams = findingsSearchToApiParams(
+    findingsSearch,
+    selectedProjectId,
+  )
   const findingsQuery = useFindingsQuery(
     findingsQueryParams,
     Boolean(selectedProjectId),
@@ -77,8 +88,8 @@ function FindingsRouteContainer() {
     >
       <RemediationQueue
         activeFindingFilters={activeFindingFilters}
-        findingAssetId={findingAssetId}
-        findingAssetKey={findingAssetKey}
+        findingAssetId={findingsSearch.assetId || null}
+        findingAssetKey={findingsSearch.assetKey || null}
         findingCount={findingCount}
         findingDirection={findingDirection}
         findingFilters={findingFilters}
@@ -92,6 +103,8 @@ function FindingsRouteContainer() {
             : ""
         }
         findingsLoading={findingsQuery.isLoading || findingsQuery.isFetching}
+        findingSearch={findingsSearchToUrlSearch(findingsSearch)}
+        onClearAssetFilter={clearFindingAssetFilter}
         onClearFilters={clearFindingFilters}
         onDirectionChange={updateFindingDirection}
         onFilterChange={updateFindingFilter}
@@ -102,7 +115,7 @@ function FindingsRouteContainer() {
           resetFindingOffset()
           setSelectedProjectId(id)
         }}
-        onSortChange={updateFindingSort}
+        onSortDirectionChange={updateFindingSortDirection}
         projectListLoading={projectListLoading}
         projectSummary={projectSummaryQuery.data ?? null}
         projects={projects}

--- a/frontend/tests/findings-route-integration.spec.ts
+++ b/frontend/tests/findings-route-integration.spec.ts
@@ -104,3 +104,142 @@ test("findings table owns horizontal scroll without page overflow", async ({
   expect(metrics.regionScrollWidth).toBeGreaterThan(metrics.regionClientWidth)
   expect(metrics.regionScrollLeft).toBeGreaterThan(0)
 })
+
+test("findings URL search state survives reload and drives API params", async ({
+  page,
+}) => {
+  const requests: URL[] = []
+  const findings = Array.from({ length: 12 }, (_, index) => ({
+    ...mockFinding,
+    cve_id: `CVE-2024-${3100 + index}`,
+    id: `finding-${index}`,
+    risk_score: 10 - index / 10,
+    vulnerability_id: `CVE-2024-${3100 + index}`,
+  }))
+  await routeWorkbenchShell(page, {
+    findings,
+    onFindingsRequest: (url) => requests.push(url),
+    projects: [mockProject],
+  })
+
+  await page.goto(
+    "/findings?assetId=asset-1&assetKey=build-host-1&ownerService=payments&priority=critical&status=open&kev=true&exposure=internet-facing&epssMin=0.7&cvssMin=9&sort=score&direction=desc&limit=10&offset=10",
+  )
+
+  await expect(page.getByLabel("Owner / Service")).toHaveValue("payments")
+  await expect(page.getByRole("combobox", { name: "Priority" })).toContainText(
+    "Critical",
+  )
+  await expect(page.getByRole("combobox", { name: "Status" })).toContainText(
+    "Open",
+  )
+  await expect(page.getByText("build-host-1", { exact: true })).toBeVisible()
+  await expect(page.getByLabel("EPSS min")).toHaveValue("0.7")
+  await expect(page.getByLabel("CVSS min")).toHaveValue("9")
+  await expect(
+    page.getByRole("table", { name: "Findings remediation queue" }),
+  ).toBeVisible()
+
+  await expect.poll(() => requests.at(-1)?.searchParams.get("asset_id")).toBe(
+    "asset-1",
+  )
+  const lastRequest = requests.at(-1)
+  expect(lastRequest?.searchParams.get("owner_service")).toBe("payments")
+  expect(lastRequest?.searchParams.get("priority")).toBe("critical")
+  expect(lastRequest?.searchParams.get("status")).toBe("open")
+  expect(lastRequest?.searchParams.get("kev")).toBe("true")
+  expect(lastRequest?.searchParams.get("exposure")).toBe("internet-facing")
+  expect(lastRequest?.searchParams.get("epss_min")).toBe("0.7")
+  expect(lastRequest?.searchParams.get("cvss_min")).toBe("9")
+  expect(lastRequest?.searchParams.get("sort")).toBe("score")
+  expect(lastRequest?.searchParams.get("direction")).toBe("desc")
+  expect(lastRequest?.searchParams.get("limit")).toBe("10")
+  expect(lastRequest?.searchParams.get("offset")).toBe("10")
+
+  await page.reload()
+
+  await expect(page.getByLabel("Owner / Service")).toHaveValue("payments")
+  await expect(page).toHaveURL(/ownerService=payments/)
+  await expect.poll(() => requests.at(-1)?.searchParams.get("offset")).toBe(
+    "10",
+  )
+})
+
+test("findings controls update canonical URLs and preserve detail back context", async ({
+  page,
+}) => {
+  const requests: URL[] = []
+  const findings = Array.from({ length: 12 }, (_, index) => ({
+    ...mockFinding,
+    cve_id: `CVE-2024-${3200 + index}`,
+    id: `finding-${index}`,
+    risk_score: 10 - index / 10,
+    vulnerability_id: `CVE-2024-${3200 + index}`,
+  }))
+  await routeWorkbenchShell(page, {
+    findings,
+    onFindingsRequest: (url) => requests.push(url),
+    projects: [mockProject],
+  })
+
+  await page.goto("/findings?assetId=asset-1&assetKey=build-host-1")
+  await page.getByRole("button", { name: "Clear asset filter" }).click()
+  await expect(page).not.toHaveURL(/assetId=/)
+
+  await page.getByRole("combobox", { name: "Priority" }).click()
+  await page.getByRole("option", { name: "Critical" }).click()
+  await expect(page).toHaveURL(/priority=critical/)
+  await expect.poll(() => requests.at(-1)?.searchParams.get("priority")).toBe(
+    "critical",
+  )
+
+  await page.getByRole("button", { name: /Sort by Score/ }).click()
+  await expect(page).toHaveURL(/sort=score/)
+  await expect(page).toHaveURL(/direction=desc/)
+  await expect.poll(() => requests.at(-1)?.searchParams.get("sort")).toBe(
+    "score",
+  )
+
+  await page.getByRole("button", { name: "Next" }).click()
+  await expect(page).toHaveURL(/offset=10/)
+  await expect.poll(() => requests.at(-1)?.searchParams.get("offset")).toBe(
+    "10",
+  )
+
+  await page.getByRole("link", { name: "CVE-2024-3210" }).click()
+  await expect(page).toHaveURL(/\/findings\/finding-10\?/)
+  await expect(page).toHaveURL(/priority=critical/)
+  await page.getByRole("link", { name: "Back to Findings" }).click()
+  await expect(page).toHaveURL(/\/findings\?/)
+  await expect(page).toHaveURL(/priority=critical/)
+  await expect(page).toHaveURL(/sort=score/)
+  await expect(page).toHaveURL(/offset=10/)
+})
+
+test("invalid findings URL params are normalized before API requests", async ({
+  page,
+}) => {
+  const requests: URL[] = []
+  await routeWorkbenchShell(page, {
+    findings: [mockFinding],
+    onFindingsRequest: (url) => requests.push(url),
+    projects: [mockProject],
+  })
+
+  await page.goto(
+    "/findings?sort=invalid&direction=sideways&limit=999&offset=-5&priority=urgent&epssMin=nope&cvssMax=42&assetKey=orphan",
+  )
+
+  await expect(page).toHaveURL(/\/findings$/)
+  await expect.poll(() => requests.at(-1)?.searchParams.get("sort")).toBe(
+    "operational",
+  )
+  const lastRequest = requests.at(-1)
+  expect(lastRequest?.searchParams.get("direction")).toBe("asc")
+  expect(lastRequest?.searchParams.get("limit")).toBe("10")
+  expect(lastRequest?.searchParams.get("offset")).toBe("0")
+  expect(lastRequest?.searchParams.has("priority")).toBe(false)
+  expect(lastRequest?.searchParams.has("epss_min")).toBe(false)
+  expect(lastRequest?.searchParams.has("cvss_max")).toBe(false)
+  expect(lastRequest?.searchParams.has("asset_id")).toBe(false)
+})

--- a/frontend/tests/findings-search-state.test.ts
+++ b/frontend/tests/findings-search-state.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  clearFindingsFilters,
+  defaultFindingsSearchState,
+  findingsSearchQueryString,
+  findingsSearchToApiParams,
+  findingsSearchToFilters,
+  findingsSearchToUrlSearch,
+  parseFindingsSearch,
+  updateFindingsSearch,
+} from "../src/components/findings/findings-search-state.ts"
+
+function definedSearch(search: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(search).filter((entry) => entry[1] !== undefined),
+  )
+}
+
+test("findings search parser validates invalid URL params back to defaults", () => {
+  const state = parseFindingsSearch({
+    assetKey: "ignored-without-asset",
+    cvssMax: "42",
+    direction: "sideways",
+    epssMin: "not-a-number",
+    kev: "maybe",
+    limit: "999",
+    offset: "-1",
+    priority: "urgent",
+    sort: "unknown",
+    status: "todo",
+  })
+
+  assert.deepEqual(state, defaultFindingsSearchState)
+  assert.equal(findingsSearchQueryString(state), "")
+})
+
+test("findings search state serializes only shareable non-default params", () => {
+  const state = parseFindingsSearch({
+    assetId: "asset-1",
+    assetKey: "payments-api",
+    cvssMin: "7.5",
+    direction: "desc",
+    epssMax: "0.9",
+    exposure: "internet-facing",
+    kev: "true",
+    limit: "25",
+    offset: "50",
+    ownerService: "platform",
+    priority: "critical",
+    sort: "score",
+    status: "open",
+  })
+
+  assert.deepEqual(definedSearch(findingsSearchToUrlSearch(state)), {
+    assetId: "asset-1",
+    assetKey: "payments-api",
+    ownerService: "platform",
+    priority: "critical",
+    status: "open",
+    kev: "true",
+    exposure: "internet-facing",
+    epssMax: "0.9",
+    cvssMin: "7.5",
+    sort: "score",
+    direction: "desc",
+    limit: 25,
+    offset: 50,
+  })
+  assert.equal(
+    findingsSearchQueryString(state),
+    "assetId=asset-1&assetKey=payments-api&cvssMin=7.5&direction=desc&epssMax=0.9&exposure=internet-facing&kev=true&limit=25&offset=50&ownerService=platform&priority=critical&sort=score&status=open",
+  )
+})
+
+test("findings search maps URL state to generated findings API params", () => {
+  const state = parseFindingsSearch({
+    assetId: "asset-1",
+    cvssMax: "9.8",
+    cvssMin: "4",
+    direction: "desc",
+    epssMin: "0.7",
+    kev: "false",
+    ownerService: "payments",
+    priority: "high",
+    sort: "epss",
+  })
+
+  assert.deepEqual(findingsSearchToFilters(state), {
+    cvssMax: "9.8",
+    cvssMin: "4",
+    epssMax: "",
+    epssMin: "0.7",
+    exposure: "",
+    kev: "false",
+    ownerService: "payments",
+    priority: "high",
+    status: "",
+  })
+  assert.deepEqual(findingsSearchToApiParams(state, "project-1"), {
+    asset_id: "asset-1",
+    cvss_max: 9.8,
+    cvss_min: 4,
+    direction: "desc",
+    epss_max: undefined,
+    epss_min: 0.7,
+    exposure: undefined,
+    kev: false,
+    limit: 10,
+    offset: 0,
+    owner_service: "payments",
+    priority: "high",
+    project_id: "project-1",
+    sort: "epss",
+    status: undefined,
+  })
+})
+
+test("findings search updates reset paging except explicit page movement", () => {
+  const state = parseFindingsSearch({
+    limit: "25",
+    offset: "50",
+    priority: "critical",
+  })
+
+  assert.equal(updateFindingsSearch(state, { status: "open" }).offset, 0)
+  assert.equal(
+    updateFindingsSearch(state, { offset: 75 }, { resetOffset: false }).offset,
+    75,
+  )
+  assert.deepEqual(clearFindingsFilters(state), {
+    ...defaultFindingsSearchState,
+    limit: 25,
+    sort: "operational",
+  })
+})

--- a/frontend/tests/workbench-route-mocks.ts
+++ b/frontend/tests/workbench-route-mocks.ts
@@ -40,6 +40,7 @@ type MockFinding = {
 
 type RouteWorkbenchShellOptions = {
   findings?: MockFinding[]
+  onFindingsRequest?: (url: URL) => void
   projects?: MockProject[]
 }
 
@@ -65,7 +66,7 @@ export const mockFinding: MockFinding = {
   cve_id: "CVE-2024-3094",
   cvss_base_score: 10,
   epss: 0.92,
-  exposure: "internet_facing",
+  exposure: "internet-facing",
   first_seen_at: "2025-01-01T00:00:00Z",
   id: "finding-1",
   in_kev: true,
@@ -87,6 +88,7 @@ export async function routeWorkbenchShell(
 ) {
   const projects = options.projects ?? []
   const findings = options.findings ?? []
+  const onFindingsRequest = options.onFindingsRequest
   await page.addInitScript(() => {
     // biome-ignore lint/suspicious/noDocumentCookie: Playwright sets a mock readable CSRF cookie before app boot.
     document.cookie = "vpw_csrf_token=mock-csrf; Path=/; SameSite=Strict"
@@ -143,6 +145,49 @@ export async function routeWorkbenchShell(
       body: JSON.stringify({ status: "ok" }),
     }),
   )
+  await page.route("**/api/v1/findings/*/explain", (route) => {
+    const findingId = route.request().url().split("/findings/")[1].split("/")[0]
+    const finding = findings.find((item) => item.id === findingId)
+    if (!finding) {
+      return route.fulfill({
+        contentType: "application/json",
+        status: 404,
+        body: JSON.stringify({ detail: "Finding not found" }),
+      })
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        cve_id: finding.cve_id,
+        finding_id: finding.id,
+        priority: finding.priority,
+        priority_rank: 0,
+        project_id: finding.project_id,
+        rationale: finding.rationale,
+        recommended_action: finding.recommended_action,
+        risk_score: finding.risk_score,
+      }),
+    })
+  })
+  await page.route("**/api/v1/findings/*", (route) => {
+    const findingId = route.request().url().split("/findings/")[1].split("?")[0]
+    const finding = findings.find((item) => item.id === findingId)
+    if (!finding) {
+      return route.fulfill({
+        contentType: "application/json",
+        status: 404,
+        body: JSON.stringify({ detail: "Finding not found" }),
+      })
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...finding,
+        attack_context: null,
+        occurrences: [],
+      }),
+    })
+  })
   await page.route("**/api/v1/projects/", (route) =>
     route.fulfill({
       contentType: "application/json",
@@ -187,7 +232,7 @@ export async function routeWorkbenchShell(
               internet_facing_criticals: findings.filter(
                 (finding) =>
                   finding.priority === "critical" &&
-                  finding.exposure === "internet_facing",
+                  finding.exposure === "internet-facing",
               ).length,
               epss_buckets: {
                 low: findings.filter(
@@ -222,10 +267,116 @@ export async function routeWorkbenchShell(
       }),
     )
     await page.route(`**/api/v1/projects/${project.id}/findings/?*`, (route) =>
-      route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify({ data: findings, count: findings.length }),
-      }),
+      {
+        const url = new URL(route.request().url())
+        onFindingsRequest?.(url)
+        const { data, count } = mockFindingsPage(findings, url)
+        return route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ data, count }),
+        })
+      },
     )
+  }
+}
+
+function numericParam(url: URL, key: string) {
+  const value = url.searchParams.get(key)
+  if (!value) return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function boolParam(url: URL, key: string) {
+  const value = url.searchParams.get(key)
+  if (value === "true") return true
+  if (value === "false") return false
+  return null
+}
+
+function compareNumber(
+  a: number | null | undefined,
+  b: number | null | undefined,
+  direction: string,
+) {
+  const aValue = a ?? Number.NEGATIVE_INFINITY
+  const bValue = b ?? Number.NEGATIVE_INFINITY
+  return direction === "asc" ? aValue - bValue : bValue - aValue
+}
+
+function compareText(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  direction: string,
+) {
+  const compared = String(a ?? "").localeCompare(String(b ?? ""), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  })
+  return direction === "asc" ? compared : -compared
+}
+
+function mockFindingsPage(findings: MockFinding[], url: URL) {
+  const priority = url.searchParams.get("priority")
+  const status = url.searchParams.get("status")
+  const exposure = url.searchParams.get("exposure")
+  const ownerService = url.searchParams.get("owner_service")?.trim().toLowerCase()
+  const kev = boolParam(url, "kev")
+  const assetId = url.searchParams.get("asset_id")
+  const epssMin = numericParam(url, "epss_min")
+  const epssMax = numericParam(url, "epss_max")
+  const cvssMin = numericParam(url, "cvss_min")
+  const cvssMax = numericParam(url, "cvss_max")
+  const sort = url.searchParams.get("sort") ?? "operational"
+  const direction = url.searchParams.get("direction") ?? "asc"
+  const offset = numericParam(url, "offset") ?? 0
+  const limit = numericParam(url, "limit") ?? 100
+  const filtered = findings.filter((finding) => {
+    if (priority && finding.priority !== priority) return false
+    if (status && finding.status !== status) return false
+    if (exposure && finding.exposure !== exposure) return false
+    if (kev !== null && finding.in_kev !== kev) return false
+    if (assetId && finding.asset_id !== assetId) return false
+    if (
+      ownerService &&
+      !`${finding.owner} ${finding.business_service}`
+        .toLowerCase()
+        .includes(ownerService)
+    ) {
+      return false
+    }
+    if (epssMin !== null && finding.epss < epssMin) return false
+    if (epssMax !== null && finding.epss > epssMax) return false
+    if (cvssMin !== null && finding.cvss_base_score < cvssMin) return false
+    if (cvssMax !== null && finding.cvss_base_score > cvssMax) return false
+    return true
+  })
+  const sorted = [...filtered].sort((a, b) => {
+    switch (sort) {
+      case "score":
+        return compareNumber(a.risk_score, b.risk_score, direction)
+      case "epss":
+        return compareNumber(a.epss, b.epss, direction)
+      case "cvss":
+        return compareNumber(a.cvss_base_score, b.cvss_base_score, direction)
+      case "priority":
+        return compareText(a.priority, b.priority, direction)
+      case "status":
+        return compareText(a.status, b.status, direction)
+      case "cve":
+        return compareText(a.cve_id, b.cve_id, direction)
+      case "component":
+        return compareText(a.component_name, b.component_name, direction)
+      case "owner":
+        return compareText(a.owner, b.owner, direction)
+      case "last_seen":
+        return compareText(a.last_seen_at, b.last_seen_at, direction)
+      default:
+        return 0
+    }
+  })
+  return {
+    count: sorted.length,
+    data: sorted.slice(offset, offset + limit),
   }
 }


### PR DESCRIPTION
## Summary
- Add a typed Findings search-state codec for filters, sort, direction, page size, offset, and asset context.
- Drive the Findings route from URL state instead of local hook state, including safe invalid-param cleanup and offset resets on state-changing controls.
- Preserve Findings search context when opening a finding detail and returning with "Back to Findings".
- Expand route mocks and Playwright coverage to assert URL state, API params, reload behavior, asset clearing, paging, sorting, and invalid-param normalization.

## Evidence
Before URL example: `/findings` lost local filter/sort/page state on reload and share.
After filtered/paged URL example:
`/findings?assetId=asset-1&assetKey=build-host-1&ownerService=payments&priority=critical&status=open&kev=true&exposure=internet-facing&epssMin=0.7&cvssMin=9&sort=score&direction=desc&limit=10&offset=10`

Invalid URL example normalized before API use:
`/findings?sort=invalid&direction=sideways&limit=999&offset=-5&priority=urgent&epssMin=nope&cvssMax=42&assetKey=orphan` -> `/findings` with default API params.

## Validation
- `npm --prefix frontend run test:unit` -> 31 passed
- `npm --prefix frontend run test -- tests/findings-route-integration.spec.ts --project=chromium` -> 6 passed
- `make frontend-build` -> passed
- `npm --prefix frontend run lint` -> passed
- `git diff --check` -> passed

## Residual Risk
- No known residual risk for the scoped URL-state behavior. Broader Findings dialog/table regression depth remains tracked by VPW-AUD-204.

Closes #406
