### PR TITLE
[VPW-AUD-304] Harden Docker defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@ PROJECT_NAME=Vuln Prioritizer Workbench
 STACK_NAME=vuln-prioritizer-workbench
 VITE_API_URL=http://localhost:8000
 
-# Backend placeholders. Replace these before any shared deployment.
-SECRET_KEY=changethis
+# Backend local-only placeholders. Replace these before any shared deployment.
+SECRET_KEY=local-workbench-dev-secret
 FIRST_SUPERUSER=admin@example.com
-FIRST_SUPERUSER_PASSWORD=changethis
+FIRST_SUPERUSER_PASSWORD=local-workbench-dev-password
 BACKEND_CORS_ORIGINS=http://localhost,http://localhost:5173,http://127.0.0.1:5173
 ALLOWED_HOSTS=localhost,127.0.0.1,testserver,backend
 # Leave blank to expose API docs only in local mode by default.
@@ -25,7 +25,16 @@ POSTGRES_SERVER=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=workbench
 POSTGRES_USER=workbench
-POSTGRES_PASSWORD=workbench
+POSTGRES_PASSWORD=local-workbench-dev-postgres-password
+
+# Optional Compose volume overrides. Fresh stacks default to Workbench-branded
+# names; set historical template-* names only long enough to back up or migrate
+# an existing pre-rename stack.
+WORKBENCH_DB_VOLUME=workbench-db-data
+WORKBENCH_IMPORT_UPLOADS_VOLUME=workbench-import-uploads
+WORKBENCH_REPORTS_VOLUME=workbench-reports
+WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME=workbench-provider-snapshots
+WORKBENCH_PROVIDER_CACHE_VOLUME=workbench-provider-cache
 
 # Container images.
 DOCKER_IMAGE_BACKEND=vuln-prioritizer-workbench-backend

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ BACKEND_TESTS := $(BACKEND_DIR)/tests
 PYTHON_AUDIT_LOCK := $(BACKEND_DIR)/requirements.lock.txt
 COMPOSE := docker compose -f compose.yml -f compose.override.yml
 PRODUCTION_SMOKE_COMPOSE := docker compose -f compose.yml -f compose.production-smoke.yml
+DOCKER_DEMO_SECRET_KEY ?= local-docker-smoke-secret-key
+DOCKER_DEMO_FIRST_SUPERUSER_PASSWORD ?= local-docker-smoke-admin-password
+DOCKER_DEMO_POSTGRES_PASSWORD ?= local-docker-smoke-postgres-password
+PRODUCTION_SMOKE_SECRET_KEY ?= production-smoke-secret-key-change-in-real-deployments
+PRODUCTION_SMOKE_FIRST_SUPERUSER_PASSWORD ?= production-smoke-admin-password
+PRODUCTION_SMOKE_POSTGRES_PASSWORD ?= production-smoke-postgres-password
 
 ATTACK_MAPPING_FILE := data/attack/ctid_kev_enterprise_2025-07-28_attack-16.1_subset.json
 ATTACK_METADATA_FILE := data/attack/attack_techniques_enterprise_16.1_subset.json
@@ -114,6 +120,15 @@ workflow-check:
 
 docker-demo-smoke:
 	@set -e; \
+	export SECRET_KEY="$(DOCKER_DEMO_SECRET_KEY)"; \
+	export FIRST_SUPERUSER_PASSWORD="$(DOCKER_DEMO_FIRST_SUPERUSER_PASSWORD)"; \
+	export POSTGRES_PASSWORD="$(DOCKER_DEMO_POSTGRES_PASSWORD)"; \
+	for port in 8000 5173; do \
+		if ! $(PYTHON) -c "import socket, sys; port=int(sys.argv[1]); sock=socket.socket(); sock.settimeout(0.2); in_use=sock.connect_ex(('127.0.0.1', port)) == 0; sock.close(); sys.exit(1 if in_use else 0)" "$$port"; then \
+			echo "Port $$port is already in use before docker-demo-smoke." >&2; \
+			exit 1; \
+		fi; \
+	done; \
 	on_exit() { status=$$?; if [ "$$status" != "0" ]; then $(COMPOSE) ps || true; $(COMPOSE) logs --no-color || true; fi; $(COMPOSE) down -v --remove-orphans; exit "$$status"; }; \
 	trap on_exit EXIT; \
 	$(COMPOSE) up -d --build backend frontend; \
@@ -154,6 +169,10 @@ docker-demo-smoke:
 
 docker-production-smoke:
 	@set -e; \
