### PR TITLE
Mitigate unbounded login username audit and limiter growth

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import secrets
 from datetime import timedelta
 from typing import Annotated
@@ -20,6 +21,9 @@ from app.services.audit import record_audit_event
 
 router = APIRouter(tags=["login"])
 
+_LOGIN_AUDIT_USERNAME_MAX_CHARS = 256
+_LOGIN_RATE_LIMIT_USERNAME_HASH_LEN = 24
+
 
 @router.post("/login/access-token")
 def login_access_token(
@@ -37,7 +41,7 @@ def login_access_token(
             action="login.failure",
             resource_type="auth_session",
             status="failure",
-            detail={"username": form_data.username},
+            detail={"username": _audit_username_hint(form_data.username)},
         )
         session.commit()
         raise HTTPException(status_code=400, detail="Incorrect email or password")
@@ -93,8 +97,9 @@ def _enforce_login_rate_limit(request: Request, username: str) -> None:
         return
     client_host = request.client.host if request.client else "unknown"
     normalized_username = username.strip().lower() or "unknown"
+    limiter_username_key = _rate_limit_username_key(normalized_username)
     decision = limiter.check(
-        f"login-user:{client_host}:{normalized_username}",
+        f"login-user:{client_host}:{limiter_username_key}",
         limit=active_settings.LOGIN_RATE_LIMIT_PER_MINUTE,
     )
     if not decision.allowed:
@@ -180,3 +185,14 @@ def _session_cookie_secure(request: Request) -> bool:
     if isinstance(active_settings, Settings) and active_settings.ENVIRONMENT != "local":
         return True
     return request.url.scheme == "https"
+
+
+def _audit_username_hint(username: str) -> str:
+    normalized = username.strip()
+    if not normalized:
+        return "unknown"
+    return normalized[:_LOGIN_AUDIT_USERNAME_MAX_CHARS]
+
+
+def _rate_limit_username_key(normalized_username: str) -> str:
+    return hashlib.sha256(normalized_username.encode()).hexdigest()[:_LOGIN_RATE_LIMIT_USERNAME_HASH_LEN]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -143,6 +143,8 @@ async def _upload_size_guard(
 
 
 def _is_template_upload_path(path: str) -> bool:
+    if path.endswith("/login/access-token"):
+        return True
     return path.startswith("/api/v1/projects/") and (
         path.endswith("/imports") or path.endswith("/assets/import")
     )

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -12,6 +13,8 @@ from app.models import AuditEvent, AuditEventStatus, User
 from app.models.api_tokens import api_token_id
 from app.repositories import AuditEventRepository
 from vuln_prioritizer.security_redaction import redact_value
+
+_MAX_AUDIT_DETAIL_JSON_BYTES = 4096
 
 
 def record_audit_event(
@@ -31,7 +34,7 @@ def record_audit_event(
         redacted_value, _paths = redact_value(detail)
         if isinstance(redacted_value, dict):
             encoded = jsonable_encoder(redacted_value)
-            redacted_detail = dict(encoded) if isinstance(encoded, dict) else {}
+            redacted_detail = _truncate_audit_detail(encoded) if isinstance(encoded, dict) else {}
     return AuditEventRepository(session).create_audit_event(
         action=action,
         resource_type=resource_type,
@@ -42,3 +45,14 @@ def record_audit_event(
         api_token_id=api_token_id(actor) if actor is not None else None,
         detail=redacted_detail,
     )
+
+
+def _truncate_audit_detail(detail: dict[str, Any]) -> dict[str, Any]:
+    serialized = json.dumps(detail, separators=(",", ":"), ensure_ascii=False)
+    if len(serialized.encode("utf-8")) <= _MAX_AUDIT_DETAIL_JSON_BYTES:
+        return detail
+    for max_chars in (512, 256, 128, 64):
+        candidate = {"truncated": True, "preview": serialized[:max_chars]}
+        if len(json.dumps(candidate, separators=(",", ":"), ensure_ascii=False).encode("utf-8")) <= _MAX_AUDIT_DETAIL_JSON_BYTES:
+            return candidate
+    return {"truncated": True}

--- a/backend/tests/api/test_template_auth_smoke.py
+++ b/backend/tests/api/test_template_auth_smoke.py
@@ -373,6 +373,57 @@ def test_template_api_responses_include_security_headers() -> None:
         _assert_security_headers(response.headers)
 
 
+
+def test_template_failed_login_audit_truncates_username(template_api_env: Any) -> None:
+    client = template_api_env.client
+    long_username = "A" * 5000
+
+    response = client.post(
+        "/api/v1/login/access-token",
+        data={"username": long_username, "password": "wrong-password"},
+    )
+
+    assert response.status_code == 400
+    with Session(template_api_env.engine) as db_session:
+        event = db_session.exec(
+            select(template_api_env.app_models.AuditEvent).where(
+                template_api_env.app_models.AuditEvent.action == "login.failure"
+            )
+        ).one()
+    stored_username = str(event.detail_json.get("username", ""))
+    assert len(stored_username) == 256
+
+
+def test_template_login_rate_limit_uses_hashed_username_key() -> None:
+    selected_app = create_app(Settings(LOGIN_RATE_LIMIT_PER_MINUTE=5))
+    client = _client(selected_app)
+    long_username = "b" * 5000
+
+    response = client.post(
+        "/api/v1/login/access-token",
+        data={"username": long_username, "password": "wrong-password"},
+    )
+
+    assert response.status_code == 400
+    limiter = selected_app.state.rate_limiter
+    keys = [key for key in limiter.attempts if key.startswith("login-user:")]
+    assert len(keys) == 1
+    assert len(keys[0]) < 128
+
+
+def test_template_login_rejects_oversized_request_body() -> None:
+    selected_app = create_app(Settings(MAX_UPLOAD_MB=1))
+    client = _client(selected_app)
+    long_username = "c" * (2 * 1024 * 1024)
+
+    response = client.post(
+        "/api/v1/login/access-token",
+        data={"username": long_username, "password": "wrong-password"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+
 def _without_generated_fields(payload: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in payload.items() if key not in {"id", "created_at"}}
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated attackers from persisting arbitrarily large username values into the audit table which can exhaust disk or DB resources.
- Prevent very large usernames from being kept in-memory as part of per-user rate-limiter keys, which can amplify memory usage.
- Ensure oversized authentication request bodies are rejected at the application level rather than allowing them to be accepted and persisted.

### Description
- Bound failed-login audit data by replacing the direct `form_data.username` persistence with a trimmed hint via `_audit_username_hint(...)` (max 256 chars) in `backend/app/api/routes/login.py`.
- Stop storing raw normalized usernames in limiter keys by hashing and truncating the username when building the limiter key via `_rate_limit_username_key(...)` in `backend/app/api/routes/login.py`.
- Add an audit-detail truncation helper `_truncate_audit_detail(...)` capped to `_MAX_AUDIT_DETAIL_JSON_BYTES = 4096` and use it before calling `AuditEventRepository.create_audit_event(...)` in `backend/app/services/audit.py`.
- Extend the POST upload-size guard to also treat `/login/access-token` as a guarded path so oversized login bodies return `413` in `backend/app/main.py`.
- Add focused tests in `backend/tests/api/test_template_auth_smoke.py` to assert truncated audit usernames, hashed limiter keys, and oversized-login rejection.

### Testing
- Added tests: `test_template_failed_login_audit_truncates_username`, `test_template_login_rate_limit_uses_hashed_username_key`, and `test_template_login_rejects_oversized_request_body` in `backend/tests/api/test_template_auth_smoke.py` (these are included in the PR).
- Attempted to run the focused tests with `cd backend && pytest tests/api/test_template_auth_smoke.py -q`, but automated test execution failed during import due to the test environment using Python 3.10 while the codebase imports `UTC` from `datetime` (a Python 3.11+ symbol), so the new tests could not be executed in this container.
- No other automated test runs completed successfully in this environment due to the import/runtime restriction described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb792b5a208325ad4084b31d936298)