### PR TITLE
[VPW-AUD-303] Harden path redaction

### DIFF
--- a/archive/vpw-evidence/vpw-aud-303-security-path-redaction.md
+++ b/archive/vpw-evidence/vpw-aud-303-security-path-redaction.md
@@ -1,0 +1,102 @@
+# VPW-AUD-303 Security Path Redaction Evidence
+
+Issue: VPW-AUD-303 / #414
+Category: Security/Deployment
+Date: 2026-05-07
+Disposition: gap
+
+## Scope
+
+This evidence covers hardening of the shared redaction utility used by API error
+projection, reports, manifests, and evidence bundle verification. The change is
+limited to local filesystem path redaction for container, POSIX, and Windows
+absolute path samples, including quoted paths and paths with spaces.
+
+Out of scope: authentication, authorization, project membership, RCAB/RBAC, and
+any deployment model change.
+
+## Behavior Verified
+
+- Shared text redaction now recognizes container paths rooted below `/app`.
+- Shared text and value redaction continue to cover POSIX workspace, service,
+  opt, state-directory, and Windows absolute path samples, including quoted paths
+  and paths with spaces.
+- API-safe request value redaction uses the shared value redaction path and
+  removes embedded local path values.
+- Workbench API-relative URLs remain visible in free text so user-facing finding
+  links are not destroyed by the broader path redaction.
+- Safe environment variable names such as `NVD_API_KEY` remain visible while
+  path values are replaced with redaction placeholders.
+- Evidence bundle verification redacts copied artifact text and warnings that
+  contain synthetic container path samples before writing bundle artifacts.
+
+## Validation Commands
+
+```text
+python3 -m pytest -q backend/tests/test_security_redaction.py backend/tests/test_evidence_bundle_verification.py::test_evidence_bundle_redacts_secret_like_text_in_copied_artifacts --no-cov
+```
+
+Result: `3 passed in 0.05s`
+
+```text
+python3 -m pytest -q backend/tests/api/test_template_github_issue_export.py::test_template_github_issue_preview_selected_findings_markdown_redacts_secrets --no-cov
+```
+
+Result: `1 passed in 0.17s`
+
+```text
+python3 -m pytest -q backend/tests/test_evidence_bundle_verification.py backend/tests/test_provider_snapshot_contract.py backend/tests/test_report_artifacts.py backend/tests/api/test_template_reports_api.py --no-cov
+```
+
+Result: `49 passed in 3.35s`
+
+```text
+make demo-evidence-bundle-check
+```
+
+Result: demo analysis, demo evidence bundle, and demo evidence bundle
+verification completed successfully. Generated verification artifacts stayed
+under the local build directory.
+
+```text
+make check
+```
+
+Result: Ruff format/check clean, mypy clean for 215 source files, and backend
+tests passed with `962 passed, 4 skipped in 45.64s`. Coverage remained above the
+required 90% threshold at `90.94%`.
+
+```text
+python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
+```
+
+Result: `5 passed in 0.20s`
+
+```text
+git diff --check
+```
+
+Result: no whitespace errors.
+
+## Evidence Hygiene
+
+The evidence above contains no secrets, tokens, cookies, customer data, or real
+private filesystem paths. Path samples used by tests are synthetic and are only
+used to verify redaction behavior.
+
+## Residual Risk
+
+None for the covered API/report/evidence redaction path. Redaction remains a
+defense-in-depth layer and does not replace rooted artifact storage checks. The
+issue requested `docs/evidence/security-path-redaction.md`; active repository
+hygiene intentionally limits `docs/evidence` to canonical contract artifacts, so
+this audit evidence is retained under the archived VPW evidence tree instead.
+
+## Scorecard Impact
+
+Before: Security/Deployment retained an audit gap where container-style runtime
+paths and embedded absolute POSIX path values could be missed by shared
+redaction.
+
+After: Shared API/report/evidence redaction covers the audited path forms and is
+backed by targeted tests plus the broader backend and evidence bundle gates.

--- a/backend/src/vuln_prioritizer/security_redaction.py
+++ b/backend/src/vuln_prioritizer/security_redaction.py
@@ -39,11 +39,14 @@ _SECRET_TEXT_PATTERNS = (
     re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
 )
 _LOCAL_PATH_PATTERN = re.compile(
-    r"(^|[\s\"'=])(/Users/|/home/|/private/|/tmp/|/var/folders/|[A-Za-z]:\\)"
+    r"(^|[\s\"'=])"
+    r"(/Users/|/home/|/app/|/workspace/|/workspaces/|/srv/|/opt/|/private/|/tmp/|"
+    r"/var/|/etc/|/root/|/mnt/|[A-Za-z]:\\)"
 )
 _LOCAL_PATH_TEXT_PATTERN = re.compile(
     r"(?P<prefix>^|[\s\"'=])"
-    r"(?P<path>(?:~[/\\]|/Users/|/home/|/private/|/tmp/|/var/folders/|[A-Za-z]:\\)"
+    r"(?P<path>(?:~[/\\]|/Users/|/home/|/app/|/workspace/|/workspaces/|/srv/|/opt/|"
+    r"/private/|/tmp/|/var/|/etc/|/root/|/mnt/|[A-Za-z]:\\)"
     r"[^\r\n\"'<>;,)]*)"
 )
 _URL_CREDENTIAL_PATTERN = re.compile(r"://[^/\s:@]+:[^/\s@]+@")