+	export SECRET_KEY="$(PRODUCTION_SMOKE_SECRET_KEY)"; \
+	export FIRST_SUPERUSER_PASSWORD="$(PRODUCTION_SMOKE_FIRST_SUPERUSER_PASSWORD)"; \
+	export POSTGRES_PASSWORD="$(PRODUCTION_SMOKE_POSTGRES_PASSWORD)"; \
+	$(PYTHON) -c "import socket, sys; sock=socket.socket(); sock.settimeout(0.2); in_use=sock.connect_ex(('127.0.0.1', 5180)) == 0; sock.close(); sys.exit('Port 5180 is already in use before docker-production-smoke.' if in_use else 0)"; \
 	on_exit() { status=$$?; if [ "$$status" != "0" ]; then $(PRODUCTION_SMOKE_COMPOSE) ps || true; $(PRODUCTION_SMOKE_COMPOSE) logs --no-color || true; fi; $(PRODUCTION_SMOKE_COMPOSE) down -v --remove-orphans; exit "$$status"; }; \
 	trap on_exit EXIT; \
 	$(PRODUCTION_SMOKE_COMPOSE) up -d --build backend frontend; \

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Open:
 Local demo login defaults from `.env.example`:
 
 - email: `admin@example.com`
-- password: `changethis`
+- password: `local-workbench-dev-password`
 
 Suggested demo path:
 

--- a/archive/vpw-evidence/vpw-aud-304-docker-defaults.md
+++ b/archive/vpw-evidence/vpw-aud-304-docker-defaults.md
@@ -1,0 +1,121 @@
+# VPW-AUD-304 Docker Defaults Evidence
+
+Issue: VPW-AUD-304 / #415
+Category: Security/Deployment
+Date: 2026-05-07
+Disposition: gap
+
+## Scope
+
+This evidence covers Docker and Compose hardening for fresh Workbench stacks.
+The change is limited to fail-closed Compose secrets, Workbench-branded fresh
+volume names, local/production smoke wiring, and deployment migration guidance.
+
+Out of scope: RCAB/RBAC, project membership, SaaS multi-tenancy, and any public
+production readiness claim.
+
+## Behavior Verified
+
+- Base `compose.yml` no longer injects weak app or database secrets. Compose
+  now requires explicit `SECRET_KEY`, `FIRST_SUPERUSER_PASSWORD`, and
+  `POSTGRES_PASSWORD`.
+- Local-only `.env.example` uses Workbench dev placeholders and labels them as
+  local-only. Those placeholders are treated as insecure outside local mode by
+  runtime validation.
+- Non-local settings fail closed when `POSTGRES_PASSWORD` is empty, `postgres`,
+  `workbench`, `changethis`, or the local placeholder.
+- Fresh Compose volumes default to Workbench-branded names:
+  `workbench-db-data`, `workbench-import-uploads`, `workbench-reports`,
+  `workbench-provider-snapshots`, and `workbench-provider-cache`.
+- Historical `template-*` volume names remain documented only as migration and
+  backup compatibility overrides.
+- Docker demo and production-like smoke targets export explicit smoke-only
+  non-default secrets and refuse to run when their host ports are already bound.
+- Compose backup and restore helpers no longer silently fall back to the weak
+  Compose database password.
+
+## Validation Commands
+
+```text
+python3 -m pytest -q backend/tests/test_backend_runtime_boundary.py backend/tests/test_workbench_integration_contracts.py --no-cov
+```
+
+Result: `23 passed in 0.28s`
+
+```text
+python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py::test_template_backend_load_settings_rejects_non_local_default_postgres_password backend/tests/api/test_template_backend_adapter.py::test_template_backend_build_database_uri_accepts_non_default_postgres_password backend/tests/api/test_template_backend_adapter.py::test_template_backend_settings_reject_non_local_default_secrets --no-cov
+```
+
+Result: `7 passed in 0.02s`
+
+```text
+make dependency-audit
+```
+
+Result: release evidence hygiene passed, `pip-audit` found no known
+vulnerabilities, and frontend `npm audit --omit=dev` found 0 vulnerabilities.
+
+```text
+make docker-demo-smoke
+```
+
+Result: passed. The smoke created and removed Workbench-branded Compose volumes,
+completed the demo import, verified locked provider data, and exercised the
+provider update path.
+
+```text
+make docker-production-smoke
+```
+
+Result: passed. The production-like same-origin smoke completed setup, import,
+findings, report generation, authenticated status, security header, and logout
+checks.
+
+```text
+make docs-check
+```
+
+Result: release evidence hygiene passed and MkDocs built successfully.
+
+```text
+make frontend-lint
+```
+
+Result: Biome checked 212 files with no fixes applied.
+
+```text
+make check
+```
+
+Result: Ruff format/check clean, mypy clean for 215 source files, and backend
+tests passed with `967 passed, 4 skipped in 45.86s`. Coverage remained above the
+required 90% threshold at `90.97%`.
+
+```text
+git diff --check
+```
+
+Result: no whitespace errors.
+
+## Evidence Hygiene
+
+The evidence above contains no secrets, token values, cookies, customer data, or
+private filesystem paths. The listed smoke credentials are deterministic
+test-only placeholders used inside local Docker validation.
+
+## Residual Risk
+
+None for fresh Compose defaults and the covered smoke paths. Existing operators
+that intentionally keep historical `template-*` volumes must use the documented
+compatibility overrides only long enough to back up, attach, or migrate the old
+volumes.
+
+## Scorecard Impact
+
+Before: Security/Deployment retained a Docker/deployment gap where fresh volume
+names still defaulted to template-era names and Compose could silently supply
+weak app or database secrets.
+
+After: Fresh Compose stacks require explicit secrets, use Workbench-branded
+volumes, keep compatibility paths documented as migration-only, and have
+passing demo plus production-like Docker smoke evidence.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,7 +12,22 @@ from urllib.parse import quote_plus, urlparse
 EnvironmentName = Literal["local", "staging", "production"]
 VALID_ENVIRONMENTS: set[str] = {"local", "staging", "production"}
 DEFAULT_WORKBENCH_SECRET = "changethis"
