### PR TITLE
[codex] Polish open-source docs and evidence gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -70,7 +70,7 @@ What should have happened instead?
 - [ ] Commands run and results are posted before closure.
 - [ ] No secrets, customer scanner exports, tokens, cookies, or private paths are
       included in public evidence.
-- [ ] Public-production readiness is not claimed unless PP5 release-readiness
+- [ ] Public deployment certification is not claimed unless release-readiness
       evidence and the final scorecard issue support it.
 
 ## Evidence

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -60,7 +60,7 @@ What simpler approaches were considered?
 - [ ] Tests or evidence artifacts are named before implementation.
 - [ ] API, DB, generated-client, UI, docs, and security impacts are identified.
 - [ ] Residual risk and follow-up work are documented.
-- [ ] Public-production readiness is not claimed unless PP5 release-readiness
+- [ ] Public deployment certification is not claimed unless release-readiness
       evidence and the final scorecard issue support it.
 
 ## Evidence

--- a/.github/ISSUE_TEMPLATE/security_hardening.md
+++ b/.github/ISSUE_TEMPLATE/security_hardening.md
@@ -42,8 +42,8 @@ Describe the smallest safe change.
 
 ## Safety Checklist
 
-- [ ] No public-production readiness is claimed without explicit threat-model,
-      deployment, release-readiness, and PP5 scorecard evidence.
+- [ ] No public deployment certification is claimed without explicit
+      threat-model, deployment, release-readiness, and final scorecard evidence.
 - [ ] No secrets, token values, cookies, API keys, customer exports, or private
       paths are exposed.
 - [ ] No scanner, exploit, PoC, active probing, credential testing, or

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,6 +61,8 @@ Commit/tag:
 Result:
 Artifact or CI URL:
 SHA-256 artifact list:
+Public TLS/header evidence:
+Archive binary manifest:
 Residual risk:
 Owner:
 Follow-up:
@@ -86,9 +88,9 @@ Decision wording:
       exposed in code, logs, screenshots, reports, or docs
 - [ ] upload limits, rooted artifact paths, safe parsing, CSRF-sensitive forms,
       security headers, and token hashing are not weakened
-- [ ] public-production Workbench readiness is not claimed before the PP5
-      scorecard closes with threat-model, deployment, release, and residual-risk
-      evidence
+- [ ] public deployment certification is not claimed before the final
+      release-readiness scorecard closes with threat-model, deployment, release,
+      and residual-risk evidence
 
 ## Docs / Release Notes
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ Thumbs.db
 # Local note exports kept outside version control
 Threat-Informed Vulnerability Prioritization Report.html
 
+# Internal audits and private scorecards
+docs/audits/
+
 # Environment and secrets
 .env
 .env.*
@@ -32,6 +35,8 @@ __pycache__/
 .benchmarks/
 .coverage
 .coverage.*
+backend/.coverage
+backend/.coverage.*
 coverage.xml
 htmlcov/
 test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 ### Added
 
 - VPW-076 release-story evidence that links v1.0 release notes, changelog, demo evidence bundle verification, screenshots, roadmap state, 15-minute technical/CISO storyline, and backup plan.
+- GitHub open-source readiness documentation, maintainer ownership guidance,
+  and stronger public repository routing links across README, Support,
+  Contributing, and MkDocs.
+
+### Changed
+
+- Updated GitHub issue and pull request templates to use the current final
+  release scorecard language and include public TLS/header plus archive binary
+  evidence fields where release-readiness evidence is requested.
 
 ## [1.1.0] - 2026-04-25
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,15 @@
 # Contributing
 
-Thanks for contributing to `vuln-prioritizer`.
+Thanks for contributing to `vuln-prioritizer-workbench`.
+
+Start with the public GitHub routing docs before opening broad changes:
+
+- [README.md](README.md)
+- [SUPPORT.md](SUPPORT.md)
+- [MAINTAINERS.md](MAINTAINERS.md)
+- [docs/current-product-state.md](docs/current-product-state.md)
+- [docs/github-open-source-readiness.md](docs/github-open-source-readiness.md)
+- [docs/documentation-map.md](docs/documentation-map.md)
 
 ## Scope Guardrails
 
@@ -66,10 +75,9 @@ directories too.
 - Use focused branches, normally under `codex/` for Codex-authored work.
 - Prefer one roadmap issue per PR unless the dependency group is documented in
   the PR body.
-- For the Full Stack FastAPI Template migration, keep stacked branches explicit
-  and state the base branch in the PR. Do not claim old Jinja2/SQLAlchemy
-  Workbench behavior as completion evidence for React/JWT/SQLModel/template
-  issues.
+- For historical migration follow-ups, keep stacked branches explicit and state
+  the base branch in the PR. Do not claim removed or archived Workbench behavior
+  as completion evidence for the active FastAPI/React runtime.
 - Open draft PRs while evidence is still being collected.
 - Keep direct pushes to `main` for emergencies only.
 
@@ -159,6 +167,10 @@ To validate the browsable documentation site:
 ```bash
 make docs-check
 ```
+
+This gate includes stale wording checks, archive binary evidence manifest
+validation, public deployment evidence contract validation, and a clean MkDocs
+build.
 
 ## Commit Discipline
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,68 @@
+# Maintainers
+
+This file defines the public maintainer and ownership model for the repository.
+It complements `.github/CODEOWNERS`, `CONTRIBUTING.md`, `SECURITY.md`, and the
+GitHub-side repository settings that cannot be versioned in this checkout.
+
+## Current Ownership
+
+| Area | Primary owner | Notes |
+| --- | --- | --- |
+| Repository default ownership | `@Noetheon` | Mirrors `.github/CODEOWNERS`. |
+| Security policy and disclosure routing | `@Noetheon` | Private security reports follow `SECURITY.md`. |
+| Release evidence and package publication | `@Noetheon` | Release claims require current evidence in the release ledger. |
+| Documentation architecture | `@Noetheon` | Current truth is owned through `docs/current-product-state.md` and `docs/documentation-map.md`. |
+
+## Maintainer Responsibilities
+
+Maintainers are expected to:
+
+- keep the project focused on defensive prioritization of already-known CVEs
+- protect the no-scanner, no-exploit, no-autopatcher, and no-heuristic
+  ATT&CK-mapping boundaries
+- review contributions through pull requests unless an emergency path is
+  required
+- require local or CI evidence for behavior, API, DB, frontend, docs, Docker,
+  release, and security changes
+- keep public documentation aligned with the active FastAPI/React Workbench and
+  retained CLI/core package
+- keep historical evidence clearly labelled as historical or demo evidence
+- avoid public release or deployment claims that are not backed by current
+  release-candidate evidence
+
+## Review Expectations
+
+Normal pull requests should include:
+
+- a clear scope statement
+- affected surfaces such as CLI, backend API, DB/migrations, frontend, Docker,
+  docs, release, packaging, or security
+- commands run and results
+- screenshots, traces, generated-client drift checks, migration output, or
+  release evidence when relevant
+- residual risk and follow-up issues when something is intentionally deferred
+
+Docs-only changes normally need `make docs-check`. Behavior changes normally
+need `make check` plus narrower frontend, Docker, Playwright, release, or
+security gates when those surfaces are touched.
+
+## Release Ownership
+
+Release candidates are not accepted from historical evidence alone. Before a
+candidate is described as externally certified, maintainers must attach fresh
+evidence for the exact commit, tag, or release candidate in the public release
+ledger.
+
+Required release evidence is tracked in
+`docs/public-production-release-evidence-ledger.md` and
+`docs/release_operations.md`.
+
+## Escalation
+
+- Usage and workflow questions follow `SUPPORT.md`.
+- Security issues follow `SECURITY.md`.
+- Conduct issues follow `CODE_OF_CONDUCT.md`.
+- GitHub repository topics, branch protection, discussions, private
+  vulnerability reporting, and trusted-publisher settings are configured on
+  GitHub and tracked through `docs/github-open-source-readiness.md` and
+  `docs/community_repository_setup.md`.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DEMO_EVIDENCE_ANALYSIS_FILE := build/v1.0-demo-analysis.json
 DEMO_EVIDENCE_BUNDLE_FILE := build/v1.0-demo-evidence-bundle.zip
 DEMO_EVIDENCE_VERIFICATION_FILE := build/v1.0-demo-evidence-bundle-verification.json
 
-.PHONY: install test lint format fix typecheck check benchmark-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-unit frontend-test-unit-coverage frontend-generate-client api-client-drift-check frontend-audit frontend-check python-lock-check release-evidence-hygiene-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke docker-production-smoke dependency-audit clean-local clean-deps provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-contents-check package-check package-check-temp pipx-source-smoke release-check release-readiness-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
+.PHONY: install test lint format fix typecheck check benchmark-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-unit frontend-test-unit-coverage frontend-generate-client api-client-drift-check frontend-audit frontend-check python-lock-check archive-evidence-check public-production-evidence-check release-evidence-hygiene-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke docker-production-smoke dependency-audit clean-local clean-deps provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-contents-check package-check package-check-temp pipx-source-smoke release-check release-readiness-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
 
 install:
 	$(PYTHON) -m pip install -e "$(BACKEND_DIR)[dev]"
@@ -100,10 +100,16 @@ frontend-check: frontend-install frontend-lint frontend-build frontend-test-unit
 release-evidence-hygiene-check:
 	$(PYTHON) scripts/check_release_evidence_hygiene.py
 
+archive-evidence-check:
+	$(PYTHON) scripts/check_archive_evidence_manifest.py
+
+public-production-evidence-check:
+	$(PYTHON) scripts/check_public_deployment_evidence.py
+
 python-lock-check:
 	$(PYTHON) scripts/check_release_evidence_hygiene.py
 
-docs-check: release-evidence-hygiene-check
+docs-check: release-evidence-hygiene-check archive-evidence-check public-production-evidence-check
 	$(PYTHON) -m mkdocs build --clean
 
 docs-serve:
@@ -219,7 +225,7 @@ clean-local:
 	rm -rf .cache .mypy_cache .pytest_cache .ruff_cache .playwright-cli .playwright-mcp
 	rm -rf backend/.mypy_cache backend/.pytest_cache backend/.ruff_cache
 	rm -rf build dist site htmlcov test-results frontend/test-results frontend/playwright-report frontend/dist
-	rm -rf .coverage .coverage.* coverage.xml backend-uvicorn.log frontend-vite.log
+	rm -rf .coverage .coverage.* backend/.coverage backend/.coverage.* coverage.xml backend-uvicorn.log frontend-vite.log
 	find . -name __pycache__ -type d -not -path './.git/*' -prune -exec rm -rf {} +
 	find . -name '*.py[co]' -not -path './.git/*' -delete
 
@@ -288,7 +294,7 @@ release-check:
 	$(MAKE) pipx-source-smoke
 	$(MAKE) demo-sync-check
 
-release-readiness-check: release-check api-client-drift-check demo-evidence-bundle-check playwright-check docker-production-smoke
+release-readiness-check: release-check api-client-drift-check archive-evidence-check public-production-evidence-check demo-evidence-bundle-check playwright-check docker-production-smoke
 
 demo-report:
 	$(DEMO_ENV) $(PYTHON) -m vuln_prioritizer.cli analyze --input data/sample_cves.txt --output docs/example_report.md --format markdown $(DEMO_PROVIDER_FLAGS)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ and [Reporting and CI Integration](docs/integrations/reporting_and_ci.md).
 
 Public docs:
 