--- a/backend/tests/test_evidence_bundle_verification.py
+++ b/backend/tests/test_evidence_bundle_verification.py
@@ -341,6 +341,7 @@ def test_evidence_bundle_redacts_secret_like_text_in_copied_artifacts(tmp_path: 
                 "CVE-2026-0711",
                 "NVD_API_KEY=super-secret-token",
                 "source=/Users/Alice/My Project/secret-cves.txt",
+                'container="/app/workbench-import-uploads/private input/cves.txt"',
                 r"mirror=C:\Users\Alice\My Project\secret-cves.txt",
             ]
         ),
@@ -358,7 +359,10 @@ def test_evidence_bundle_redacts_secret_like_text_in_copied_artifacts(tmp_path: 
                     "token": "super-secret-token",
                 },
                 "findings": [],
-                "warnings": ["Bearer super-secret-token"],
+                "warnings": [
+                    "Bearer super-secret-token",
+                    "Parser failed at /app/workbench-reports/private report.json",
+                ],
             }
         ),
         encoding="utf-8",
@@ -382,8 +386,10 @@ def test_evidence_bundle_redacts_secret_like_text_in_copied_artifacts(tmp_path: 
     assert "super-secret-token" not in combined
     assert str(tmp_path) not in combined
     assert "/Users/Alice" not in combined
+    assert "/app/workbench-" not in combined
     assert r"C:\Users\Alice" not in combined
     assert "My Project" not in combined
+    assert "private report.json" not in combined
     assert "NVD_API_KEY=<redacted>" in combined
     assert "[REDACTED-PATH]" in combined
 

--- a/backend/tests/test_security_redaction.py
+++ b/backend/tests/test_security_redaction.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from app.api.errors import redact_request_safe_value
+from vuln_prioritizer.security_redaction import redact_text, redact_value
+
+
+def test_redact_text_covers_container_posix_and_windows_paths_with_spaces() -> None:
+    value = (
+        'parser failed at "/app/workbench-reports/private report.json"; '
+        "source=/home/alice/My Project/secret-cves.txt; "
+        "workspace=/workspace/project/private report.json; "
+        "service=/srv/workbench/imports/private report.json; "
+        "opt=/opt/vpw/private report.json; "
+        "state=/var/lib/vpw/private report.json; "
+        r"mirror=C:\Users\Alice\My Project\secret-cves.txt; "
+        "finding=/api/v1/findings/123; "
+        "env=NVD_API_KEY"
+    )
+
+    redacted = redact_text(value)
+
+    assert "/app/" not in redacted
+    assert "/home/alice" not in redacted
+    assert "/workspace/project" not in redacted
+    assert "/srv/workbench" not in redacted
+    assert "/opt/vpw" not in redacted
+    assert "/var/lib/vpw" not in redacted
+    assert r"C:\Users\Alice" not in redacted
+    assert "My Project" not in redacted
+    assert "private report.json" not in redacted
+    assert redacted.count("[REDACTED-PATH]") == 7
+    assert "finding=/api/v1/findings/123" in redacted
+    assert "env=NVD_API_KEY" in redacted
+
+
+def test_redact_value_and_api_error_projection_covers_embedded_container_paths() -> None:
+    payload = {
+        "nvd_api_key_env": "NVD_API_KEY",
+        "detail": "failed while opening /app/workbench-import-uploads/input files/cves.txt",
+        "source_path": "/app/workbench-reports/private report.json",
+    }
+
+    redacted, paths = redact_value(payload)
+    api_safe = redact_request_safe_value(
+        'Upload failed for "/app/workbench-import-uploads/input files/cves.txt".'
+    )
+
+    assert redacted["nvd_api_key_env"] == "NVD_API_KEY"
+    assert redacted["detail"] == "[REDACTED]"
+    assert redacted["source_path"] == "[REDACTED]"
+    assert sorted(paths) == ["detail", "source_path"]
+    assert "/app/" not in api_safe
+    assert "input files" not in api_safe
+    assert "[REDACTED-PATH]" in api_safe


### PR DESCRIPTION
## Summary
- Harden shared redaction to cover container/workspace/service/state POSIX path roots plus Windows paths in free text.
- Add regression coverage for API error projection, evidence bundle copied artifacts, warnings, and GitHub issue preview link preservation.
- Archive VPW-AUD-303 evidence under the controlled VPW evidence tree because public `docs/evidence` is intentionally limited to canonical contract artifacts.

Closes #414

## Validation
- `python3 -m pytest -q backend/tests/test_security_redaction.py backend/tests/test_evidence_bundle_verification.py::test_evidence_bundle_redacts_secret_like_text_in_copied_artifacts --no-cov` -> 3 passed
- `python3 -m pytest -q backend/tests/api/test_template_github_issue_export.py::test_template_github_issue_preview_selected_findings_markdown_redacts_secrets --no-cov` -> 1 passed
- `python3 -m pytest -q backend/tests/test_evidence_bundle_verification.py backend/tests/test_provider_snapshot_contract.py backend/tests/test_report_artifacts.py backend/tests/api/test_template_reports_api.py --no-cov` -> 49 passed
- `make demo-evidence-bundle-check` -> passed
- `make check` -> 962 passed, 4 skipped, coverage 90.94%
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed
- `git diff --check` -> passed

## Evidence
- `archive/vpw-evidence/vpw-aud-303-security-path-redaction.md`

## Residual Risk
- None for the covered API/report/evidence redaction path. Redaction remains defense-in-depth and does not replace rooted artifact storage checks.