-INSECURE_WORKBENCH_SECRET_VALUES = {"", DEFAULT_WORKBENCH_SECRET}
+LOCAL_WORKBENCH_SECRET_PLACEHOLDER = "local-workbench-dev-secret"
+LOCAL_WORKBENCH_PASSWORD_PLACEHOLDER = "local-workbench-dev-password"
+LOCAL_WORKBENCH_POSTGRES_PASSWORD_PLACEHOLDER = "local-workbench-dev-postgres-password"
+INSECURE_WORKBENCH_SECRET_VALUES = {
+    "",
+    DEFAULT_WORKBENCH_SECRET,
+    LOCAL_WORKBENCH_SECRET_PLACEHOLDER,
+    LOCAL_WORKBENCH_PASSWORD_PLACEHOLDER,
+}
+INSECURE_POSTGRES_PASSWORD_VALUES = {
+    "",
+    "postgres",
+    "workbench",
+    DEFAULT_WORKBENCH_SECRET,
+    LOCAL_WORKBENCH_POSTGRES_PASSWORD_PLACEHOLDER,
+}
 DEFAULT_ALLOWED_HOSTS = ("localhost", "127.0.0.1", "testserver", "backend")
 LOCAL_ONLY_ALLOWED_HOSTS = {"localhost", "127.0.0.1", "testserver", "backend"}
 TRUE_VALUES = {"1", "true", "yes", "on"}
@@ -147,7 +162,9 @@ def build_database_uri() -> str:
     postgres_server = environ.get("POSTGRES_SERVER")
     if postgres_server:
         user = quote_plus(environ.get("POSTGRES_USER", "postgres"))
-        password = quote_plus(environ.get("POSTGRES_PASSWORD", "postgres"))
+        raw_password = environ.get("POSTGRES_PASSWORD", "postgres")
+        _validate_postgres_password_default(raw_password)
+        password = quote_plus(raw_password)
         port = environ.get("POSTGRES_PORT", "5432")
         db = quote_plus(environ.get("POSTGRES_DB", "app"))
         return f"postgresql+psycopg://{user}:{password}@{postgres_server}:{port}/{db}"
@@ -276,6 +293,16 @@ def _allowed_hosts_from_env() -> tuple[str, ...]:
 
 def _is_insecure_workbench_secret(value: str) -> bool:
     return value.strip().lower() in INSECURE_WORKBENCH_SECRET_VALUES
+
+
+def _validate_postgres_password_default(value: str) -> None:
+    environment = _validate_environment_name(environ.get("ENVIRONMENT", "local"))
+    if environment == "local":
+        return
+    if value.strip().lower() in INSECURE_POSTGRES_PASSWORD_VALUES:
+        raise ValueError(
+            f"POSTGRES_PASSWORD must be set to a non-default value when ENVIRONMENT={environment}."
+        )
 
 
 def _validate_environment_name(value: str) -> EnvironmentName:

