### PR TITLE
[VPW-AUD-501] Enforce local generated-client drift check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ api-client-drift-check: frontend-generate-client
 frontend-audit:
 	cd frontend && npm --workspaces=false audit --omit=dev
 
-frontend-check: frontend-install frontend-lint frontend-build frontend-test-unit frontend-generate-client
+frontend-check: frontend-install frontend-lint frontend-build frontend-test-unit api-client-drift-check
 
 release-evidence-hygiene-check:
 	$(PYTHON) scripts/check_release_evidence_hygiene.py

--- a/backend/tests/test_v11_output_contracts.py
+++ b/backend/tests/test_v11_output_contracts.py
@@ -851,7 +851,7 @@ def test_release_check_keeps_demo_sync_manual_and_deterministic() -> None:
     assert "frontend-test-unit:" in makefile
     assert (
         "frontend-check: frontend-install frontend-lint frontend-build "
-        "frontend-test-unit frontend-generate-client" in makefile
+        "frontend-test-unit api-client-drift-check" in makefile
     )
     assert "$(MAKE) dependency-audit" in release_block
     assert "$(MAKE) docker-demo-smoke" in release_block


### PR DESCRIPTION
## Summary
- make `frontend-check` depend on `api-client-drift-check` instead of stopping at client generation
- keep `api-client-drift-check` as the generation plus `git diff --exit-code -- frontend/src/client` contract
- update the Makefile contract test so future edits preserve the local drift gate

Closes #423

## Validation
- `python3 -m pytest -q backend/tests/test_v11_output_contracts.py --no-cov` -> 27 passed
- `make api-client-drift-check` -> generated client and clean `frontend/src/client` diff
- `make frontend-check` -> npm ci, lint, build, unit tests, generated client, clean client diff; 31 frontend unit tests passed
- `git diff --exit-code -- frontend/src/client` -> passed
- `git diff --check` -> passed

## Evidence
- `Makefile`
- `backend/tests/test_v11_output_contracts.py`
- Local command transcript confirms generated-client drift is asserted during `frontend-check`

## Residual Risk
None for local client drift gating. API/OpenAPI changes still require intentional generated-client commits when the drift check fails.