### PR TITLE
Fix CodeQL cleanup alerts

### DIFF
--- a/backend/app/services/import_execution_persistence.py
+++ b/backend/app/services/import_execution_persistence.py
@@ -56,6 +56,24 @@ from app.services.import_execution_persistence_queries import (
     _existing_findings_by_dedup_key,
 )
 
+__all__ = [
+    "DEDUP_DECISION_SAMPLE_LIMIT",
+    "_analysis_evidence_for_occurrence",
+    "_analysis_semantics_summary",
+    "_attack_context_defensive_note",
+    "_attack_context_review_status",
+    "_chunks",
+    "_chunks_any",
+    "_decision_payload_for_occurrence",
+    "_finding_status_for_occurrence",
+    "_jsonable_model",
+    "_persist_workbench_occurrences",
+    "_priority_state_for_occurrence",
+    "_suppressed_by_vex_for_occurrence",
+    "_technique_ids_from_context",
+    "_valid_attack_tactic_ids",
+]
+
 
 def _persist_workbench_occurrences(
     *,

--- a/backend/app/services/report_renderers.py
+++ b/backend/app/services/report_renderers.py
@@ -12,7 +12,7 @@ import app.services.report_bundle as _report_bundle
 
 # fmt: off
 from app.services.report_exports import render_analysis_result_json, render_findings_csv
-from app.services.report_formatting import safe_html as _safe_html
+from app.services.report_formatting import safe_html
 from app.services.report_html import EXECUTIVE_REPORT_CSS, _business_impact_summary, _decision_statement, _executive_summary_text, _html_asset_rollup_row, _html_governance_rollups, _html_metric, _html_provider_snapshot, _html_recommendation_item, _html_service_rollup_row, _html_top_risk_row, _html_waiver_debt_row, render_html_executive_report
 from app.services.report_markdown import _markdown_detection_coverage_section, _markdown_governance_section, render_markdown_report
 from app.services.report_projection import _analysis_finding, _analysis_provider_snapshot, _asset_label, _component_label, _data_quality_confidence, _data_quality_flags, _decision_guidance, _decision_sla, _decision_text, _finding_payload, _flag_items, _governance_decision_statement, _governance_detail_clause, _occurrence_payload, _provider_snapshot_payload, _vulnerability_payload
@@ -34,7 +34,6 @@ _safe_bundle_filename = _report_bundle._safe_bundle_filename
 _write_deterministic_zip_member = _report_bundle._write_deterministic_zip_member
 render_evidence_bundle_zip = _report_bundle.render_evidence_bundle_zip
 verify_evidence_bundle_archive = _report_bundle.verify_evidence_bundle_archive
-_REPORT_FORMATTING_MARKER = _safe_html
 
 
 def verify_evidence_bundle_zip(
@@ -57,6 +56,6 @@ def verify_evidence_bundle_zip(
 # fmt: off
 __all__ = [
     "Counter", "EXECUTIVE_REPORT_CSS", "_analysis_finding", "_analysis_provider_snapshot", "_asset_context_rows", "_asset_label", "_boolish_signal", "_bundle_file_entry", "_bundle_input_hashes", "_business_impact_summary", "_component_label", "_counts_by_priority", "_data_quality_confidence", "_data_quality_flags", "_decision_guidance", "_decision_guidance_from_payload", "_decision_sla", "_decision_statement", "_decision_text", "_dict_list", "_executive_summary_text", "_finding_payload", "_flag_items", "_governance_asset_context_export", "_governance_bundle_entries", "_governance_decision_statement", "_governance_detail_clause", "_governance_detection_coverage_export", "_governance_finding_row", "_governance_rollups_export", "_governance_vex_export", "_governance_vex_summary", "_governance_waivers_export",
-    "_html_asset_rollup_row", "_html_governance_rollups", "_html_metric", "_html_provider_snapshot", "_html_recommendation_item", "_html_service_rollup_row", "_html_top_risk_row", "_html_waiver_debt_row", "_json_bytes", "_list_value", "_markdown_detection_coverage_section", "_markdown_governance_section", "_occurrence_payload", "_priority_label", "_provider_snapshot_payload", "_redact_bundle_value", "_redacted_bundle_payload", "_safe_bundle_filename", "_string_from_mapping", "_vex_status_counts_from_explanation", "_vex_statuses_label", "_vex_statuses_label_from_explanation", "_vulnerability_payload", "_write_deterministic_zip_member", "render_analysis_result_json", "render_evidence_bundle_zip", "render_findings_csv", "render_html_executive_report", "render_markdown_report", "verify_evidence_bundle_archive", "verify_evidence_bundle_zip",
+    "_html_asset_rollup_row", "_html_governance_rollups", "_html_metric", "_html_provider_snapshot", "_html_recommendation_item", "_html_service_rollup_row", "_html_top_risk_row", "_html_waiver_debt_row", "_json_bytes", "_list_value", "_markdown_detection_coverage_section", "_markdown_governance_section", "_occurrence_payload", "_priority_label", "_provider_snapshot_payload", "_redact_bundle_value", "_redacted_bundle_payload", "_safe_bundle_filename", "_string_from_mapping", "_vex_status_counts_from_explanation", "_vex_statuses_label", "_vex_statuses_label_from_explanation", "_vulnerability_payload", "_write_deterministic_zip_member", "render_analysis_result_json", "render_evidence_bundle_zip", "render_findings_csv", "render_html_executive_report", "render_markdown_report", "safe_html", "verify_evidence_bundle_archive", "verify_evidence_bundle_zip",
 ]
 # fmt: on

--- a/backend/src/vuln_prioritizer/reporting_evidence_verify.py
+++ b/backend/src/vuln_prioritizer/reporting_evidence_verify.py
@@ -5,29 +5,18 @@ from __future__ import annotations
 
 import hashlib
 import json
-import ntpath
 import zipfile
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 from pydantic import ValidationError
 
 from vuln_prioritizer.models import (
     EvidenceBundleFile,
-    EvidenceBundleGovernanceArtifact,
-    EvidenceBundleInputHash,
     EvidenceBundleManifest,
     EvidenceBundleVerificationItem,
     EvidenceBundleVerificationMetadata,
     EvidenceBundleVerificationSummary,
 )
-from vuln_prioritizer.reporter import (
-    generate_evidence_bundle_manifest_json,
-    generate_html_report,
-    generate_summary_markdown,
-)
-from vuln_prioritizer.security_redaction import redact_text, redact_value
 from vuln_prioritizer.utils import iso_utc_now
 
 DETERMINISTIC_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)

--- a/backend/src/vuln_prioritizer/reporting_executive_model_attack.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_model_attack.py
@@ -7,31 +7,14 @@ from collections import Counter
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_constants import (
-    PRIORITY_ORDER,
     PRIORITY_TONES,
-    SECTION_NAV,
 )
 from vuln_prioritizer.reporting_executive_utils import (
-    _attack_label,
-    _attr,
-    _baseline_delta_label,
-    _basename,
     _dict_value,
-    _float_value,
-    _format_report_timestamp,
     _int_value,
-    _list_first,
     _list_values,
-    _pct,
-    _positive_int,
     _priority_label,
-    _provider_value,
-    _report_period,
-    _score,
-    _sha_preview,
-    _short_provider_date,
     _text,
-    _truncate,
 )
 
 # ruff: noqa: F403,F405

--- a/backend/src/vuln_prioritizer/reporting_executive_model_builder.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_model_builder.py
@@ -3,35 +3,18 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_constants import (
-    PRIORITY_ORDER,
-    PRIORITY_TONES,
     SECTION_NAV,
 )
 from vuln_prioritizer.reporting_executive_utils import (
-    _attack_label,
-    _attr,
-    _baseline_delta_label,
     _basename,
     _dict_value,
-    _float_value,
     _format_report_timestamp,
-    _int_value,
-    _list_first,
-    _list_values,
-    _pct,
     _positive_int,
-    _priority_label,
-    _provider_value,
     _report_period,
-    _score,
-    _sha_preview,
-    _short_provider_date,
     _text,
-    _truncate,
 )
 
 # ruff: noqa: F403,F405

--- a/backend/src/vuln_prioritizer/reporting_executive_model_findings.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_model_findings.py
@@ -3,35 +3,20 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_constants import (
-    PRIORITY_ORDER,
     PRIORITY_TONES,
-    SECTION_NAV,
 )
 from vuln_prioritizer.reporting_executive_utils import (
     _attack_label,
-    _attr,
     _baseline_delta_label,
-    _basename,
     _dict_value,
-    _float_value,
-    _format_report_timestamp,
     _int_value,
-    _list_first,
     _list_values,
-    _pct,
-    _positive_int,
     _priority_label,
-    _provider_value,
-    _report_period,
     _score,
-    _sha_preview,
-    _short_provider_date,
     _text,
-    _truncate,
 )
 
 # ruff: noqa: F403,F405

--- a/backend/src/vuln_prioritizer/reporting_executive_model_helpers.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_model_helpers.py
@@ -8,30 +8,15 @@ from typing import Any
 
 from vuln_prioritizer.reporting_executive_constants import (
     PRIORITY_ORDER,
-    PRIORITY_TONES,
-    SECTION_NAV,
 )
 from vuln_prioritizer.reporting_executive_utils import (
-    _attack_label,
-    _attr,
-    _baseline_delta_label,
-    _basename,
     _dict_value,
     _float_value,
-    _format_report_timestamp,
     _int_value,
     _list_first,
-    _list_values,
     _pct,
-    _positive_int,
     _priority_label,
-    _provider_value,
-    _report_period,
-    _score,
-    _sha_preview,
-    _short_provider_date,
     _text,
-    _truncate,
 )
 
 

--- a/backend/src/vuln_prioritizer/reporting_executive_model_overview.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_model_overview.py
@@ -3,35 +3,18 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_constants import (
     PRIORITY_ORDER,
     PRIORITY_TONES,
-    SECTION_NAV,
 )
 from vuln_prioritizer.reporting_executive_utils import (
-    _attack_label,
-    _attr,
-    _baseline_delta_label,
-    _basename,
-    _dict_value,
     _float_value,
-    _format_report_timestamp,
     _int_value,
-    _list_first,
-    _list_values,
     _pct,
-    _positive_int,
     _priority_label,
-    _provider_value,
-    _report_period,
-    _score,
-    _sha_preview,
-    _short_provider_date,
     _text,
-    _truncate,
 )
 
 # ruff: noqa: F403,F405

--- a/backend/src/vuln_prioritizer/reporting_executive_model_remediation.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_model_remediation.py
@@ -3,33 +3,17 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_constants import (
     PRIORITY_ORDER,
     PRIORITY_TONES,
-    SECTION_NAV,
 )
 from vuln_prioritizer.reporting_executive_utils import (
-    _attack_label,
-    _attr,
-    _baseline_delta_label,
-    _basename,
-    _dict_value,
     _float_value,
-    _format_report_timestamp,
     _int_value,
-    _list_first,
-    _list_values,
     _pct,
-    _positive_int,
     _priority_label,
-    _provider_value,
-    _report_period,
-    _score,
-    _sha_preview,
-    _short_provider_date,
     _text,
     _truncate,
 )

--- a/backend/src/vuln_prioritizer/reporting_executive_sections_chrome.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_sections_chrome.py
@@ -3,18 +3,11 @@
 
 from __future__ import annotations
 
-import math
 from html import escape
 from typing import Any
 
-from vuln_prioritizer.reporting_executive_model import _kpi_value
 from vuln_prioritizer.reporting_executive_utils import (
-    _float_value,
-    _int_value,
-    _pct,
-    _score,
     _text,
-    _truncate,
 )
 
 

--- a/backend/src/vuln_prioritizer/reporting_executive_sections_components.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_sections_components.py
@@ -3,18 +3,11 @@
 
 from __future__ import annotations
 
-import math
 from html import escape
 from typing import Any
 
-from vuln_prioritizer.reporting_executive_model import _kpi_value
 from vuln_prioritizer.reporting_executive_utils import (
-    _float_value,
-    _int_value,
     _pct,
-    _score,
-    _text,
-    _truncate,
 )
 
 

--- a/backend/src/vuln_prioritizer/reporting_executive_sections_evidence.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_sections_evidence.py
@@ -3,18 +3,11 @@
 
 from __future__ import annotations
 
-import math
 from html import escape
 from typing import Any
 
-from vuln_prioritizer.reporting_executive_model import _kpi_value
 from vuln_prioritizer.reporting_executive_utils import (
-    _float_value,
-    _int_value,
-    _pct,
-    _score,
     _text,
-    _truncate,
 )
 
 # ruff: noqa: F403,F405

--- a/backend/src/vuln_prioritizer/reporting_executive_sections_summary.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_sections_summary.py
@@ -3,19 +3,10 @@
 
 from __future__ import annotations
 
-import math
 from html import escape
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_model import _kpi_value
-from vuln_prioritizer.reporting_executive_utils import (
-    _float_value,
-    _int_value,
-    _pct,
-    _score,
-    _text,
-    _truncate,
-)
 
 
 def _prioritization_flow_html(model: dict[str, Any]) -> str:

--- a/backend/src/vuln_prioritizer/reporting_executive_sections_top.py
+++ b/backend/src/vuln_prioritizer/reporting_executive_sections_top.py
@@ -3,17 +3,11 @@
 
 from __future__ import annotations
 
-import math
 from html import escape
 from typing import Any
 
 from vuln_prioritizer.reporting_executive_model import _kpi_value
 from vuln_prioritizer.reporting_executive_utils import (
-    _float_value,
-    _int_value,
-    _pct,
-    _score,
-    _text,
     _truncate,
 )
 

--- a/backend/src/vuln_prioritizer/reporting_markdown_analysis.py
+++ b/backend/src/vuln_prioritizer/reporting_markdown_analysis.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 
 from vuln_prioritizer.models import (
     AnalysisContext,
-    AttackData,
-    ComparisonFinding,
-    EpssData,
-    KevData,
-    NvdData,
     PrioritizedFinding,
 )
 from vuln_prioritizer.reporting_format import (
@@ -20,13 +15,10 @@ from vuln_prioritizer.reporting_format import (
     _format_vex_statuses,
     _format_waiver_status,
     _mapping_types,
-    _priority_display_label,
     _run_metadata_lines,
     _summary_lines,
     _warning_lines,
-    comma_or_na,
     escape_pipes,
-    format_change,
     format_data_quality_flags,
     format_score,
     normalize_whitespace,

--- a/backend/src/vuln_prioritizer/reporting_markdown_compare.py
+++ b/backend/src/vuln_prioritizer/reporting_markdown_compare.py
@@ -5,34 +5,20 @@ from __future__ import annotations
 
 from vuln_prioritizer.models import (
     AnalysisContext,
-    AttackData,
     ComparisonFinding,
-    EpssData,
-    KevData,
-    NvdData,
-    PrioritizedFinding,
 )
 from vuln_prioritizer.reporting_format import (
     _attack_methodology_lines,
     _attack_summary_lines,
-    _capability_groups,
     _format_attack_indicator,
-    _format_vex_statuses,
-    _format_waiver_status,
-    _mapping_types,
     _priority_display_label,
     _run_metadata_lines,
     _summary_lines,
     _warning_lines,
-    comma_or_na,
     escape_pipes,
     format_change,
     format_data_quality_flags,
     format_score,
-    normalize_whitespace,
-)
-from vuln_prioritizer.services.baseline_comparison import (
-    build_cvss_baseline_comparison_payload,
 )
 
 

--- a/backend/src/vuln_prioritizer/reporting_markdown_explain.py
+++ b/backend/src/vuln_prioritizer/reporting_markdown_explain.py
@@ -13,26 +13,15 @@ from vuln_prioritizer.models import (
     PrioritizedFinding,
 )
 from vuln_prioritizer.reporting_format import (
-    _attack_methodology_lines,
-    _attack_summary_lines,
-    _capability_groups,
-    _format_attack_indicator,
     _format_vex_statuses,
     _format_waiver_status,
-    _mapping_types,
-    _priority_display_label,
     _run_metadata_lines,
-    _summary_lines,
-    _warning_lines,
     comma_or_na,
     escape_pipes,
     format_change,
     format_data_quality_flags,
     format_score,
     normalize_whitespace,
-)
-from vuln_prioritizer.services.baseline_comparison import (
-    build_cvss_baseline_comparison_payload,
 )
 from vuln_prioritizer.reporting_markdown_analysis import (
     _business_impact,

--- a/backend/src/vuln_prioritizer/reporting_payloads.py
+++ b/backend/src/vuln_prioritizer/reporting_payloads.py
@@ -45,6 +45,29 @@ from vuln_prioritizer.services.baseline_comparison import (
     build_cvss_baseline_comparison_payload,
 )
 
+__all__ = [
+    "build_analysis_report_payload",
+    "build_snapshot_report_payload",
+    "generate_compare_json",
+    "generate_compact_summary_markdown",
+    "generate_doctor_json",
+    "generate_evidence_bundle_manifest_json",
+    "generate_evidence_bundle_verification_json",
+    "generate_explain_json",
+    "generate_json_report",
+    "generate_rollup_json",
+    "generate_sarif_report",
+    "generate_snapshot_diff_json",
+    "generate_state_history_json",
+    "generate_state_import_json",
+    "generate_state_init_json",
+    "generate_state_service_history_json",
+    "generate_state_top_services_json",
+    "generate_state_trends_json",
+    "generate_state_waivers_json",
+    "generate_summary_markdown",
+]
+
 
 def generate_json_report(
     findings: list[PrioritizedFinding],

--- a/frontend/src/components/risk/ProviderStatusBadge.tsx
+++ b/frontend/src/components/risk/ProviderStatusBadge.tsx
@@ -11,7 +11,7 @@ export function ProviderStatusBadge({
 }: ProviderStatusBadgeProps) {
   const normalized = (status ?? "unknown").toLowerCase()
 
-  let tone: VpwBadgeTone = "neutral"
+  let tone: VpwBadgeTone
   let label = status ?? "Unknown"
 
   switch (normalized) {
@@ -33,8 +33,8 @@ export function ProviderStatusBadge({
       break
     case "loading":
     case "pending":
-      tone = "neutral"
       label = "Loading..."
+      tone = "neutral"
       break
     default:
       tone = "neutral"

--- a/frontend/src/components/risk/RiskBadge.tsx
+++ b/frontend/src/components/risk/RiskBadge.tsx
@@ -10,7 +10,7 @@ export function RiskBadge({ score, className }: RiskBadgeProps) {
     return <VpwBadge className={className}>N/A</VpwBadge>
   }
 
-  let tone: VpwBadgeTone = "info"
+  let tone: VpwBadgeTone
 
   if (score >= 90) {
     tone = "critical"


### PR DESCRIPTION
## Summary
- remove unused Python imports across reporting and executive report modules
- mark compatibility facade re-exports with explicit __all__ entries
- remove two unused TypeScript badge assignments

## Validation
- make check
- npm run lint
- npm run build
- python3 -m ruff check --select F401 --ignore-noqa on touched Python files