--- a/backend/tests/api/test_template_backend_adapter.py
+++ b/backend/tests/api/test_template_backend_adapter.py
@@ -359,6 +359,36 @@ def test_template_backend_load_settings_rejects_non_local_default_secret_env(
         load_settings()
 
 
+@pytest.mark.parametrize("password", ["", "postgres", "workbench", "changethis"])
+def test_template_backend_load_settings_rejects_non_local_default_postgres_password(
+    monkeypatch: pytest.MonkeyPatch,
+    password: str,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("POSTGRES_SERVER", "db")
+    monkeypatch.setenv("POSTGRES_PASSWORD", password)
+    monkeypatch.setenv("SECRET_KEY", "production-secret-key")
+    monkeypatch.setenv("FIRST_SUPERUSER_PASSWORD", "production-admin-password")
+
+    with pytest.raises(ValueError, match="POSTGRES_PASSWORD must be set"):
+        load_settings()
+
+
+def test_template_backend_build_database_uri_accepts_non_default_postgres_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("POSTGRES_SERVER", "db")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "workbench")
+    monkeypatch.setenv("POSTGRES_USER", "workbench")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "non-default-production-password")
+
+    assert build_database_uri() == (
+        "postgresql+psycopg://workbench:non-default-production-password@db:5432/workbench"
+    )
+
+
 def test_template_backend_settings_reject_local_default_secrets_with_public_hosts() -> None:
     with pytest.raises(ValueError, match="non-local ALLOWED_HOSTS"):
         Settings(ENVIRONMENT="local", ALLOWED_HOSTS=("localhost", "workbench.example.com"))

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -176,6 +176,7 @@ def test_import_service_modules_do_not_import_http_or_route_boundaries() -> None
 def test_default_compose_services_start_only_active_backend_runtime() -> None:
     compose = yaml.safe_load((REPO_ROOT / "compose.yml").read_text(encoding="utf-8"))
     services = compose["services"]
+    volumes = compose["volumes"]
     backend_environment = services["backend"]["environment"]
     backend_healthcheck = _as_text(services["backend"]["healthcheck"])
 
@@ -196,17 +197,34 @@ def test_default_compose_services_start_only_active_backend_runtime() -> None:
     assert backend_environment["SQLALCHEMY_DATABASE_URI"] == ""
     assert backend_environment["RATE_LIMIT_ENABLED"] == "${RATE_LIMIT_ENABLED:-true}"
     assert backend_environment["MAX_UPLOAD_MB"] == "${MAX_UPLOAD_MB:-25}"
+    assert backend_environment["POSTGRES_PASSWORD"].startswith(
+        "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD"
+    )
     assert backend_environment["LOGIN_RATE_LIMIT_PER_MINUTE"] == (
         "${LOGIN_RATE_LIMIT_PER_MINUTE:-60}"
     )
     assert backend_environment["TRUSTED_PROXY_CIDRS"] == "${TRUSTED_PROXY_CIDRS:-}"
