### PR TITLE
[VPW-AUD-999] Add final 10/10 audit scorecard

### DIFF
--- a/archive/vpw-evidence/vpw-aud-999-final-scorecard.md
+++ b/archive/vpw-evidence/vpw-aud-999-final-scorecard.md
@@ -1,0 +1,77 @@
+# VPW-AUD-999 Final Audit 10/10 Scorecard
+
+Issue: VPW-AUD-999 / #430
+Category: Final Scorecard
+Date: 2026-05-08
+
+## Decision
+
+The VPW audit remediation roadmap is rated 10/10 for the audited roadmap scope
+after all category scorecards closed and the final validation matrix passed
+with fresh evidence.
+
+This score covers the self-hosted Workbench, API, CLI compatibility, docs,
+release gates, Docker smoke paths, generated client drift, package checks, and
+repo hygiene boundaries covered by PP7 through PP14.
+
+## Category Scorecards
+
+| Category | Scorecard | State | Before | After | Decision |
+| --- | --- | --- | --- | --- | --- |
+| Backend/API | VPW-AUD-199 / #403 | Closed | 8/10 | 10/10 | Import dedupe, parser/report contracts, and service boundaries are validated. |
+| Frontend/UI | VPW-AUD-299 / #411 | Closed | 8/10 | 10/10 | Table containment, query aggregation, URL state, UI states, and dependency hygiene are validated. |
+| Security/Deployment | VPW-AUD-399 / #417 | Closed | 8/10 | 10/10 | Token fail-closed behavior, redaction, Docker defaults, and audit coverage are validated. |
+| Docs | VPW-AUD-499 / #422 | Closed | 8/10 | 10/10 | Support claims, release commands, auth docs, and historical ledger references are rebaselined. |
+| CI/Release | VPW-AUD-599 / #425 | Closed | 8/10 | 10/10 | Client drift, release evidence, and CI/release scorecard gates are validated. |
+| Repo Hygiene | VPW-AUD-699 / #429 | Closed | 7/10 | 10/10 | Ignored artifact policy, archive ownership, and legacy runtime naming are validated. |
+
+## Fresh Validation Matrix
+
+| Command | Result |
+| --- | --- |
+| `make check` | Passed: 971 passed, 4 skipped, coverage 90.96%. |
+| `make frontend-lint` | Passed: Biome checked 212 files with no fixes applied. |
+| `make frontend-build` | Passed: TypeScript and Vite production build completed. |
+| `make frontend-test-unit` | Passed: 31 Node unit tests passed. |
+| `make playwright-check` | Passed: 15 Playwright tests across UI smoke, responsive desktop/mobile, and accessibility. |
+| `make docs-check` | Passed: stale wording audit, release ledger structure, release evidence hygiene, and MkDocs build. |
+| `make dependency-audit` | Passed: backend pip audit found no known vulnerabilities; frontend npm production audit found 0 vulnerabilities. |
+| `make docker-demo-smoke` | Passed: Workbench demo import path, health checks, four findings, locked provider data, and cleanup. |
+| `make docker-production-smoke` | Passed: production-like same-origin host, import, four findings, report download, and cleanup. |
+| `make api-client-drift-check` | Passed: OpenAPI client regenerated and `frontend/src/client` diff remained clean. |
+| `make package-check` | Passed: package contents check OK; wheel and source distribution passed `twine check`. |
+| `make release-readiness-check` | Passed: repeated the release, frontend, client drift, dependency, demo evidence, Playwright, Docker, package, and pipx source smoke gates. |
+| `git diff --check` | Passed: no whitespace errors. |
+
+## Evidence Artifacts
+
+| Evidence | Purpose |
+| --- | --- |
+| `archive/vpw-evidence/vpw-aud-699-repo-hygiene-scorecard.md` | Final category scorecard dependency for repo hygiene. |
+| `archive/vpw-evidence/vpw-aud-599-ci-release-scorecard.md` | Final category scorecard dependency for CI/release. |
+| `archive/vpw-evidence/vpw-aud-499-docs-scorecard.md` | Final category scorecard dependency for docs. |
+| `archive/vpw-evidence/vpw-aud-399-security-deployment-scorecard.md` | Final category scorecard dependency for security/deployment. |
+| `archive/vpw-evidence/vpw-aud-299-frontend-ui-scorecard.md` | Final category scorecard dependency for frontend/UI. |
+| Issue closeout comments and PR check results for PP8 through PP14 | Linked implementation, validation, residual risk, and Project #9 synchronization evidence. |
+
+## Residual Risk Decisions
+
+- Historical PP1 through PP6 and earlier 10/10 artifacts remain historical
+  context only. The final score uses the fresh VPW-AUD-999 validation matrix.
+- Public-production readiness is supported only for the validated local and
+  production-like Docker evidence paths. A real external deployment still needs
+  operator-specific proof for TLS/proxy, host/CORS policy, secrets handling,
+  backup/restore operation, monitoring, and incident response.
+- Multi-user membership expansion is intentionally outside this closeout per
+  user request and is not part of the final score claim.
+- No secrets, tokens, cookies, customer data, or private filesystem paths are
+  recorded in this evidence artifact.
+
+## Final Score
+
+Before the audit remediation roadmap: 7/10 overall.
+
+After PP7 through PP14: 10/10 overall for the audited VPW roadmap scope.
+
+Decision: VPW-AUD-999 can close once this final scorecard PR is merged, the
+issue closeout comment links the merge evidence, and Project #9 is synchronized.


### PR DESCRIPTION
Closes #430

## Summary
- Adds the final VPW-AUD-999 scorecard evidence artifact.
- Records all six category scorecards as closed and rated 10/10.
- Records the fresh final validation matrix and residual-risk decisions without secrets or private paths.

## Validation
- `make check` -> passed; 971 passed, 4 skipped, coverage 90.96%.
- `make frontend-lint` -> passed; Biome checked 212 files.
- `make frontend-build` -> passed.
- `make frontend-test-unit` -> passed; 31 tests.
- `make playwright-check` -> passed; 15 tests.
- `make docs-check` -> passed.
- `make dependency-audit` -> passed; backend no known vulnerabilities, frontend 0 vulnerabilities.
- `make docker-demo-smoke` -> passed; demo import, 4 findings, locked provider data.
- `make docker-production-smoke` -> passed; production-like same-origin smoke, 4 findings, report download.
- `make api-client-drift-check` -> passed; generated client diff clean.
- `make package-check` -> passed; package contents OK and twine checks passed.
- `make release-readiness-check` -> passed; repeated release, browser, Docker, package, client drift, and evidence gates.
- `git diff --check` -> passed.

## Evidence
- `archive/vpw-evidence/vpw-aud-999-final-scorecard.md`

## Residual risk
- Final score applies to the audited VPW roadmap scope and validated local/production-like evidence paths.
- A real external deployment still needs operator-specific TLS/proxy, host/CORS, secrets, backup/restore, monitoring, and incident-response proof.
- Multi-user membership expansion remains outside this closeout per user request.