+- [Current product state](docs/current-product-state.md)
+- [Documentation map](docs/documentation-map.md)
+- [GitHub Open Source Readiness](docs/github-open-source-readiness.md)
 - [Documentation home](docs/index.md)
 - [User Documentation Guide](docs/user_documentation.md)
 - [Product Architecture](docs/architecture.md)
@@ -165,6 +168,8 @@ Public docs:
 - [Support Matrix](docs/support_matrix.md)
 - [Workbench Threat Model](docs/workbench-threat-model.md)
 - [Public-Production Release Evidence Ledger](docs/public-production-release-evidence-ledger.md)
+- [Roadmap](docs/roadmap.md)
+- [Community Repository Setup](docs/community_repository_setup.md)
 
 Submission and reviewer docs:
 
@@ -183,9 +188,12 @@ README:
 - [Presentation evidence index](archive/vpw-evidence/presentation-pack/evidence-index.md)
 - [Presentation pack overview](archive/vpw-evidence/presentation-pack/README.md)
 - [Historical evidence archive](archive/vpw-evidence/MANIFEST.md)
-- [Example technical report artifact](docs/examples/vpw-054-template-technical-report.md)
-- [Example executive report artifact](docs/examples/vpw-054-template-executive-report.html)
-- [Example analysis result artifact](docs/examples/vpw-054-template-analysis-result.v1.json)
+- [Example Markdown report](docs/example_report.md)
+- [Example ATT&CK-aware report](docs/example_attack_report.md)
+- [Example PR comment body](docs/examples/example_pr_comment.md)
+- [VPW-054 technical report snapshot](docs/examples/vpw-054-template-technical-report.md)
+- [VPW-054 executive report snapshot](docs/examples/vpw-054-template-executive-report.html)
+- [VPW-054 analysis result snapshot](docs/examples/vpw-054-template-analysis-result.v1.json)
 - [GitHub Actions report artifact workflow](.github/examples/workbench-report-artifacts.yml)
 
 Canonical report/evidence contract artifacts remain under `docs/evidence/` and
@@ -218,7 +226,7 @@ cd frontend && npm run lint
 cd frontend && npm run test:unit
 cd frontend && npm run test -- tests/ui-smoke.spec.ts
 
-python3 -m pytest -q backend/tests/api/test_template_reports_api.py --no-cov
+python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
 python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
 python3 -m mkdocs build --clean
 make docs-check