-    assert backend_environment["SECRET_KEY"] == "${SECRET_KEY:-changethis}"
-    assert backend_environment["FIRST_SUPERUSER_PASSWORD"] == (
-        "${FIRST_SUPERUSER_PASSWORD:-changethis}"
+    assert backend_environment["SECRET_KEY"].startswith("${SECRET_KEY:?Set SECRET_KEY")
+    assert backend_environment["FIRST_SUPERUSER_PASSWORD"].startswith(
+        "${FIRST_SUPERUSER_PASSWORD:?Set FIRST_SUPERUSER_PASSWORD"
     )
     assert backend_environment["DEMO_PROVIDER_SNAPSHOT_ENABLED"] == (
         "${DEMO_PROVIDER_SNAPSHOT_ENABLED:-false}"
     )
+    assert volumes["app-db-data"]["name"] == "${WORKBENCH_DB_VOLUME:-workbench-db-data}"
+    assert volumes["workbench-import-uploads"]["name"] == (
+        "${WORKBENCH_IMPORT_UPLOADS_VOLUME:-workbench-import-uploads}"
+    )
+    assert volumes["workbench-reports"]["name"] == (
+        "${WORKBENCH_REPORTS_VOLUME:-workbench-reports}"
+    )
+    assert volumes["workbench-provider-snapshots"]["name"] == (
+        "${WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME:-workbench-provider-snapshots}"
+    )
+    assert volumes["workbench-provider-cache"]["name"] == (
+        "${WORKBENCH_PROVIDER_CACHE_VOLUME:-workbench-provider-cache}"
+    )
+    assert "template-" not in _as_text(volumes)
     assert "/api/v1/utils/health-check/" in backend_healthcheck
     assert "assert data is True" in backend_healthcheck
     assert "headers={'Host': host}" in backend_healthcheck
@@ -255,6 +273,14 @@ def test_env_example_does_not_pin_api_docs_on_for_shared_deployments() -> None:
     assert "\nTRUSTED_PROXY_CIDRS=\n" in env_example
     assert "\nTRAEFIK_APP_ENABLED=false\n" in env_example
     assert "\nMAX_UPLOAD_MB=25\n" in env_example
+    assert "\nSECRET_KEY=local-workbench-dev-secret\n" in env_example
+    assert "\nFIRST_SUPERUSER_PASSWORD=local-workbench-dev-password\n" in env_example
+    assert "\nPOSTGRES_PASSWORD=local-workbench-dev-postgres-password\n" in env_example
+    assert "\nWORKBENCH_DB_VOLUME=workbench-db-data\n" in env_example
+    assert "\nWORKBENCH_IMPORT_UPLOADS_VOLUME=workbench-import-uploads\n" in env_example
+    assert "\nWORKBENCH_REPORTS_VOLUME=workbench-reports\n" in env_example
+    assert "\nWORKBENCH_PROVIDER_SNAPSHOTS_VOLUME=workbench-provider-snapshots\n" in env_example
+    assert "\nWORKBENCH_PROVIDER_CACHE_VOLUME=workbench-provider-cache\n" in env_example
 
 
 def test_public_deployment_runbook_documents_backup_retention_and_tls() -> None:
@@ -263,6 +289,9 @@ def test_public_deployment_runbook_documents_backup_retention_and_tls() -> None:
     assert "scripts/workbench-backup.sh" in runbook
     assert "scripts/workbench-restore.sh" in runbook
     assert "WORKBENCH_ARTIFACT_MODE=compose" in runbook
+    assert "WORKBENCH_IMPORT_UPLOADS_VOLUME=workbench-import-uploads" in runbook
+    assert "WORKBENCH_IMPORT_UPLOADS_VOLUME=template-import-uploads" in runbook
+    assert "POSTGRES_PASSWORD=<long random value>" in runbook
     assert "import-upload, report, provider-snapshot, and\nprovider-cache" in runbook
     assert "/app/template-import-uploads" not in runbook
     assert "python -m app.core.retention --dry-run" in runbook
@@ -276,6 +305,8 @@ def test_backup_restore_scripts_support_database_url_and_compose_artifacts() -> 
 
     assert 'pg_dump --format=custom --file="$BACKUP_DIR/workbench.dump" "$DATABASE_URL"' in backup
     assert 'pg_restore --clean --if-exists --dbname="$DATABASE_URL"' in restore
+    assert "POSTGRES_PASSWORD must be set in the Compose db container." in backup
+    assert "POSTGRES_PASSWORD must be set in the Compose db container." in restore
     assert "WORKBENCH_ARTIFACT_MODE:-host" in backup
     assert "WORKBENCH_ARTIFACT_MODE:-host" in restore
     assert "docker compose ps -q backend" in backup

--- a/backend/tests/test_workbench_integration_contracts.py
+++ b/backend/tests/test_workbench_integration_contracts.py
@@ -40,17 +40,24 @@ def test_compose_uses_workbench_shell_without_legacy_runtime_services() -> None:
     assert "workbench-provider-cache:/app/workbench-provider-cache" in backend["volumes"]
     assert "./data:/app/examples:ro" in backend["volumes"]
     assert "/api/v1/utils/health-check/" in backend["healthcheck"]["test"][3]
+    assert backend["environment"]["SECRET_KEY"].startswith("${SECRET_KEY:?Set SECRET_KEY")
+    assert backend["environment"]["FIRST_SUPERUSER_PASSWORD"].startswith(
+        "${FIRST_SUPERUSER_PASSWORD:?Set FIRST_SUPERUSER_PASSWORD"
+    )
+    assert backend["environment"]["POSTGRES_PASSWORD"].startswith(
+        "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD"
+    )
     assert compose["volumes"]["workbench-import-uploads"]["name"] == (
-        "${WORKBENCH_IMPORT_UPLOADS_VOLUME:-template-import-uploads}"
+        "${WORKBENCH_IMPORT_UPLOADS_VOLUME:-workbench-import-uploads}"
     )
     assert compose["volumes"]["workbench-reports"]["name"] == (
-        "${WORKBENCH_REPORTS_VOLUME:-template-reports}"
+        "${WORKBENCH_REPORTS_VOLUME:-workbench-reports}"
     )
     assert compose["volumes"]["workbench-provider-snapshots"]["name"] == (
-        "${WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME:-template-provider-snapshots}"
+        "${WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME:-workbench-provider-snapshots}"
     )
     assert compose["volumes"]["workbench-provider-cache"]["name"] == (
-        "${WORKBENCH_PROVIDER_CACHE_VOLUME:-template-provider-cache}"
+        "${WORKBENCH_PROVIDER_CACHE_VOLUME:-workbench-provider-cache}"
     )
 
     frontend = services["frontend"]
@@ -59,6 +66,9 @@ def test_compose_uses_workbench_shell_without_legacy_runtime_services() -> None:
 
     db = services["db"]
     assert db["environment"]["POSTGRES_DB"] == "${POSTGRES_DB:-workbench}"
+    assert db["environment"]["POSTGRES_PASSWORD"].startswith(
+        "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD"
+    )
     assert db["healthcheck"]["test"][0] == "CMD-SHELL"
 
     assert "workbench-postgres" not in services
@@ -90,6 +100,11 @@ def test_docker_demo_smoke_runs_quickstart_api_import() -> None:
 
     docker_smoke_block = makefile.split("docker-demo-smoke:", 1)[1].split("dependency-audit:", 1)[0]
     assert "$(PYTHON) scripts/docker_quickstart_api_smoke.py" in docker_smoke_block
+    assert 'export FIRST_SUPERUSER_PASSWORD="$(DOCKER_DEMO_FIRST_SUPERUSER_PASSWORD)"' in (
+        docker_smoke_block
+    )
+    assert 'export POSTGRES_PASSWORD="$(DOCKER_DEMO_POSTGRES_PASSWORD)"' in docker_smoke_block
+    assert '"local-workbench-dev-password"' in script
     assert "locked_provider_data" in script
     assert "demo_provider_snapshot.json" in script
     assert "providers/update-jobs" in script
@@ -115,7 +130,11 @@ def test_production_smoke_overlay_uses_same_origin_public_contract() -> None:
     frontend_args = compose["services"]["frontend"]["build"]["args"]
 
     assert backend_env["ENVIRONMENT"] == "production"
-    assert backend_env["FIRST_SUPERUSER_PASSWORD"] != "changethis"
+    assert backend_env["SECRET_KEY"].startswith("${SECRET_KEY:?Set SECRET_KEY")
+    assert backend_env["FIRST_SUPERUSER_PASSWORD"].startswith(
+        "${FIRST_SUPERUSER_PASSWORD:?Set FIRST_SUPERUSER_PASSWORD"
+    )
+    assert backend_env["POSTGRES_PASSWORD"].startswith("${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD")
     assert backend_env["API_DOCS_ENABLED"] == "false"
     assert backend_env["FRONTEND_HOST"] == "https://workbench.example.test"
     assert backend_env["BACKEND_CORS_ORIGINS"] == "https://workbench.example.test"

--- a/compose.production-smoke.yml
+++ b/compose.production-smoke.yml
@@ -1,13 +1,16 @@
 services:
   db:
     restart: "no"
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for production smoke.}
 
   backend:
     restart: "no"
     environment:
       ENVIRONMENT: production
