### PR TITLE
[VPW-AUD-499] Add docs 10/10 scorecard

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,12 @@ runtime, React frontend, retained CLI/domain package, VPW design system,
 evidence/reporting surfaces, public docs, CI cost controls, and package release
 automation.
 
-Public-production readiness is still tracked as explicit PP5 evidence work.
+Public-production readiness is still tracked as explicit VPW-AUD-999 evidence
+work.
 Do not treat this README, the local Workbench quickstart, or local release gates
-as a final internet-facing certification until the public-production scorecard
-issue closes with evidence.
+as a final internet-facing certification until
+[VPW-AUD-999](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/430)
+closes with evidence.
 
 ## License, Security, And Contributing
 

--- a/archive/vpw-evidence/vpw-aud-499-docs-scorecard.md
+++ b/archive/vpw-evidence/vpw-aud-499-docs-scorecard.md
@@ -1,0 +1,56 @@
+# VPW-AUD-499 Docs Category Scorecard
+
+Audit source: Codex full-codebase audit on 2026-05-07
+VPW ID: VPW-AUD-499
+Category: Docs
+Disposition: verified-shipped pending PR merge
+
+## Decision
+
+Docs category is ready to score 10/10 after the PP11 child issues closed with
+fresh pull requests, local validation, GitHub checks, and residual-risk
+decisions. This is a category score only; final project-wide 10/10 and
+public-production readiness remain gated by VPW-AUD-999.
+
+## Child Issue Evidence
+
+| VPW ID | Issue | PR | Result |
+| --- | --- | --- | --- |
+| VPW-AUD-401 | #418 | #451 | Closed. Active docs now describe implemented GitHub issue preview/export only and mark Jira/ServiceNow as future integrations. |
+| VPW-AUD-402 | #419 | #452 | Closed. Release recovery docs now use `make package` and document the backend package build path. |
+| VPW-AUD-403 | #420 | #453 | Closed. Auth docs now distinguish implemented local JWT sessions/scoped API tokens from broader public/shared deployment certification. |
+| VPW-AUD-404 | #421 | #454 | Closed. Historical PP evidence is bounded as provenance, with current final acceptance owned by VPW-AUD-999/#430. |
+
+## Validation
+
+Commands run for this scorecard:
+
+- `make docs-check` passed. The release-evidence hygiene script reported stale
+  wording audit OK, release ledger structure OK, and release evidence hygiene
+  OK. MkDocs built successfully.
+- `rg -n 'Jira|ServiceNow|template|PP5|PP6|10/10|public-production' docs README.md`
+  completed. Remaining Jira/ServiceNow matches are future/out-of-scope or
+  historical CLI-line references; remaining PP5/PP6 matches are explicitly
+  historical evidence/provenance; remaining `template` matches are legitimate
+  FastAPI-template architecture, issue-template, report-template, or schema
+  contract wording.
+- `gh issue view` for #418, #419, #420, and #421 confirmed all four child
+  issues are closed.
+- `git diff --check` passed.
+
+## Residual Risk
+
+No Docs-category residual risk remains from VPW-AUD-401 through VPW-AUD-404.
+The final project-wide score still requires VPW-AUD-599, VPW-AUD-699, and
+VPW-AUD-999 evidence before any final 10/10 or public-production claim.
+
+## Scorecard Impact
+
+Before: 8/10. Active docs overclaimed unimplemented ticket integrations, mixed
+implemented auth controls with stale future-auth wording, included a package
+recovery command that could build the wrong artifact, and allowed historical PP
+evidence to be misread as current readiness.
+
+After: 10/10 for the Docs category. Active docs now match implemented behavior,
+historical evidence is bounded, release commands align with the package layout,
+and final readiness is explicitly gated by VPW-AUD-999.

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,8 +123,8 @@ Workbench remains local-first and uses the import-format matrix documented in
 - Use [roadmap.md](roadmap.md) for shipped scope and deliberate non-goals.
 - Use [release_operations.md](release_operations.md) for maintainer-only release, GitHub Release recovery, and PyPI/TestPyPI operations.
 - Use [public-production-release-evidence-ledger.md](public-production-release-evidence-ledger.md)