@@ -243,9 +251,29 @@ as a final internet-facing certification until
 [VPW-AUD-999](https://github.com/Noetheon/vuln-prioritizer-workbench/issues/430)
 closes with evidence.
 
+## GitHub Community Health
+
+This repository keeps the public GitHub entrypoints versioned in the repo:
+
+- [Contributing guide](CONTRIBUTING.md)
+- [Support guide](SUPPORT.md)
+- [Security policy](SECURITY.md)
+- [Code of conduct](CODE_OF_CONDUCT.md)
+- [Maintainers](MAINTAINERS.md)
+- [Changelog](CHANGELOG.md)
+- [GitHub Open Source Readiness](docs/github-open-source-readiness.md)
+
+Repository settings such as discussions, branch protection, repository topics,
+private vulnerability reporting, and trusted publisher configuration must still
+be confirmed in GitHub; the maintainer checklist is in
+[Community Repository Setup](docs/community_repository_setup.md).
+
 ## License, Security, And Contributing
 
 - License: [MIT](LICENSE)
 - Security policy: [SECURITY.md](SECURITY.md)
 - Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Support: [SUPPORT.md](SUPPORT.md)
+- Code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Maintainers: [MAINTAINERS.md](MAINTAINERS.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ CVE-to-ATT&CK mappings with heuristics or AI.
 
 The current VPW cycle hardens the implemented `backend/app` Workbench, retained
 CLI/core package, React frontend, generated-client boundary, docs, packaging,
-and release gates for public-production review.
+and release gates for public release-readiness review.
 
 1. Security/auth/deployment baseline: document and verify the implemented
    session, token, upload/report, CSP/routing, health/readiness, dependency, and
@@ -31,11 +31,12 @@ and release gates for public-production review.
 2. Migration/package/docs coherence: keep issue templates, package boundaries,
    generated-client ownership, archive boundaries, and current-state docs
    aligned with the implemented runtime.
-3. Public-production release evidence: collect package contents, source-tag
+3. Public release evidence: collect package contents, source-tag
    install smoke, docs build, client drift, evidence bundle verification, Docker
    smoke, and residual-risk decisions in the release evidence ledger.
-4. PP5 certification: run the final quality gate and close the 10/10 scorecard
-   only when every category has current evidence and no unresolved P1/P2 blocker.
+4. Final readiness certification: run the final quality gate and close the
+   release-readiness scorecard only when every category has current evidence and
+   no unresolved high-priority blocker.
 
 ## Roadmap Guardrails
 
@@ -44,8 +45,8 @@ and release gates for public-production review.
   artifacts, residual risk, and follow-up links.
 - Treat historical template-era and removed-runtime notes as reference material,
   not automatic completion evidence for current `backend/app` work.
-- Preserve the local-first posture until public-production deployment hardening
-  and PP5 evidence explicitly support a stronger claim.
+- Preserve the local-first posture until public deployment hardening and fresh
+  release evidence explicitly support a stronger claim.
 - Keep ATT&CK defensive and evidence-based. Do not infer mappings.
 
 ## Key References

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ exploit framework, or asset discovery platform.
 
 The Workbench is local-first and self-hosted by default. Treat it as a trusted
 single-workspace operator tool unless the public deployment runbook, threat
-model, release evidence ledger, and PP5 scorecard all cover the target
+model, release evidence ledger, and final release scorecard all cover the target
 deployment's TLS/proxy configuration, backup and restore, audit retention, token
 handling, role boundaries, upload/download storage, and residual risks.
 
@@ -71,6 +71,6 @@ Include, when possible:
 - XML, SBOM, scanner, and advisory inputs are treated as local exported evidence
   files. The tool must not scan remote systems to create those files.
 - Public internet deployment remains gated by the threat model, public
-  deployment runbook, release evidence ledger, and PP5 scorecard. Do not claim
-  public-production readiness from local quickstart or package-release evidence
-  alone.
+  deployment runbook, release evidence ledger, and final release scorecard. Do
+  not claim public deployment certification from local quickstart or
+  package-release evidence alone.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,7 +15,9 @@ Start with the repo docs first:
 
 - [README.md](README.md)
 - [docs/index.md](docs/index.md)
+- [docs/user_documentation.md](docs/user_documentation.md)
 - [docs/playbooks.md](docs/playbooks.md)
+- [docs/github-open-source-readiness.md](docs/github-open-source-readiness.md)
 
 ## Bugs And Feature Requests
 
@@ -36,4 +38,6 @@ Use GitHub private vulnerability reporting for this public repository. If that f
 
 ## Scope Reminder
 
-`vuln-prioritizer` is a local-first CLI for prioritizing known CVEs and existing findings. It is not a scanner, SaaS platform, or heuristic CVE-to-ATT&CK mapper.
+`vuln-prioritizer` is a local-first CLI and self-hosted Workbench for
+prioritizing known CVEs and existing findings. It is not a scanner, SaaS
+platform, exploit framework, autopatcher, or heuristic CVE-to-ATT&CK mapper.

--- a/archive/vpw-evidence/BINARY-MANIFEST.json
+++ b/archive/vpw-evidence/BINARY-MANIFEST.json
@@ -1,0 +1,462 @@
+{
+  "files": [
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/01-dashboard-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "aa7bf36eb50099c980a88001af752d50635ace5db42752c56aa4be92b7199a73",
+      "size_bytes": 258389
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/01-dashboard.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "aa7bf36eb50099c980a88001af752d50635ace5db42752c56aa4be92b7199a73",
+      "size_bytes": 258389
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/02-projects-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "9bfe5ef49df4c7989bae165407e6af9587ba1e8d8315c39b08f553b964ec5ab3",
+      "size_bytes": 181769
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/02-projects.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "9bfe5ef49df4c7989bae165407e6af9587ba1e8d8315c39b08f553b964ec5ab3",
+      "size_bytes": 181769
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/03-imports-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "438866032619f09e7f6b904d61476036af561adc2d748f299aad008fdee35c63",
+      "size_bytes": 195643
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/03-imports.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "438866032619f09e7f6b904d61476036af561adc2d748f299aad008fdee35c63",
+      "size_bytes": 195643
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/04-findings-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "43e70afbfa9104939c7bd504011be4e8180aa65d869554d473f9102eeb6da643",
+      "size_bytes": 283208
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/04-findings.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "43e70afbfa9104939c7bd504011be4e8180aa65d869554d473f9102eeb6da643",
+      "size_bytes": 283208
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/05-finding-detail-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "b9281863e398964b2456f8ba9aafbc5ddd3115c0728c25ed120fa4b90740fb84",
+      "size_bytes": 467021
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/05-finding-detail.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "8f31153642e7b40250df1ac18e78da4fcc4ebfb83fe68724b5c2da63b393be40",
+      "size_bytes": 457670
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/06-ttp-context-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "c7e6b03c683f3e3f816bd538336b590b0baf5aaea364a6fb4f12759eeaff4a31",
+      "size_bytes": 277782
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/06-ttp-context-mapped-demo.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "46c62728d7b5a16b3a0102a87e84f777204ba93c0fc7a29b240b168e8d1e93b3",
+      "size_bytes": 311618
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/06-ttp-context.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "8a7f3c834b51c49cec756895b118b828fa0c815de5fdb1640e1201968bef5a4e",
+      "size_bytes": 278270
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/07-waivers-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "5545119a11bfd4ca086f4d4c1f602bcb741293ba0ec18d3a3babe40e9f79cff5",
+      "size_bytes": 195828
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/07-waivers.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "5545119a11bfd4ca086f4d4c1f602bcb741293ba0ec18d3a3babe40e9f79cff5",
+      "size_bytes": 195828
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/08-evidence-center-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "f30d8b1bb7443bb79d7f8da4f7aea8a90f95e6d0aa497701b4fa67a41ae32ca4",
+      "size_bytes": 216812
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/08-evidence-center.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "8a271f545e43089994d1ef5d4828dbce6f8c8797e288dca117a5826392391b5f",
+      "size_bytes": 213243
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/09-report-generated.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "9c346748e02387a9f7aaa938841a73a575f71d149ff91fb67b241769a4301b6f",
+      "size_bytes": 200592
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/final-demo-flow/09-report-or-bundle-generated-final.png",
+      "purpose": "Historical final demo flow screenshot.",
+      "sha256": "abe537ac1e6a59ffe949e27385f555768547f80425b0569b438ccf15c97cbc3c",
+      "size_bytes": 225043
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-036-openapi-docs.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "dd6894019111ae39a0be49a3487d01724c69b31d518a26237cfb1393ad511b36",
+      "size_bytes": 427827
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-037-sidebar.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "dbea252e2764cb23a84cb098ecf8ef67d7d9c3bf8daf432d71561c9599130d8b",
+      "size_bytes": 25648
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-038-dashboard.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "35a5bbc0d9df5369bb998a8c8bf98363aa974cb7f35f1d5ee48f8cd0f8594f81",
+      "size_bytes": 187635
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-039-projects.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "1ddd3caf227328807d9f2e5fb61903a24112cd7cd998a57a6b47a678c5c763db",
+      "size_bytes": 174421
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-040-import-wizard.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "7db3728c6232d2ae2ab265f561ba06fca7c7d690f75dc165211e23b15473b373",
+      "size_bytes": 197678
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-041-import-runs.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "1b78a301191b2dc946c64055f5236ec9e3aafdff448720bdd382eea5e4654cfb",
+      "size_bytes": 144586
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-041-run-detail.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "e7a27f7353c055629307111157c9b293ed214caf8bff39dce98f800ca3ee8608",
+      "size_bytes": 109017
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-042-findings-table.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "aa9540ac15e1d808cca623b0b7b635fa3c532c2b06315e4b1c6b7e1dac5ad74b",
+      "size_bytes": 126965
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-043-finding-detail.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "ba2a64927bc3c4a8bdffa8436c9f81be456375e0e59a7d5b3e4100ddadff536e",
+      "size_bytes": 306279
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-044-assets-page.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "30d54be6174f7240eed54ba829e5e7db857e608b3a9d0265f20e9dd17f506669",
+      "size_bytes": 127485
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-044-finding-context.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "8438bdd38024d21790e0a4be511d6b48adf291a0ef6e91075787eecc67842fba",
+      "size_bytes": 306032
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-045-provider-status.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "265deae8c13d0668add8aadf08f4cb6f610f992869d1f9c7f4cd18068f60bd82",
+      "size_bytes": 104959
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-046-reports-page.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "866a525cd0cd5520f64598f44c96fd349d18e8daad36f1a5fa17d7c1071eff7a",
+      "size_bytes": 204039
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-047-core-workbench-flow.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "ba2a64927bc3c4a8bdffa8436c9f81be456375e0e59a7d5b3e4100ddadff536e",
+      "size_bytes": 306279
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-049-html-executive-report.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "f4491d354dc2c217d7280c1cc0369c00a71e3ed99b2d4e8ba2fa27d07bde0fe8",
+      "size_bytes": 199421
+    },
+    {
+      "kind": "zip",
+      "path": "archive/vpw-evidence/vpw-051-evidence-bundle.zip",
+      "purpose": "Historical evidence bundle artifact retained for verification context.",
+      "sha256": "981fff35db0c80e31a432fa051a46ec66b84c424f5016bf80153075b27570b81",
+      "size_bytes": 6649
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-053-report-downloads.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "08ba6a0bd86c63ce2a5b5ae6e58df111c559979747727b12095c551acd3e7edc",
+      "size_bytes": 144956
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-058-ttp-context-tab.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "97fddbe949fce518211574ca339907bb0b5e622ef215b704451402eaa84af331",
+      "size_bytes": 196554
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-059-attack-summary-dashboard.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "c6df486c51ff5a86ccf86a810c71e67477a5f7168e0024fb6ffea04a93abff9e",
+      "size_bytes": 133232
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-060-attack-navigator-layer.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "2422ba352e0ef723be3bab5cf622dbe69b05db74459b837e4718d832e3d5716e",
+      "size_bytes": 131727
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-063-asset-context-editor.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "876c4803fb2727c90c6f423e8b639d045b796c399b6fc7b0e1d6e5106df0c7df",
+      "size_bytes": 221491
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-063-asset-recalculate.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "eef7a9801a74a926d3ef21f8ac7d4061cdc9043229c8dfadda9f71c9d6d0c1ca",
+      "size_bytes": 120274
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-064-waiver-risk-acceptance.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "f68e7293053c35bbae1b89e5759d6b8111b09732c765bb676e47b2a7a66f49ad",
+      "size_bytes": 346182
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-065-openvex-status-application.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "a81636d54f5123e0743547f2219c9a7cd05b61d76ea494ce783a37383d8aa1fa",
+      "size_bytes": 306759
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-066-cyclonedx-vex-parser.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "0101679bed71d78de26de3e025b273b36be35d8a0a989ed590149bca26e18993",
+      "size_bytes": 310899
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-067-governance-rollups-waiver-debt.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "8c721bdbbf7aa53cbe21a3d9fdf6eb46b1a4ab6ab9f7e21fe7d648362bd965a1",
+      "size_bytes": 211368
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-067-top-services-by-risk.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "9dd3574f2b5931ce631efba3ab5330a7ff6e4e99f095f5f633d5782fbcad6291",
+      "size_bytes": 215193
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-075-dashboard.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "111a62d2790072a7936a5594f51a04ba8fc46285f1fd5fea3bd356d2026fb666",
+      "size_bytes": 214739
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-075-findings.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "f522b924033b325acb17435547f6eb7144ee55e1d21fbb1d67ddbab55f55e00f",
+      "size_bytes": 158228
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-079-detection-coverage-dashboard.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "a3fbb45f69ac39d1bd08cc3c96cf575f04329681249d4e057305aad34937db36",
+      "size_bytes": 493890
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-081-settings-token-ui.png",
+      "purpose": "Historical issue-level Workbench evidence screenshot.",
+      "sha256": "500d75ebd9518deae718e273372a2522ed66c7fc339a50746b0755aa3910de3b",
+      "size_bytes": 174819
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/assets-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "4ebe6054d1c2c75af057ace92a1f680c5e9754f22ca929ba3d6491845c6113c0",
+      "size_bytes": 291352
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/evidence-center-vpw-integrated-clean.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "0a327f7de68aa14f1b4601dac405acf20eca5ffbed7caaa9a3ac40b99181cd80",
+      "size_bytes": 400133
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/evidence-center-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "20ba59b09410565746d6b27db1597430dfd7ee9e804ea1631f2591cf2be7b9c1",
+      "size_bytes": 407595
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/imports-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "0d218bde0480e69ba84ec980562bec2507d909f77db2313328f4a30d42567c59",
+      "size_bytes": 296831
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/projects-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "ff94650ede4511d9f262e9c730a6c44f9dc4e56c5cab6e092c4e7b48ce6c1163",
+      "size_bytes": 295445
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/providers-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "a0f15a6cd3b69a51171d0fd487b63628b0aa87403f6fb83e1ee9faa2a6b4f666",
+      "size_bytes": 172317
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/settings-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "069e643cf33d3624e298e5f7e313665c58190e129a2d46f9b6cd5b72d034f2c9",
+      "size_bytes": 241639
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-complete-set-desktop.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "ec3beb6ec7d32fb6d987594f9dcf1a139d8fd2e11d2ab9c237aa390869b8c88d",
+      "size_bytes": 718562
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-complete-set-mobile.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "eba3833a29a14702970fd96fcbf0dd0326eaa756c4454518ebd6fb92b33f9d45",
+      "size_bytes": 774819
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-dashboard.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "8348a0e3dc95f24ddd283403a29b1028ccce21779f5f3b5bccb4d3c248fc2393",
+      "size_bytes": 243981
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-evidence-center.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "f8390e81738bc99daf0550e46f55d78d5d26bf6c0fb3d38250acb64b36b22070",
+      "size_bytes": 197113
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-finding-detail.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "fffdc2135447636fce6055f753e394ec23b1953512eced93b45cb4f92556f4ef",
+      "size_bytes": 286992
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-findings.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "c60c7973d6579ec0011f3ec7ca32060f24d26b7792d28f8d66f68c7a517dab79",
+      "size_bytes": 314951
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/vpw-design-system-foundation-showcase.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "ec3beb6ec7d32fb6d987594f9dcf1a139d8fd2e11d2ab9c237aa390869b8c88d",
+      "size_bytes": 718562
+    },
+    {
+      "kind": "png",
+      "path": "archive/vpw-evidence/vpw-design-system-foundation/waivers-vpw-integrated.png",
+      "purpose": "Historical design-system evidence screenshot.",
+      "sha256": "755bf16bb3c4239684c090d3ac31f475d8142d29990fc60966c26834aabbffbb",
+      "size_bytes": 362472
+    }
+  ],
+  "policy": "Historical binary evidence must be public-safe, purpose-labelled, and hash-pinned. ZIP members are checked for unsafe paths and sensitive-looking names.",
+  "root": "archive/vpw-evidence",
+  "schema_version": 1
+}

--- a/archive/vpw-evidence/MANIFEST.md
+++ b/archive/vpw-evidence/MANIFEST.md
@@ -13,6 +13,8 @@ repo hygiene cleanup.
 - Root-level `vpw-*.png`: issue-level browser evidence.
 - Root-level `vpw-*.json`, `vpw-*.csv`, and `vpw-*.zip`: machine-readable
   validation and bundle artifacts.
+- `BINARY-MANIFEST.json`: hash-pinned inventory of tracked binary evidence,
+  including purpose labels and ZIP-safety validation.
 
 ## Ownership Rules
 
@@ -27,6 +29,10 @@ repo hygiene cleanup.
   the repository.
 - Update this manifest when adding a new evidence subdirectory or a new class of
   root-level artifact.
+- Update `BINARY-MANIFEST.json` with
+  `python3 scripts/check_archive_evidence_manifest.py --update` when adding,
+  removing, or intentionally replacing tracked binary evidence, then run
+  `python3 scripts/check_archive_evidence_manifest.py`.
 - Do not archive secrets, tokens, cookies, customer data, private absolute
   paths, or raw local ignored-artifact inventories.
 

--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -8,8 +8,15 @@ import yaml
 from paths import REPO_ROOT
 
 MKDOCS_FILE = REPO_ROOT / "mkdocs.yml"
+README_FILE = REPO_ROOT / "README.md"
 ARCHIVE_ROOT = REPO_ROOT / "archive"
 REPORTS_AND_EVIDENCE_FILE = REPO_ROOT / "docs" / "reports-and-evidence.md"
+CURRENT_PRODUCT_STATE_FILE = REPO_ROOT / "docs" / "current-product-state.md"
+DOCUMENTATION_MAP_FILE = REPO_ROOT / "docs" / "documentation-map.md"
+GITHUB_READINESS_FILE = REPO_ROOT / "docs" / "github-open-source-readiness.md"
+COMMUNITY_SETUP_FILE = REPO_ROOT / "docs" / "community_repository_setup.md"
+MAINTAINERS_FILE = REPO_ROOT / "MAINTAINERS.md"
+SUPPORT_FILE = REPO_ROOT / "SUPPORT.md"
 TEXT_SUFFIXES = {
     ".css",
     ".html",
@@ -195,3 +202,56 @@ def test_archives_have_entrypoints_and_public_evidence_tree_is_limited() -> None
     assert "Ownership Rules" in archive_manifest
     assert "Update this manifest" in archive_manifest
     assert "Do not archive secrets" in archive_manifest
+
+
+def test_documentation_map_defines_current_and_historical_boundaries() -> None:
+    mkdocs = yaml.safe_load(MKDOCS_FILE.read_text(encoding="utf-8"))
+    nav_pages = _nav_markdown_pages(mkdocs["nav"])
+    current_state = CURRENT_PRODUCT_STATE_FILE.read_text(encoding="utf-8")
+    documentation_map = DOCUMENTATION_MAP_FILE.read_text(encoding="utf-8")
+
+    assert Path("docs/current-product-state.md") in nav_pages
+    assert Path("docs/documentation-map.md") in nav_pages
+    assert "FastAPI" in current_state
+    assert "`backend/app`" in current_state
+    assert "React, Vite, TypeScript" in current_state
+    assert "CLI and domain core" in current_state
+    assert "Historical evidence in `archive/**`" in current_state
+    assert "Source-Of-Truth Order" in documentation_map
+    assert "Historical Reference" in documentation_map
+    assert "Must not be used as current completion evidence" in documentation_map
+
+
+def test_github_open_source_entrypoints_are_linked_and_versioned() -> None:
+    mkdocs = yaml.safe_load(MKDOCS_FILE.read_text(encoding="utf-8"))
+    nav_pages = _nav_markdown_pages(mkdocs["nav"])
+    readme = README_FILE.read_text(encoding="utf-8")
+    documentation_map = DOCUMENTATION_MAP_FILE.read_text(encoding="utf-8")
+    github_readiness = GITHUB_READINESS_FILE.read_text(encoding="utf-8")
+    community_setup = COMMUNITY_SETUP_FILE.read_text(encoding="utf-8")
+    maintainers = MAINTAINERS_FILE.read_text(encoding="utf-8")
+    support = SUPPORT_FILE.read_text(encoding="utf-8")
+
+    assert Path("docs/github-open-source-readiness.md") in nav_pages
+    for path in (
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "CODE_OF_CONDUCT.md",
+        "SUPPORT.md",
+        "MAINTAINERS.md",
+        "CHANGELOG.md",
+        "docs/github-open-source-readiness.md",
+    ):
+        assert path in readme
+
+    assert "Open-source repository health" in documentation_map
+    assert "GitHub-Side Settings Checklist" in github_readiness
+    assert "`MAINTAINERS.md`" in github_readiness
+    assert "`SECURITY.md`" in github_readiness
+    assert "`CONTRIBUTING.md`" in github_readiness
+    assert "`SUPPORT.md`" in github_readiness
+    assert "`CODE_OF_CONDUCT.md`" in github_readiness
+    assert "Release Ownership" in maintainers
+    assert "Security issues follow `SECURITY.md`" in maintainers
+    assert "github-open-source-readiness.md" in support
+    assert "GitHub Open Source Readiness" in community_setup

--- a/backend/tests/test_v11_output_contracts.py
+++ b/backend/tests/test_v11_output_contracts.py
@@ -864,6 +864,7 @@ def test_release_check_keeps_demo_sync_manual_and_deterministic() -> None:
     assert "Generated frontend client changed." in makefile
     assert (
         "release-readiness-check: release-check api-client-drift-check "
+        "archive-evidence-check public-production-evidence-check "
         "demo-evidence-bundle-check playwright-check docker-production-smoke" in makefile
     )
     assert "VULN_PRIORITIZER_FIXED_NOW" in makefile

--- a/docs/architecture/analysis-run-provider-schema.md
+++ b/docs/architecture/analysis-run-provider-schema.md
@@ -158,7 +158,7 @@ auditable traceability.
 
 ## Import Deduplication
 
-Template import persistence uses a stable finding dedup key before each
+Workbench import persistence uses a stable finding dedup key before each
 occurrence is attached to a run. The key material is:
 
 - `project_id`

--- a/docs/community_repository_setup.md
+++ b/docs/community_repository_setup.md
@@ -7,13 +7,17 @@ Use it for two different jobs:
 - keep the local repository documentation consistent
 - configure the small set of GitHub-side settings that cannot be created from files in this repo
 
+For the public reader-facing map of GitHub entrypoints and repository health,
+start with [GitHub Open Source Readiness](./github-open-source-readiness.md).
+
 ## What Lives Where
 
 The split matters:
 
 | Item | Where it is managed | Notes |
 | --- | --- | --- |
-| `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md` | local docs in the repo | Versioned guidance. GitHub can surface these automatically. |
+| `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `MAINTAINERS.md`, `CHANGELOG.md` | local docs in the repo | Versioned guidance. GitHub can surface several of these automatically; README and docs link the rest. |
+| [docs/github-open-source-readiness.md](./github-open-source-readiness.md) | local doc in the repo | Public GitHub-facing map for community health, routing, and claim boundaries. |
 | `.github/ISSUE_TEMPLATE/*.md` and `.github/ISSUE_TEMPLATE/config.yml` | local files in the repo | Versioned templates and contact links. GitHub uses them after they land on the default branch. |
 | [docs/release_operations.md](./release_operations.md) | local doc in the repo | Maintainer runbook for GitHub Releases and PyPI publishing. |
 | This document | local doc in the repo | Maintainer reference only. It does not create labels, topics, or repository settings by itself. |
@@ -172,7 +176,7 @@ These steps must be done on GitHub. They are not created by local files alone:
 6. Enable delete-branch-on-merge for normal PR hygiene.
 7. Protect `main` against force-push and deletion at minimum. Add stricter PR or status-check requirements only when they match the maintainer workflow you actually intend to enforce.
 8. Enable GitHub code security features that fit a public repository: secret scanning, push protection, vulnerability alerts, automated security fixes, and the existing CodeQL workflow.
-9. Confirm GitHub is surfacing `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SUPPORT.md` in the community health surface where applicable.
+9. Confirm GitHub is surfacing `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SUPPORT.md` in the community health surface where applicable, and that `README.md` links `MAINTAINERS.md`, `CHANGELOG.md`, and the GitHub readiness page.
 10. If private vulnerability reporting is desired, enable the repository security/advisory setting in GitHub after the repository is public.
 11. If public releases are enabled, confirm the GitHub Release object exists for the current tag and that the release workflow still matches the maintainer guidance in [docs/release_operations.md](./release_operations.md), including tag-only publish behavior.
 12. If PyPI publishing is enabled, confirm the PyPI Trusted Publisher points at this repository, the `.github/workflows/release.yml` workflow, and the `pypi` environment, and that the hosted-index install verification job is green.
@@ -209,7 +213,11 @@ These items stay versioned in the repository and should be reviewed together:
 
 1. Keep `CONTRIBUTING.md` aligned with the real local quality gate and scope guardrails.
 2. Keep `SECURITY.md` aligned with the actual disclosure path.
-3. Keep issue templates aligned with the current label names.
-4. Keep [docs/release_operations.md](./release_operations.md) aligned with the actual GitHub Release and PyPI publishing flow.
-5. Revalidate README install wording and public quickstart examples whenever the supported public install path changes, especially when PyPI moves from gated to live.
-6. Update this document when topics, labels, or triage conventions change.
+3. Keep `SUPPORT.md`, `CODE_OF_CONDUCT.md`, and `MAINTAINERS.md` aligned with
+   the actual support, conduct, and ownership paths.
+4. Keep issue templates aligned with the current label names.
+5. Keep [docs/github-open-source-readiness.md](./github-open-source-readiness.md)
+   aligned with the GitHub-facing repository surface.
+6. Keep [docs/release_operations.md](./release_operations.md) aligned with the actual GitHub Release and PyPI publishing flow.
+7. Revalidate README install wording and public quickstart examples whenever the supported public install path changes, especially when PyPI moves from gated to live.
+8. Update this document when topics, labels, or triage conventions change.

--- a/docs/current-product-state.md
+++ b/docs/current-product-state.md
@@ -1,0 +1,109 @@
+# Current Product State
+
+This page is the canonical current-state entrypoint for reviewers,
+maintainers, and operators. If another document appears to conflict with this
+page, treat this page as the current product truth and update or reclassify the
+older page.
+
+## Product Identity
+
+Vuln Prioritizer Workbench is a local-first CLI and self-hosted Workbench for
+prioritizing already-known CVEs from supplied evidence. It accepts CVE lists,
+scanner exports, SBOM outputs, VEX statements, and asset context, then explains
+priority using transparent signals such as CVSS, EPSS, CISA KEV, provider
+freshness, reviewed ATT&CK/TTP context, lifecycle state, waivers, and evidence
+artifacts.
+
+The product is intentionally defensive. It is not a vulnerability scanner, not
+an exploit framework, not an active probing tool, not an autopatcher, and not a
+hosted SaaS product.
+
+## Active Stack
+
+| Layer | Current source of truth | Notes |
+| --- | --- | --- |
+| Backend runtime | `backend/app` | Active FastAPI app, `/api/v1` routes, SQLModel models, repositories, services, auth/session support, and Alembic migrations. |
+| Frontend runtime | `frontend` | React, Vite, TypeScript, TanStack Router/Query, Playwright tests, and Workbench UI. |
+| Generated client | `frontend/src/client/**` | Generated from backend OpenAPI. Do not edit generated files manually. |
+| Frontend integration wrapper | `frontend/src/api-client.ts` | Handwritten wrapper over generated client code. Normal app code should use this boundary. |
+| CLI and domain core | `backend/src/vuln_prioritizer` | Retained Typer CLI, parsers, providers, scoring, report helpers, state helpers, and neutral domain logic shared with Workbench services. |
+| Docs site | `mkdocs.yml` and `docs/**` | Public docs, contracts, examples, release notes, submission material, and historical references. |
+| Historical evidence | `archive/**` | Historical screenshots, issue proof, demo flow evidence, presentation material, and archived validation notes. |
+
+## Current User Surfaces
+
+- Workbench UI: Dashboard, Projects, Imports, Findings, Finding Detail, TTP
+  Context, Waivers, Assets, Providers, Reports, Evidence Center, and Settings.
+- API: versioned FastAPI routes under `/api/v1`.
+- CLI: `vuln-prioritizer` commands for analysis, comparison, explanation,
+  input validation, ATT&CK support, provider data, reports, and evidence bundle
+  verification.
+- GitHub Action: repository action for locked analysis/report workflows.
+- Docker Compose: local self-hosted Workbench quickstart and production-like
+  smoke topology.
+
+## Canonical Docs
+
+| Need | Start here |
+| --- | --- |
+| Full user path | [User Documentation Guide](user_documentation.md) |
+| Product architecture | [Product Architecture](architecture.md) |
+| Documentation ownership and classification | [Documentation Map](documentation-map.md) |
+| Stable API/CLI/report behavior | [Contracts](contracts.md) |
+| Supported inputs and outputs | [Support Matrix](support_matrix.md) |
+| Scoring rules | [Scoring Methodology](scoring-methodology.md) |
+| ATT&CK/TTP provenance | [ATT&CK/TTP Methodology](attack-ttp-methodology.md) |
+| Reports and evidence bundles | [Reports and Evidence](reports-and-evidence.md) |
+| Security boundaries | [Workbench Threat Model](workbench-threat-model.md) |
+| Deployment caveats | [Workbench Public Deployment](workbench-public-deployment.md) |
+| Release evidence | [Public-Production Release Evidence Ledger](public-production-release-evidence-ledger.md) |
+| GitHub repository health | [GitHub Open Source Readiness](github-open-source-readiness.md) |
+
+## Current Release And Evidence Posture
+
+The repository has strong local and CI-oriented gates, including backend
+format/lint/type/test coverage, docs hygiene, frontend lint/build/unit coverage,
+generated-client drift checks, Playwright browser tests, Docker smokes, package
+checks, public deployment evidence contract checks, archive binary evidence
+manifest checks, and release-readiness automation.
+
+These gates do not by themselves certify a public internet deployment. Public
+production readiness still requires fresh evidence for the exact deployment
+candidate, including proxy/TLS topology, strict CORS and cookie behavior,
+security headers, backup/restore, schema readiness, retention, auditability,
+rate limits, and dependency/container posture.
+
+Historical evidence in `archive/**` is useful context and demo proof. It is not
+current release certification unless a current release or evidence page
+explicitly links it as such and explains the scope. Tracked binary evidence under
+`archive/vpw-evidence/**` is hash-pinned in
+`archive/vpw-evidence/BINARY-MANIFEST.json`.
+
+## Compatibility And Historical Material
+
+Some names still contain `template`, `Template`, or historical compatibility
+phrasing. The active app is not a second template runtime. The remaining names
+fall into three classes:
+
+- compatibility shims that protect existing local data or scripts
+- historical evidence and release snapshots that should not be renamed
+- naming debt that can be cleaned up in focused follow-up work
+
+Do not use historical migration plans, old roadmap notes, or archived issue
+evidence as proof that current runtime behavior is complete. Use current tests,
+current docs, and current release evidence.
+
+## Quality Bar For Future Docs
+
+Every new or edited doc should make its status obvious:
+
+- current product behavior
+- stable contract
+- operator runbook
+- release evidence
+- submission/demo evidence
+- historical reference
+- archived proof
+
+Current docs must prefer Workbench-first wording and must avoid CLI-only product
+claims. Historical docs may use older terms only when their status is explicit.

--- a/docs/documentation-map.md
+++ b/docs/documentation-map.md
@@ -1,0 +1,109 @@
+# Documentation Map
+
+This map defines how the repository documentation is organized and how to decide
+which page owns a claim. It exists to prevent the CLI, early GUI, FastAPI
+template migration, Workbench release, submission, and archive eras from being
+mixed together again.
+
+## Source-Of-Truth Order
+
+When two pages appear to conflict, use this order:
+
+1. [Current Product State](current-product-state.md)
+2. [Product Architecture](architecture.md)
+3. [Contracts](contracts.md) and [Support Matrix](support_matrix.md)
+4. [User Documentation Guide](user_documentation.md)
+5. [Release Operations](release_operations.md) and current release notes
+6. [GitHub Open Source Readiness](github-open-source-readiness.md) and
+   [Community Repository Setup](community_repository_setup.md) for public
+   repository routing and GitHub-side checklist items
+7. [Historical Reference](#historical-reference) pages
+8. `archive/**` evidence and historical planning material
+
+Historical evidence can support a story, but it does not override current code,
+current tests, current contracts, or current release evidence.
+
+## Public Docs Inventory
+
+| Category | Pages | Owner | Rules |
+| --- | --- | --- | --- |
+| Current product truth | `current-product-state.md`, `architecture.md`, `documentation-map.md` | Maintainers | Must describe the active Workbench-first runtime only. |
+| User and operator docs | `user_documentation.md`, `use_cases.md`, `playbooks.md`, `playbooks/**` | Product/docs owner | Must favor external-user paths and mark repo-checkout-only commands. |
+| Methodology | `methodology.md`, `scoring-methodology.md`, `attack-ttp-methodology.md`, `workbench-attack-methodology.md`, `benchmarking.md` | Domain owner | Must keep scoring, ATT&CK, VEX, and asset-context semantics transparent. |
+| Contracts | `contracts.md`, `support_matrix.md`, `asset-context-csv.md`, importer docs, examples, schemas | API/CLI/report owners | Must change with tests and generated/example artifacts when contracts change. |
+| Security and deployment | `workbench-threat-model.md`, `workbench-public-deployment.md`, `public-production-release-evidence-ledger.md`, `release_operations.md` | Security/release owner | Must separate local demo readiness from public-production evidence. |
+| Open-source repository health | `github-open-source-readiness.md`, `community_repository_setup.md`, root `CONTRIBUTING.md`, `SUPPORT.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `MAINTAINERS.md`, `CHANGELOG.md`, `.github/**` templates | Maintainers | Must route public questions, contributions, security reports, conduct issues, ownership, and GitHub-side settings without overstating what repo files configure. |
+| Release history | `docs/releases/**`, `CHANGELOG.md` | Release owner | Must describe tagged or historical releases, not future state. |
+| Submission package | `docs/submission/**` | Submission owner | May link archived demo proof, but must label it as demo or historical evidence. |
+| Historical reference | `full_stack_fastapi_template_migration.md`, `vpw_template_execution_sequence.md`, `architecture/template-replacement.md`, `architecture/template-service-layer.md`, `architecture/vpw-013-importer-contract.md`, selected `architecture/vpw-*.md` cards | Maintainers | Must not be used as current completion evidence unless revalidated. |
+| Archive pointer | `evidence.md`, `archive/README.md`, `archive/vpw-evidence/MANIFEST.md` | Evidence owner | Must point to archive contents without copying large artifacts into public docs. |
+
+## Historical Reference
+
+Historical reference pages explain why the repository moved from CLI-first work
+through GUI experiments and into the current FastAPI/React Workbench shape. They
+remain useful for migration context, but they do not certify current behavior by
+themselves. Current behavior must be verified through active docs, current code,
+tests, release evidence, and the audit trail.
+
+## Navigation Rules
+
+- Current pages must appear before historical pages in `mkdocs.yml`.
+- Open-source repository health pages must stay discoverable from both
+  `README.md` and the MkDocs navigation.
+- Historical migration and template-era pages must live under a clearly labelled
+  historical/reference navigation group.
+- `docs/evidence/**` is limited to small contract fixtures referenced by tests
+  or schemas.
+- Screenshots, broad issue proof, demo screenshots, and ZIP evidence belong in
+  `archive/vpw-evidence/**` or external CI artifacts.
+- Tracked binary evidence under `archive/vpw-evidence/**` must be listed in
+  `archive/vpw-evidence/BINARY-MANIFEST.json` and pass
+  `python3 scripts/check_archive_evidence_manifest.py`.
+- New Markdown files in `docs/**` must be added to `mkdocs.yml`, except the
+  small non-public contract fixture allowlist enforced by
+  `backend/tests/test_docs_hygiene.py`.
+- Internal audits and private scorecards should stay outside `docs/**` unless
+  they are intentionally published as public release evidence.
+
+## Current Vs Historical Wording
+
+Use this wording for active docs:
+
+- "active Workbench runtime"
+- "FastAPI backend under `backend/app`"
+- "React/TanStack frontend under `frontend`"
+- "retained CLI/core package under `backend/src/vuln_prioritizer`"
+- "historical evidence" or "demo snapshot" for archive references
+
+Avoid this wording in active docs unless the sentence explicitly describes
+compatibility or history:
+
+- CLI-only product claims
+- unqualified public-production readiness claims
+- template-era evidence as closure proof
+- template behavior described as current product behavior
+
+The release evidence hygiene script checks this wording across the public docs
+navigation and allows historical pages only through explicit path-based
+classification.
+
+## How To Add Or Change Docs
+
+1. Decide the page category before writing.
+2. Link to [Current Product State](current-product-state.md) if the page might
+   otherwise be confused with historical material.
+3. Put current behavior, stable contracts, and historical context in separate
+   sections.
+4. If a page links to `archive/**`, describe whether the link is historical
+   proof, demo evidence, or current release evidence.
+5. Run:
+
+```bash
+python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
+make docs-check
+```
+
+For behavior, API, frontend, or release-adjacent documentation changes, also run
+the relevant backend, frontend, Docker, and release gates described in
+[Release Operations](release_operations.md).

--- a/docs/github-open-source-readiness.md
+++ b/docs/github-open-source-readiness.md
@@ -1,0 +1,149 @@
+# GitHub Open Source Readiness
+
+This page is the public GitHub-facing documentation map for repository health,
+community entrypoints, contribution flow, security reporting, and release-claim
+boundaries.
+
+Use [Current Product State](current-product-state.md) for product truth and
+[Documentation Map](documentation-map.md) for documentation ownership. Use this
+page when deciding whether the GitHub repository surface is coherent for
+external readers and contributors.
+
+## Visitor Entry Points
+
+| Need | Entry point | Notes |
+| --- | --- | --- |
+| Understand the project quickly | [`README.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/README.md) | Public overview, quickstarts, safety boundaries, docs links, and project status. |
+| Find the canonical product truth | [Current Product State](current-product-state.md) | Active stack, user surfaces, release posture, and historical boundaries. |
+| Use the CLI or Workbench | [User Documentation Guide](user_documentation.md) | Full external-user path across install, Docker, CLI, Workbench, providers, reports, and limitations. |
+| Check supported inputs and outputs | [Support Matrix](support_matrix.md) | Import formats, report formats, evidence outputs, and feature overlays. |
+| Understand stable contracts | [Contracts](contracts.md) | CLI, report, evidence bundle, API, and schema contract details. |
+| Contribute safely | [`CONTRIBUTING.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/CONTRIBUTING.md) | Local setup, quality gates, branch/PR rules, and scope guardrails. |
+| Ask for help | [`SUPPORT.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/SUPPORT.md) | Issue, discussion, and security-report routing. |
+| Report security issues | [`SECURITY.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/SECURITY.md) | Private disclosure path and project-specific security notes. |
+| Understand conduct expectations | [`CODE_OF_CONDUCT.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/CODE_OF_CONDUCT.md) | Community behavior and conduct escalation. |
+| Understand ownership | [`MAINTAINERS.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/MAINTAINERS.md) and [`.github/CODEOWNERS`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/.github/CODEOWNERS) | Maintainer responsibilities and default review ownership. |
+| Review releases | [`CHANGELOG.md`](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/CHANGELOG.md), [Release Operations](release_operations.md), and [Release Evidence Ledger](public-production-release-evidence-ledger.md) | Historical changes, release workflow, evidence requirements, and residual-risk tracking. |
+
+## Community Health Files
+
+GitHub can surface these files automatically when they exist on the default
+branch:
+
+- `README.md`
+- `LICENSE`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `CODE_OF_CONDUCT.md`
+- `SUPPORT.md`
+- `CHANGELOG.md`
+- `MAINTAINERS.md`
+- `.github/CODEOWNERS`
+- `.github/ISSUE_TEMPLATE/*.md`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/pull_request_template.md`
+
+These files are versioned. Repository settings such as discussions, branch
+protection, private vulnerability reporting, repository topics, homepage,
+trusted publishing, and security features must still be checked on GitHub.
+
+## Issue Routing
+
+Use public issues for reproducible public work:
+
+- bugs with sanitized reproduction steps
+- feature requests with a clear user or maintainer problem
+- parser/provider/import-format changes with small sanitized fixtures
+- documentation fixes
+- security hardening requests that do not disclose a private vulnerability
+
+Do not use public issues for:
+
+- vulnerability disclosures with sensitive reproduction detail
+- customer exports, private scan data, tokens, cookies, or internal hostnames
+- exploit payloads or public proof-of-concept detail
+- requests that would turn the project into a scanner, exploit framework,
+  credential tester, hosted SaaS workflow, autopatcher, or heuristic
+  CVE-to-ATT&CK mapper
+
+Private vulnerability reporting follows `SECURITY.md`.
+
+## Pull Request Quality Bar
+
+A reviewable pull request should include:
+
+- a concise summary and linked issue or roadmap ID when relevant
+- changed surfaces: CLI, backend API, DB/migrations, generated client, frontend,
+  Docker, docs, release, packaging, or security
+- exact commands run and result summaries
+- generated artifacts or screenshots when the changed surface needs them
+- residual risk and follow-up issues when something remains open
+- release-readiness evidence when the PR affects release, deployment, public
+  documentation claims, Docker, package publication, or security boundaries
+
+The pull request template encodes this checklist. Maintainers should not close
+strict evidence issues from old notes, archived screenshots, or historical demo
+proof without fresh evidence for the current candidate.
+
+## Documentation Quality Bar
+
+Public docs are acceptable for GitHub only when they preserve these boundaries:
+
+- one canonical product truth in [Current Product State](current-product-state.md)
+- one documentation ownership map in [Documentation Map](documentation-map.md)
+- clear current vs historical separation in `mkdocs.yml`
+- no overclaiming of public deployment certification from local quickstarts
+- archive links labelled as historical evidence or demo snapshots unless a
+  current release page explicitly scopes them as current evidence
+- tracked archive binaries pinned in `archive/vpw-evidence/BINARY-MANIFEST.json`
+- `make docs-check` passing before handoff
+
+## Release And Deployment Claim Boundary
+
+The repository can document a release process, local validation, and expected
+public deployment evidence. It cannot prove a live public deployment only from
+checked-in Markdown.
+
+Before an external deployment claim is made for a release candidate, the public
+release ledger must include fresh evidence for that exact candidate:
+
+- `make release-readiness-check` or a documented equivalent with owner-approved
+  skip rationale
+- public TLS/header captures from the deployed host
+- Traefik/proxy topology evidence
+- strict CORS, cookie, CSRF, and security-header behavior
+- backup/restore, schema readiness, retention, and audit evidence where relevant
+- dependency and container/image posture evidence
+- residual-risk decision with owner and follow-up
+
+## GitHub-Side Settings Checklist
+
+These settings are not created by files in this repository. Maintainers should
+verify them in GitHub before broad public launch or release promotion:
+
+- repository description and topics match the current Workbench plus CLI scope
+- homepage points to stable docs or is intentionally empty
+- discussions are enabled only if they are actively supported
+- wiki is disabled if versioned docs remain canonical
+- delete-branch-on-merge is enabled
+- `main` is protected against force-push and deletion
+- required checks match the real CI policy
+- secret scanning, push protection, vulnerability alerts, Dependabot, and CodeQL
+  are enabled where available
+- private vulnerability reporting is enabled if `SECURITY.md` points to it
+- PyPI and TestPyPI trusted-publisher settings match the release workflows
+
+The detailed maintainer checklist lives in
+[Community And Public Repository Setup](community_repository_setup.md).
+
+## Current Scope And External Checks
+
+The repository documentation now defines the expected open-source GitHub surface
+for a security tool: clear README, license, contribution path, support path,
+security policy, conduct policy, maintainer ownership, changelog, roadmap, docs
+site, issue/PR templates, release evidence boundaries, and automated docs
+checks.
+
+The remaining public-release work is outside pure documentation: attach live
+release-candidate deployment evidence, confirm GitHub-side settings, and add
+image supply-chain evidence for releases.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,9 @@ submission material.
 
 ![Documentation grid preview](media/grid.png)
 
+- [Current product state](current-product-state.md)
+- [Documentation map](documentation-map.md)
+- [GitHub open source readiness](github-open-source-readiness.md)
 - [External user documentation guide](user_documentation.md)
 - [Current product architecture](architecture.md)
 - [Scoring methodology](scoring-methodology.md)
@@ -96,6 +99,12 @@ Workbench remains local-first and uses the import-format matrix documented in
 
 ## Documentation Structure
 
+- Start with [current-product-state.md](current-product-state.md) when you need
+  the canonical current truth for product identity, active stack, release
+  posture, and historical boundaries.
+- Start with [documentation-map.md](documentation-map.md) when you need to know
+  which page owns a claim or whether a page is current, historical, release,
+  submission, evidence, or archive material.
 - Start with [user_documentation.md](user_documentation.md) when you need the full external-user path.
 - Start with [concept.md](concept.md) for positioning and scope.
 - Use [submission/README.md](submission/README.md) for the final Applied
@@ -122,9 +131,12 @@ Workbench remains local-first and uses the import-format matrix documented in
 - Use [user_documentation.md#known-limitations](user_documentation.md#known-limitations) for the consolidated external-user limitations list.
 - Use [roadmap.md](roadmap.md) for shipped scope and deliberate non-goals.
 - Use [release_operations.md](release_operations.md) for maintainer-only release, GitHub Release recovery, and PyPI/TestPyPI operations.
+- Use [github-open-source-readiness.md](github-open-source-readiness.md) for
+  public GitHub entrypoints, community health files, issue/PR routing, and
+  repository-setting checks.
 - Use [public-production-release-evidence-ledger.md](public-production-release-evidence-ledger.md)
   for VPW-AUD release-readiness targets, evidence boundaries, and residual-risk
-  tracking through the final VPW-AUD-999 scorecard.
+  tracking through the final release-readiness scorecard.
 - Use [community_repository_setup.md](community_repository_setup.md) for maintainer-facing public repo topics, labels, and triage defaults.
 - Use [releases/v1.1.0.md](releases/v1.1.0.md) for the current package release.
 

--- a/docs/public-production-release-evidence-ledger.md
+++ b/docs/public-production-release-evidence-ledger.md
@@ -46,11 +46,13 @@ linked from an issue or PR.
 | `make pipx-source-smoke` | Source-at-tag install path compatibility | pipx smoke output and generated smoke artifacts |
 | `make api-client-drift-check` | OpenAPI/generated-client compatibility | `scripts/generate-client.sh`; clean `frontend/src/client` diff |
 | `make docs-check` | Public documentation build | clean MkDocs build |
+| `python3 scripts/check_public_deployment_evidence.py` | Public TLS and Traefik evidence contract | Static validation that Compose Traefik labels, production-smoke topology, and deployment docs cover same-origin routing, optional direct API routing, TLS, dashboard controls, and header evidence |
+| `python3 scripts/check_archive_evidence_manifest.py` | Archive binary evidence manifest | Hash/size/purpose validation for tracked historical binary evidence and ZIP member safety checks |
 | `make demo-evidence-bundle-check` | Evidence bundle integrity | `build/v1.0-demo-evidence-bundle-verification.json` |
 | `make docker-demo-smoke` | Compose runtime smoke | backend/frontend health, Postgres Alembic/schema/repository smoke, plus import/provider smoke |
 | `make docker-production-smoke` | Production-like same-origin smoke | production env, non-default secrets, Postgres Alembic/schema/repository smoke, CSP, cookies, CSRF, health/status split, import, report download, logout |
 | `make playwright-check` | Browser smoke and accessibility path | frontend Playwright smoke, responsive shell, and Axe no serious/critical violations |
-| `make release-readiness-check` | Full local readiness handoff | release gate, client drift, evidence bundle, Playwright/A11y, and production-like Docker smoke |
+| `make release-readiness-check` | Full local readiness handoff | release gate, client drift, public deployment evidence contract, archive binary evidence manifest, evidence bundle, Playwright/A11y, and production-like Docker smoke |
 
 ## VPW-AUD-999 Fresh Evidence Gate
 
@@ -70,6 +72,8 @@ Required before VPW-AUD-999 closure:
   and `make frontend-test-unit` output
 - `make playwright-check`
 - `make docs-check`
+- `python3 scripts/check_public_deployment_evidence.py`
+- `python3 scripts/check_archive_evidence_manifest.py`
 - `make dependency-audit`
 - `make docker-demo-smoke`
 - `make docker-production-smoke`
@@ -82,6 +86,13 @@ Required before VPW-AUD-999 closure:
 Evidence must not include secrets, token values, cookies, customer exports,
 private absolute paths, or shell history. When using workflow artifacts, link
 the run URL and artifact name rather than pasting raw logs into public docs.
+
+Public TLS and Traefik evidence must include the commands from the
+[Public TLS Evidence Checklist](./workbench-public-deployment.md#public-tls-evidence-checklist),
+including header captures for the frontend, same-origin health route, and
+reviewed direct API route. The archive binary evidence manifest must match
+`archive/vpw-evidence/BINARY-MANIFEST.json`; update the manifest only when the
+new binary evidence is public-safe and purpose-labelled.
 
 ## Release Candidate Ledger
 

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -48,10 +48,12 @@ make release-check
 make release-readiness-check
 ```
 
-This adds generated-client drift, demo evidence-bundle verification, and
+This adds generated-client drift, archive binary evidence validation, public
+deployment evidence contract validation, demo evidence-bundle verification, and
 Playwright smoke evidence to the normal release gate. It also runs the
 production-like Docker smoke. It does not by itself close the VPW-AUD-999 final
-scorecard.
+scorecard because live public TLS/header evidence still has to be captured for
+the exact deployed candidate.
 For tagged releases, `.github/workflows/release.yml` runs this gate before any
 GitHub Release or PyPI publish job can proceed.
 
@@ -68,6 +70,8 @@ Commit/tag:
 Result:
 Artifact or CI URL:
 SHA-256 artifact list:
+Public TLS/header evidence:
+Archive binary manifest:
 Residual risk:
 Owner:
 Follow-up:

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -71,4 +71,5 @@ The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIX
 - Use [docs/releases/workbench-v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/workbench-v1.0.0.md) for Workbench milestone scope and evidence details. The package tag for this tree must be `v1.1.0` because `pyproject.toml` is versioned `1.1.0`.
 - Public PyPI/TestPyPI publication remains gated until trusted-publisher setup is explicitly enabled in the repository.
 - The backend distribution intentionally ships both the CLI/core package and the
-  active Workbench FastAPI app. It should not be described as CLI-only.
+  active Workbench FastAPI app. Do not describe this release as shipping only
+  the CLI package.

--- a/docs/workbench-public-deployment.md
+++ b/docs/workbench-public-deployment.md
@@ -58,6 +58,48 @@ Do not trust arbitrary forwarded headers from the public internet. Place Traefik
 as the only public entrypoint and keep backend container ports unbound except in
 local override files.
 
+## Public TLS Evidence Checklist
+
+Before claiming public-production readiness, capture public-safe evidence from
+the exact deployed candidate. Redact cookies, tokens, IP addresses that identify
+private infrastructure, private paths, and shell history.
+
+Required topology evidence:
+
+```bash
+python3 scripts/check_public_deployment_evidence.py
+docker compose -f compose.yml -f compose.traefik.yml config
+```
+
+Required public header evidence:
+
+```bash
+curl -I https://${DOMAIN}/
+curl -I https://${DOMAIN}/api/v1/workbench/health
+curl -I https://api.${DOMAIN}/api/v1/workbench/health
+```
+
+Required browser/API behavior evidence:
+
+- `https://${DOMAIN}/` returns the frontend with security headers and a CSP that
+  keeps same-origin API routing unless a split-domain deployment is explicitly
+  approved.
+- `https://${DOMAIN}/api/v1/workbench/health` returns the minimal public health
+  response.
+- `https://${DOMAIN}/api/v1/workbench/status` is auth-gated.
+- `https://${DOMAIN}/docs` and `/api/v1/openapi.json` are not public when
+  `API_DOCS_ENABLED=false`.
+- `https://api.${DOMAIN}/api/v1/workbench/health` is treated as the Optional
+  direct API route for automation; if exposed publicly, record the split-domain
+  CORS, CSRF, cookie, and CSP decision in the release evidence ledger.
+- HTTP requests redirect to HTTPS.
+- Traefik dashboard routing stays disabled unless a short maintenance window and
+  IP allowlist are documented.
+
+Do not include secrets, token values, cookies, customer exports, private
+absolute paths, shell history, or unredacted environment dumps in public
+evidence.
+
 ## Compose Volumes And Compatibility
 
 Fresh Compose stacks use Workbench-branded named volumes by default:
@@ -244,10 +286,13 @@ the release evidence ledger or linked issue evidence:
 - `make package-check`
 - `make dependency-audit`
 - `make api-client-drift-check`
+- `python3 scripts/check_public_deployment_evidence.py`
+- `python3 scripts/check_archive_evidence_manifest.py`
 - `make docker-demo-smoke`
 - `make docker-production-smoke`
 - `make playwright-check`
-- header captures for the public frontend and API routes
+- Public TLS Evidence Checklist output and header captures for the public
+  frontend and API routes
 - residual-risk decision with owner and follow-up issue for every exception
 
 Do not include secrets, token values, cookies, customer exports, private

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,9 +22,9 @@ bash scripts/generate-client.sh
 git diff --exit-code -- frontend/src/client
 ```
 
-The official template uses Bun. This repository keeps Bun-compatible scripts in
-`package.json`, but the audited local and Docker fallback uses npm with the
-checked-in `frontend/package-lock.json`.
+This repository keeps Bun-compatible scripts in `package.json`, but the audited
+local and Docker fallback uses npm with the checked-in
+`frontend/package-lock.json`.
 
 ## Dependency Audit Notes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ nav:
   - Concept: concept.md
   - Executive Summary: executive_summary.md
   - Current Product State:
+      - Current Product State: current-product-state.md
+      - Documentation Map: documentation-map.md
       - Product Architecture: architecture.md
       - Dependency and Package Policy: dependency-and-package-policy.md
       - Scoring Methodology: scoring-methodology.md
@@ -28,7 +30,6 @@ nav:
   - Benchmarking: benchmarking.md
   - Architecture:
       - Overview: architecture/index.md
-      - Template Replacement Strategy: architecture/template-replacement.md
       - Model Import Registry: architecture/model-imports.md
       - Core Workbench Schema: architecture/core-workbench-schema.md
       - Analysis Run Provider Schema: architecture/analysis-run-provider-schema.md
@@ -39,11 +40,13 @@ nav:
       - Provider Snapshot Replay: architecture/vpw-026-provider-snapshot-replay.md
       - Provider Data Quality Flags: architecture/vpw-027-provider-data-quality-flags.md
       - Provider Status API Card: architecture/vpw-028-provider-status-api-card.md
+      - Parser and Provider Extension Strategy: extension_strategy.md
+  - Historical Reference:
+      - Full Stack FastAPI Template Migration: full_stack_fastapi_template_migration.md
+      - VPW Template Execution Sequence: vpw_template_execution_sequence.md
+      - Template Replacement Strategy: architecture/template-replacement.md
       - Template Repository Layer: architecture/template-service-layer.md
       - Template Importer Contract: architecture/vpw-013-importer-contract.md
-      - Parser and Provider Extension Strategy: extension_strategy.md
-  - Historical Full Stack Template Migration: full_stack_fastapi_template_migration.md
-  - Historical VPW Template Execution Sequence: vpw_template_execution_sequence.md
   - Use Cases: use_cases.md
   - Playbooks:
       - Overview: playbooks.md
@@ -55,7 +58,9 @@ nav:
   - Support Matrix: support_matrix.md
   - Integrations: integrations/reporting_and_ci.md
   - Gap Analysis: reference_cve_prioritizer_gap_analysis.md
-  - Community Setup: community_repository_setup.md
+  - Open Source Project:
+      - GitHub Open Source Readiness: github-open-source-readiness.md
+      - Community Repository Setup: community_repository_setup.md
   - CI Cost Optimization: ci-cost-optimization.md
   - Release Operations: release_operations.md
   - Public-Production Release Evidence Ledger: public-production-release-evidence-ledger.md

--- a/scripts/check_archive_evidence_manifest.py
+++ b/scripts/check_archive_evidence_manifest.py
@@ -1,0 +1,197 @@
+"""Validate tracked archive binary evidence against a public-safe manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "archive" / "vpw-evidence" / "BINARY-MANIFEST.json"
+BINARY_SUFFIXES = {".gif", ".jpeg", ".jpg", ".png", ".webp", ".zip"}
+TEXT_ZIP_SUFFIXES = {".csv", ".json", ".md", ".sarif", ".txt", ".xml", ".yml", ".yaml"}
+FORBIDDEN_ZIP_NAME_TOKENS = (".env", "secret", "token", "cookie", "credential", "password")
+PRIVATE_PATH_MARKERS = ("/Users/", "/private/", "/tmp/", "/var/folders/", "C:\\", "C:/")
+
+
+@dataclass(frozen=True)
+class BinaryEvidence:
+    path: str
+    kind: str
+    size_bytes: int
+    sha256: str
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Rewrite the binary evidence manifest from tracked archive files.",
+    )
+    args = parser.parse_args()
+
+    evidence = _tracked_binary_evidence()
+    failures = _validate_binary_contents(evidence)
+    if args.update:
+        _write_manifest(evidence)
+        print(f"{MANIFEST.relative_to(ROOT)} updated with {len(evidence)} binary entries.")
+        return 0
+
+    failures.extend(_validate_manifest(evidence))
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    print(f"archive binary evidence manifest: OK ({len(evidence)} tracked binary files)")
+    return 0
+
+
+def _tracked_binary_evidence() -> list[BinaryEvidence]:
+    result = subprocess.run(
+        ["git", "ls-files", "archive"],
+        check=True,
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    entries: list[BinaryEvidence] = []
+    for rel_path in sorted(line for line in result.stdout.splitlines() if line):
+        path = ROOT / rel_path
+        suffix = path.suffix.lower()
+        if suffix not in BINARY_SUFFIXES:
+            continue
+        entries.append(
+            BinaryEvidence(
+                path=rel_path,
+                kind=suffix.removeprefix("."),
+                size_bytes=path.stat().st_size,
+                sha256=_sha256(path),
+            )
+        )
+    return entries
+
+
+def _validate_manifest(evidence: list[BinaryEvidence]) -> list[str]:
+    if not MANIFEST.exists():
+        return [f"{MANIFEST.relative_to(ROOT)} is missing; run with --update."]
+
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    if payload.get("schema_version") != 1:
+        failures.append("archive binary manifest schema_version must be 1.")
+    if payload.get("root") != "archive/vpw-evidence":
+        failures.append("archive binary manifest root must be archive/vpw-evidence.")
+
+    actual = {entry.path: entry for entry in evidence}
+    expected_entries = payload.get("files")
+    if not isinstance(expected_entries, list):
+        return [*failures, "archive binary manifest files must be a list."]
+    expected = {
+        str(entry.get("path")): entry for entry in expected_entries if isinstance(entry, dict)
+    }
+
+    missing = sorted(actual.keys() - expected.keys())
+    extra = sorted(expected.keys() - actual.keys())
+    if missing:
+        failures.append("archive binary manifest is missing tracked files: " + ", ".join(missing))
+    if extra:
+        failures.append("archive binary manifest lists non-tracked files: " + ", ".join(extra))
+
+    for rel_path, actual_entry in actual.items():
+        expected_entry = expected.get(rel_path)
+        if not expected_entry:
+            continue
+        if expected_entry.get("sha256") != actual_entry.sha256:
+            failures.append(f"{rel_path}: sha256 drifted from archive binary manifest.")
+        if expected_entry.get("size_bytes") != actual_entry.size_bytes:
+            failures.append(f"{rel_path}: size drifted from archive binary manifest.")
+        if expected_entry.get("kind") != actual_entry.kind:
+            failures.append(f"{rel_path}: kind drifted from archive binary manifest.")
+        purpose = str(expected_entry.get("purpose", "")).strip()
+        if not purpose:
+            failures.append(f"{rel_path}: purpose is required in archive binary manifest.")
+    return failures
+
+
+def _validate_binary_contents(evidence: list[BinaryEvidence]) -> list[str]:
+    failures: list[str] = []
+    for entry in evidence:
+        if entry.kind == "zip":
+            failures.extend(_validate_zip(ROOT / entry.path))
+    return failures
+
+
+def _validate_zip(path: Path) -> list[str]:
+    failures: list[str] = []
+    with zipfile.ZipFile(path) as archive:
+        for member in archive.infolist():
+            name = member.filename
+            normalized = Path(name)
+            if normalized.is_absolute() or ".." in normalized.parts:
+                failures.append(f"{path.relative_to(ROOT)} contains unsafe ZIP member path: {name}")
+            lower_name = name.lower()
+            if any(token in lower_name for token in FORBIDDEN_ZIP_NAME_TOKENS):
+                failures.append(
+                    f"{path.relative_to(ROOT)} contains sensitive-looking member: {name}"
+                )
+            if Path(name).suffix.lower() in TEXT_ZIP_SUFFIXES:
+                content = archive.read(member).decode("utf-8", errors="ignore")
+                for marker in PRIVATE_PATH_MARKERS:
+                    if marker in content:
+                        failures.append(
+                            f"{path.relative_to(ROOT)} member {name} contains private path marker "
+                            f"{marker!r}."
+                        )
+    return failures
+
+
+def _write_manifest(evidence: list[BinaryEvidence]) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "root": "archive/vpw-evidence",
+        "policy": (
+            "Historical binary evidence must be public-safe, purpose-labelled, "
+            "and hash-pinned. ZIP members are checked for unsafe paths and "
+            "sensitive-looking names."
+        ),
+        "files": [
+            {
+                "path": entry.path,
+                "kind": entry.kind,
+                "size_bytes": entry.size_bytes,
+                "sha256": entry.sha256,
+                "purpose": _default_purpose(entry.path),
+            }
+            for entry in evidence
+        ],
+    }
+    MANIFEST.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _default_purpose(path: str) -> str:
+    if "/final-demo-flow/" in path:
+        return "Historical final demo flow screenshot."
+    if "/vpw-design-system-foundation/" in path:
+        return "Historical design-system evidence screenshot."
+    if path.endswith(".zip"):
+        return "Historical evidence bundle artifact retained for verification context."
+    return "Historical issue-level Workbench evidence screenshot."
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_public_deployment_evidence.py
+++ b/scripts/check_public_deployment_evidence.py
@@ -1,0 +1,172 @@
+"""Validate public deployment evidence docs and Compose/TLS topology contracts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = ROOT / "compose.yml"
+TRAEFIK_COMPOSE = ROOT / "compose.traefik.yml"
+PRODUCTION_SMOKE_COMPOSE = ROOT / "compose.production-smoke.yml"
+DEPLOYMENT_DOC = ROOT / "docs" / "workbench-public-deployment.md"
+LEDGER = ROOT / "docs" / "public-production-release-evidence-ledger.md"
+
+
+def main() -> int:
+    failures: list[str] = []
+    compose = _yaml(COMPOSE)
+    traefik = _yaml(TRAEFIK_COMPOSE)
+    production_smoke = _yaml(PRODUCTION_SMOKE_COMPOSE)
+    failures.extend(_check_traefik_service(traefik))
+    failures.extend(_check_app_labels(compose))
+    failures.extend(_check_production_smoke(production_smoke))
+    failures.extend(_check_docs())
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    print("public deployment evidence contract: OK")
+    return 0
+
+
+def _yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path.relative_to(ROOT)} must contain a YAML mapping.")
+    return payload
+
+
+def _check_traefik_service(compose: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    services = _mapping(compose.get("services"))
+    traefik = _mapping(services.get("traefik"))
+    labels = _string_list(traefik.get("labels"))
+    command = _string_list(traefik.get("command"))
+    ports = _string_list(traefik.get("ports"))
+    volumes = _string_list(traefik.get("volumes"))
+
+    required_commands = {
+        "--providers.docker",
+        "--providers.docker.exposedbydefault=false",
+        "--entrypoints.http.address=:80",
+        "--entrypoints.https.address=:443",
+        "--certificatesresolvers.le.acme.tlschallenge=true",
+        "--accesslog",
+    }
+    for item in sorted(required_commands):
+        if item not in command:
+            failures.append(f"compose.traefik.yml traefik command is missing {item!r}.")
+    if "80:80" not in ports or "443:443" not in ports:
+        failures.append("compose.traefik.yml must expose public HTTP and HTTPS ports.")
+    if "/var/run/docker.sock:/var/run/docker.sock:ro" not in volumes:
+        failures.append("compose.traefik.yml must mount Docker socket read-only.")
+    if not any("/certificates" in volume for volume in volumes):
+        failures.append("compose.traefik.yml must persist ACME certificates.")
+
+    required_labels = {
+        "traefik.enable=${TRAEFIK_DASHBOARD_ENABLED:-false}",
+        "traefik.http.routers.traefik-dashboard-https.tls=true",
+        "traefik.http.routers.traefik-dashboard-https.middlewares=traefik-dashboard-ipallowlist",
+        "traefik.http.routers.traefik-dashboard-http.middlewares=https-redirect",
+    }
+    for item in sorted(required_labels):
+        if item not in labels:
+            failures.append(f"compose.traefik.yml traefik label is missing {item!r}.")
+    return failures
+
+
+def _check_app_labels(compose: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    services = _mapping(compose.get("services"))
+    backend_labels = _string_list(_mapping(services.get("backend")).get("labels"))
+    frontend_labels = _string_list(_mapping(services.get("frontend")).get("labels"))
+
+    for service_name, labels in {"backend": backend_labels, "frontend": frontend_labels}.items():
+        if "traefik.enable=${TRAEFIK_APP_ENABLED:-false}" not in labels:
+            failures.append(f"compose.yml {service_name} must keep Traefik app routing opt-in.")
+        if not any(label.endswith(".tls=true") for label in labels):
+            failures.append(f"compose.yml {service_name} HTTPS router must enable TLS.")
+        if not any("entrypoints=http" in label for label in labels):
+            failures.append(f"compose.yml {service_name} must define HTTP router for redirect.")
+        if not any("entrypoints=https" in label for label in labels):
+            failures.append(f"compose.yml {service_name} must define HTTPS router.")
+
+    if not any("workbench-upload-limit" in label for label in backend_labels):
+        failures.append("compose.yml backend route must keep upload-limit middleware.")
+    if not any("api.${DOMAIN" in label for label in backend_labels):
+        failures.append("compose.yml backend direct API route must remain explicit for review.")
+    if not any("Host(`${DOMAIN" in label for label in frontend_labels):
+        failures.append("compose.yml frontend route must bind to the public Workbench host.")
+    return failures
+
+
+def _check_production_smoke(compose: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    services = _mapping(compose.get("services"))
+    backend = _mapping(services.get("backend"))
+    frontend = _mapping(services.get("frontend"))
+    backend_env = _mapping(backend.get("environment"))
+    frontend_build = _mapping(frontend.get("build"))
+    frontend_args = _mapping(frontend_build.get("args"))
+
+    expected_backend_env = {
+        "ENVIRONMENT": "production",
+        "FRONTEND_HOST": "https://workbench.example.test",
+        "BACKEND_CORS_ORIGINS": "https://workbench.example.test",
+        "API_DOCS_ENABLED": "false",
+    }
+    for key, value in expected_backend_env.items():
+        if backend_env.get(key) != value:
+            failures.append(f"compose.production-smoke.yml backend {key} must be {value!r}.")
+    if frontend_args.get("VITE_API_URL") != "":
+        failures.append("compose.production-smoke.yml frontend must build same-origin API calls.")
+    if "127.0.0.1:5180:80" not in _string_list(frontend.get("ports")):
+        failures.append("compose.production-smoke.yml must bind frontend smoke to localhost.")
+    return failures
+
+
+def _check_docs() -> list[str]:
+    failures: list[str] = []
+    deployment_doc = DEPLOYMENT_DOC.read_text(encoding="utf-8")
+    ledger = LEDGER.read_text(encoding="utf-8")
+    required_deployment_phrases = (
+        "Public TLS Evidence Checklist",
+        "same-origin API routing",
+        "Optional direct API route for automation",
+        "curl -I https://${DOMAIN}/",
+        "curl -I https://api.${DOMAIN}/api/v1/workbench/health",
+        "Do not include secrets",
+    )
+    for phrase in required_deployment_phrases:
+        if phrase not in deployment_doc:
+            failures.append(f"workbench public deployment runbook is missing {phrase!r}.")
+
+    required_ledger_phrases = (
+        "Public TLS and Traefik evidence",
+        "archive binary evidence manifest",
+        "scripts/check_public_deployment_evidence.py",
+        "scripts/check_archive_evidence_manifest.py",
+    )
+    for phrase in required_ledger_phrases:
+        if phrase not in ledger:
+            failures.append(f"public production ledger is missing {phrase!r}.")
+    return failures
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_evidence_hygiene.py
+++ b/scripts/check_release_evidence_hygiene.py
@@ -6,8 +6,12 @@ import re
 import sys
 import tomllib
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
+MKDOCS_FILE = ROOT / "mkdocs.yml"
 PYPROJECT = ROOT / "backend" / "pyproject.toml"
 PYTHON_AUDIT_INPUT = ROOT / "backend" / "requirements.txt"
 PYTHON_AUDIT_LOCK = ROOT / "backend" / "requirements.lock.txt"
@@ -53,6 +57,12 @@ STALE_WORDING_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 STALE_WORDING_ALLOWLIST: dict[str, tuple[re.Pattern[str], ...]] = {
     "docs/dependency-and-package-policy.md": (re.compile(r"\bnot\s+CLI-only\b", re.IGNORECASE),),
     ".github/pull_request_template.md": (re.compile(r"\bnot claimed\b", re.IGNORECASE),),
+    "docs/current-product-state.md": (re.compile(r"\bnot\s+a\s+CLI-only\b", re.IGNORECASE),),
+    "docs/documentation-map.md": (
+        re.compile(r"\bCLI-only product claims\b", re.IGNORECASE),
+        re.compile(r"\bunqualified public-production readiness claims\b", re.IGNORECASE),
+        re.compile(r"\btemplate-era evidence as closure proof\b", re.IGNORECASE),
+    ),
     "docs/workbench-public-deployment.md": (
         re.compile(r"\btemplate\.db\b", re.IGNORECASE),
         re.compile(r"\btemplate-[a-z0-9-]+\b", re.IGNORECASE),
@@ -60,15 +70,18 @@ STALE_WORDING_ALLOWLIST: dict[str, tuple[re.Pattern[str], ...]] = {
     ),
 }
 
-ACTIVE_DOC_PATHS = (
-    ROOT / ".github" / "pull_request_template.md",
-    ROOT / "docs" / "contracts.md",
-    ROOT / "docs" / "release_operations.md",
-    ROOT / "docs" / "workbench-threat-model.md",
-    ROOT / "docs" / "workbench-public-deployment.md",
-    ROOT / "docs" / "public-production-release-evidence-ledger.md",
-    ROOT / "docs" / "dependency-and-package-policy.md",
-)
+# These pages are intentionally historical or compatibility inventory. They stay
+# in public navigation, but stale wording inside them is not a current product
+# claim when the page status is explicit.
+STALE_WORDING_HISTORICAL_DOC_PATHS = {
+    Path("docs/full_stack_fastapi_template_migration.md"),
+    Path("docs/vpw_template_execution_sequence.md"),
+    Path("docs/architecture/template-replacement.md"),
+    Path("docs/architecture/template-service-layer.md"),
+    Path("docs/architecture/vpw-013-importer-contract.md"),
+}
+
+NON_NAV_STALE_WORDING_PATHS = (ROOT / ".github" / "pull_request_template.md",)
 
 
 def main() -> int:
@@ -245,7 +258,7 @@ def _pinned_lock_package_names(lock_text: str) -> set[str]:
 def _check_stale_wording() -> list[str]:
     failures: list[str] = []
     matches = 0
-    for path in ACTIVE_DOC_PATHS:
+    for path in _stale_wording_scan_paths():
         rel_path = path.relative_to(ROOT).as_posix()
         lines = path.read_text(encoding="utf-8").splitlines()
         for line_number, line in enumerate(lines, start=1):
@@ -266,6 +279,32 @@ def _check_stale_wording() -> list[str]:
 
 def _is_stale_wording_allowed(rel_path: str, line: str) -> bool:
     return any(pattern.search(line) for pattern in STALE_WORDING_ALLOWLIST.get(rel_path, ()))
+
+
+def _stale_wording_scan_paths() -> list[Path]:
+    mkdocs_config = yaml.safe_load(MKDOCS_FILE.read_text(encoding="utf-8"))
+    nav_pages = _nav_markdown_pages(mkdocs_config["nav"])
+    current_pages = [
+        ROOT / page for page in nav_pages if page not in STALE_WORDING_HISTORICAL_DOC_PATHS
+    ]
+    all_pages = [*current_pages, *NON_NAV_STALE_WORDING_PATHS]
+    return sorted({path for path in all_pages if path.exists()})
+
+
+def _nav_markdown_pages(node: Any) -> set[Path]:
+    pages: set[Path] = set()
+    if isinstance(node, str):
+        if node.endswith(".md"):
+            pages.add(Path("docs") / node)
+        return pages
+    if isinstance(node, list):
+        for item in node:
+            pages.update(_nav_markdown_pages(item))
+        return pages
+    if isinstance(node, dict):
+        for value in node.values():
+            pages.update(_nav_markdown_pages(value))
+    return pages
 
 
 def _check_ledger() -> list[str]:


### PR DESCRIPTION
## Summary
- polish public GitHub documentation around canonical product state, docs navigation, maintainer ownership, support, security, roadmap, and release boundaries
- add evidence guardrails for public deployment claims and archived binary evidence
- keep internal audit material out of the public docs/site while documenting the canonical open-source path

## Validation
- `make docs-check`
- Markdown local-link scan: OK (115 tracked Markdown files)
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py backend/tests/test_v11_output_contracts.py::test_release_check_keeps_demo_sync_manual_and_deterministic --no-cov` (8 passed)
- `python3 -m pytest -q backend/tests/api/test_template_reports_api.py::test_vpw054_demo_report_artifacts_are_linked_and_secret_free --no-cov` (1 passed)
- `git diff --check`
- `make check` (1179 passed, 4 skipped, coverage 96.74%)

## Notes
- This does not claim fresh live public-production TLS/header evidence; the docs now require that evidence before public production claims are treated as complete.
- GitHub-side settings such as branch protection, required checks, and project metadata still need repository-level confirmation after merge.