-      SECRET_KEY: production-smoke-secret-key-change-in-real-deployments
-      FIRST_SUPERUSER_PASSWORD: production-smoke-admin-password
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY for production smoke.}
+      FIRST_SUPERUSER_PASSWORD: ${FIRST_SUPERUSER_PASSWORD:?Set FIRST_SUPERUSER_PASSWORD for production smoke.}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD for production smoke.}
       DOMAIN: workbench.example.test
       FRONTEND_HOST: https://workbench.example.test
       BACKEND_CORS_ORIGINS: https://workbench.example.test

--- a/compose.yml
+++ b/compose.yml
@@ -12,7 +12,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
       POSTGRES_DB: ${POSTGRES_DB:-workbench}
       POSTGRES_USER: ${POSTGRES_USER:-workbench}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-workbench}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD before running Compose. For local-only quickstart, copy .env.example to .env.}
     volumes:
       - app-db-data:/var/lib/postgresql/data/pgdata
 
@@ -35,9 +35,9 @@ services:
     environment:
       PROJECT_NAME: ${PROJECT_NAME:-Vuln Prioritizer Workbench}
       ENVIRONMENT: ${ENVIRONMENT:-local}
-      SECRET_KEY: ${SECRET_KEY:-changethis}
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY before running Compose. For local-only quickstart, copy .env.example to .env.}
       FIRST_SUPERUSER: ${FIRST_SUPERUSER:-admin@example.com}
