### PR TITLE
[VPW-AUD-299] Add Frontend/UI audit scorecard

### DIFF
--- a/archive/vpw-evidence/vpw-aud-299-frontend-ui-scorecard.md
+++ b/archive/vpw-evidence/vpw-aud-299-frontend-ui-scorecard.md
@@ -1,0 +1,106 @@
+# VPW-AUD-299 Frontend/UI 10/10 Scorecard
+
+Date: 2026-05-07
+
+## Decision
+
+Frontend/UI category score: 10/10.
+
+The category is ready for the final audit scorecard because all scoped
+Frontend/UI remediation issues are closed with strict-DoD evidence, fresh
+frontend/browser gates pass, and residual risks are recorded below. This is not
+a public-production release claim; VPW-AUD-999 owns the final cross-category
+release decision.
+
+## Dependency Closure
+
+| VPW ID | Issue | Remediation PR | Scorecard Result |
+| --- | --- | --- | --- |
+| VPW-AUD-201 | #404 | #437 | Findings table clipping and scroll containment fixed and browser-verified. |
+| VPW-AUD-202 | #405 | #438 | Dashboard query fanout replaced with aggregate API contract. |
+| VPW-AUD-203 | #406 | #439 | Findings filters, sort, paging, and asset context are URL-synced. |
+| VPW-AUD-204 | #407 | #441 | Detail, sheets, dialogs, table scroll, mobile, and a11y coverage expanded. |
+| VPW-AUD-205 | #408 | #442 | Disabled and busy controls are visually and semantically unambiguous. |
+| VPW-AUD-206 | #409 | #443 | Fallback CSS retired and active palette drift tokenized/allowlisted. |
+| VPW-AUD-207 | #410 | #444 | Unused frontend dependencies removed or documented with depcheck evidence. |
+
+Verification snapshot:
+
+```text
+PP9 open remediation findings: none
+Remaining PP9 open issues: VPW-AUD-299 scorecard and VPW-AUD-E20 epic closeout
+Project #9 status for VPW-AUD-201 through VPW-AUD-207: Done / verified-shipped
+```
+
+## Fresh Validation
+
+Commands run from the repository root:
+
+```text
+make frontend-lint
+Result: checked 212 files; no fixes applied.
+
+make frontend-build
+Result: Vite production build passed; 2696 modules transformed.
+
+make frontend-test-unit
+Result: 31 passed.
+
+make playwright-check
+Result: npm ci installed 297 packages and audited 298 with 0 vulnerabilities;
+15 Playwright tests passed across Chromium and mobile Chromium.
+```
+
+The Playwright gate covers:
+
+- Login labels, required fields, and keyboard submit.
+- Authenticated shell landmarks and account controls.
+- Core authenticated routes with no serious accessibility violations.
+- Findings dialogs, detail, loading, and busy states with no serious
+  accessibility violations.
+- Dashboard, imports, findings, reports/evidence center, providers, settings,
+  and sign-out smoke flows.
+- Mobile drawer navigation without page-width overflow.
+- Desktop, tablet, and mobile route containment.
+- Findings table horizontal scroll containment across desktop, tablet, and
+  mobile widths.
+
+## Evidence Links
+
+Primary closeout evidence:
+
+- VPW-AUD-201: #404 closeout and PR #437.
+- VPW-AUD-202: #405 closeout and PR #438.
+- VPW-AUD-203: #406 closeout and PR #439.
+- VPW-AUD-204: #407 closeout and PR #441.
+- VPW-AUD-205: #408 closeout and PR #442.
+- VPW-AUD-206: #409 closeout, PR #443, and
+  `archive/vpw-evidence/vpw-aud-206-frontend-color-scan.md`.
+- VPW-AUD-207: #410 closeout, PR #444, and
+  `archive/vpw-evidence/vpw-aud-207-frontend-dependencies.md`.
+
+## Residual Risk
+
+- Final public-production readiness remains out of scope until VPW-AUD-999
+  links the complete cross-category evidence bundle.
+- Browser validation is local/CI Workbench evidence, not live customer-data or
+  public-production smoke evidence.
+- `frontend/src/styles/finding-detail.css` remains a documented VPW-AUD-206
+  color-scan allowlist item and should only be retokenized as part of a scoped
+  finding-detail visual redesign.
+- Root `bun.lock` remains historical Bun-compatible convenience metadata; the
+  audited frontend install source is `frontend/package-lock.json`.
+
+## Score Breakdown
+
+| Area | Score | Rationale |
+| --- | ---: | --- |
+| Responsiveness and containment | 10 | Findings table and shell containment have desktop/tablet/mobile Playwright coverage. |
+| Data loading shape | 10 | Dashboard fanout was replaced by aggregate API usage and covered by frontend/backend gates. |
+| URL/shareability | 10 | Findings state survives reload/deep links through typed URL state. |
+| Interaction and accessibility coverage | 10 | Detail, dialogs, sheets, busy states, mobile, and a11y are covered by Playwright. |
+| Control-state clarity | 10 | Disabled/busy tokens and ARIA state are implemented and tested. |
+| Design-token maintainability | 10 | Fallback CSS is removed; active palette drift is tokenized with documented exceptions. |
+| Dependency surface | 10 | Direct frontend dependencies are pruned; depcheck and npm lock evidence are current. |
+
+Final category decision: 10/10, verified-shipped for Frontend/UI.


### PR DESCRIPTION
## Summary

Closes #411.
VPW ID: VPW-AUD-299
Disposition: verified-shipped

This PR adds the Frontend/UI 10/10 category scorecard after VPW-AUD-201 through VPW-AUD-207 were closed with strict-DoD evidence.

## Scope

- Adds `archive/vpw-evidence/vpw-aud-299-frontend-ui-scorecard.md`.
- Links Frontend/UI child issues and remediation PRs.
- Records fresh frontend/browser validation and residual risks.
- Explicitly leaves final public-production readiness to VPW-AUD-999.

## Validation

- `make frontend-lint` -> 212 checked
- `make frontend-build` -> passed; 2696 modules transformed
- `make frontend-test-unit` -> 31 passed
- `make playwright-check` -> 15 passed; npm ci audited 298 with 0 vulnerabilities
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed
- `git diff --check` -> passed

## Scorecard Decision

Frontend/UI category score: 10/10, verified-shipped, with residual risks documented in the evidence artifact.