-  for PP4/PP5 release-readiness targets, evidence boundaries, and residual-risk
-  tracking.
+  for VPW-AUD release-readiness targets, evidence boundaries, and residual-risk
+  tracking through the final VPW-AUD-999 scorecard.
 - Use [community_repository_setup.md](community_repository_setup.md) for maintainer-facing public repo topics, labels, and triage defaults.
 - Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current package release.
 

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -50,7 +50,8 @@ make release-readiness-check
 
 This adds generated-client drift, demo evidence-bundle verification, and
 Playwright smoke evidence to the normal release gate. It also runs the
-production-like Docker smoke. It does not by itself close the PP5 scorecard.
+production-like Docker smoke. It does not by itself close the VPW-AUD-999 final
+scorecard.
 For tagged releases, `.github/workflows/release.yml` runs this gate before any
 GitHub Release or PyPI publish job can proceed.
 

--- a/docs/submission/reviewer-checklist.md
+++ b/docs/submission/reviewer-checklist.md
@@ -55,8 +55,8 @@ reproducibly.
 ## Limitations
 
 - [ ] Demo data is clearly marked as sample/evidence data.
-- [ ] Public-production readiness is not claimed unless PP5 evidence and the
-      final scorecard support it.
+- [ ] Public-production readiness is not claimed unless VPW-AUD-999 evidence
+      and the final scorecard support it.
 - [ ] Detection coverage is not overstated as proof of effectiveness.
 - [ ] Waivers are described as governance context, not as risk deletion.
 

--- a/docs/workbench-v1-release-checklist.md
+++ b/docs/workbench-v1-release-checklist.md
@@ -6,7 +6,7 @@ Use this checklist before tagging or publishing a Workbench-capable package rele
 
 The Workbench v1.0 milestone evidence is preserved here, but the current package tree is versioned `1.1.0`. A tag cut from this tree must therefore be `v1.1.0`; the release workflow rejects tags that do not match `pyproject.toml`.
 
-For public-production remediation and PP5 certification, use
+For current public-production remediation and VPW-AUD-999 certification, use
 [Public-Production Release Evidence Ledger](public-production-release-evidence-ledger.md).
 This historical checklist remains useful release context, but it is not the
 final public-production scorecard.
@@ -198,7 +198,7 @@ The v1.0 release must keep these boundaries visible in docs, UI copy, examples, 
 ## Residual Risks to State
 
 - [x] The Workbench v1.0 evidence was local-first; public-production certification
-  requires the separate PP5 evidence ledger and scorecard.
+  requires the separate VPW-AUD-999 evidence ledger and scorecard.
 - [x] SSO, multi-user isolation, audit logging, and ticket sync remain outside the v1.0 local Workbench scope unless explicitly shipped; the later local API-token gate is documented as a v1.2 automation control, not a full internet-facing auth model.
 - [x] SQLite backup, retention, filesystem permissions, and local disk protection remain operator responsibilities.
 - [x] Evidence bundles provide integrity checks but not encryption.


### PR DESCRIPTION
## Summary
- add the VPW-AUD-499 Docs category scorecard evidence artifact
- verify #418, #419, #420, and #421 are closed with strict DoD evidence
- remove remaining active PP5 wording from README/checklist/release docs by pointing current certification to VPW-AUD-999/#430
- record residual-risk decision: Docs category is 10/10, final project score remains gated by later category scorecards and VPW-AUD-999

Closes #422

## Validation
- `make docs-check` -> passed; stale wording audit OK, release ledger structure OK, release evidence hygiene OK, MkDocs built successfully
- `rg -n 'Jira|ServiceNow|template|PP5|PP6|10/10|public-production' docs README.md` -> remaining matches are legitimate future/out-of-scope, historical, template architecture/schema, or VPW-AUD-999 scorecard references
- `gh issue view 418/419/420/421 --json number,title,state,url` -> all four child issues are closed
- `git diff --check` -> passed

## Evidence
- `archive/vpw-evidence/vpw-aud-499-docs-scorecard.md`
- Docs wording updates in `README.md`, `docs/index.md`, `docs/release_operations.md`, `docs/submission/reviewer-checklist.md`, and `docs/workbench-v1-release-checklist.md`

## Residual Risk
No Docs-category residual risk remains from VPW-AUD-401 through VPW-AUD-404. Final project-wide 10/10 and public-production readiness remain gated by VPW-AUD-999 and remaining category scorecards.