-      FIRST_SUPERUSER_PASSWORD: ${FIRST_SUPERUSER_PASSWORD:-changethis}
+      FIRST_SUPERUSER_PASSWORD: ${FIRST_SUPERUSER_PASSWORD:?Set FIRST_SUPERUSER_PASSWORD before running Compose. For local-only quickstart, copy .env.example to .env.}
       DOMAIN: ${DOMAIN:-localhost}
       FRONTEND_HOST: ${FRONTEND_HOST:-http://localhost:5173}
       BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS:-http://localhost,http://localhost:5173,http://127.0.0.1:5173}
@@ -57,7 +57,7 @@ services:
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}
       POSTGRES_DB: ${POSTGRES_DB:-workbench}
       POSTGRES_USER: ${POSTGRES_USER:-workbench}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-workbench}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD before running Compose. For local-only quickstart, copy .env.example to .env.}
       IMPORT_UPLOAD_DIR: /app/workbench-import-uploads
       REPORT_DIR: /app/workbench-reports
       PROVIDER_SNAPSHOT_DIR: /app/provider-snapshots
@@ -123,11 +123,12 @@ services:
 
 volumes:
   app-db-data:
+    name: ${WORKBENCH_DB_VOLUME:-workbench-db-data}
   workbench-import-uploads:
-    name: ${WORKBENCH_IMPORT_UPLOADS_VOLUME:-template-import-uploads}
+    name: ${WORKBENCH_IMPORT_UPLOADS_VOLUME:-workbench-import-uploads}
   workbench-reports:
-    name: ${WORKBENCH_REPORTS_VOLUME:-template-reports}
+    name: ${WORKBENCH_REPORTS_VOLUME:-workbench-reports}
   workbench-provider-snapshots:
-    name: ${WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME:-template-provider-snapshots}
+    name: ${WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME:-workbench-provider-snapshots}
   workbench-provider-cache:
-    name: ${WORKBENCH_PROVIDER_CACHE_VOLUME:-template-provider-cache}
+    name: ${WORKBENCH_PROVIDER_CACHE_VOLUME:-workbench-provider-cache}

--- a/docs/workbench-public-deployment.md
+++ b/docs/workbench-public-deployment.md
@@ -15,6 +15,7 @@ Use non-default secrets and exact public origins:
 ENVIRONMENT=production
 SECRET_KEY=<long random value>
 FIRST_SUPERUSER_PASSWORD=<long random value>
+POSTGRES_PASSWORD=<long random value>
 DOMAIN=workbench.example.com
 FRONTEND_HOST=https://workbench.example.com
 VITE_API_URL=
@@ -56,6 +57,34 @@ with `TRAEFIK_APP_ENABLED=true`.
 Do not trust arbitrary forwarded headers from the public internet. Place Traefik
 as the only public entrypoint and keep backend container ports unbound except in
 local override files.
+
+## Compose Volumes And Compatibility
+
+Fresh Compose stacks use Workbench-branded named volumes by default:
+
+```bash
+WORKBENCH_DB_VOLUME=workbench-db-data
+WORKBENCH_IMPORT_UPLOADS_VOLUME=workbench-import-uploads
+WORKBENCH_REPORTS_VOLUME=workbench-reports
+WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME=workbench-provider-snapshots
+WORKBENCH_PROVIDER_CACHE_VOLUME=workbench-provider-cache
+```
+
+Existing deployments created before the volume rename can temporarily point the
+same variables at the historical compatibility names:
+
+```bash
+WORKBENCH_IMPORT_UPLOADS_VOLUME=template-import-uploads
+WORKBENCH_REPORTS_VOLUME=template-reports
+WORKBENCH_PROVIDER_SNAPSHOTS_VOLUME=template-provider-snapshots
+WORKBENCH_PROVIDER_CACHE_VOLUME=template-provider-cache
+```
+
+Use those compatibility names only to attach, back up, or restore existing
+volumes. For a rename migration, back up the old volumes with
+`WORKBENCH_ARTIFACT_MODE=compose`, unset the compatibility overrides, start a
+fresh stack with Workbench-branded volume names, then restore the backup into
+the new stack.
 
 ## Rate Limits And Sessions
 
@@ -136,6 +165,7 @@ scripts/workbench-backup.sh
 Docker Compose named volumes:
 
 ```bash
+POSTGRES_PASSWORD=<password> \
 WORKBENCH_DATABASE_MODE=compose \
 WORKBENCH_ARTIFACT_MODE=compose \
 scripts/workbench-backup.sh
@@ -170,6 +200,7 @@ alembic -c backend/alembic.ini upgrade head
 Docker Compose named volumes:
 
 ```bash
+POSTGRES_PASSWORD=<password> \
 WORKBENCH_DATABASE_MODE=compose \
 WORKBENCH_ARTIFACT_MODE=compose \
 scripts/workbench-restore.sh backups/<backup-dir>

--- a/frontend/tests/auth-helpers.ts
+++ b/frontend/tests/auth-helpers.ts
@@ -5,7 +5,7 @@ export const testUserEmail =
 export const testUserPassword =
   process.env.VPW_E2E_PASSWORD ??
   process.env.FIRST_SUPERUSER_PASSWORD ??
