### PR TITLE
Stabilize workbench project E2E delete flow

### DIFF
--- a/frontend/tests/workbench-login-status.spec.ts
+++ b/frontend/tests/workbench-login-status.spec.ts
@@ -261,7 +261,10 @@ test("workbench frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(
     page.getByText(`Project ${editedUiProjectName} updated.`),
   ).toBeVisible()
-  await expect(page.getByText(editedUiProjectName).first()).toBeVisible()
+  await expect(projectsTable).toContainText(editedUiProjectName)
+  await expect(
+    page.getByRole("heading", { name: editedUiProjectName }),
+  ).toBeVisible()
   await page.getByLabel(/Confirm deletion for this project/).check()
   await page.getByRole("button", { name: "Delete project" }).click()
   await expect(


### PR DESCRIPTION
## Summary
- Wait for the edited project to be reflected in the project table and active project heading before deleting it in the Workbench E2E smoke.
- Removes the timing race that only appeared in the post-merge GitHub frontend job.

## Verification
- npm run test -- tests/workbench-login-status.spec.ts --repeat-each=3
- make frontend-check
- make playwright-check
- git diff --check