### PR TITLE
[VPW-AUD-603] Rebrand active runtime naming as Workbench

### DIFF
--- a/archive/vpw-evidence/vpw-aud-603-template-runtime-naming.md
+++ b/archive/vpw-evidence/vpw-aud-603-template-runtime-naming.md
@@ -1,0 +1,45 @@
+# VPW-AUD-603 Legacy Template Runtime Naming Audit
+
+Issue: VPW-AUD-603
+Category: Repo Hygiene
+Date: 2026-05-08
+
+## Active Runtime Decision
+
+Active backend service names now use Workbench terminology:
+
+- `WorkbenchAnalysisError`
+- `WorkbenchAnalysisResult`
+- `DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT`
+- Workbench-branded package, route, repository, service, report, and security
+  module docstrings
+
+## Retained Compatibility Aliases
+
+The following template-era names remain intentionally because they can be used
+by older local tests, scripts, or self-hosted data paths:
+
+- `TemplateAnalysisError`, `TemplateAnalysisResult`, and
+  `DEFAULT_TEMPLATE_PROVIDER_SNAPSHOT` as aliases to the Workbench-branded names.
+- `resolve_template_provider_snapshot_path` and
+  `resolve_template_attack_artifact_path` as import-path aliases.
+- `TemplateProviderUpdateConflict` and
+  `TemplateProviderUpdateValidationError` as provider-update aliases.
+- `app.state.template_settings` and `app.state.template_engine` as state aliases
+  for older local test and script integrations.
+- `template.db` and `data/template-*` storage roots as migration fallbacks only
+  when existing data is present and the Workbench-branded path is empty.
+- `template-*` Compose volume names as documented historical compatibility
+  names for attach, backup, restore, or rename migration only.
+
+## Remaining Non-Runtime Uses
+
+Remaining `template` matches are accepted where they are not active runtime
+names: historical migration docs, GitHub issue or summary templates, decision
+template fields in report contracts, CSS `grid-template-*`, test filenames and
+fixtures, and checked-in example artifact filenames.
+
+## Safety Decision
+
+No existing self-hosted data path was removed. Runtime defaults stay
+Workbench-branded, while migration aliases are explicitly documented and tested.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,1 @@
-"""Template-aligned backend application shell for the active Workbench runtime."""
+"""Backend application shell for the active Workbench runtime."""

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,1 +1,1 @@
-"""Template-style API route modules."""
+"""Workbench API route modules."""

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,4 @@
-"""Template-style JWT helpers for the active backend runtime."""
+"""Workbench JWT helpers for the active backend runtime."""
 
 from __future__ import annotations
 

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,4 +1,4 @@
-"""Template Workbench repository exports."""
+"""Workbench repository exports."""
 
 from app.repositories.api_tokens import ApiTokenRepository
 from app.repositories.assets import AssetRepository

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,6 +1,12 @@
-"""Template Workbench service layer."""
+"""Workbench service layer."""
 
-from app.services.analysis import AnalysisService, TemplateAnalysisError, TemplateAnalysisResult
+from app.services.analysis import (
+    AnalysisService,
+    TemplateAnalysisError,
+    TemplateAnalysisResult,
+    WorkbenchAnalysisError,
+    WorkbenchAnalysisResult,
+)
 from app.services.attack import (
     ATTACK_NAVIGATOR_FILTERS,
     build_attack_navigator_layer_payload,
@@ -52,6 +58,8 @@ __all__ = [
     "ReportService",
     "TemplateAnalysisError",
     "TemplateAnalysisResult",
+    "WorkbenchAnalysisError",
+    "WorkbenchAnalysisResult",
     "ATTACK_NAVIGATOR_FILTERS",
     "build_attack_navigator_layer_payload",
     "build_project_attack_summary_payload",

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -1,4 +1,4 @@
-"""Template Workbench analysis orchestration backed by the core engine."""
+"""Workbench analysis orchestration backed by the core engine."""
 
 from __future__ import annotations
 
@@ -26,17 +26,17 @@ from vuln_prioritizer.services.analysis import (
     prepare_analysis,
 )
 
-DEFAULT_TEMPLATE_PROVIDER_SNAPSHOT = "demo_provider_snapshot.json"
+DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT = "demo_provider_snapshot.json"
 PRIORITY_LABELS = ("Critical", "High", "Medium", "Low")
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-class TemplateAnalysisError(RuntimeError):
+class WorkbenchAnalysisError(RuntimeError):
     """Raised when a Workbench import cannot complete decision analysis."""
 
 
 @dataclass(frozen=True, slots=True)
-class TemplateAnalysisResult:
+class WorkbenchAnalysisResult:
     """Decision state produced for a Workbench import before persistence."""
 
     findings_by_cve: dict[str, PrioritizedFinding]
@@ -108,7 +108,7 @@ class AnalysisService:
         attack_mapping_file: Path | None = None,
         attack_technique_metadata_file: Path | None = None,
         vex_files: list[Path] | None = None,
-    ) -> TemplateAnalysisResult:
+    ) -> WorkbenchAnalysisResult:
         """Run parse/enrich/score/explain for one uploaded Workbench import."""
         snapshot_path = provider_snapshot_file or self.default_provider_snapshot_file()
         use_locked_snapshot = locked_provider_data or snapshot_path is not None
