### PR TITLE
[VPW-AUD-602] Define evidence ownership boundaries

### DIFF
--- a/archive/vpw-evidence/MANIFEST.md
+++ b/archive/vpw-evidence/MANIFEST.md
@@ -14,6 +14,20 @@ repo hygiene cleanup.
 - Root-level `vpw-*.json`, `vpw-*.csv`, and `vpw-*.zip`: machine-readable
   validation and bundle artifacts.
 
+## Ownership Rules
+
+- Keep long-lived public-safe VPW-AUD scorecards, closeout summaries, and
+  historical screenshots in this archive instead of `docs/evidence/`.
+- Keep `docs/evidence/` limited to contract fixtures that are referenced by
+  schemas or regression tests.
+- Keep raw CI logs, package files, Docker logs, and Playwright reports as CI
+  artifacts for the exact run unless a redacted Markdown summary is needed in
+  the repository.
+- Update this manifest when adding a new evidence subdirectory or a new class of
+  root-level artifact.
+- Do not archive secrets, tokens, cookies, customer data, private absolute
+  paths, or raw local ignored-artifact inventories.
+
 ## Removed During Cleanup
 
 - `vpw-011-openapi-docs.png` was deleted because it had no text references and

--- a/archive/vpw-evidence/vpw-aud-602-archive-evidence-boundary.md
+++ b/archive/vpw-evidence/vpw-aud-602-archive-evidence-boundary.md
@@ -1,0 +1,33 @@
+# VPW-AUD-602 Archive And Evidence Boundary Evidence
+
+Issue: VPW-AUD-602
+Category: Repo Hygiene
+Date: 2026-05-08
+
+## Boundary Decision
+
+The repo now distinguishes four evidence owners:
+
+- `docs/evidence/`: backend/API contract owners; only small fixtures referenced
+  by schemas or regression tests.
+- `archive/vpw-evidence/`: release and roadmap maintainers; public-safe
+  long-lived VPW evidence, scorecards, screenshots, demo summaries, and issue
+  closeout artifacts.
+- CI artifacts: release owner for the exact workflow run; raw command output,
+  package files, Docker logs, Playwright reports, and release-readiness bundles.
+- Historical screenshots: demo or submission owner; stored under named archive
+  directories and linked instead of duplicated.
+
+## Evidence Growth Rule
+
+New VPW-AUD evidence should use a small tracked Markdown summary under
+`archive/vpw-evidence/` when it must survive the PR. Raw CI output should stay
+linked from the PR, issue, release, or scorecard comment for the exact run.
+
+Do not place screenshots, raw logs, demo bundles, or broad historical issue
+proof under `docs/evidence/`.
+
+## Safety Rule
+
+Evidence must not include secrets, tokens, cookies, customer data, private
+absolute paths, or raw ignored-artifact inventories.

--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -9,6 +9,7 @@ from paths import REPO_ROOT
 
 MKDOCS_FILE = REPO_ROOT / "mkdocs.yml"
 ARCHIVE_ROOT = REPO_ROOT / "archive"
+REPORTS_AND_EVIDENCE_FILE = REPO_ROOT / "docs" / "reports-and-evidence.md"
 TEXT_SUFFIXES = {
     ".css",
     ".html",
@@ -178,6 +179,8 @@ def test_archives_have_entrypoints_and_public_evidence_tree_is_limited() -> None
     assert (ARCHIVE_ROOT / "historical-planning" / "README.md").is_file()
 
     archive_readme = (ARCHIVE_ROOT / "README.md").read_text(encoding="utf-8")
+    archive_manifest = (ARCHIVE_ROOT / "vpw-evidence" / "MANIFEST.md").read_text(encoding="utf-8")
+    reports_and_evidence = REPORTS_AND_EVIDENCE_FILE.read_text(encoding="utf-8")
     assert "`build/`" in archive_readme
     assert "`docs/evidence/`" in archive_readme
     assert "`archive/vpw-evidence/`" in archive_readme
@@ -186,3 +189,12 @@ def test_archives_have_entrypoints_and_public_evidence_tree_is_limited() -> None
     assert "`make clean-deps`" in archive_readme
     assert "not release evidence" in archive_readme
     assert "Do not delete user-local artifacts" in archive_readme
+
+    assert "Evidence Ownership Matrix" in reports_and_evidence
+    assert "CI artifacts" in reports_and_evidence
+    assert "Historical screenshots" in reports_and_evidence
+    assert "do not copy raw artifacts into `docs/evidence/`" in reports_and_evidence
+
+    assert "Ownership Rules" in archive_manifest
+    assert "Update this manifest" in archive_manifest
+    assert "Do not archive secrets" in archive_manifest

--- a/docs/reports-and-evidence.md
+++ b/docs/reports-and-evidence.md
@@ -63,6 +63,20 @@ contract artifacts used by backend report/evidence tests:
 Do not add screenshots, broad historical evidence, or ad hoc demo artifacts
 under `docs/evidence/`. The docs hygiene test enforces this boundary.
 
+## Evidence Ownership Matrix
+
+| Location | Owner | Use | Boundary |
+| --- | --- | --- | --- |
+| `docs/evidence/` | Backend/API contract owners | Small, reviewed contract fixtures referenced by schemas or regression tests. | No screenshots, ad hoc logs, demo bundles, or historical issue proof. |
+| `archive/vpw-evidence/` | Release and roadmap maintainers | Public-safe historical VPW evidence, scorecards, screenshots, demo summaries, and issue closeout artifacts. | Keep entrypoints in `archive/vpw-evidence/MANIFEST.md`; add redacted summaries instead of raw local logs. |
+| CI artifacts | Release owner for the exact run | Ephemeral command output, package files, Docker logs, Playwright reports, and release-readiness bundles for a commit, tag, or PR. | Link from the PR/issue/release evidence comment; do not copy raw artifacts into `docs/evidence/`. |
+| Historical screenshots | Demo or submission owner | Locked UI proof referenced by submission and demo documentation. | Store under `archive/vpw-evidence/` or a named subdirectory; do not duplicate screenshots across docs pages. |
+
+New VPW-AUD evidence should be a small tracked Markdown summary under
+`archive/vpw-evidence/` when it must survive the PR, or an external CI artifact
+link when the raw output belongs to the exact workflow run. Evidence comments
+must identify which path was used and why.
+
 ## Historical Evidence Archive
 
 Historical VPW evidence now lives under `archive/vpw-evidence/`. Important


### PR DESCRIPTION
Closes #427

Disposition: gap

Scope changed:
- Added an Evidence Ownership Matrix to `docs/reports-and-evidence.md`.
- Added archive ownership rules to `archive/vpw-evidence/MANIFEST.md`.
- Added closeout evidence at `archive/vpw-evidence/vpw-aud-602-archive-evidence-boundary.md`.
- Extended docs hygiene tests to enforce the boundary wording for `docs/evidence`, archive evidence, CI artifacts, and screenshots.

Validation:
- `rg -n 'archive|docs/evidence|vpw-evidence|artifact|screenshot' docs README.md archive/vpw-evidence/MANIFEST.md` -> boundary terms present.
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov` -> 5 passed.
- `make docs-check` -> passed.
- `git diff --check` -> passed before commit.
- pre-commit hooks -> passed after formatter run.

Residual risk:
- Historical archive contents remain intentionally retained; this change clarifies ownership and growth rules without deleting evidence.

Scorecard impact:
- Repo Hygiene before: evidence ownership boundaries were scattered.
- Repo Hygiene after: durable evidence locations, CI artifact ownership, screenshot handling, and manifest update rules are explicit and tested.