### PR TITLE
Harden audit findings and quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,37 @@ jobs:
             build/vpw-082-action-smoke/workbench-report.md
             build/vpw-082-action-smoke/workbench-report.json
 
+  dependency-audit:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            backend/pyproject.toml
+            backend/requirements.lock.txt
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install audit tooling
+        run: python -m pip install -e "backend[dev]"
+
+      - name: Run dependency audit
+        run: make dependency-audit
+
   frontend:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,8 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     env:
-      GRYPE_VERSION: v0.106.0
-      SYFT_VERSION: v1.40.0
+      GRYPE_IMAGE: docker.io/anchore/grype:v0.106.0@sha256:f6fa9ac31f97591957edb13b7c7c24fd172cf11b6e2a2df5dd3464ebb8eefefc
+      SYFT_IMAGE: docker.io/anchore/syft:v1.40.0@sha256:11a68ff5cd49a1579e1f05b061a96edf0a5add161ea5f38d62fc979704c46918
 
     steps:
       - name: Skip Docker smoke for non-runtime PR
@@ -114,34 +114,43 @@ jobs:
         if: needs.changes.outputs.run-docker == 'true'
         run: make docker-production-smoke
 
-      - name: Install image supply-chain scanners
-        if: needs.changes.outputs.run-docker == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh" \
-            | sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
-          curl -sSfL "https://raw.githubusercontent.com/anchore/grype/${GRYPE_VERSION}/install.sh" \
-            | sh -s -- -b /usr/local/bin "${GRYPE_VERSION}"
-
       - name: Generate image SBOMs
         if: needs.changes.outputs.run-docker == 'true'
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p build/docker-sbom
-          syft vuln-prioritizer-workbench-backend:local \
-            -o spdx-json=build/docker-sbom/backend.spdx.json
-          syft vuln-prioritizer-workbench-frontend:local \
-            -o spdx-json=build/docker-sbom/frontend.spdx.json
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD/build/docker-sbom:/output" \
+            "$SYFT_IMAGE" \
+            vuln-prioritizer-workbench-backend:local \
+            -o spdx-json=/output/backend.spdx.json
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD/build/docker-sbom:/output" \
+            "$SYFT_IMAGE" \
+            vuln-prioritizer-workbench-frontend:local \
+            -o spdx-json=/output/frontend.spdx.json
 
-      - name: Scan images for fixable critical vulnerabilities
+      - name: Scan images for high and critical vulnerabilities
         if: needs.changes.outputs.run-docker == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          grype vuln-prioritizer-workbench-backend:local --only-fixed --fail-on critical
-          grype vuln-prioritizer-workbench-frontend:local --only-fixed --fail-on critical
+          for image in \
+            vuln-prioritizer-workbench-backend:local \
+            vuln-prioritizer-workbench-frontend:local
+          do
+            docker run --rm \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              "$GRYPE_IMAGE" \
+              "$image" --only-fixed --fail-on high
+            docker run --rm \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              "$GRYPE_IMAGE" \
+              "$image" --fail-on critical
+          done
 
       - name: Upload container SBOM artifacts
         if: needs.changes.outputs.run-docker == 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,7 +133,24 @@ jobs:
             vuln-prioritizer-workbench-frontend:local \
             -o spdx-json=/output/frontend.spdx.json
 
-      - name: Scan images for high and critical vulnerabilities
+      - name: Generate image vulnerability reports
+        if: needs.changes.outputs.run-docker == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p build/docker-sbom
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            "$GRYPE_IMAGE" \
+            vuln-prioritizer-workbench-backend:local \
+            -o json > build/docker-sbom/backend.grype.json
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            "$GRYPE_IMAGE" \
+            vuln-prioritizer-workbench-frontend:local \
+            -o json > build/docker-sbom/frontend.grype.json
+
+      - name: Fail on fixable high and critical image vulnerabilities
         if: needs.changes.outputs.run-docker == 'true'
         shell: bash
         run: |
@@ -146,19 +163,17 @@ jobs:
               -v /var/run/docker.sock:/var/run/docker.sock \
               "$GRYPE_IMAGE" \
               "$image" --only-fixed --fail-on high
-            docker run --rm \
-              -v /var/run/docker.sock:/var/run/docker.sock \
-              "$GRYPE_IMAGE" \
-              "$image" --fail-on critical
           done
 
-      - name: Upload container SBOM artifacts
+      - name: Upload container security artifacts
         if: needs.changes.outputs.run-docker == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: docker-image-sboms
+          name: docker-image-security-reports
           retention-days: 14
