### PR TITLE
[VPW-AUD-205] Make disabled and busy controls distinct

### DIFF
--- a/frontend/src/components/assets/AssetContextForm.tsx
+++ b/frontend/src/components/assets/AssetContextForm.tsx
@@ -32,6 +32,7 @@ import type {
 import { formatLabel as labelize } from "../../lib/ui-copy"
 
 export function AssetForm({
+  busy = false,
   buttonLabel,
   disabled,
   error,
@@ -40,6 +41,7 @@ export function AssetForm({
   onChange,
   onSubmit,
 }: {
+  busy?: boolean
   buttonLabel: string
   disabled: boolean
   error: string
@@ -205,7 +207,7 @@ export function AssetForm({
           {error}
         </VpwStatusBanner>
       ) : null}
-      <Button disabled={disabled} type="submit">
+      <Button aria-busy={busy} disabled={disabled} type="submit">
         {buttonLabel}
       </Button>
     </form>
@@ -265,6 +267,7 @@ export function AssetContextForms({
               />
             </VpwField>
             <Button
+              aria-busy={assetActionLoading}
               disabled={
                 assetActionLoading || projectCount === 0 || !assetContextFile
               }
@@ -297,6 +300,7 @@ export function AssetContextForms({
           title="Create asset"
         />
         <AssetForm
+          busy={assetActionLoading}
           buttonLabel="Create Asset"
           disabled={assetActionLoading || projectCount === 0}
           error={createError}

--- a/frontend/src/components/assets/AssetLinkedFindingsPanel.tsx
+++ b/frontend/src/components/assets/AssetLinkedFindingsPanel.tsx
@@ -118,6 +118,7 @@ export function AssetLinkedFindingsPanel({
               Edit context
             </Button>
             <Button
+              aria-busy={assetActionLoading}
               disabled={
                 assetActionLoading || (selectedAsset.finding_count ?? 0) === 0
               }
@@ -195,6 +196,7 @@ export function AssetLinkedFindingsPanel({
                 title="Edit selected asset"
               />
               <AssetForm
+                busy={assetActionLoading}
                 buttonLabel="Save Asset"
                 disabled={assetActionLoading}
                 error={editError}

--- a/frontend/src/components/imports/ImportsWorkbench.tsx
+++ b/frontend/src/components/imports/ImportsWorkbench.tsx
@@ -316,6 +316,7 @@ function ImportWizard({
               </VpwStatusBanner>
             ) : null}
             <Button
+              aria-busy={importLoading}
               disabled={importLoading || projects.length === 0}
               type="submit"
             >

--- a/frontend/src/components/projects/ProjectsWorkbench.tsx
+++ b/frontend/src/components/projects/ProjectsWorkbench.tsx
@@ -335,7 +335,11 @@ function CreateProjectPanel({
               value={createProjectForm.description}
             />
           </VpwField>
-          <Button disabled={projectActionLoading} type="submit">
+          <Button
+            aria-busy={projectActionLoading}
+            disabled={projectActionLoading}
+            type="submit"
+          >
             <Plus aria-hidden="true" />
             {projectActionLoading ? "Creating project" : "Create project"}
           </Button>
@@ -726,7 +730,11 @@ function ActiveProjectPanel({
             />
           </VpwField>
           <VpwToolbarGroup>
-            <Button disabled={projectActionLoading} type="submit">
+            <Button
+              aria-busy={projectActionLoading}
+              disabled={projectActionLoading}
+              type="submit"
+            >
               Save project
             </Button>
             <Button
@@ -757,6 +765,7 @@ function ActiveProjectPanel({
             </span>
           </label>
           <Button
+            aria-busy={projectActionLoading}
             disabled={projectActionLoading || !deleteConfirmed}
             onClick={() => onDeleteProject(selectedProject)}
             type="button"

--- a/frontend/src/components/providers/ProvidersWorkbench.tsx
+++ b/frontend/src/components/providers/ProvidersWorkbench.tsx
@@ -368,7 +368,6 @@ export function ProvidersWorkbench({
             <VpwToolbarGroup>
               <Button
                 aria-busy={providerStatusLoading}
-                className="disabled:bg-[var(--vpw-blue)] disabled:text-white disabled:opacity-100"
                 disabled={providerStatusLoading}
                 onClick={onRefreshProviderStatus}
                 type="button"

--- a/frontend/src/components/reports/EvidenceCenter.tsx
+++ b/frontend/src/components/reports/EvidenceCenter.tsx
@@ -394,6 +394,7 @@ function ArtifactSection({
             <VpwEvidenceArtifactCard
               actionLabel={isActive ? "Generating..." : card.actionLabel}
               audience={card.audience}
+              busy={isActive}
               description={card.description}
               disabled={!reportActionsEnabled || isActive}
               format={card.format}
@@ -546,6 +547,9 @@ function ReportHistory({
           {report.format === "zip" && !isDemo ? (
             <Button
               aria-label={`Verify ${report.filename}`}
+              aria-busy={
+                verificationLoading && verificationReportTarget?.id === report.id
+              }
               disabled={
                 verificationLoading && verificationReportTarget?.id === report.id
               }

--- a/frontend/src/components/settings/SettingsWorkbench.tsx
+++ b/frontend/src/components/settings/SettingsWorkbench.tsx
@@ -358,6 +358,7 @@ export function SettingsWorkbench({
       cell: (token) =>
         token.active ? (
           <Button
+            aria-busy={apiTokenActionLoading}
             disabled={apiTokenActionLoading}
             onClick={() => void onRevokeApiToken(token)}
             size="sm"
@@ -665,6 +666,7 @@ export function SettingsWorkbench({
               </VpwField>
 
               <Button
+                aria-busy={apiTokenActionLoading}
                 disabled={
                   apiTokenActionLoading ||
                   (!tokenHasAdminScope && apiTokenProjectOptions.length === 0)

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--vpw-radius-md)] text-sm font-medium outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-100 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--vpw-radius-md)] text-sm font-medium outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-100 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/frontend/src/components/vpw/VpwEvidenceArtifactCard.tsx
+++ b/frontend/src/components/vpw/VpwEvidenceArtifactCard.tsx
@@ -14,6 +14,7 @@ export type VpwEvidenceArtifactCardProps = {
   description: string
   actionLabel: string
   actionType?: "button" | "submit" | "reset"
+  busy?: boolean
   className?: string
   disabled?: boolean
   icon?: ReactNode
@@ -24,6 +25,7 @@ export function VpwEvidenceArtifactCard({
   actionLabel,
   actionType = "button",
   audience,
+  busy = false,
   className,
   description,
   disabled = false,
@@ -53,6 +55,7 @@ export function VpwEvidenceArtifactCard({
           {description}
         </p>
         <Button
+          aria-busy={busy}
           className="mt-auto w-full"
           disabled={disabled}
           onClick={onAction}

--- a/frontend/src/components/waivers/WaiversWorkbench.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbench.tsx
@@ -395,6 +395,7 @@ export function WaiversWorkbench({
           ) : null}
           {waiver.status !== "expired" ? (
             <Button
+              aria-busy={waiverActionLoading}
               disabled={waiverActionLoading}
               onClick={() => onExpireWaiver(waiver)}
               size="sm"
@@ -675,6 +676,7 @@ export function WaiversWorkbench({
               </VpwGrid>
               <div className="flex flex-wrap gap-2">
                 <Button
+                  aria-busy={waiverActionLoading}
                   disabled={
                     waiverActionLoading ||
                     projectListLoading ||

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -62,13 +62,19 @@
   --vpw-bg-success: #ecfdf5;
   --vpw-bg-warning: #fffbeb;
   --vpw-bg-critical: #fef2f2;
+  --vpw-bg-disabled: #e2e8f0;
+  --vpw-bg-busy: #e0f2fe;
 
   --vpw-text-primary: #0b1220;
   --vpw-text-secondary: #4b5563;
   --vpw-text-muted: #64748b;
+  --vpw-text-disabled: #334155;
+  --vpw-text-busy: #075985;
   --vpw-border-default: #e5e7eb;
   --vpw-border-subtle: #eef2f7;
   --vpw-border-strong: #d1d5db;
+  --vpw-border-disabled: #94a3b8;
+  --vpw-border-busy: #38bdf8;
   --vpw-focus-ring: #3b82f6;
 
   --vpw-blue: #2563eb;

--- a/frontend/src/styles/vpw-components.css
+++ b/frontend/src/styles/vpw-components.css
@@ -164,3 +164,32 @@
     text-align: center;
   }
 }
+
+[data-slot="button"]:disabled,
+[data-slot="button"][aria-disabled="true"] {
+  border-color: var(--vpw-border-disabled);
+  background: var(--vpw-bg-disabled);
+  color: var(--vpw-text-disabled);
+  box-shadow: none;
+  opacity: 1;
+}
+
+[data-slot="button"]:disabled svg,
+[data-slot="button"][aria-disabled="true"] svg {
+  color: currentColor;
+  opacity: 0.72;
+}
+
+[data-slot="button"][aria-busy="true"] {
+  border-color: var(--vpw-border-busy);
+  background: var(--vpw-bg-busy);
+  color: var(--vpw-text-busy);
+  box-shadow: none;
+  cursor: wait;
+  opacity: 1;
+}
+
+[data-slot="button"][aria-busy="true"] svg {
+  color: currentColor;
+  opacity: 1;
+}

--- a/frontend/tests/control-states.spec.ts
+++ b/frontend/tests/control-states.spec.ts
@@ -1,0 +1,117 @@
+import { expect, type Locator, test } from "@playwright/test"
+import { evidenceScreenshotPath } from "./evidence-paths"
+import { mockFinding, mockProject, routeWorkbenchShell } from "./workbench-route-mocks"
+
+async function expectButtonStateTokens(
+  button: Locator,
+  tokens: { background: string; border: string; text: string },
+) {
+  const colors = await button.evaluate((element, tokenNames) => {
+    const rootStyle = window.getComputedStyle(document.documentElement)
+    const buttonStyle = window.getComputedStyle(element)
+    const probe = document.createElement("span")
+    document.body.append(probe)
+
+    probe.style.backgroundColor = rootStyle
+      .getPropertyValue(tokenNames.background)
+      .trim()
+    const expectedBackground = window.getComputedStyle(probe).backgroundColor
+
+    probe.style.borderTopColor = rootStyle
+      .getPropertyValue(tokenNames.border)
+      .trim()
+    const expectedBorder = window.getComputedStyle(probe).borderTopColor
+
+    probe.style.color = rootStyle.getPropertyValue(tokenNames.text).trim()
+    const expectedText = window.getComputedStyle(probe).color
+
+    probe.remove()
+
+    return {
+      background: buttonStyle.backgroundColor,
+      border: buttonStyle.borderTopColor,
+      expectedBackground,
+      expectedBorder,
+      expectedText,
+      text: buttonStyle.color,
+    }
+  }, tokens)
+
+  expect(colors.background).toBe(colors.expectedBackground)
+  expect(colors.border).toBe(colors.expectedBorder)
+  expect(colors.text).toBe(colors.expectedText)
+}
+
+test("shared controls show distinct default, outline, ghost, icon, and disabled states", async ({
+  page,
+}) => {
+  await page.setViewportSize({ height: 1000, width: 1440 })
+  await routeWorkbenchShell(page, {
+    findings: [mockFinding],
+    projects: [mockProject],
+  })
+
+  await page.goto("/findings")
+  await expect(
+    page.getByRole("table", { name: "Findings remediation queue" }),
+  ).toBeVisible()
+
+  await expect(
+    page.getByRole("link", { name: /Generate evidence/ }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("link", { name: /Import findings/ }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("button", { name: `Quick view ${mockFinding.cve_id}` }),
+  ).toBeVisible()
+
+  const resetButton = page.getByRole("button", { name: "Reset" })
+  await expect(resetButton).toBeDisabled()
+  await expectButtonStateTokens(resetButton, {
+    background: "--vpw-bg-disabled",
+    border: "--vpw-border-disabled",
+    text: "--vpw-text-disabled",
+  })
+
+  await page.screenshot({
+    fullPage: true,
+    path: evidenceScreenshotPath(
+      "ui-productization",
+      "screenshots",
+      "vpw-aud-205-button-states-findings-1440.png",
+    ),
+  })
+})
+
+test("shared controls show tokenized busy state separately from disabled", async ({
+  page,
+}) => {
+  await page.setViewportSize({ height: 1000, width: 1440 })
+  await routeWorkbenchShell(page, {
+    providerStatusDelayMs: 3_000,
+    projects: [mockProject],
+  })
+
+  await page.goto("/providers")
+  const refreshButton = page
+    .getByLabel("Provider actions")
+    .getByRole("button", { name: "Refresh providers" })
+  await expect(refreshButton).toBeVisible()
+  await expect(refreshButton).toBeDisabled()
+  await expect(refreshButton).toHaveAttribute("aria-busy", "true")
+  await expectButtonStateTokens(refreshButton, {
+    background: "--vpw-bg-busy",
+    border: "--vpw-border-busy",
+    text: "--vpw-text-busy",
+  })
+
+  await page.screenshot({
+    fullPage: true,
+    path: evidenceScreenshotPath(
+      "ui-productization",
+      "screenshots",
+      "vpw-aud-205-button-busy-providers-1440.png",
+    ),
+  })
+})

--- a/frontend/tests/workbench-route-mocks.ts
+++ b/frontend/tests/workbench-route-mocks.ts
@@ -42,6 +42,7 @@ type RouteWorkbenchShellOptions = {
   findings?: MockFinding[]
   findingsDelayMs?: number
   onFindingsRequest?: (url: URL) => void
+  providerStatusDelayMs?: number
   projects?: MockProject[]
 }
 
@@ -91,6 +92,7 @@ export async function routeWorkbenchShell(
   const findings = options.findings ?? []
   const findingsDelayMs = options.findingsDelayMs ?? 0
   const onFindingsRequest = options.onFindingsRequest
+  const providerStatusDelayMs = options.providerStatusDelayMs ?? 0
   await page.addInitScript(() => {
     // biome-ignore lint/suspicious/noDocumentCookie: Playwright sets a mock readable CSRF cookie before app boot.
     document.cookie = "vpw_csrf_token=mock-csrf; Path=/; SameSite=Strict"
@@ -122,8 +124,11 @@ export async function routeWorkbenchShell(
       }),
     }),
   )
-  await page.route("**/api/v1/providers/status", (route) =>
-    route.fulfill({
+  await page.route("**/api/v1/providers/status", async (route) => {
+    if (providerStatusDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, providerStatusDelayMs))
+    }
+    return route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
         status: "ok",
@@ -139,8 +144,8 @@ export async function routeWorkbenchShell(
         },
         sources: [],
       }),
-    }),
-  )
+    })
+  })
   await page.route("**/api/v1/utils/health-check/", (route) =>
     route.fulfill({
       contentType: "application/json",


### PR DESCRIPTION
## Summary
- Adds VPW disabled and busy button tokens plus shared `data-slot="button"` state styling.
- Removes the Providers local disabled override that made a busy button look active.
- Marks mutating frontend actions with `aria-busy` so busy and unavailable-disabled states render distinctly.
- Adds a Playwright state/evidence spec with screenshots for default, outline, ghost, icon, disabled, and busy states.

VPW ID: VPW-AUD-205
Disposition: gap -> verified-shipped after merge
Closes #408

## Validation
- `npm --prefix frontend run lint` -> passed
- `npm --prefix frontend run test:unit` -> 31 passed
- `npm --prefix frontend run test -- tests/control-states.spec.ts --project=chromium` -> 2 passed
- `npm --prefix frontend run test -- tests/accessibility.spec.ts --project=chromium` -> 5 passed
- `make frontend-build` -> passed
- `make playwright-check` -> 15 passed
- `git diff --check` -> passed

## Evidence
- `frontend/test-results/evidence/ui-productization/screenshots/vpw-aud-205-button-states-findings-1440.png`
- `frontend/test-results/evidence/ui-productization/screenshots/vpw-aud-205-button-busy-providers-1440.png`

## Residual Risk
- No known residual risk. Screenshots are local ignored Playwright artifacts and contain no secrets, tokens, cookies, customer data, or private paths.
