### PR TITLE
[VPW-AUD-601] Document ignored artifact policy

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -25,3 +25,27 @@ repository-root operational files.
 - local ignored paths such as `.cache/`, `.pytest_cache/`, `.ruff_cache/`,
   `dist/`, `site/`, `htmlcov/`, and `test-results/`: disposable maintainer
   outputs cleaned by `make clean-local`.
+
+## Ignored Local Artifact Policy
+
+Ignored files are local maintainer state, not release evidence. They can be
+useful while validating a change, but they are not reviewed, shipped, or used to
+support public-production readiness claims unless a reviewer promotes a redacted
+summary into a tracked evidence file.
+
+Use `git status --short --ignored` before release or scorecard handoff:
+
+```bash
+git status --short --ignored
+```
+
+Expected ignored categories include editor metadata, dependency caches, Python
+bytecode caches, coverage output, package/build output, Playwright or test
+results, local logs, local databases, and local upload/report scratch data.
+Review new categories before relying on them in evidence, especially files that
+could contain secrets, tokens, cookies, customer data, or private paths.
+
+Use `make clean-local` to remove disposable command output, caches, logs, and
+test/build products. Use `make clean-deps` only when dependency directories and
+browser runtimes should also be removed. Do not delete user-local artifacts as
+part of an audit issue without explicit approval.

--- a/archive/vpw-evidence/vpw-aud-601-ignored-artifact-policy.md
+++ b/archive/vpw-evidence/vpw-aud-601-ignored-artifact-policy.md
@@ -1,0 +1,39 @@
+# VPW-AUD-601 Ignored Artifact Policy Evidence
+
+Issue: VPW-AUD-601
+Category: Repo Hygiene
+Date: 2026-05-08
+
+## Inventory Summary
+
+`git status --short --ignored` was used to classify ignored local artifacts. The
+raw local inventory was not committed because ignored files can contain private
+paths, local environment data, tokens, cookies, or customer data.
+
+Observed ignored categories:
+
+- OS/editor metadata such as `.DS_Store`, IDE state, and agent-local notes.
+- Dependency/runtime caches such as `.cache`, `.ruff_cache`, `.pytest_cache`,
+  `.mypy_cache`, Playwright caches, and `node_modules`.
+- Python bytecode and package metadata such as `__pycache__` and egg-info
+  directories.
+- Build, coverage, package, docs, and browser-test output such as `build`,
+  `dist`, `site`, `htmlcov`, and `test-results`.
+- Local runtime state such as logs, local SQLite databases, and upload scratch
+  directories.
+
+## Policy Decision
+
+Ignored artifacts are local maintainer state and are not release evidence.
+Release, scorecard, or public-production evidence must be tracked in a reviewed
+repo path, linked from an issue or PR, and redacted so it contains no secrets,
+tokens, cookies, customer data, or private absolute paths.
+
+## Cleanup Guidance
+
+- Use `make clean-local` for disposable command output, caches, logs, test
+  output, build output, and local report artifacts.
+- Use `make clean-deps` only when dependency directories and browser runtimes
+  should also be removed.
+- Do not delete user-local ignored artifacts as part of audit remediation unless
+  the user explicitly approves that cleanup.

--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -181,4 +181,8 @@ def test_archives_have_entrypoints_and_public_evidence_tree_is_limited() -> None
     assert "`build/`" in archive_readme
     assert "`docs/evidence/`" in archive_readme
     assert "`archive/vpw-evidence/`" in archive_readme
+    assert "`git status --short --ignored`" in archive_readme
     assert "`make clean-local`" in archive_readme
+    assert "`make clean-deps`" in archive_readme
+    assert "not release evidence" in archive_readme
+    assert "Do not delete user-local artifacts" in archive_readme


### PR DESCRIPTION
Closes #426

Disposition: gap

Scope changed:
- Added an explicit ignored-local-artifact policy to `archive/README.md`.
- Added redacted inventory evidence at `archive/vpw-evidence/vpw-aud-601-ignored-artifact-policy.md`.
- Extended docs hygiene coverage so the inventory command, cleanup commands, and no-delete rule remain documented.

Validation:
- `git status --short --ignored` -> reviewed ignored inventory categories; raw local output not committed.
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed.
- `make docs-check` -> passed.
- `git diff --check` -> passed.

Residual risk:
- Ignored local artifacts remain present by design and are not release evidence unless promoted to tracked, redacted evidence.

Scorecard impact:
- Repo Hygiene before: ignored artifact policy incomplete.
- Repo Hygiene after: ignored artifacts are explicitly inventoried, scoped, cleanable, and excluded from release evidence by policy.