### PR TITLE
Require admin scope for GitHub issue export (non-dry-run)

### DIFF
--- a/backend/app/api/routes/github_issues.py
+++ b/backend/app/api/routes/github_issues.py
@@ -7,7 +7,7 @@ import uuid
 from fastapi import APIRouter
 from sqlalchemy.exc import IntegrityError
 
-from app.api.deps import ScopedReportUser, SessionDep
+from app.api.deps import ScopedAdminUser, ScopedReportUser, SessionDep
 from app.api.routes.workbench_access import require_visible_project
 from app.models import (
     GitHubIssueExportCreate,
@@ -52,7 +52,7 @@ def export_project_github_issues(
     project_id: uuid.UUID,
     payload: GitHubIssueExportCreate,
     session: SessionDep,
-    current_user: ScopedReportUser,
+    current_user: ScopedAdminUser,
 ) -> GitHubIssueExportPublic:
     """Dry-run or explicitly create GitHub issues for selected visible findings."""
     require_visible_project(session, current_user, project_id)


### PR DESCRIPTION
### Motivation
- Prevent a confused-deputy path where report-scoped callers could supply `repository` and `token_env` to cause the backend to use server-side GitHub credentials to create issues in arbitrary repos. 

### Description
- Tighten the authorization on the real export route by changing the dependency for `POST /projects/{project_id}/github/issues/export` from `ScopedReportUser` to `ScopedAdminUser` and updating the import in `backend/app/api/routes/github_issues.py`. 

### Testing
- Attempted to run `pytest backend/tests/api/test_template_github_issue_export.py -q` but the test execution in this environment failed early with an unrelated Python runtime import error (`ImportError: cannot import name 'UTC' from datetime`), so a full automated test pass could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb79b364288325bfdb586a2d517962)