@@ -157,16 +157,16 @@ class AnalysisService:
             AnalysisInputError,
             AnalysisNoFindingsError,
         ) as exc:
-            raise TemplateAnalysisError(str(exc)) from exc
+            raise WorkbenchAnalysisError(str(exc)) from exc
 
         findings_by_cve = {finding.cve_id: finding for finding in findings}
         if len(findings_by_cve) != len(findings):
-            raise TemplateAnalysisError("Decision analysis produced duplicate CVE keys.")
+            raise WorkbenchAnalysisError("Decision analysis produced duplicate CVE keys.")
         snapshot_id = self.persist_provider_snapshot(
             snapshot_path,
             locked_provider_data=use_locked_snapshot,
         )
-        return TemplateAnalysisResult(
+        return WorkbenchAnalysisResult(
             findings_by_cve=findings_by_cve,
             context=context,
             provider_snapshot_id=snapshot_id,
@@ -179,14 +179,14 @@ class AnalysisService:
         """Return the local demo snapshot only when demo replay is explicitly enabled."""
         if not self.settings.DEMO_PROVIDER_SNAPSHOT_ENABLED:
             return None
-        candidate = self.settings.provider_snapshot_dir_path / DEFAULT_TEMPLATE_PROVIDER_SNAPSHOT
+        candidate = self.settings.provider_snapshot_dir_path / DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT
         if candidate.exists():
             return candidate
         if not self.settings.provider_snapshot_dir_path.is_absolute():
             repo_candidate = (
                 REPO_ROOT
                 / self.settings.provider_snapshot_dir_path
-                / DEFAULT_TEMPLATE_PROVIDER_SNAPSHOT
+                / DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT
             )
             return repo_candidate if repo_candidate.exists() else None
         return None
@@ -205,7 +205,7 @@ class AnalysisService:
             report = load_provider_snapshot(snapshot_path)
         except ValueError as exc:
             if locked_provider_data:
-                raise TemplateAnalysisError(str(exc)) from exc
+                raise WorkbenchAnalysisError(str(exc)) from exc
             snapshot = RunRepository(self.session).get_or_create_provider_snapshot(
                 content_hash=content_hash,
                 source_hashes_json={"provider_snapshot": content_hash},
@@ -287,3 +287,10 @@ def _provider_quality_flags(raw_flags: dict[str, list[Any]]) -> dict[str, list[d
     return {
         source: [_serialize_flag(item) for item in flags] for source, flags in raw_flags.items()
     }
+
+
+# Compatibility aliases retained for older local tests or scripts that imported
+# template-era names before the runtime was fully Workbench-branded.
+DEFAULT_TEMPLATE_PROVIDER_SNAPSHOT = DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT
+TemplateAnalysisError = WorkbenchAnalysisError
+TemplateAnalysisResult = WorkbenchAnalysisResult

--- a/backend/app/services/import_artifacts.py
+++ b/backend/app/services/import_artifacts.py
@@ -95,5 +95,6 @@ def validate_attack_import_options(
     return normalized_source
 
 
+# Compatibility aliases for template-era local integrations.
 resolve_template_provider_snapshot_path = resolve_workbench_provider_snapshot_path
 resolve_template_attack_artifact_path = resolve_workbench_attack_artifact_path

--- a/backend/app/services/import_execution.py
+++ b/backend/app/services/import_execution.py
@@ -20,7 +20,7 @@ from app.models import (
     User,
 )
 from app.repositories import RunRepository
-from app.services import AnalysisService, TemplateAnalysisError
+from app.services import AnalysisService, WorkbenchAnalysisError
 from app.services.import_artifacts import (
     resolve_workbench_attack_artifact_path as _resolve_workbench_attack_artifact_path,
 )
@@ -541,7 +541,7 @@ async def execute_project_import_upload(
             attack_technique_metadata_file=attack_metadata_path,
             vex_files=[vex_path] if vex_path is not None else [],
         )
-    except TemplateAnalysisError as exc:
+    except WorkbenchAnalysisError as exc:
         _raise_analysis_failure(
             session=session,
             run_repo=run_repo,

--- a/backend/app/services/import_execution_persistence.py
+++ b/backend/app/services/import_execution_persistence.py
@@ -33,7 +33,7 @@ from app.models import (
 )
 from app.models.base import get_datetime_utc
 from app.repositories import AssetRepository, FindingRepository, RunRepository
-from app.services import TemplateAnalysisError, TemplateAnalysisResult
+from app.services import WorkbenchAnalysisError, WorkbenchAnalysisResult
 from vuln_prioritizer.models import PrioritizedFinding
 
 DEDUP_DECISION_SAMPLE_LIMIT = 500
@@ -45,7 +45,7 @@ def _persist_workbench_occurrences(
     project_id: uuid.UUID,
     run_id: uuid.UUID,
     occurrences: list[NormalizedOccurrence],
-    analysis_result: TemplateAnalysisResult,
+    analysis_result: WorkbenchAnalysisResult,
 ) -> dict[str, Any]:
     bulk_summary = _persist_workbench_occurrences_bulk_insert(
         session=session,
@@ -268,7 +268,7 @@ def _persist_workbench_occurrences_bulk_insert(
     project_id: uuid.UUID,
     run_id: uuid.UUID,
     occurrences: list[NormalizedOccurrence],
-    analysis_result: TemplateAnalysisResult,
+    analysis_result: WorkbenchAnalysisResult,
 ) -> dict[str, Any] | None:
     """Fast path for large all-new occurrence imports with no component rows."""
     if len(occurrences) < 1000:
@@ -524,7 +524,7 @@ def _persist_workbench_occurrences_bulk_insert(
 
 
 def _attack_context_enabled(
-    analysis_result: TemplateAnalysisResult,
+    analysis_result: WorkbenchAnalysisResult,
     decision: PrioritizedFinding,
 ) -> bool:
     return analysis_result.context.attack_source != "none" or decision.attack_context.mapped
@@ -581,7 +581,7 @@ def _decision_payload_for_occurrence(
 
 
 def _analysis_evidence_for_occurrence(
-    analysis_result: TemplateAnalysisResult,
+    analysis_result: WorkbenchAnalysisResult,
     decision: PrioritizedFinding,
     occurrence: NormalizedOccurrence,
     *,
@@ -906,12 +906,12 @@ def _normalized_identity_value(value: str | None) -> str:
 
 
 def _decision_for_occurrence(
-    analysis_result: TemplateAnalysisResult,
+    analysis_result: WorkbenchAnalysisResult,
     occurrence: NormalizedOccurrence,
 ) -> PrioritizedFinding:
     decision = analysis_result.findings_by_cve.get(occurrence.cve)
     if decision is None:
-        raise TemplateAnalysisError(f"Decision analysis did not produce {occurrence.cve}.")
+        raise WorkbenchAnalysisError(f"Decision analysis did not produce {occurrence.cve}.")
     return decision
 
 

--- a/backend/app/services/provider_updates.py
+++ b/backend/app/services/provider_updates.py
@@ -61,6 +61,7 @@ class ProviderUpdateValidationError(ValueError):
     """Raised when a provider update request is invalid."""
 
 
+# Compatibility aliases for template-era local integrations.
 TemplateProviderUpdateConflict = ProviderUpdateConflict
 TemplateProviderUpdateValidationError = ProviderUpdateValidationError
 

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -1,4 +1,4 @@
-"""Template-stack report generation services."""
+"""Workbench report generation services."""
 
 from __future__ import annotations
 

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -154,6 +154,56 @@ def test_template_backend_import_graph_does_not_reach_legacy_runtime() -> None:
     assert legacy_runtime_modules == []
 
 
+def test_template_runtime_names_are_documented_compatibility_aliases() -> None:
+    analysis_service = _read_repo_text("backend/app/services/analysis.py")
+    import_artifacts = _read_repo_text("backend/app/services/import_artifacts.py")
+    provider_updates = _read_repo_text("backend/app/services/provider_updates.py")
+    app_state = _read_repo_text("backend/app/core/app_state.py")
+    public_deployment = _read_repo_text("docs/workbench-public-deployment.md")
+    frontend_defaults = _read_repo_text("frontend/src/lib/app-defaults.ts")
+
+    assert "class WorkbenchAnalysisError" in analysis_service
+    assert "class WorkbenchAnalysisResult" in analysis_service
+    assert "DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT" in analysis_service
+    assert "TemplateAnalysisError = WorkbenchAnalysisError" in analysis_service
+    assert "TemplateAnalysisResult = WorkbenchAnalysisResult" in analysis_service
+    assert "DEFAULT_TEMPLATE_PROVIDER_SNAPSHOT = DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT" in (
+        analysis_service
+    )
+
+    assert "Compatibility aliases for template-era local integrations." in import_artifacts
+    assert "resolve_template_provider_snapshot_path" in import_artifacts
+    assert "Compatibility aliases for template-era local integrations." in provider_updates
+    assert "TemplateProviderUpdateConflict = ProviderUpdateConflict" in provider_updates
+
+    assert 'LEGACY_SETTINGS_STATE_KEY = "template_settings"' in app_state
+    assert "Backward-compatible aliases for older local tests and scripts." in app_state
+    assert "historical compatibility names" in public_deployment
+    assert "separate template-era Workbench runtime" in public_deployment
+    assert "WorkbenchReportFormat" in frontend_defaults
+    assert "TemplateReportFormat" not in frontend_defaults
+
+    active_runtime_docs = [
+        _read_repo_text("backend/app/__init__.py"),
+        _read_repo_text("backend/app/api/routes/__init__.py"),
+        _read_repo_text("backend/app/core/security.py"),
+        _read_repo_text("backend/app/repositories/__init__.py"),
+        _read_repo_text("backend/app/services/__init__.py"),
+        _read_repo_text("backend/app/services/reports.py"),
+    ]
+    forbidden_phrases = (
+        "Template Workbench",
+        "Template-stack",
+        "Template-style",
+        "Template-aligned",
+    )
+    violations = [
+        phrase for text in active_runtime_docs for phrase in forbidden_phrases if phrase in text
+    ]
+
+    assert violations == []
+
+
 def test_import_service_modules_do_not_import_http_or_route_boundaries() -> None:
     violations: dict[str, list[str]] = {}
     blocked_prefixes = ("fastapi", "starlette", "app.api")

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -83,7 +83,7 @@ from `make check` so the default developer loop stays fast, but it is available
 for release hardening and regression checks.
 
 The smoke generates 10,000 synthetic `generic-occurrence-csv` rows, imports them
-through the template Workbench API with locked provider data, verifies that
+through the Workbench API with locked provider data, verifies that
 10,000 findings are persisted, and checks that a high-offset findings page is
 stable across repeated requests.
 

--- a/docs/workbench-attack-methodology.md
+++ b/docs/workbench-attack-methodology.md
@@ -105,7 +105,7 @@ Evidence artifacts make ATT&CK provenance auditable.
 - Generated Markdown/HTML/JSON/CSV/SARIF reports: ATT&CK context remains separate from base priority and uses defensive wording.
 - `attack-navigator-layer.json`: optional Navigator layer containing CTID-backed mapped techniques for the run.
 - `governance/detection-coverage.json`: optional evidence-bundle export of operator-supplied detection controls, coverage-gap rollups, and review limitations.
-- Template evidence bundles include `attack-navigator-layer.json` when the run
+- Workbench evidence bundles include `attack-navigator-layer.json` when the run
   has persisted mapped ATT&CK context. The layer comments findings, KEV status,
   confidence, review status, source, and the current `not assessed` coverage
   placeholder.

--- a/frontend/src/lib/app-defaults.ts
+++ b/frontend/src/lib/app-defaults.ts
@@ -71,7 +71,7 @@ export const mvpImportFormats = [
 
 export type ImportFormat = (typeof mvpImportFormats)[number]["value"]
 
-export type TemplateReportFormat =
+export type WorkbenchReportFormat =
   | "markdown"
   | "html"
   | "json"
@@ -85,7 +85,7 @@ export const reportActionCards: Array<{
   detail: string
   format: string
   icon: LucideIcon
-  reportFormat: TemplateReportFormat
+  reportFormat: WorkbenchReportFormat
   title: string
 }> = [
   {

--- a/frontend/src/workbench/useReportsRouteState.ts
+++ b/frontend/src/workbench/useReportsRouteState.ts
@@ -11,7 +11,7 @@ import {
 } from "../api-client"
 import { getAccessToken } from "../auth"
 import type { WorkbenchPath } from "../components/app/AppShell"
-import type { TemplateReportFormat } from "../lib/app-defaults"
+import type { WorkbenchReportFormat } from "../lib/app-defaults"
 import {
   apiErrorDetail,
   apiErrorMessage,
@@ -69,7 +69,7 @@ export function useReportsRouteState({
   const [reportActionMessage, setReportActionMessage] = useState("")
   const [reportActionError, setReportActionError] = useState("")
   const [activeReportFormat, setActiveReportFormat] = useState<
-    TemplateReportFormat | ""
+    WorkbenchReportFormat | ""
   >("")
   const reportsQuery = useQuery({
     enabled: currentPath === "/reports" && Boolean(selectedRunId),
@@ -79,7 +79,7 @@ export function useReportsRouteState({
     staleTime: 15_000,
   })
   const createReportMutation = useMutation({
-    mutationFn: (format: TemplateReportFormat) =>
+    mutationFn: (format: WorkbenchReportFormat) =>
       ReportsService.createRunReport({
         run_id: selectedRunId,
         reportCreate: { format },
@@ -132,7 +132,7 @@ export function useReportsRouteState({
     })
   }
 
-  async function createReport(format: TemplateReportFormat) {
+  async function createReport(format: WorkbenchReportFormat) {
     if (!selectedRunId) {
       setReportActionError(
         "Select a completed analysis run before generating reports.",


### PR DESCRIPTION
Closes #428

Disposition: gap

Scope changed:
- Replaced active backend/frontend runtime names with Workbench-branded names: `WorkbenchAnalysisError`, `WorkbenchAnalysisResult`, `DEFAULT_WORKBENCH_PROVIDER_SNAPSHOT`, and `WorkbenchReportFormat`.
- Kept template-era imports only as explicitly commented compatibility aliases.
- Updated active module docstrings and two active docs references from template wording to Workbench wording.
- Added runtime-boundary test coverage that documents retained aliases and blocks old active-runtime phrases from returning.
- Added audit evidence at `archive/vpw-evidence/vpw-aud-603-template-runtime-naming.md`.

Validation:
- `rg -n 'template|Template' backend/app backend/tests frontend/src docs compose.yml README.md` -> audited; remaining hits are compatibility aliases, tests, historical docs, decision-template fields, GitHub templates, CSS `grid-template-*`, or example artifact names.
- `rg -n 'TemplateAnalysis|TemplateProvider|resolve_template|TemplateReportFormat|Template Workbench|Template-stack|Template-style|Template-aligned|template Workbench API|Template evidence bundles' backend/app frontend/src docs/benchmarking.md docs/workbench-attack-methodology.md` -> only compatibility aliases remain.
- `python3 -m pytest -q backend/tests/test_backend_runtime_boundary.py --no-cov` -> 17 passed.
- `make check` -> 971 passed, 4 skipped, coverage 90.96%.
- `make docs-check` -> passed.
- `make frontend-lint` -> passed.
- `cd frontend && npm run test:unit` -> 31 passed.
- `make frontend-build` -> passed.
- `git diff --check` -> passed.

Residual risk:
- Historical docs, test filenames, example artifact filenames, decision-template contract fields, and compatibility aliases intentionally retain `template` wording. No self-hosted data path was removed.

Scorecard impact:
- Repo Hygiene before: active runtime naming still had template-era residue.
- Repo Hygiene after: runtime defaults and active names are Workbench-branded; retained template names are documented/test-covered compatibility or historical references.