-  "changethis"
+  "local-workbench-dev-password"
 
 export async function login(page: Page): Promise<string> {
   const responsePromise = page.waitForResponse(

--- a/scripts/docker_quickstart_api_smoke.py
+++ b/scripts/docker_quickstart_api_smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import mimetypes
+import os
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -65,8 +66,9 @@ def main() -> None:
 
 
 def _login() -> str:
+    password = os.environ.get("FIRST_SUPERUSER_PASSWORD", "local-workbench-dev-password")
     payload = urllib.parse.urlencode(
-        {"username": "admin@example.com", "password": "changethis"}
+        {"username": "admin@example.com", "password": password}
     ).encode()
     response = _request(
         f"{BASE_URL}/login/access-token",

--- a/scripts/start-template-playwright-backend.sh
+++ b/scripts/start-template-playwright-backend.sh
@@ -24,6 +24,8 @@ export REPORT_DIR="$report_dir"
 export PROVIDER_SNAPSHOT_DIR="$repo_root/data"
 export DEMO_PROVIDER_SNAPSHOT_ENABLED=true
 export RATE_LIMIT_ENABLED=false
+export SECRET_KEY="${SECRET_KEY:-local-workbench-dev-secret}"
+export FIRST_SUPERUSER_PASSWORD="${FIRST_SUPERUSER_PASSWORD:-local-workbench-dev-password}"
 
 python3 -m app.core.migration_bootstrap
 python3 -m alembic -c backend/alembic.ini upgrade head

--- a/scripts/workbench-backup.sh
+++ b/scripts/workbench-backup.sh
@@ -14,7 +14,7 @@ backup_compose_database() {
     exit 2
   fi
   docker exec "$container" sh -c \
-    'PGPASSWORD="${POSTGRES_PASSWORD:-workbench}" pg_dump --format=custom --file=- --username="${POSTGRES_USER:-workbench}" --dbname="${POSTGRES_DB:-workbench}"' \
+    ': "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the Compose db container.}"; PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --format=custom --file=- --username="${POSTGRES_USER:-workbench}" --dbname="${POSTGRES_DB:-workbench}"' \
     > "$BACKUP_DIR/workbench.dump"
 }
 

--- a/scripts/workbench-restore.sh
+++ b/scripts/workbench-restore.sh
@@ -17,7 +17,7 @@ restore_compose_database() {
     exit 2
   fi
   docker exec -i "$container" sh -c \
-    'PGPASSWORD="${POSTGRES_PASSWORD:-workbench}" pg_restore --clean --if-exists --username="${POSTGRES_USER:-workbench}" --dbname="${POSTGRES_DB:-workbench}"' \
+    ': "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the Compose db container.}"; PGPASSWORD="$POSTGRES_PASSWORD" pg_restore --clean --if-exists --username="${POSTGRES_USER:-workbench}" --dbname="${POSTGRES_DB:-workbench}"' \
     < "$BACKUP_DIR/workbench.dump"
 }
 


### PR DESCRIPTION
## Summary
- Make base Compose fail closed for app and database secrets instead of injecting weak defaults.
- Move fresh Compose volumes to Workbench-branded names with template-era compatibility documented as migration-only.
- Wire local and production-like Docker smokes to explicit non-default test secrets and add host-port preflight checks.
- Require the Compose DB password for backup/restore and add runtime tests for non-local Postgres defaults.

Closes #415

## Validation
- `python3 -m pytest -q backend/tests/test_backend_runtime_boundary.py backend/tests/test_workbench_integration_contracts.py --no-cov` -> 23 passed
- `python3 -m pytest -q backend/tests/api/test_template_backend_adapter.py::test_template_backend_load_settings_rejects_non_local_default_postgres_password backend/tests/api/test_template_backend_adapter.py::test_template_backend_build_database_uri_accepts_non_default_postgres_password backend/tests/api/test_template_backend_adapter.py::test_template_backend_settings_reject_non_local_default_secrets --no-cov` -> 7 passed
- `make dependency-audit` -> passed; pip-audit no known vulnerabilities and frontend audit 0 vulnerabilities
- `make docker-demo-smoke` -> passed
- `make docker-production-smoke` -> passed
- `make docs-check` -> passed
- `make frontend-lint` -> passed
- `make check` -> 967 passed, 4 skipped, coverage 90.97%
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed
- `git diff --check` -> passed

## Evidence
- `archive/vpw-evidence/vpw-aud-304-docker-defaults.md`

## Residual Risk
None for fresh Compose defaults and covered smoke paths. Existing operators using historical `template-*` volumes must use documented overrides only for backup, attach, or migration.