-          path: build/docker-sbom/*.spdx.json
+          path: |
+            build/docker-sbom/*.spdx.json
+            build/docker-sbom/*.grype.json
 
       - name: Show compose status and logs on failure
         if: failure() && needs.changes.outputs.run-docker == 'true'

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DEMO_EVIDENCE_ANALYSIS_FILE := build/v1.0-demo-analysis.json
 DEMO_EVIDENCE_BUNDLE_FILE := build/v1.0-demo-evidence-bundle.zip
 DEMO_EVIDENCE_VERIFICATION_FILE := build/v1.0-demo-evidence-bundle-verification.json
 
-.PHONY: install test lint format fix typecheck check benchmark-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-unit frontend-test-unit-coverage frontend-generate-client api-client-drift-check frontend-audit frontend-check python-lock-check archive-evidence-check public-production-evidence-check release-evidence-hygiene-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke docker-production-smoke dependency-audit clean-local clean-deps provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-contents-check package-check package-check-temp pipx-source-smoke release-check release-readiness-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
+.PHONY: install test lint format fix typecheck check benchmark-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-unit frontend-test-unit-coverage frontend-generate-client api-client-drift-check frontend-audit frontend-check python-lock-check docker-base-image-check archive-evidence-check public-production-evidence-check release-evidence-hygiene-check docs-check docs-serve actionlint-check workflow-check docker-demo-smoke docker-production-smoke dependency-audit clean-local clean-deps provider-snapshot-validate provider-testmatrix demo-offline-no-key-proof demo-sync-check demo-sync-check-temp package package-contents-check package-check package-check-temp pipx-source-smoke release-check release-readiness-check demo-report demo-compare demo-explain demo-attack-report demo-attack-compare demo-attack-explain demo-attack-coverage demo-attack-navigator demo-pr-comment demo-results-sarif demo-html-report demo-evidence-analysis demo-evidence-bundle demo-evidence-bundle-check precommit-install
 
 install:
 	$(PYTHON) -m pip install -e "$(BACKEND_DIR)[dev]"
@@ -110,6 +110,9 @@ public-production-evidence-check:
 python-lock-check:
 	$(PYTHON) scripts/check_release_evidence_hygiene.py
 
+docker-base-image-check:
+	$(PYTHON) scripts/check_dockerfile_base_digests.py
+
 docs-check: release-evidence-hygiene-check archive-evidence-check public-production-evidence-check
 	$(PYTHON) -m mkdocs build --clean
 
@@ -133,6 +136,7 @@ actionlint-check:
 
 workflow-check:
 	$(MAKE) check
+	$(MAKE) docker-base-image-check
 	$(MAKE) docs-check
 	$(MAKE) actionlint-check
 	$(PYTHON) -m pre_commit run --all-files
@@ -227,7 +231,7 @@ docker-production-smoke:
 	$(PYTHON) scripts/production_readiness_smoke.py; \
 	echo "Workbench production-like Docker smoke passed."
 
-dependency-audit: python-lock-check
+dependency-audit: python-lock-check docker-base-image-check
 	@$(PYTHON) -c "import pip_audit" >/dev/null 2>&1 || { \
 		echo "Install pip-audit first: python3 -m pip install pip-audit" >&2; \
 		exit 1; \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -121,7 +121,11 @@ def error_response_content(
     return content
 
 
-def install_error_openapi_schema(app: FastAPI) -> None:
+def install_error_openapi_schema(
+    app: FastAPI,
+    *,
+    oauth2_token_url: str | None = None,
+) -> None:
     """Document FastAPI validation errors with the runtime error envelope."""
     original_openapi = app.openapi
 
@@ -132,11 +136,31 @@ def install_error_openapi_schema(app: FastAPI) -> None:
         schema = original_openapi()
         components = schema.setdefault("components", {}).setdefault("schemas", {})
         components["ApiErrorEnvelope"] = deepcopy(API_ERROR_ENVELOPE_SCHEMA)
+        if oauth2_token_url:
+            _set_oauth2_token_url(schema, oauth2_token_url)
         _replace_fastapi_validation_error_schemas(schema)
         app.openapi_schema = schema
         return schema
 
     app.openapi = custom_openapi  # type: ignore[method-assign]
+
+
+def _set_oauth2_token_url(schema: dict[str, Any], token_url: str) -> None:
+    components = schema.get("components")
+    if not isinstance(components, dict):
+        return
+    security_schemes = components.get("securitySchemes")
+    if not isinstance(security_schemes, dict):
+        return
+    for scheme in security_schemes.values():
+        if not isinstance(scheme, dict) or scheme.get("type") != "oauth2":
+            continue
+        flows = scheme.get("flows")
+        if not isinstance(flows, dict):
+            continue
+        password_flow = flows.get("password")
+        if isinstance(password_flow, dict):
+            password_flow["tokenUrl"] = token_url
 
 
 def redact_request_safe_value(value: Any) -> Any:

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -25,13 +25,14 @@ from app.api.routes import (
     workbench,
 )
 
-PUBLIC_API_ROUTE_PATHS = frozenset(
+PUBLIC_API_ROUTE_SUFFIXES = frozenset(
     {
-        "/api/v1/login/access-token",
-        "/api/v1/workbench/health",
-        "/api/v1/utils/health-check/",
+        "/login/access-token",
+        "/workbench/health",
+        "/utils/health-check/",
     }
 )
+PUBLIC_API_ROUTE_PATHS = frozenset(f"/api/v1{path}" for path in PUBLIC_API_ROUTE_SUFFIXES)
 
 api_router = APIRouter()
 api_router.include_router(login.router)
@@ -54,8 +55,8 @@ api_router.include_router(workbench.router)
 def assert_api_auth_policy(api_prefix: str) -> None:
     """Fail fast if a non-public API route lacks an explicit auth dependency."""
     public_paths = {
-        *PUBLIC_API_ROUTE_PATHS,
-        *(path.removeprefix(api_prefix) for path in PUBLIC_API_ROUTE_PATHS),
+        *PUBLIC_API_ROUTE_SUFFIXES,
+        *(f"{api_prefix}{path}" for path in PUBLIC_API_ROUTE_SUFFIXES),
     }
     missing: list[str] = []
     for route in api_router.routes:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -72,6 +72,7 @@ class Settings:
     LOGIN_RATE_LIMIT_PER_MINUTE: int = 60
     TOKEN_FAILURE_RATE_LIMIT_PER_MINUTE: int = 60
     API_TOKEN_DEFAULT_EXPIRE_DAYS: int = DEFAULT_API_TOKEN_EXPIRE_DAYS
+    BACKGROUND_IMPORT_STALE_MINUTES: int = 120
     TRUSTED_PROXY_CIDRS: tuple[str, ...] = field(default_factory=tuple)
     AUDIT_RETENTION_DAYS: int = 365
     SESSION_RETENTION_DAYS: int = 30
@@ -225,6 +226,10 @@ def load_settings() -> Settings:
         API_TOKEN_DEFAULT_EXPIRE_DAYS=_positive_int_from_env(
             "API_TOKEN_DEFAULT_EXPIRE_DAYS",
             DEFAULT_API_TOKEN_EXPIRE_DAYS,
+        ),
+        BACKGROUND_IMPORT_STALE_MINUTES=_positive_int_from_env(
+            "BACKGROUND_IMPORT_STALE_MINUTES",
+            120,
         ),
         TRUSTED_PROXY_CIDRS=parse_trusted_proxy_cidrs(environ.get("TRUSTED_PROXY_CIDRS", "")),
         AUDIT_RETENTION_DAYS=_positive_int_from_env("AUDIT_RETENTION_DAYS", 365),

--- a/backend/app/core/migration_bootstrap.py
+++ b/backend/app/core/migration_bootstrap.py
@@ -2,17 +2,39 @@
 
 from __future__ import annotations
 
+from importlib import resources
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine import Inspector
 
 from app.core.config import settings
 
-ALEMBIC_HEAD = "20260508_0013"
 ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+ALEMBIC_HEAD = ""
+
+
+def _alembic_config(config_path: Path | None = None) -> Config:
+    active_config_path = config_path or ALEMBIC_INI
+    config = Config(str(active_config_path)) if active_config_path.exists() else Config()
+    if not config.get_main_option("script_location"):
+        config.set_main_option("script_location", str(resources.files("app.alembic")))
+    return config
+
+
+def current_alembic_head(config_path: Path | None = None) -> str:
+    """Return the current Alembic script head from the configured migration path."""
+    config = _alembic_config(config_path)
+    head = ScriptDirectory.from_config(config).get_current_head()
+    if not head:
+        raise RuntimeError("Alembic migration head could not be resolved.")
+    return head
+
+
+ALEMBIC_HEAD = current_alembic_head()
 
 
 def stamp_legacy_create_all_database(
@@ -39,7 +61,7 @@ def stamp_legacy_create_all_database(
     if revision is None:
         return None
 
-    config = Config(str(config_path or ALEMBIC_INI))
+    config = _alembic_config(config_path)
     config.set_main_option("sqlalchemy.url", active_database_url)
     command.stamp(config, revision)
     return revision

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.core.config import Settings, settings
 from app.core.db import create_db_engine
 from app.core.rate_limit import RateLimiter, create_rate_limiter, rate_limit_key
 from app.core.schema_smoke import assert_migrated_schema
+from app.services.import_background import reconcile_stale_background_import_runs
 
 SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
@@ -73,6 +74,12 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
     app.state.rate_limiter = create_rate_limiter(selected_settings, active_engine)
     if selected_settings.ENVIRONMENT != "local":
         app.router.on_startup.append(lambda: assert_migrated_schema(active_engine))
+        app.router.on_startup.append(
+            lambda: reconcile_stale_background_import_runs(
+                engine=active_engine,
+                settings=selected_settings,
+            )
+        )
     app.add_middleware(
         TrustedHostMiddleware,
         allowed_hosts=list(selected_settings.ALLOWED_HOSTS),
@@ -92,7 +99,10 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
     app.add_exception_handler(StarletteHTTPException, http_exception_handler)
     app.add_exception_handler(RequestValidationError, validation_error_handler)
     app.add_exception_handler(Exception, unhandled_exception_handler)
-    install_error_openapi_schema(app)
+    install_error_openapi_schema(
+        app,
+        oauth2_token_url=f"{selected_settings.API_V1_STR}/login/access-token",
+    )
     return app
 
 

--- a/backend/app/repositories/runs.py
+++ b/backend/app/repositories/runs.py
@@ -175,6 +175,21 @@ class RunRepository:
         """Return an analysis run by primary key."""
         return self.session.get(AnalysisRun, run_id)
 
+    def list_active_analysis_runs_started_before(
+        self,
+        started_before: datetime,
+    ) -> list[AnalysisRun]:
+        """Return non-terminal analysis runs older than a cutoff."""
+        statement = (
+            select(AnalysisRun)
+            .where(
+                col(AnalysisRun.status).in_([AnalysisRunStatus.PENDING, AnalysisRunStatus.RUNNING]),
+                AnalysisRun.started_at < started_before,
+            )
+            .order_by(col(AnalysisRun.started_at).asc())
+        )
+        return list(self.session.exec(statement).all())
+
     def get_latest_failed_provider_update_run(self) -> AnalysisRun | None:
         """Return the newest failed provider-update run, if the Workbench shell recorded one."""
         statement = (

--- a/backend/app/services/import_background.py
+++ b/backend/app/services/import_background.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 
 from sqlalchemy.engine import Engine
 from sqlmodel import Session
@@ -11,6 +12,7 @@ from app.core.config import Settings
 from app.core.db import ensure_configured_superuser
 from app.models import AnalysisRun, AnalysisRunStatus, User
 from app.models.api_tokens import ApiTokenContext, attach_api_token_context
+from app.models.base import get_datetime_utc
 from app.repositories import RunRepository
 from app.services.import_errors import ImportServiceError
 from app.services.import_execution import (
@@ -26,6 +28,31 @@ _TERMINAL_IMPORT_STATUSES = {
     AnalysisRunStatus.FAILED,
     AnalysisRunStatus.CANCELLED,
 }
+
+
+def reconcile_stale_background_import_runs(
+    *,
+    engine: Engine,
+    settings: Settings,
+) -> int:
+    """Fail old background imports that could not survive a process restart."""
+    stale_before = get_datetime_utc() - timedelta(minutes=settings.BACKGROUND_IMPORT_STALE_MINUTES)
+    reconciled = 0
+    with Session(engine) as session:
+        run_repo = RunRepository(session)
+        for run in run_repo.list_active_analysis_runs_started_before(stale_before):
+            if not _is_background_import_run(run):
+                continue
+            failed = mark_import_run_background_failed(
+                session=session,
+                run_id=run.id,
+                error_message=(
+                    "Background import did not finish before the Workbench process restarted."
+                ),
+            )
+            if failed is not None and failed.status == AnalysisRunStatus.FAILED:
+                reconciled += 1
+    return reconciled
 
 
 async def execute_project_import_upload_background(
@@ -122,3 +149,8 @@ def _append_job_status(
     if status_history and status_history[-1].get("status") == status:
         return status_history
     return [*status_history, _job_status_entry(status)]
+
+
+def _is_background_import_run(run: AnalysisRun) -> bool:
+    job = run.summary_json.get("import_job")
+    return isinstance(job, dict) and job.get("execution_mode") == "background"

--- a/backend/tests/api/test_template_backend_adapter.py
+++ b/backend/tests/api/test_template_backend_adapter.py
@@ -109,6 +109,23 @@ def test_template_backend_openapi_documents_error_envelope() -> None:
     ]["schema"] == {"$ref": "#/components/schemas/ApiErrorEnvelope"}
 
 
+def test_template_backend_openapi_token_url_uses_active_api_prefix(tmp_path) -> None:
+    selected_app = create_app(
+        Settings(
+            API_V1_STR="/api/custom",
+            SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'custom-openapi.db'}",
+        )
+    )
+    client = TestClient(selected_app)
+
+    response = client.get("/api/custom/openapi.json")
+
+    assert response.status_code == 200
+    security_schemes = response.json()["components"]["securitySchemes"]
+    password_flow = security_schemes["OAuth2PasswordBearer"]["flows"]["password"]
+    assert password_flow["tokenUrl"] == "/api/custom/login/access-token"
+
+
 def test_workbench_api_routes_are_auth_protected_unless_allowlisted() -> None:
     public_paths: set[str] = set()
     unprotected_paths: list[str] = []

--- a/backend/tests/api/test_template_import_upload_api.py
+++ b/backend/tests/api/test_template_import_upload_api.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import uuid
 from dataclasses import replace
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -28,8 +29,10 @@ from app.domain.import_asset_context import (
     canonicalize_asset_exposure_value,
 )
 from app.main import _upload_size_guard
+from app.models.base import get_datetime_utc
 from app.services import TemplateAnalysisError
 from app.services import import_uploads as upload_helpers
+from app.services.import_background import reconcile_stale_background_import_runs
 from app.services.import_errors import ImportServiceError
 from app.services.import_execution import (
     ImportUploadContent,
@@ -379,6 +382,59 @@ def test_import_upload_service_can_defer_and_resume_background_execution(
             item["status"] for item in resumed_run.summary_json["import_job"]["status_history"]
         ] == ["pending", "running", "succeeded"]
         assert resumed_run.summary_json["created_findings"] == 1
+
+
+def test_background_import_reconciliation_fails_stale_deferred_runs(
+    template_api_env: TemplateApiEnv,
+    tmp_path: Path,
+) -> None:
+    _configure_upload_dir(template_api_env, tmp_path)
+    headers = auth_headers(template_api_env.client)
+    project = create_project_via_api(template_api_env.client, headers)
+    active_settings = replace(
+        template_api_env.client.app.state.workbench_settings,
+        BACKGROUND_IMPORT_STALE_MINUTES=1,
+    )
+    upload = ProjectImportUploadRequest(
+        input_type="cve-list",
+        file=ImportUploadContent(
+            filename="stale-background-cves.txt",
+            content_type="text/plain",
+            content=b"CVE-2024-3094\n",
+        ),
+    )
+
+    with Session(template_api_env.engine) as session:
+        current_user = ensure_configured_superuser(session, active_settings=active_settings)
+        deferred_run = asyncio.run(
+            execute_project_import_upload(
+                project_id=uuid.UUID(project["id"]),
+                session=session,
+                current_user=current_user,
+                settings=active_settings,
+                upload=upload,
+                defer_execution=True,
+                execution_mode="background",
+            )
+        )
+        deferred_run.started_at = get_datetime_utc() - timedelta(minutes=5)
+        session.add(deferred_run)
+        session.commit()
+        run_id = deferred_run.id
+
+    reconciled = reconcile_stale_background_import_runs(
+        engine=template_api_env.engine,
+        settings=active_settings,
+    )
+
+    assert reconciled == 1
+    with Session(template_api_env.engine) as session:
+        run = session.get(app_models.AnalysisRun, run_id)
+        assert run is not None
+        assert run.status == app_models.AnalysisRunStatus.FAILED
+        assert run.finished_at is not None
+        assert run.summary_json["import_job"]["status"] == "failed"
+        assert run.summary_json["background_error"]["stage"] == "background_import"
 
 
 def test_non_local_background_import_audit_retains_api_token_id(

--- a/backend/tests/api/test_template_model_metadata.py
+++ b/backend/tests/api/test_template_model_metadata.py
@@ -16,6 +16,7 @@ from app.core.migration_bootstrap import (
     ALEMBIC_HEAD,
     _connect_args,
     _legacy_revision_for_tables,
+    current_alembic_head,
     stamp_legacy_create_all_database,
 )
 
@@ -91,6 +92,12 @@ def test_template_alembic_head_matches_model_metadata(tmp_path: Path) -> None:
         engine.dispose()
 
     assert diffs == []
+
+
+def test_template_migration_head_resolves_without_checked_out_alembic_ini(
+    tmp_path: Path,
+) -> None:
+    assert current_alembic_head(tmp_path / "missing-alembic.ini") == ALEMBIC_HEAD
 
 
 @pytest.mark.parametrize(

--- a/docs/dependency-and-package-policy.md
+++ b/docs/dependency-and-package-policy.md
@@ -125,10 +125,12 @@ make docker-base-image-check
 ```
 
 The Docker workflow smoke-tests the built Workbench stack, emits SBOMs for the
-backend and frontend images with digest-pinned Syft, and gates Grype on fixable
-high/critical findings plus any critical finding. Public production release
-evidence still needs candidate-specific image digests and any required
-signing/provenance attestation for those exact images.
+backend and frontend images with digest-pinned Syft, emits full Grype JSON
+reports, and gates Grype on fixable high/critical findings. Non-fixable
+upstream base-image findings remain visible in the uploaded reports for
+maintainer triage without making the required PR smoke permanently red. Public
+production release evidence still needs candidate-specific image digests and
+any required signing/provenance attestation for those exact images.
 
 ## Dependabot Labels
 

--- a/docs/dependency-and-package-policy.md
+++ b/docs/dependency-and-package-policy.md
@@ -116,17 +116,19 @@ be used as release evidence unless that policy changes.
 
 ## Container Images
 
-The checked-in Dockerfiles use named upstream image tags so maintainers can
-receive compatible base-image security updates during local-first development.
-That is not byte-for-byte production pinning. Release owners who need pinned
-container provenance must record the resolved image digests for the backend,
-frontend, and compose stack used by the release candidate.
+The checked-in Dockerfiles pin upstream base-image references with image
+digests. Keep the human-readable tag in the `FROM` line for maintenance context,
+but every base image must also include `@sha256:...`. The local guard is:
+
+```bash
+make docker-base-image-check
+```
 
 The Docker workflow smoke-tests the built Workbench stack, emits SBOMs for the
-backend and frontend images, and fails CI on fixable critical image
-vulnerabilities. Public production release evidence still needs
-candidate-specific image digests and any required signing/provenance attestation
-for those exact images.
+backend and frontend images with digest-pinned Syft, and gates Grype on fixable
+high/critical findings plus any critical finding. Public production release
+evidence still needs candidate-specific image digests and any required
+signing/provenance attestation for those exact images.
 
 ## Dependabot Labels
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build-stage
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS build-stage
 
 WORKDIR /app/frontend
 
@@ -15,7 +15,7 @@ ENV NODE_ENV=$NODE_ENV
 
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
 
 USER root
 RUN apk upgrade --no-cache

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,10 +1,3 @@
-declare const __VPW_LEGACY_SESSION_TOKEN_STORAGE__: boolean | undefined
-
-const legacySessionTokenStorage =
-  typeof __VPW_LEGACY_SESSION_TOKEN_STORAGE__ === "boolean"
-    ? __VPW_LEGACY_SESSION_TOKEN_STORAGE__
-    : false
-const legacySessionTokenKey = "vpw.legacySessionToken"
 const csrfCookieNames = [
   "vpw_csrf_token",
   "vpw_csrf",
@@ -16,37 +9,26 @@ const csrfMetaNames = ["csrf-token", "vpw-csrf-token"]
 const csrfHeaderName = "X-CSRF-Token"
 const unsafeMethods = new Set(["DELETE", "PATCH", "POST", "PUT"])
 
-let inMemoryAccessToken = readLegacySessionToken()
 let authenticatedInCurrentTab = false
 
 export function getAccessToken(): string {
-  if (!legacySessionTokenStorage) {
-    return ""
-  }
-  if (!inMemoryAccessToken) {
-    inMemoryAccessToken = readLegacySessionToken()
-  }
-  return inMemoryAccessToken
+  return ""
 }
 
 export function isLoggedIn(): boolean {
-  return authenticatedInCurrentTab || getAccessToken().length > 0
+  return authenticatedInCurrentTab
 }
 
 export function markAuthenticatedSession(): void {
   authenticatedInCurrentTab = true
 }
 
-export function setAccessToken(token?: string): void {
-  inMemoryAccessToken = legacySessionTokenStorage ? (token ?? "") : ""
+export function setAccessToken(_token?: string): void {
   markAuthenticatedSession()
-  writeLegacySessionToken(inMemoryAccessToken)
 }
 
 export function clearAccessToken(): void {
-  inMemoryAccessToken = ""
   authenticatedInCurrentTab = false
-  clearLegacySessionToken()
   expireReadableAuthCookies()
 }
 
@@ -86,43 +68,6 @@ export function withCsrfHeader(request: Request): Request {
 
 function browserCookie() {
   return typeof document === "undefined" ? "" : document.cookie
-}
-
-function readLegacySessionToken() {
-  if (!legacySessionTokenStorage || typeof sessionStorage === "undefined") {
-    return ""
-  }
-  try {
-    return sessionStorage.getItem(legacySessionTokenKey) ?? ""
-  } catch {
-    return ""
-  }
-}
-
-function writeLegacySessionToken(token: string) {
-  if (!legacySessionTokenStorage || typeof sessionStorage === "undefined") {
-    return
-  }
-  try {
-    if (token) {
-      sessionStorage.setItem(legacySessionTokenKey, token)
-    } else {
-      sessionStorage.removeItem(legacySessionTokenKey)
-    }
-  } catch {
-    // Session storage can be blocked; cookie sessions remain the primary path.
-  }
-}
-
-function clearLegacySessionToken() {
-  if (!legacySessionTokenStorage || typeof sessionStorage === "undefined") {
-    return
-  }
-  try {
-    sessionStorage.removeItem(legacySessionTokenKey)
-  } catch {
-    // Session storage can be blocked; cookie sessions remain the primary path.
-  }
 }
 
 function readFirstCookieValue(cookie: string, names: readonly string[]) {

--- a/frontend/src/components/app/AppShell.tsx
+++ b/frontend/src/components/app/AppShell.tsx
@@ -80,7 +80,7 @@ type PageHeaderProps = {
 }
 
 type AppShellProps = PageHeaderProps & {
-  activePath: WorkbenchPath
+  activePath: WorkbenchPath | null
   children: ReactNode
   currentUserLabel: string
   healthLabel: string
@@ -91,7 +91,7 @@ type AppShellProps = PageHeaderProps & {
 }
 
 type ProductAppShellProps = PageHeaderProps & {
-  activePath: WorkbenchPath
+  activePath: WorkbenchPath | null
   children: ReactNode
   currentUser: UserPublic | null
   hideStatusStrip?: boolean

--- a/frontend/src/components/assets/AssetTable.tsx
+++ b/frontend/src/components/assets/AssetTable.tsx
@@ -170,6 +170,7 @@ export function AssetTable({
       data={assets}
       density="compact"
       getRowKey={(asset) => asset.id}
+      minWidth="1120px"
     />
   )
 }

--- a/frontend/src/components/dashboard/DashboardSignalOverview.tsx
+++ b/frontend/src/components/dashboard/DashboardSignalOverview.tsx
@@ -46,6 +46,34 @@ type DashboardSignalOverviewProps = {
   trendItems: readonly ChartDatum[]
 }
 
+function ChartDataSummary({
+  data,
+  label,
+}: {
+  data: readonly ChartDatum[]
+  label: string
+}) {
+  return (
+    <table className="sr-only">
+      <caption>{label}</caption>
+      <thead>
+        <tr>
+          <th scope="col">Signal</th>
+          <th scope="col">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((item) => (
+          <tr key={item.label}>
+            <th scope="row">{item.label}</th>
+            <td>{item.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
 function priorityFill(tone: ChartDatum["tone"]) {
   return tone === "critical"
     ? "var(--vpw-red)"
@@ -118,25 +146,31 @@ export function DashboardSignalOverview({
                   title="No findings yet"
                 />
               ) : (
-                <ResponsiveContainer height={196} width="100%">
-                  <BarChart
+                <>
+                  <ResponsiveContainer height={196} width="100%">
+                    <BarChart
+                      data={priorityItems}
+                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                    >
+                      <CartesianGrid
+                        className="opacity-40"
+                        strokeDasharray="3 3"
+                      />
+                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                      <YAxis tick={{ fontSize: 12 }} />
+                      <RechartsTooltip />
+                      <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                        {priorityItems.map((entry) => (
+                          <Cell key={entry.label} fill={priorityFill(entry.tone)} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                  <ChartDataSummary
                     data={priorityItems}
-                    margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                  >
-                    <CartesianGrid
-                      className="opacity-40"
-                      strokeDasharray="3 3"
-                    />
-                    <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                    <YAxis tick={{ fontSize: 12 }} />
-                    <RechartsTooltip />
-                    <Bar dataKey="value" radius={[4, 4, 0, 0]}>
-                      {priorityItems.map((entry) => (
-                        <Cell key={entry.label} fill={priorityFill(entry.tone)} />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
+                    label="Findings by priority chart data"
+                  />
+                </>
               )}
             </ChartCard>
           </TabsContent>
@@ -162,25 +196,31 @@ export function DashboardSignalOverview({
                   title="No EPSS data"
                 />
               ) : (
-                <ResponsiveContainer height={196} width="100%">
-                  <BarChart
+                <>
+                  <ResponsiveContainer height={196} width="100%">
+                    <BarChart
+                      data={epssItems}
+                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                    >
+                      <CartesianGrid
+                        className="opacity-40"
+                        strokeDasharray="3 3"
+                      />
+                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                      <YAxis tick={{ fontSize: 12 }} />
+                      <RechartsTooltip />
+                      <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                        {epssItems.map((entry) => (
+                          <Cell key={entry.label} fill={epssFill(entry.tone)} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                  <ChartDataSummary
                     data={epssItems}
-                    margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                  >
-                    <CartesianGrid
-                      className="opacity-40"
-                      strokeDasharray="3 3"
-                    />
-                    <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                    <YAxis tick={{ fontSize: 12 }} />
-                    <RechartsTooltip />
-                    <Bar dataKey="value" radius={[4, 4, 0, 0]}>
-                      {epssItems.map((entry) => (
-                        <Cell key={entry.label} fill={epssFill(entry.tone)} />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
+                    label="EPSS distribution chart data"
+                  />
+                </>
               )}
             </ChartCard>
           </TabsContent>
@@ -213,25 +253,33 @@ export function DashboardSignalOverview({
                   title="No rollup data"
                 />
               ) : (
-                <ResponsiveContainer height={220} width="100%">
-                  <BarChart
+                <>
+                  <ResponsiveContainer height={220} width="100%">
+                    <BarChart
+                      data={serviceItems}
+                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                    >
+                      <CartesianGrid
+                        className="opacity-40"
+                        strokeDasharray="3 3"
+                      />
+                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                      <YAxis tick={{ fontSize: 12 }} />
+                      <RechartsTooltip />
+                      <Bar
+                        dataKey="value"
+                        fill="var(--vpw-teal)"
+                        radius={[4, 4, 0, 0]}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                  <ChartDataSummary
                     data={serviceItems}
-                    margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                  >
-                    <CartesianGrid
-                      className="opacity-40"
-                      strokeDasharray="3 3"
-                    />
-                    <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                    <YAxis tick={{ fontSize: 12 }} />
-                    <RechartsTooltip />
-                    <Bar
-                      dataKey="value"
-                      fill="var(--vpw-teal)"
-                      radius={[4, 4, 0, 0]}
-                    />
-                  </BarChart>
-                </ResponsiveContainer>
+                    label={`${
+                      topServiceSource === "assets" ? "Top assets" : "Top services"
+                    } chart data`}
+                  />
+                </>
               )}
             </ChartCard>
           </TabsContent>
@@ -268,27 +316,33 @@ export function DashboardSignalOverview({
                   title="No trend data"
                 />
               ) : (
-                <ResponsiveContainer height={220} width="100%">
-                  <LineChart
+                <>
+                  <ResponsiveContainer height={220} width="100%">
+                    <LineChart
+                      data={trendItems}
+                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                    >
+                      <CartesianGrid
+                        className="opacity-40"
+                        strokeDasharray="3 3"
+                      />
+                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                      <YAxis tick={{ fontSize: 12 }} />
+                      <RechartsTooltip />
+                      <Line
+                        dataKey="value"
+                        dot={{ r: 3 }}
+                        stroke="var(--vpw-violet)"
+                        strokeWidth={2}
+                        type="monotone"
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                  <ChartDataSummary
                     data={trendItems}
-                    margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                  >
-                    <CartesianGrid
-                      className="opacity-40"
-                      strokeDasharray="3 3"
-                    />
-                    <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                    <YAxis tick={{ fontSize: 12 }} />
-                    <RechartsTooltip />
-                    <Line
-                      dataKey="value"
-                      dot={{ r: 3 }}
-                      stroke="var(--vpw-violet)"
-                      strokeWidth={2}
-                      type="monotone"
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
+                    label="Risk trend chart data"
+                  />
+                </>
               )}
             </ChartCard>
           </TabsContent>

--- a/frontend/src/components/findings/RemediationQueue.tsx
+++ b/frontend/src/components/findings/RemediationQueue.tsx
@@ -36,6 +36,7 @@ export type RemediationQueueProps = {
   selectedProject: ProjectPublic | null
   projects: ProjectPublic[]
   projectListLoading: boolean
+  projectListError: string
   selectedProjectId: string
   projectSummary: ProjectDecisionSummaryPublic | null
   findingSearch: FindingsUrlSearch
@@ -72,6 +73,7 @@ export function RemediationQueue({
   selectedProject,
   projects,
   projectListLoading,
+  projectListError,
   selectedProjectId,
   projectSummary,
   findingSearch,
@@ -96,7 +98,11 @@ export function RemediationQueue({
   const queueSort: QueueSort = findingSort
 
   const isDemo =
-    DEMO_MODE_ENABLED && projects.length === 0 && !projectListLoading
+    DEMO_MODE_ENABLED &&
+    projects.length === 0 &&
+    !projectListLoading &&
+    !projectListError &&
+    !findingsError
   const sourceFindings = isDemo ? DEMO_FINDINGS : findings
   const displayFindings = isDemo
     ? sortDisplayFindings(sourceFindings, queueSort, findingDirection)
@@ -192,6 +198,7 @@ export function RemediationQueue({
     onPageSizeChange,
     onProjectChange,
     onSortDirectionChange,
+    projectListError,
     projectListLoading,
     projectSummary,
     projects,

--- a/frontend/src/components/findings/findings-search-state.ts
+++ b/frontend/src/components/findings/findings-search-state.ts
@@ -159,22 +159,50 @@ function numericFilterText(value: string, min: number, max: number) {
   return Number.isFinite(parsed) && parsed >= min && parsed <= max ? value : ""
 }
 
+function numericRange(
+  rawMin: string,
+  rawMax: string,
+  min: number,
+  max: number,
+) {
+  const minValue = numericFilterText(rawMin, min, max)
+  const maxValue = numericFilterText(rawMax, min, max)
+  if (!minValue || !maxValue) {
+    return { maxValue, minValue }
+  }
+  return Number(minValue) <= Number(maxValue)
+    ? { maxValue, minValue }
+    : { maxValue: "", minValue }
+}
+
 export function parseFindingsSearch(input: unknown): FindingsSearchState {
   const source = searchRecord(input)
   const assetId = searchValue(source, "assetId")
+  const cvssRange = numericRange(
+    searchValue(source, "cvssMin"),
+    searchValue(source, "cvssMax"),
+    0,
+    10,
+  )
+  const epssRange = numericRange(
+    searchValue(source, "epssMin"),
+    searchValue(source, "epssMax"),
+    0,
+    1,
+  )
   return {
     ...defaultFindingsSearchState,
     assetId,
     assetKey: assetId ? searchValue(source, "assetKey") : "",
-    cvssMax: numericFilterText(searchValue(source, "cvssMax"), 0, 10),
-    cvssMin: numericFilterText(searchValue(source, "cvssMin"), 0, 10),
+    cvssMax: cvssRange.maxValue,
+    cvssMin: cvssRange.minValue,
     direction: enumValue(
       searchValue(source, "direction"),
       directionOptions,
       defaultFindingsSearchState.direction,
     ),
-    epssMax: numericFilterText(searchValue(source, "epssMax"), 0, 1),
-    epssMin: numericFilterText(searchValue(source, "epssMin"), 0, 1),
+    epssMax: epssRange.maxValue,
+    epssMin: epssRange.minValue,
     exposure: optionalEnumValue<AssetExposure>(
       searchValue(source, "exposure"),
       findingExposureOptions,

--- a/frontend/src/components/imports/ImportsWorkbench.tsx
+++ b/frontend/src/components/imports/ImportsWorkbench.tsx
@@ -13,14 +13,20 @@ export function ImportsWorkbench(props: ImportsWorkbenchProps) {
   const hasProject = Boolean(props.selectedProjectId)
 
   return (
-    <VpwPageContainer className="space-y-8 px-0 py-0">
+    <VpwPageContainer className="space-y-6 px-0 py-0">
       <ImportHero
         importWizard={props.importWizard}
+        projectListError={props.projectListError}
         projectRuns={props.projectRuns}
         providerStatus={props.providerStatus}
         selectedProject={props.selectedProject}
       />
-      {!hasProject && !props.projectListLoading ? (
+      {props.projectListError ? (
+        <VpwStatusBanner title="Projects unavailable" tone="critical">
+          {props.projectListError}
+        </VpwStatusBanner>
+      ) : null}
+      {!hasProject && !props.projectListLoading && !props.projectListError ? (
         <VpwStatusBanner title="Project required" tone="warning">
           Create or select a project before uploading import files.
         </VpwStatusBanner>

--- a/frontend/src/components/imports/ImportsWorkbenchHero.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchHero.tsx
@@ -16,17 +16,22 @@ import {
 
 export function ImportHero({
   importWizard,
+  projectListError,
   projectRuns,
   providerStatus,
   selectedProject,
 }: Pick<
   ImportsWorkbenchProps,
-  "importWizard" | "projectRuns" | "providerStatus" | "selectedProject"
+  | "importWizard"
+  | "projectListError"
+  | "projectRuns"
+  | "providerStatus"
+  | "selectedProject"
 >) {
   const providerSummary = providerStatus
     ? formatProviderFreshness(providerStatus)
     : null
-  const isDemo = DEMO_MODE_ENABLED && !selectedProject
+  const isDemo = DEMO_MODE_ENABLED && !selectedProject && !projectListError
 
   return (
     <VpwSection>

--- a/frontend/src/components/imports/imports-workbench-model.ts
+++ b/frontend/src/components/imports/imports-workbench-model.ts
@@ -38,6 +38,7 @@ export type ImportsWorkbenchProps = {
   onSubmit: FormEventHandler<HTMLFormElement>
   onVexFileChange: (file: File | null) => void
   projectListLoading: boolean
+  projectListError: string
   projectRuns: AnalysisRunPublic[]
   projects: ProjectPublic[]
   providerStatus: ProviderStatusPublic | null

--- a/frontend/src/components/projects/ProjectsWorkbench.tsx
+++ b/frontend/src/components/projects/ProjectsWorkbench.tsx
@@ -16,7 +16,7 @@ export type {
 
 export function ProjectsWorkbench(props: ProjectsWorkbenchProps) {
   return (
-    <VpwPageContainer className="space-y-8 px-0 py-0">
+    <VpwPageContainer className="space-y-6 px-0 py-0">
       <ProjectHero
         projectSummary={props.projectSummary}
         projects={props.projects}

--- a/frontend/src/components/reports/EvidenceCenter.tsx
+++ b/frontend/src/components/reports/EvidenceCenter.tsx
@@ -28,6 +28,7 @@ export type EvidenceCenterProps = {
   selectedReportRun: AnalysisRunPublic | null
   selectedRunSummary: AnalysisRunSummaryPublic | null
   projectRuns: AnalysisRunPublic[]
+  projectListError: string
   runsLoading: boolean
   runsError: string
   runDetailError: string
@@ -54,6 +55,7 @@ export function EvidenceCenter({
   onDownloadReport,
   onRunIdChange,
   onVerifyReport,
+  projectListError,
   projectRuns,
   projectSummary,
   providerStatus,
@@ -74,8 +76,8 @@ export function EvidenceCenter({
   verificationReport,
   verificationReportTarget,
 }: EvidenceCenterProps) {
-  const isDemo = DEMO_MODE_ENABLED && !selectedProject
   const combinedError = [
+    projectListError,
     runsError,
     runDetailError,
     reportsError,
@@ -83,9 +85,10 @@ export function EvidenceCenter({
   ]
     .filter(Boolean)
     .join(" ")
+  const isDemo = DEMO_MODE_ENABLED && !selectedProject && !combinedError
 
   return (
-    <VpwPageContainer className="space-y-8 px-0 py-0">
+    <VpwPageContainer className="space-y-6 px-0 py-0">
       <RunContext
         isDemo={isDemo}
         onRunIdChange={onRunIdChange}

--- a/frontend/src/components/vpw/VpwDataTable.tsx
+++ b/frontend/src/components/vpw/VpwDataTable.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import type { CSSProperties, ReactNode } from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -20,6 +20,7 @@ export type VpwDataTableProps<TData> = {
   className?: string
   density?: VpwDataTableDensity
   emptyState?: ReactNode
+  minWidth?: string
 }
 
 const densityClass: Record<VpwDataTableDensity, string> = {
@@ -36,15 +37,21 @@ export function VpwDataTable<TData>({
   density = "standard",
   emptyState,
   getRowKey,
+  minWidth,
 }: VpwDataTableProps<TData>) {
   if (data.length === 0 && emptyState) {
     return <>{emptyState}</>
   }
 
+  const tableStyle = {
+    "--vpw-table-min-width": minWidth ?? `${Math.max(640, columns.length * 160)}px`,
+  } as CSSProperties
+
   return (
     <section
       aria-label={caption ?? "Data table"}
       className={cn("vpw-table-wrap", className)}
+      style={tableStyle}
       // biome-ignore lint/a11y/noNoninteractiveTabindex: Data table wrappers can scroll horizontally and need keyboard access.
       tabIndex={0}
     >

--- a/frontend/src/lib/app-route-config.ts
+++ b/frontend/src/lib/app-route-config.ts
@@ -1,13 +1,15 @@
 import type { WorkbenchPath } from "../components/app/AppShell"
 
+type RouteDetail = {
+  eyebrow: string
+  title: string
+  panelTitle: string
+  panelDetail: string
+}
+
 export const routeDetails: Record<
   WorkbenchPath,
-  {
-    eyebrow: string
-    title: string
-    panelTitle: string
-    panelDetail: string
-  }
+  RouteDetail
 > = {
   "/": {
     eyebrow: "Security Operations",
@@ -64,4 +66,38 @@ export const routeDetails: Record<
     panelTitle: "User Settings",
     panelDetail: "Current authenticated user and workspace session",
   },
+}
+
+export const unknownRouteDetail: RouteDetail = {
+  eyebrow: "Workbench",
+  title: "Workspace",
+  panelTitle: "Workbench",
+  panelDetail: "Current workspace route",
+}
+
+const routePathOrder: readonly WorkbenchPath[] = [
+  "/projects",
+  "/imports",
+  "/findings",
+  "/waivers",
+  "/assets",
+  "/providers",
+  "/reports",
+  "/settings",
+  "/",
+]
+
+export function workbenchPathFromPathname(
+  pathname: string,
+): WorkbenchPath | null {
+  if (pathname === "/" || pathname === "") return "/"
+  for (const routePath of routePathOrder) {
+    if (
+      routePath !== "/" &&
+      (pathname === routePath || pathname.startsWith(`${routePath}/`))
+    ) {
+      return routePath
+    }
+  }
+  return null
 }

--- a/frontend/src/lib/runtime-config.ts
+++ b/frontend/src/lib/runtime-config.ts
@@ -6,7 +6,6 @@ type RuntimeEnv = {
 
 declare const __VPW_API_URL__: string | undefined
 declare const __VPW_DEMO_MODE__: boolean | undefined
-declare const __VPW_LEGACY_SESSION_TOKEN_STORAGE__: boolean | undefined
 
 const LOCAL_API_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"])
 
@@ -59,8 +58,3 @@ export const DEMO_MODE_ENABLED =
   typeof __VPW_DEMO_MODE__ === "boolean"
     ? __VPW_DEMO_MODE__
     : isExplicitDemoModeEnabled(import.meta.env)
-
-export const LEGACY_SESSION_TOKEN_STORAGE =
-  typeof __VPW_LEGACY_SESSION_TOKEN_STORAGE__ === "boolean"
-    ? __VPW_LEGACY_SESSION_TOKEN_STORAGE__
-    : false

--- a/frontend/src/styles/vpw-components.css
+++ b/frontend/src/styles/vpw-components.css
@@ -121,7 +121,8 @@
   }
 
   .vpw-table {
-    width: 100%;
+    width: max(100%, var(--vpw-table-min-width, 100%));
+    min-width: var(--vpw-table-min-width, 100%);
     border-collapse: separate;
     border-spacing: 0;
     color: var(--vpw-text-primary);

--- a/frontend/src/workbench/WorkbenchContext.tsx
+++ b/frontend/src/workbench/WorkbenchContext.tsx
@@ -68,6 +68,7 @@ function persistSelectedProjectId(projectId: string) {
 export type WorkbenchContextValue = {
   currentUser: UserPublic | null
   handleAuthExpired: () => Promise<void>
+  projectListError: string
   projectListLoading: boolean
   projects: ProjectPublic[]
   providerStatus: ProviderStatusPublic | null
@@ -203,6 +204,9 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     () => ({
       currentUser: currentUserQuery.data ?? null,
       handleAuthExpired,
+      projectListError: projectsQuery.isError
+        ? apiErrorMessage("Projects unavailable", projectsQuery.error)
+        : "",
       projectListLoading: projectsQuery.isLoading || projectsQuery.isFetching,
       projects,
       providerStatus: providerStatusQuery.data ?? null,
@@ -229,7 +233,9 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
       providerStatusQuery.isError,
       providerStatusQuery.isFetching,
       providerStatusQuery.isLoading,
+      projectsQuery.error,
       projectsQuery.isFetching,
+      projectsQuery.isError,
       projectsQuery.isLoading,
       refreshProjects,
       refreshProviderStatus,

--- a/frontend/src/workbench/WorkbenchShell.tsx
+++ b/frontend/src/workbench/WorkbenchShell.tsx
@@ -2,26 +2,19 @@ import { type ReactNode, Suspense } from "react"
 import { useLocation } from "@tanstack/react-router"
 import { ProductAppShell, type WorkbenchPath } from "../components/app/AppShell"
 import { LoadingSkeleton } from "../components/states"
-import { routeDetails } from "../lib/app-route-config"
+import {
+  routeDetails,
+  unknownRouteDetail,
+  workbenchPathFromPathname,
+} from "../lib/app-route-config"
 import { useWorkbenchContext, WorkbenchProvider } from "./WorkbenchContext"
 
 type WorkbenchShellProps = {
   children: ReactNode
-  routePath?: WorkbenchPath
+  routePath?: WorkbenchPath | null
 }
 
-function workbenchPathFromPathname(pathname: string): WorkbenchPath {
-  if (pathname === "/" || pathname === "") return "/"
-  if (pathname.startsWith("/projects")) return "/projects"
-  if (pathname.startsWith("/imports")) return "/imports"
-  if (pathname.startsWith("/findings")) return "/findings"
-  if (pathname.startsWith("/waivers")) return "/waivers"
-  if (pathname.startsWith("/assets")) return "/assets"
-  if (pathname.startsWith("/providers")) return "/providers"
-  if (pathname.startsWith("/reports")) return "/reports"
-  if (pathname.startsWith("/settings")) return "/settings"
-  return "/"
-}
+const routesWithStatusStrip = new Set<WorkbenchPath>(["/providers", "/settings"])
 
 function WorkbenchShellFrame({ children, routePath }: WorkbenchShellProps) {
   const location = useLocation()
@@ -32,10 +25,13 @@ function WorkbenchShellFrame({ children, routePath }: WorkbenchShellProps) {
     statusError,
   } = useWorkbenchContext()
   const activeRoutePath = routePath ?? workbenchPathFromPathname(location.pathname)
-  const routeDetail = routeDetails[activeRoutePath]
+  const routeDetail = activeRoutePath
+    ? routeDetails[activeRoutePath]
+    : unknownRouteDetail
   const isFindingDetail =
     activeRoutePath === "/findings" && /^\/findings\/[^/]+$/.test(location.pathname)
-  const hideStatusStrip = activeRoutePath === "/" || activeRoutePath === "/findings"
+  const hideStatusStrip =
+    !activeRoutePath || !routesWithStatusStrip.has(activeRoutePath)
 
   return (
     <ProductAppShell

--- a/frontend/src/workbench/routes/DashboardRoute.tsx
+++ b/frontend/src/workbench/routes/DashboardRoute.tsx
@@ -15,6 +15,7 @@ function DashboardRouteContainer() {
   const queryClient = useQueryClient()
   const {
     projectListLoading,
+    projectListError,
     projects,
     providerStatus,
     providerStatusError,
@@ -52,12 +53,13 @@ function DashboardRouteContainer() {
   return (
     <RiskOperationsDashboard
       dashboardError={
-        projectDashboardQuery.isError
+        projectListError ||
+        (projectDashboardQuery.isError
           ? apiErrorMessage(
               "Project dashboard unavailable",
               projectDashboardQuery.error,
             )
-          : ""
+          : "")
       }
       epssBuckets={epssBucketChartData(dashboardSignalCounts.epssBuckets)}
       findings={dashboardFindings}

--- a/frontend/src/workbench/routes/FindingsRoute.tsx
+++ b/frontend/src/workbench/routes/FindingsRoute.tsx
@@ -21,6 +21,7 @@ function FindingsRouteContainer() {
   const location = useLocation()
   const {
     projectListLoading,
+    projectListError,
     projects,
     selectedProject,
     selectedProjectId,
@@ -122,6 +123,7 @@ function FindingsRouteContainer() {
         }}
         onSortDirectionChange={updateFindingSortDirection}
         projectListLoading={projectListLoading}
+        projectListError={projectListError}
         projectSummary={projectSummaryQuery.data ?? null}
         projects={projects}
         selectedProject={selectedProject}

--- a/frontend/src/workbench/routes/ImportsRoute.tsx
+++ b/frontend/src/workbench/routes/ImportsRoute.tsx
@@ -42,6 +42,7 @@ function ImportsRouteContainer() {
   const queryClient = useQueryClient()
   const {
     projectListLoading,
+    projectListError,
     projects,
     providerStatus,
     refreshProjects,
@@ -255,6 +256,7 @@ function ImportsRouteContainer() {
         setImportWizard((state) => ({ ...state, vexFile: file }))
       }
       projectListLoading={projectListLoading}
+      projectListError={projectListError}
       projectRuns={projectRuns}
       projects={projects}
       providerStatus={providerStatus}

--- a/frontend/src/workbench/routes/ReportsRoute.tsx
+++ b/frontend/src/workbench/routes/ReportsRoute.tsx
@@ -12,6 +12,7 @@ import { useReportsRouteState } from "../useReportsRouteState"
 function ReportsRouteContent() {
   const {
     handleAuthExpired,
+    projectListError,
     providerStatus,
     selectedProject,
     selectedProjectId,
@@ -46,6 +47,7 @@ function ReportsRouteContent() {
         onDownloadReport={reportsState.downloadReport}
         onRunIdChange={setSelectedRunId}
         onVerifyReport={reportsState.verifyEvidenceReport}
+        projectListError={projectListError}
         projectRuns={projectRuns}
         projectSummary={projectSummaryQuery.data ?? null}
         providerStatus={providerStatus}

--- a/frontend/src/workbench/useWorkbenchQueries.ts
+++ b/frontend/src/workbench/useWorkbenchQueries.ts
@@ -273,7 +273,7 @@ export function useFindingDetailQuery(findingId: string | null) {
       if (!findingId) {
         throw new Error("findingId is required")
       }
-      const demoDetail = DEMO_MODE_ENABLED
+      const demoDetail = DEMO_MODE_ENABLED && findingId.startsWith("demo-")
         ? demoFindingDetailForId(findingId)
         : null
       if (demoDetail) {

--- a/frontend/tests/findings-search-state.test.ts
+++ b/frontend/tests/findings-search-state.test.ts
@@ -118,6 +118,37 @@ test("findings search maps URL state to generated findings API params", () => {
   })
 })
 
+test("findings search drops invalid max range values that are below min", () => {
+  const state = parseFindingsSearch({
+    cvssMax: "4",
+    cvssMin: "9",
+    epssMax: "0.2",
+    epssMin: "0.7",
+  })
+
+  assert.equal(state.cvssMin, "9")
+  assert.equal(state.cvssMax, "")
+  assert.equal(state.epssMin, "0.7")
+  assert.equal(state.epssMax, "")
+  assert.deepEqual(findingsSearchToApiParams(state, "project-1"), {
+    asset_id: undefined,
+    cvss_max: undefined,
+    cvss_min: 9,
+    direction: "asc",
+    epss_max: undefined,
+    epss_min: 0.7,
+    exposure: undefined,
+    kev: undefined,
+    limit: 10,
+    offset: 0,
+    owner_service: undefined,
+    priority: undefined,
+    project_id: "project-1",
+    sort: "operational",
+    status: undefined,
+  })
+})
+
 test("findings search updates reset paging except explicit page movement", () => {
   const state = parseFindingsSearch({
     limit: "25",

--- a/frontend/tests/route-organization.test.ts
+++ b/frontend/tests/route-organization.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict"
 import { readFileSync, readdirSync } from "node:fs"
 import test from "node:test"
 
+import { workbenchPathFromPathname } from "../src/lib/app-route-config.ts"
+
 const routesDir = new URL("../src/routes/_layout/", import.meta.url)
 const authenticatedLayoutFile = new URL("../src/routes/_layout.tsx", import.meta.url)
 const workbenchRoutesDir = new URL("../src/workbench/routes/", import.meta.url)
@@ -102,6 +104,14 @@ test("Workbench shell is mounted once at the authenticated layout boundary", () 
       `${file} should rely on the authenticated layout shell`,
     )
   }
+})
+
+test("Workbench route matching does not highlight dashboard for unknown paths", () => {
+  assert.equal(workbenchPathFromPathname("/"), "/")
+  assert.equal(workbenchPathFromPathname("/findings/demo-f1"), "/findings")
+  assert.equal(workbenchPathFromPathname("/reports/exported/123"), "/reports")
+  assert.equal(workbenchPathFromPathname("/findings-old"), null)
+  assert.equal(workbenchPathFromPathname("/unknown"), null)
 })
 
 test("frontend unit test scripts automatically include every unit test file", () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({ mode }) => {
     define: {
       __VPW_API_URL__: JSON.stringify(bundledApiUrl),
       __VPW_DEMO_MODE__: JSON.stringify(demoMode),
-      __VPW_LEGACY_SESSION_TOKEN_STORAGE__: JSON.stringify(!isProductionBuild),
     },
     resolve: {
       alias: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vuln-prioritizer-workbench-workspace"
-version = "0.0.0"
+version = "1.1.0"
 description = "Workspace metadata for the Vuln Prioritizer Workbench migration."
 requires-python = ">=3.11"
 dependencies = []

--- a/scripts/check_dockerfile_base_digests.py
+++ b/scripts/check_dockerfile_base_digests.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+FROM_RE = re.compile(r"^\s*FROM\s+(?P<image>\S+)", re.IGNORECASE)
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILES = (
+    ROOT / "backend" / "Dockerfile",
+    ROOT / "frontend" / "Dockerfile",
+)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for dockerfile in DOCKERFILES:
+        for line_number, line in enumerate(dockerfile.read_text(encoding="utf-8").splitlines(), 1):
+            match = FROM_RE.match(line)
+            if match is None:
+                continue
+            image = match.group("image")
+            if "@sha256:" not in image:
+                failures.append(f"{dockerfile.relative_to(ROOT)}:{line_number}: {image}")
+
+    if failures:
+        print("Dockerfile base images must be pinned by digest:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -2364,7 +2364,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "vuln-prioritizer-workbench-workspace"
-version = "0.0.0"
+version = "1.1.0"
 source = { virtual = "." }
 
 [[package]]


### PR DESCRIPTION
## Summary
- harden Workbench UI/UX audit findings across route handling, demo/live fallback behavior, table overflow, chart accessibility, and compact page spacing
- tighten backend/API migration, OpenAPI prefix, background import reconciliation, and installed wheel Alembic behavior
- pin Docker base images by digest, add Dockerfile digest guardrail, and harden CI supply-chain checks
- keep container image scanning actionable by failing on fixable high/critical findings while uploading full Grype JSON reports for non-fixable base-image triage
- bump package metadata to 1.1.0 and preserve generated-client drift checks

## Local validation
- `make frontend-check`
- `make package-check`
- `make playwright-check` (`34 passed`)
- `make docker-demo-smoke`
- `make docker-production-smoke`
- `make check` (`1207 passed, 4 skipped`, backend coverage `96.78%`)
- `make workflow-check`
- `make dependency-audit` (`pip-audit`: no known vulnerabilities, `npm audit --omit=dev`: 0 vulnerabilities)
- `make docs-check` after the follow-up workflow change
- `make docker-base-image-check` after the follow-up workflow change
- workflow YAML parse after the follow-up workflow change
- `git diff --check`

## Remote validation
- CI `check (3.11)`: passed
- CI `check (3.12)`: passed
- CI `frontend`: passed
- CI `dependency-audit`: passed
- CI `action-smoke`: passed
- Docker `changes`: passed
- Docker `compose-smoke`: passed
- CodeQL `Analyze Python`: passed
- CodeQL `Analyze JavaScript/TypeScript`: passed

## Notes
- Public-production certification/evidence updates are intentionally out of scope for this PR.
- Public-production evidence files were not changed.
