### PR TITLE
Add backend provider status edge coverage

### DIFF
--- a/backend/tests/api/test_template_model_metadata.py
+++ b/backend/tests/api/test_template_model_metadata.py
@@ -150,6 +150,24 @@ def test_template_migration_bootstrap_ignores_empty_and_already_versioned_databa
         engine.dispose()
 
 
+def test_template_migration_bootstrap_leaves_unknown_legacy_schema_unstamped(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite:///{tmp_path / 'unknown-legacy.db'}"
+    engine = create_engine(database_url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(text("CREATE TABLE legacy_cache (id INTEGER PRIMARY KEY)"))
+
+        assert stamp_legacy_create_all_database(database_url=database_url) is None
+
+        inspector = inspect(engine)
+        assert "legacy_cache" in set(inspector.get_table_names())
+        assert "alembic_version" not in set(inspector.get_table_names())
+    finally:
+        engine.dispose()
+
+
 def test_template_migration_bootstrap_stamps_legacy_create_all_database(
     tmp_path: Path,
 ) -> None:

--- a/backend/tests/api/test_template_provider_status_api.py
+++ b/backend/tests/api/test_template_provider_status_api.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from sqlmodel import Session
 from utils.template_workbench import TemplateApiEnv, auth_headers
 
+from app.services.provider_status import provider_status_payload
 from vuln_prioritizer.models import (
     KevData,
     ProviderSnapshotItem,
@@ -276,6 +277,116 @@ def test_template_provider_status_redacts_production_paths_and_cache_details(
     }
     assert str(tmp_path) not in response.text
     assert "cache_namespace_hash" not in response.text
+
+
+def test_provider_status_projection_uses_source_hashes_when_metadata_omits_selection(
+    template_api_env: TemplateApiEnv,
+) -> None:
+    active_settings = template_api_env.client.app.state.workbench_settings
+    snapshot = template_api_env.app_models.ProviderSnapshot(
+        id=uuid.UUID("00000000-0000-4000-8000-000000000201"),
+        created_at=datetime(2026, 4, 28, 10, 0),
+        content_hash="sha256:provider-source-hash-fallback",
+        source_hashes_json={"kev": "sha256:kev-cache", "custom_feed": "sha256:custom"},
+        source_metadata_json={
+            "requested_cves": "7",
+            "cache_only": "true",
+            "output_path": "provider-snapshot.json",
+        },
+    )
+
+    payload = provider_status_payload(
+        snapshot,
+        latest_update_run=None,
+        active_settings=active_settings,
+    )
+
+    assert payload.snapshot.selected_sources == ["kev", "custom_feed"]
+    assert payload.snapshot.requested_cves == 7
+    assert payload.snapshot.mode == "cache-only"
+    assert payload.snapshot.source_path == "provider-snapshot.json"
+    sources = {source.name: source for source in payload.sources}
+    assert sources["kev"].selected is True
+    assert sources["kev"].available is True
+    assert sources["custom_feed"].selected is True
+    assert sources["custom_feed"].available is True
+    assert sources["custom_feed"].detail == "custom_feed status from the latest stored snapshot."
+    assert isinstance(payload.cache_age_seconds, int)
+
+
+def test_provider_status_projection_falls_back_to_available_snapshot_columns(
+    template_api_env: TemplateApiEnv,
+) -> None:
+    active_settings = template_api_env.client.app.state.workbench_settings
+    snapshot = template_api_env.app_models.ProviderSnapshot(
+        id=uuid.UUID("00000000-0000-4000-8000-000000000202"),
+        created_at=datetime(2026, 4, 28, 10, 0, tzinfo=UTC),
+        content_hash="sha256:provider-column-fallback",
+        nvd_last_sync="2026-04-28T10:15:00Z",
+        epss_date="2026-04-28",
+        source_metadata_json={"locked_provider_data": "yes"},
+    )
+
+    payload = provider_status_payload(
+        snapshot,
+        latest_update_run=None,
+        active_settings=active_settings,
+    )
+
+    assert payload.snapshot.selected_sources == ["nvd", "epss"]
+    assert payload.snapshot.mode == "locked"
+    sources = {source.name: source for source in payload.sources}
+    assert sources["nvd"].selected is True
+    assert sources["nvd"].last_sync == "2026-04-28T10:15:00Z"
+    assert sources["epss"].selected is True
+    assert sources["epss"].last_sync == "2026-04-28"
+    assert sources["kev"].selected is False
+    assert sources["kev"].available is False
+
+
+def test_provider_status_projection_redacts_failed_job_error_json_fallback(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    active_settings = template_api_env.client.app.state.workbench_settings
+    private_path = tmp_path / "private-cache" / "provider.json"
+    failed_run = template_api_env.app_models.AnalysisRun(
+        id=uuid.UUID("00000000-0000-4000-8000-000000000203"),
+        project_id=uuid.UUID("00000000-0000-4000-8000-000000000204"),
+        input_type="provider_update",
+        status=template_api_env.app_models.AnalysisRunStatus.FAILED,
+        error_json={"nested": {"path": str(private_path)}, "fallback": str(private_path)},
+        summary_json={
+            "sources": ["nvd"],
+            "execution_mode": "scheduled",
+            "provider_cache_dir": str(private_path.parent),
+        },
+        started_at=datetime(2026, 4, 28, 10, 0, tzinfo=UTC),
+    )
+
+    payload = provider_status_payload(
+        None,
+        latest_update_run=failed_run,
+        active_settings=replace(
+            active_settings,
+            ENVIRONMENT="production",
+            SECRET_KEY="template-shell-secret",
+            FIRST_SUPERUSER_PASSWORD="template-shell-password",
+            FRONTEND_HOST="https://workbench.example.com",
+            ALLOWED_HOSTS=("workbench.example.com",),
+        ),
+    )
+
+    assert payload.status == "degraded"
+    assert payload.cache_dir is None
+    assert payload.snapshot_dir is None
+    assert payload.latest_update_job is not None
+    assert payload.latest_update_job.execution_mode == "scheduled"
+    assert payload.latest_update_job.requested_sources == ["nvd"]
+    assert "provider_cache_dir" not in payload.latest_update_job.metadata_
+    assert payload.last_error is not None
+    assert str(tmp_path) not in payload.last_error
+    assert all(str(tmp_path) not in warning for warning in payload.warnings)
 
 
 def test_template_provider_update_job_create_list_and_status(

--- a/backend/tests/api/test_template_provider_updates_service.py
+++ b/backend/tests/api/test_template_provider_updates_service.py
@@ -158,6 +158,34 @@ def test_provider_update_lock_stale_check_treats_stat_errors_as_active(
     assert _provider_update_lock_is_stale(lock_path) is False
 
 
+def test_provider_update_lock_rejects_stale_lock_reclaim_race(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    lock_path = tmp_path / PROVIDER_UPDATE_LOCK_FILE
+    lock_path.write_text("stale", encoding="utf-8")
+    open_calls = 0
+
+    def fail_open(*_args: object, **_kwargs: object) -> int:
+        nonlocal open_calls
+        open_calls += 1
+        raise FileExistsError("race")
+
+    monkeypatch.setattr(provider_updates_module.os, "open", fail_open)
+    monkeypatch.setattr(
+        provider_updates_module,
+        "_provider_update_lock_is_stale",
+        lambda _path: True,
+    )
+
+    with pytest.raises(ProviderUpdateConflict, match="Provider update already running"):
+        with _provider_update_lock(tmp_path):
+            pass
+
+    assert open_calls == 2
+    assert not lock_path.exists()
+
+
 def test_cached_provider_records_load_valid_nvd_and_warn_on_invalid_payloads(
     tmp_path: Path,
 ) -> None:
@@ -200,10 +228,11 @@ def test_cached_provider_records_load_kev_catalog_and_warn_on_invalid_items(
     records, warnings = _cached_provider_records(
         source="kev",
         cache=cache,
-        cve_ids=["CVE-2024-3094", "CVE-2021-44228"],
+        cve_ids=["CVE-2024-3094", "CVE-2021-44228", "CVE-1999-0001"],
     )
 
     assert records["CVE-2024-3094"].in_kev is True
+    assert "CVE-1999-0001" not in records
     assert warnings == ["Cache-only KEV data invalid for CVE(s): CVE-2021-44228."]
 
 


### PR DESCRIPTION
## Summary
- add provider status projection tests for source-selection fallbacks, locked/cache-only mode parsing, and production-safe failed-job redaction
- cover unknown legacy schema migration-bootstrap behavior so unmatched pre-Alembic tables remain unstamped
- add provider update lock-race and KEV cache-miss edge coverage

## Coverage impact
- provider_status.py: 96.98%
- provider_updates.py: 97.74%
- migration_bootstrap.py: 96.55%
- total backend coverage: 96.74%

## Verification
- python3 -m pytest -q backend/tests/api/test_template_provider_status_api.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_provider_updates_service.py --no-cov
- python3 -m ruff format --check backend/tests/api/test_template_provider_status_api.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_provider_updates_service.py
- python3 -m ruff check backend/tests/api/test_template_provider_status_api.py backend/tests/api/test_template_model_metadata.py backend/tests/api/test_template_provider_updates_service.py
- cd backend && python3 -m mypy app src
- make check