### PR TITLE
[VPW-AUD-402] Fix release recovery package command

### DIFF
--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -99,13 +99,19 @@ git push origin vX.Y.Z
 If a tag exists but the GitHub Release object is missing, recreate it from the current tag:
 
 ```bash
-python3 -m build
+make package
 gh release create vX.Y.Z dist/* \
   --title vX.Y.Z \
   --notes-file docs/releases/vX.Y.Z.md
 ```
 
-This is the correct recovery path after accidental GitHub-side deletion or repository history cleanup, as long as the release tag still points to the intended tree.
+`make package` removes stale `dist/` artifacts and runs
+`python3 -m build backend --outdir dist`, matching the GitHub release and
+TestPyPI workflows. Run `make package-check` first when the recovery needs a
+fresh local packaging validation before recreating the GitHub Release object.
+This is the correct recovery path after accidental GitHub-side deletion or
+repository history cleanup, as long as the release tag still points to the
+intended tree.
 
 ## TestPyPI Validation Path
 


### PR DESCRIPTION
## Summary
- replace the bare repo-root `python3 -m build` recovery command with `make package`
- document that `make package` runs `python3 -m build backend --outdir dist`, matching release/TestPyPI workflows
- point maintainers to `make package-check` when recovery needs fresh local package validation

Closes #419

## Validation
- `rg -n 'python3 -m build|make package' docs/release_operations.md Makefile .github/workflows` -> docs now use `make package` and align to backend build commands
- `make package-check` -> built sdist/wheel, package contents OK, twine check passed
- `make docs-check` -> passed
- `git diff --check` -> passed

## Evidence
- `docs/release_operations.md` recovery command diff
- local package-check transcript: `dist/vuln_prioritizer-1.1.0-py3-none-any.whl` and `.tar.gz` passed twine check

## Residual Risk
None for package recovery docs. Actual publishing still depends on the release workflow and trusted-publisher configuration.