### PR TITLE
[VPW-AUD-502] Require fresh release-readiness evidence for final score

### DIFF
--- a/archive/vpw-evidence/vpw-aud-502-release-readiness-evidence.md
+++ b/archive/vpw-evidence/vpw-aud-502-release-readiness-evidence.md
@@ -1,0 +1,82 @@
+# VPW-AUD-502 Release-Readiness Evidence Gate
+
+Audit source: Codex full-codebase audit on 2026-05-07
+VPW ID: VPW-AUD-502
+Category: CI/Release
+Disposition: gap pending PR merge
+
+## Decision
+
+VPW-AUD-502 requires final project scoring to use fresh evidence for the exact
+commit, tag, or release candidate being accepted. Historical PP artifacts,
+ignored local build outputs, and previous candidate logs are not sufficient for
+VPW-AUD-999 closure.
+
+This evidence note records the release-readiness gate added to the public
+production ledger and release operations docs. It is not a final project-wide
+10/10 claim; that remains gated by VPW-AUD-999 after all category scorecards
+are closed.
+
+## Scope Changed
+
+- `docs/public-production-release-evidence-ledger.md` now defines the
+  VPW-AUD-999 fresh-evidence gate and lists the required command families.
+- `docs/release_operations.md` now requires release-readiness evidence for the
+  exact commit, tag, or release candidate before final scorecard acceptance.
+- Evidence hygiene rules explicitly reject secrets, token values, cookies,
+  customer exports, private absolute paths, and raw shell history.
+
+## Validation
+
+Commands run for this issue:
+
+- `make docs-check` passed. Release-evidence hygiene reported stale wording
+  audit OK, release ledger structure OK, and release evidence hygiene OK.
+  MkDocs built successfully.
+- `make check` passed with 970 tests passed, 4 skipped, and 90.96% coverage.
+- `make dependency-audit` passed. Python `pip-audit` reported no known
+  vulnerabilities, and frontend `npm audit --omit=dev` reported 0
+  vulnerabilities.
+- `make playwright-check` passed with 15 browser tests passed across desktop,
+  mobile, responsive shell, findings-table scroll containment, and accessibility
+  smoke coverage.
+- `make release-readiness-check` passed. It covered the release gate, package
+  build and twine validation, frontend lint/build/unit checks, generated client
+  generation, dependency audit, Docker demo smoke, pipx/source smoke, demo
+  evidence-bundle verification, Playwright, and production-like Docker smoke.
+  This full gate was rerun after rebasing onto `origin/main` with
+  VPW-AUD-501/#455 included, so the stricter generated-client drift check is in
+  the final branch-head evidence.
+- `git diff --exit-code -- frontend/src/client` passed after client generation.
+- `git diff --check` passed before the PR commit.
+
+## Required Final Evidence For VPW-AUD-999
+
+VPW-AUD-999 can close only after fresh evidence exists for:
+
+- `make check`
+- frontend lint, build, and unit tests
+- `make playwright-check`
+- `make docs-check`
+- `make dependency-audit`
+- `make docker-demo-smoke`
+- `make docker-production-smoke`
+- `make api-client-drift-check`
+- `make package-check`
+- `make release-readiness-check`
+- final residual-risk decisions
+
+## Residual Risk
+
+No CI/release documentation gap remains for requiring fresh evidence before the
+final scorecard. The remaining risk is operational: VPW-AUD-999 must still link
+the fresh command output or CI artifacts for the exact final candidate, and it
+must not reuse this issue's local evidence as a substitute for final acceptance.
+
+## Scorecard Impact
+
+Before: final release-readiness acceptance could be misread as reusable from
+historical PP evidence or local ignored artifacts.
+
+After: final scoring is fail-closed on fresh evidence for the exact candidate,
+with required categories and command families named explicitly.

--- a/docs/public-production-release-evidence-ledger.md
+++ b/docs/public-production-release-evidence-ledger.md
@@ -52,6 +52,37 @@ linked from an issue or PR.
 | `make playwright-check` | Browser smoke and accessibility path | frontend Playwright smoke, responsive shell, and Axe no serious/critical violations |
 | `make release-readiness-check` | Full local readiness handoff | release gate, client drift, evidence bundle, Playwright/A11y, and production-like Docker smoke |
 
+## VPW-AUD-999 Fresh Evidence Gate
+
+VPW-AUD-999 cannot close from historical PP evidence, local ignored artifacts,
+or a previous candidate run. The final scorecard must link public-safe command
+output, CI artifacts, or issue evidence produced for the exact commit, tag, or
+release candidate being scored.
+
+Required before VPW-AUD-999 closure:
+
+- category scorecards are closed for Backend/API (#403), Frontend/UI (#411),
+  Security/Deployment (#417), Docs (#422), CI/Release (#425), and Repo Hygiene
+  (#429)
+- `make check`
+- frontend lint, build, and unit-test evidence, either through
+  `make frontend-check` or explicit `make frontend-lint`, `make frontend-build`,
+  and `make frontend-test-unit` output
+- `make playwright-check`
+- `make docs-check`
+- `make dependency-audit`
+- `make docker-demo-smoke`
+- `make docker-production-smoke`
+- `make api-client-drift-check`
+- `make package-check`
+- `make release-readiness-check`
+- final residual-risk decisions that name an owner and follow-up issue, or state
+  why no follow-up is required
+
+Evidence must not include secrets, token values, cookies, customer exports,
+private absolute paths, or shell history. When using workflow artifacts, link
+the run URL and artifact name rather than pasting raw logs into public docs.
+
 ## Release Candidate Ledger
 
 Every release candidate entry must include the exact command, commit or tag,

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -55,6 +55,11 @@ scorecard.
 For tagged releases, `.github/workflows/release.yml` runs this gate before any
 GitHub Release or PyPI publish job can proceed.
 
+For VPW-AUD-999, do not reuse historical PP artifacts or local ignored build
+outputs as final evidence. Link fresh output or CI artifacts for the exact
+commit, tag, or release candidate, and confirm every category scorecard is
+closed before recording the final residual-risk decision.
+
 4. Record the readiness evidence with owner-facing fields:
 
 ```text


### PR DESCRIPTION
## Summary
- Adds a VPW-AUD-999 fresh-evidence gate to the public production release evidence ledger.
- Documents that final scorecard acceptance must link fresh output or CI artifacts for the exact commit, tag, or release candidate.
- Adds a public-safe VPW-AUD-502 evidence artifact under `archive/vpw-evidence/`.

## Validation
- `make docs-check` -> passed.
- `make check` -> passed with 970 passed, 4 skipped, 90.96% coverage.
- `make dependency-audit` -> passed; Python and frontend audits reported no known vulnerabilities.
- `make playwright-check` -> passed with 15 browser tests.
- `make release-readiness-check` -> passed after rebasing onto current `origin/main` including VPW-AUD-501/#455.
- `git diff --exit-code -- frontend/src/client` -> passed.
- `git diff --check` -> passed.

## Evidence
- `archive/vpw-evidence/vpw-aud-502-release-readiness-evidence.md`

## Residual Risk
- VPW-AUD-999 must still link fresh final-candidate evidence; this PR only makes that gate explicit and enforceable in release docs.

Closes #424