### PR TITLE
[codex] Harden Workbench UI evidence and release safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ data/workbench-import-uploads/
 data/workbench-reports/
 data/workbench-provider-cache/
 data/provider-snapshots/
+data/provider-snapshot-*.json
 data/template-import-uploads/
 data/template-reports/
 data/template-provider-cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,9 @@ When hosted GitHub Actions are unavailable, the recommended local equivalent is:
 make workflow-check
 ```
 
-This adds:
-
-- `python3 -m pre_commit run --all-files`
-- `python3 -m mkdocs build --clean`
-- `python3 -m build backend --outdir dist`
-- `python3 -m twine check dist/*`
+This runs the backend quality gate, Docker base-image digest check, docs build
+and evidence hygiene checks, GitHub workflow linting, pre-commit hooks, and the
+Python package build/check/smoke path.
 
 Use `make clean-local` to remove ignored local caches, logs, build outputs,
 coverage files, generated docs sites, and `.DS_Store` files without deleting

--- a/Makefile
+++ b/Makefile
@@ -278,10 +278,11 @@ demo-sync-check-temp:
 	@set -e; \
 	tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
+	tracked="$$(git ls-files docs archive)"; \
 	rsync -a --exclude .git --exclude .venv --exclude .cache --exclude Library --exclude node_modules --exclude dist --exclude build --exclude site --exclude .mypy_cache --exclude .pytest_cache --exclude .ruff_cache . "$$tmp"/; \
 	git -C "$$tmp" init -q; \
-	git -C "$$tmp" add docs; \
-	git -C "$$tmp" -c user.email=codex@example.invalid -c user.name=Codex commit -q -m baseline-docs -- docs; \
+	printf '%s\n' "$$tracked" | git -C "$$tmp" add --pathspec-from-file=-; \
+	git -C "$$tmp" -c user.email=codex@example.invalid -c user.name=Codex commit -q -m baseline-docs-archive; \
 	$(MAKE) -C "$$tmp" demo-sync-check
 
 package:

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -6,7 +6,7 @@ import uuid
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel import Session, create_engine, select
 
 from app.core import security
 from app.core.config import Settings, settings
@@ -39,8 +39,7 @@ def configured_superuser_id(email: str) -> uuid.UUID:
 
 
 def init_db(session: Session, active_settings: Settings | None = None) -> None:
-    """Create metadata in local/dev contexts and ensure the configured user exists."""
-    SQLModel.metadata.create_all(session.get_bind())
+    """Ensure the configured bootstrap user exists on an already migrated schema."""
     ensure_configured_superuser(session, active_settings=active_settings)
 
 

--- a/backend/src/vuln_prioritizer/reporting_evidence_provider.py
+++ b/backend/src/vuln_prioritizer/reporting_evidence_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 from typing import Any
 
@@ -37,19 +38,44 @@ def provider_snapshot_manifest_entry(
 
 
 def resolve_provider_snapshot_path(reported_path: object, analysis_path: Path) -> Path | None:
-    """Resolve a provider snapshot only when it is a sidecar beside the analysis file."""
+    """Resolve a safe relative provider snapshot path for evidence bundling."""
     if not isinstance(reported_path, str) or not reported_path.strip():
         return None
     candidate = Path(reported_path)
     if candidate.is_absolute() or ".." in candidate.parts:
         return None
-    analysis_root = analysis_path.parent.resolve()
-    resolved = (analysis_root / candidate).resolve()
-    if not resolved.is_relative_to(analysis_root) or not resolved.is_file():
-        return None
-    if resolved.stat().st_size > PROVIDER_SNAPSHOT_MAX_BYTES:
-        return None
-    return resolved
+    roots = (analysis_path.parent.resolve(), Path.cwd().resolve())
+    for root in roots:
+        resolved = (root / candidate).resolve()
+        if not resolved.is_relative_to(root) or not resolved.is_file():
+            continue
+        if resolved.stat().st_size > PROVIDER_SNAPSHOT_MAX_BYTES:
+            continue
+        if not _looks_like_provider_snapshot(resolved):
+            continue
+        return resolved
+    return None
+
+
+def _looks_like_provider_snapshot(path: Path) -> bool:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    return (
+        metadata.get("artifact_kind") == "provider-snapshot"
+        and metadata.get("snapshot_format") == "provider-snapshot.v1.json"
+        and isinstance(metadata.get("snapshot_id"), str)
+        and isinstance(metadata.get("generated_at"), str)
+        and isinstance(metadata.get("selected_sources"), list)
+        and isinstance(payload.get("items"), list)
+        and isinstance(payload.get("warnings"), list)
+    )
 
 
 def _sha256_file(path: Path, *, max_bytes: int) -> str | None:

--- a/backend/tests/api/test_template_core_runtime_edges.py
+++ b/backend/tests/api/test_template_core_runtime_edges.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from sqlmodel import Session, create_engine, select
+from sqlmodel import Session, SQLModel, create_engine, select
 from starlette.requests import Request
 from utils.template_workbench import (
     TemplateApiEnv,
@@ -79,6 +79,7 @@ def test_user_defaults_to_non_superuser_while_bootstrap_remains_admin(
 
     assert User().is_superuser is False
 
+    SQLModel.metadata.create_all(engine)
     with Session(engine) as session:
         db_module.init_db(session, active_settings=active_settings)
         user = session.exec(select(User).where(User.email == active_settings.FIRST_SUPERUSER)).one()
@@ -100,6 +101,7 @@ def test_db_bootstrap_helpers_create_and_update_configured_superuser(tmp_path: P
         db_module.configured_superuser_id("admin@example.test")
     )
 
+    SQLModel.metadata.create_all(engine)
     with Session(engine) as session:
         db_module.init_db(session, active_settings=active_settings)
         user = session.exec(select(User).where(User.email == active_settings.FIRST_SUPERUSER)).one()

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -460,6 +460,16 @@ def test_active_runtime_entrypoints_use_workbench_backend_app() -> None:
         assert marker not in playwright_backend
 
 
+def test_init_db_does_not_create_schema_metadata() -> None:
+    db_source = _read_repo_text("backend/app/core/db.py")
+    init_body = db_source.split("def init_db", 1)[1].split(
+        "def ensure_configured_superuser",
+        1,
+    )[0]
+
+    assert "metadata.create_all" not in init_body
+
+
 def test_generated_browser_api_client_is_built_from_active_backend_app() -> None:
     generate_client = (REPO_ROOT / "scripts/generate-client.sh").read_text(encoding="utf-8")
 

--- a/backend/tests/test_evidence_bundle_verification.py
+++ b/backend/tests/test_evidence_bundle_verification.py
@@ -19,7 +19,10 @@ from vuln_prioritizer.models import EpssData, KevData, NvdData
 from vuln_prioritizer.providers.epss import EpssProvider
 from vuln_prioritizer.providers.kev import KevProvider
 from vuln_prioritizer.providers.nvd import NvdProvider
-from vuln_prioritizer.reporting_evidence import write_evidence_bundle
+from vuln_prioritizer.reporting_evidence import (
+    resolve_provider_snapshot_path,
+    write_evidence_bundle,
+)
 
 
 def test_cli_verify_evidence_bundle_succeeds_for_clean_bundle(
@@ -329,6 +332,48 @@ def test_cli_evidence_bundle_includes_provider_snapshot_and_replays_offline(
         item["path"] == "provider/provider-snapshot.json" and item["kind"] == "provider-snapshot"
         for item in manifest["files"]
     )
+
+
+def test_evidence_bundle_resolves_repo_relative_provider_snapshot(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    analysis_file = tmp_path / "build" / "analysis.json"
+    analysis_file.parent.mkdir()
+    analysis_file.write_text("{}", encoding="utf-8")
+    snapshot_file = tmp_path / "data" / "demo_provider_snapshot.json"
+    snapshot_file.parent.mkdir()
+    snapshot_file.write_text(
+        json.dumps(
+            {
+                "items": [],
+                "metadata": {
+                    "artifact_kind": "provider-snapshot",
+                    "generated_at": "2026-04-21T12:00:00+00:00",
+                    "selected_sources": ["nvd", "epss", "kev"],
+                    "snapshot_format": "provider-snapshot.v1.json",
+                    "snapshot_id": "test-provider-snapshot",
+                },
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text("SECRET_KEY=local-secret\n", encoding="utf-8")
+    secret_json = tmp_path / "secrets" / "export.json"
+    secret_json.parent.mkdir()
+    secret_json.write_text('{"SECRET_KEY": "local-secret"}', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        resolve_provider_snapshot_path("data/demo_provider_snapshot.json", analysis_file)
+        == snapshot_file
+    )
+    assert resolve_provider_snapshot_path("../private/provider.json", analysis_file) is None
+    assert resolve_provider_snapshot_path(str(snapshot_file), analysis_file) is None
+    assert resolve_provider_snapshot_path(".env", analysis_file) is None
+    assert resolve_provider_snapshot_path("secrets/export.json", analysis_file) is None
 
 
 def test_evidence_bundle_redacts_secret_like_text_in_copied_artifacts(tmp_path: Path) -> None:

--- a/backend/tests/test_report_io_helpers.py
+++ b/backend/tests/test_report_io_helpers.py
@@ -188,9 +188,26 @@ def test_evidence_bundle_helper_functions_cover_manifest_and_path_edges(
     input_file = tmp_path / "input.txt"
     analysis_file = tmp_path / "analysis.json"
     snapshot_file = tmp_path / "snapshot.json"
+    invalid_snapshot_file = tmp_path / "not-a-snapshot.json"
     input_file.write_text("CVE-2024-0001\n", encoding="utf-8")
     analysis_file.write_text("{}", encoding="utf-8")
-    snapshot_file.write_text('{"metadata": {}}', encoding="utf-8")
+    snapshot_file.write_text(
+        json.dumps(
+            {
+                "items": [],
+                "metadata": {
+                    "artifact_kind": "provider-snapshot",
+                    "generated_at": "2026-04-21T12:00:00+00:00",
+                    "selected_sources": ["nvd"],
+                    "snapshot_format": "provider-snapshot.v1.json",
+                    "snapshot_id": "snapshot-1",
+                },
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    invalid_snapshot_file.write_text('{"metadata": {}}', encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)
 
@@ -219,6 +236,18 @@ def test_evidence_bundle_helper_functions_cover_manifest_and_path_edges(
         "id": "snapshot-1",
         "sha256": hashlib.sha256(snapshot_file.read_bytes()).hexdigest(),
         "path": "snapshot.json",
+        "sources": ["nvd"],
+    }
+    assert provider_snapshot_manifest_entry(
+        {
+            "provider_snapshot_id": "snapshot-invalid",
+            "provider_snapshot_file": "not-a-snapshot.json",
+            "provider_snapshot_sources": ["nvd"],
+        },
+        analysis_path=analysis_file,
+    ) == {
+        "id": "snapshot-invalid",
+        "path": "not-a-snapshot.json",
         "sources": ["nvd"],
     }
     assert provider_snapshot_manifest_entry(

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -489,7 +489,7 @@ The public combinations currently intended for use are:
 - `data export-provider-snapshot`: JSON file output
 - `report workbench`: `json`, `markdown`, `html`, `csv`, `sarif`
 - `report html`: HTML file output
-- `report evidence-bundle`: ZIP file output containing `analysis.json`, `report.html`, `summary.md`, `manifest.json`, and optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, `governance/asset-context.json`, and `governance/detection-coverage.json`
+- `report evidence-bundle`: ZIP file output containing `analysis.json`, `report.html`, `summary.md`, `manifest.json`, optional `attack-navigator-layer.json`, optional `provider/provider-snapshot.json`, optional source input copies under `input/`, and optional `governance/rollups.json`, `governance/waivers.json`, `governance/vex-summary.json`, `governance/asset-context.json`, and `governance/detection-coverage.json`
 - `report verify-evidence-bundle`: `table` and `json`
 - `report validate-sarif`: `table` and `json`
 

--- a/docs/integrations/reporting_and_ci.md
+++ b/docs/integrations/reporting_and_ci.md
@@ -207,6 +207,8 @@ The bundle packages:
 - a regenerated `report.html`
 - a regenerated `summary.md`
 - `manifest.json` with checksums and artifact metadata
+- `provider/provider-snapshot.json` when a replay snapshot is referenced and resolvable
+- `attack-navigator-layer.json` when ATT&CK mapping evidence exists
 - the original input file when it can be resolved from the saved analysis metadata
 
 Integrity verification contract:

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -59,9 +59,9 @@ The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIX
 
 | Artifact | SHA-256 | Size |
 | --- | --- | ---: |
-| `build/v1.0-demo-analysis.json` | `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b` | 49,024 bytes |
-| `build/v1.0-demo-evidence-bundle.zip` | `246a80012271deae22be15dfbb7e24408c2431324b0a244cbe0e0ec58c8dbad2` | 28,473 bytes |
-| `build/v1.0-demo-evidence-bundle-verification.json` | `c1da50f6c006859b2737b99d1d6917c583fda05101ef663012ae432a7bca9634` | 2,566 bytes |
+| `build/v1.0-demo-analysis.json` | `3d77cca073d02abcdd007fa9d3654ffcdb0574d3813f03fc6cd41f106ba2d3a3` | 95,610 bytes |
+| `build/v1.0-demo-evidence-bundle.zip` | `a3a97bb176b80ea6c2136d6242975138e06bbcce08bc881d1c8dff044e32ef1f` | 45,862 bytes |
+| `build/v1.0-demo-evidence-bundle-verification.json` | `bc17f21cc89a0dc2cb7eec6a2f4abf4bb5fb49310aee566b8ca4bd9f5005ed2d` | 3,003 bytes |
 
 ## Notes
 

--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -64,7 +64,7 @@ make demo-evidence-bundle-check
 For an already generated bundle, the verification command is:
 
 ```bash
-PYTHONPATH=src VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00 \
+PYTHONPATH=backend/src VULN_PRIORITIZER_FIXED_NOW=2026-04-21T12:00:00+00:00 \
   python3 -m vuln_prioritizer.cli report verify-evidence-bundle \
   --input build/v1.0-demo-evidence-bundle.zip \
   --output build/v1.0-demo-evidence-bundle-verification.json \
@@ -92,31 +92,32 @@ Reference release evidence run from the locked demo path:
 
 | Artifact | SHA-256 | Size |
 | --- | --- | ---: |
-| `build/v1.0-demo-analysis.json` | `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b` | 49,024 bytes |
-| `build/v1.0-demo-evidence-bundle.zip` | `246a80012271deae22be15dfbb7e24408c2431324b0a244cbe0e0ec58c8dbad2` | 28,473 bytes |
-| `build/v1.0-demo-evidence-bundle-verification.json` | `c1da50f6c006859b2737b99d1d6917c583fda05101ef663012ae432a7bca9634` | 2,566 bytes |
-| `manifest.json` inside the ZIP | `1c828e916bd7b0e1427921acde2c77efff8c30b8790992eed010ea241fafffbb` | 2,497 bytes |
+| `build/v1.0-demo-analysis.json` | `3d77cca073d02abcdd007fa9d3654ffcdb0574d3813f03fc6cd41f106ba2d3a3` | 95,610 bytes |
+| `build/v1.0-demo-evidence-bundle.zip` | `a3a97bb176b80ea6c2136d6242975138e06bbcce08bc881d1c8dff044e32ef1f` | 45,862 bytes |
+| `build/v1.0-demo-evidence-bundle-verification.json` | `bc17f21cc89a0dc2cb7eec6a2f4abf4bb5fb49310aee566b8ca4bd9f5005ed2d` | 3,003 bytes |
+| `manifest.json` inside the ZIP | `77fb5060c4dca0a99f6f80c84ae5d74a8859e840751feeba51b3ecb7fb1f6467` | 3,302 bytes |
 
 Manifest details for that run:
 
 - `schema_version`: `1.1.0`
 - `bundle_kind`: `evidence-bundle`
 - `generated_at`: `2026-04-21T12:00:00+00:00`
-- `source_analysis_sha256`: `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b`
-- `provider_snapshot.path`: `data/demo_provider_snapshot.json`
-- `provider_snapshot.sha256`: `a110e4c372a5ec750e0b766e23f19884596f6ac82185b8fd0eefe8384be71c5b`
+- `source_analysis_sha256`: `3d77cca073d02abcdd007fa9d3654ffcdb0574d3813f03fc6cd41f106ba2d3a3`
+- `provider_snapshot.path`: `demo_provider_snapshot.json`
+- `provider_snapshot.sha256`: `d94b51defd676be1b852612d82d7f70aa213f1995af67a717c1ca6afb6c48f0c`
 - `provider_snapshot.sources`: `nvd`, `epss`, `kev`
-- verification summary: `ok=true`, `expected_files=5`, `verified_files=5`, `missing_files=0`, `modified_files=0`, `unexpected_files=0`, `manifest_errors=0`
+- verification summary: `ok=true`, `expected_files=6`, `verified_files=6`, `missing_files=0`, `modified_files=0`, `unexpected_files=0`, `manifest_errors=0`
 
 Manifest file entries:
 
 | Bundle member | Kind | SHA-256 | Size |
 | --- | --- | --- | ---: |
-| `analysis.json` | `analysis-json` | `89c65a424db58de2313d44d201c63c806155a3543d5ee1af8dc12512e5e3d77b` | 49,024 bytes |
-| `report.html` | `html-report` | `9b958bf1103add7731b8068fa2fef61353f6a01a8cb47ea979b77dd6e0988f97` | 109,325 bytes |
-| `summary.md` | `markdown-summary` | `916377f25d8a84db8d338201c9e413d5df7a9518a0f2d06ece66e405fade10a3` | 3,038 bytes |
+| `analysis.json` | `analysis-json` | `5a05ced10c550b27261ef433563708de2d831e134ad907d992004cbb3839fe39` | 95,587 bytes |
+| `report.html` | `html-report` | `3e3995ab3d49982dc8291cf43570a3861ddca1e6c6755da9c7760f6af9d91ddf` | 101,449 bytes |
+| `summary.md` | `markdown-summary` | `206e3e9d10e426f7f6fd413ce6c988a3b0b8de2a060d50f0e75f78b09977202b` | 3,950 bytes |
 | `attack-navigator-layer.json` | `attack-navigator-layer` | `18d94bbe54e47b27c10db18eeaade92b4ceddd3ab08b2370625f08c866f9d331` | 1,825 bytes |
-| `input/trivy_report.json` | `source-input` | `43b29a02a88bc6d9c8c2e8d599a5218fcc253f025f42acbcc780e377bad26e82` | 2,200 bytes |
+| `provider/provider-snapshot.json` | `provider-snapshot` | `d94b51defd676be1b852612d82d7f70aa213f1995af67a717c1ca6afb6c48f0c` | 60,530 bytes |
+| `input/trivy_report.json` | `source-input` | `24d65249ea6f77b56c7870df3dd98bc8120294b886e226117c40b22e4825a81d` | 2,188 bytes |
 
 Record the release commit with `git rev-parse HEAD`, the date of the run, and the exact command output. Do not include `.env` files, API keys, cookies, shell history, machine-specific home paths, or customer scanner exports in the public release evidence.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,7 +29,7 @@ Workbench runtime and CLI/domain tests.
 - Default prioritization stays grounded in `CVSS + EPSS + KEV`.
 - ATT&CK, asset context, and VEX remain explicit contextual layers.
 - The composite GitHub Action mirrors `analyze`, `compare`, `explain`, `doctor`, input validation, snapshot, rollup, provider verification, ATT&CK validation/coverage, reporting, evidence, SARIF validation, and provider freshness gates as additive inputs.
-- Local quality gates now start enforcing coverage with `--cov-fail-under=90`, and temp-copy package/demo checks are available for read-only validation.
+- Local quality gates now enforce backend coverage with `--cov-fail-under=95`, and temp-copy package/demo checks are available for read-only validation.
 - Docker and Compose provide a local runtime bootstrap for the Workbench while keeping the CLI core available in the same image.
 - Parser and provider contributions are governed by the static local
   [extension strategy](./extension_strategy.md), including fixture requirements,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test"
 
+const reuseExistingServer = process.env.VPW_PLAYWRIGHT_REUSE_EXISTING_SERVER === "1"
+
 export default defineConfig({
   testDir: "./tests",
   testMatch: /.*\.spec\.ts/,
@@ -15,13 +17,13 @@ export default defineConfig({
   webServer: [
     {
       command: "cd .. && bash scripts/start-workbench-playwright-backend.sh",
-      reuseExistingServer: true,
+      reuseExistingServer,
       timeout: 120_000,
       url: "http://127.0.0.1:8000/api/v1/utils/health-check/",
     },
     {
       command: "npm run dev -- --host 127.0.0.1 --port 5173",
-      reuseExistingServer: true,
+      reuseExistingServer,
       timeout: 120_000,
       url: "http://127.0.0.1:5173/login",
     },

--- a/frontend/src/components/app/AppShell.tsx
+++ b/frontend/src/components/app/AppShell.tsx
@@ -1,32 +1,12 @@
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import {
-  Database,
-  FileArchive,
-  FileCheck2,
-  FileInput,
-  FolderKanban,
-  LayoutDashboard,
-  ListChecks,
   LogOut,
-  type LucideIcon,
   Menu,
-  Settings,
-  ShieldCheck,
   Sidebar,
 } from "lucide-react"
 import { type ReactNode, useEffect, useState } from "react"
-import {
-  LoginService,
-  type ProviderStatusPublic,
-  type UserPublic,
-  type WorkbenchStatus,
-} from "../../api-client"
-import { clearAccessToken } from "../../auth"
-import {
-  dataServicesSummary,
-  workspaceHealthLabel,
-} from "../../lib/provider-format"
 import { cn } from "../../lib/utils"
+import type { NavigationEntry, WorkbenchPath } from "../../lib/workbench-navigation"
 import { Button } from "../ui/button"
 import {
   DropdownMenu,
@@ -52,23 +32,6 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip"
 
-export type WorkbenchPath =
-  | "/"
-  | "/projects"
-  | "/imports"
-  | "/findings"
-  | "/waivers"
-  | "/assets"
-  | "/providers"
-  | "/reports"
-  | "/settings"
-
-export type NavigationEntry = {
-  icon: LucideIcon
-  label: string
-  to: WorkbenchPath
-}
-
 export type StatusSummaryItem = {
   label: string
   value: ReactNode
@@ -90,29 +53,15 @@ type AppShellProps = PageHeaderProps & {
   statusItems: readonly StatusSummaryItem[]
 }
 
-type ProductAppShellProps = PageHeaderProps & {
-  activePath: WorkbenchPath | null
-  children: ReactNode
-  currentUser: UserPublic | null
-  hideStatusStrip?: boolean
-  providerStatus: ProviderStatusPublic | null
-  status: WorkbenchStatus | null
-  statusError: string
-}
-
 const sidebarStorageKey = "vpw-sidebar-collapsed"
 
-export const workbenchNavigation: readonly NavigationEntry[] = [
-  { label: "Dashboard", icon: LayoutDashboard, to: "/" },
-  { label: "Projects", icon: FolderKanban, to: "/projects" },
-  { label: "Imports", icon: FileInput, to: "/imports" },
-  { label: "Findings", icon: ListChecks, to: "/findings" },
-  { label: "Waivers", icon: FileCheck2, to: "/waivers" },
-  { label: "Assets", icon: ShieldCheck, to: "/assets" },
-  { label: "Providers", icon: Database, to: "/providers" },
-  { label: "Reports", icon: FileArchive, to: "/reports" },
-  { label: "Settings", icon: Settings, to: "/settings" },
-]
+function compactHealthLabel(healthLabel: string, isHealthy: boolean) {
+  const normalizedHealthLabel = healthLabel.toLowerCase()
+  if (isHealthy) return "Healthy"
+  if (normalizedHealthLabel.includes("degraded")) return "Degraded"
+  if (normalizedHealthLabel.includes("checking")) return "Checking"
+  return "Issue"
+}
 
 export function AppShell({
   activePath,
@@ -140,6 +89,7 @@ export function AppShell({
     !healthLabel.toLowerCase().includes("unavailable") &&
     !healthLabel.toLowerCase().includes("error") &&
     !healthLabel.toLowerCase().includes("degraded")
+  const mobileHealthLabel = compactHealthLabel(healthLabel, isHealthy)
 
   return (
     <TooltipProvider>
@@ -192,7 +142,9 @@ export function AppShell({
                     <Sidebar aria-hidden="true" size={16} />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="right">Collapse sidebar</TooltipContent>
+                <TooltipContent align="end" side="bottom" sideOffset={8}>
+                  Collapse sidebar
+                </TooltipContent>
               </Tooltip>
             ) : null}
           </div>
@@ -423,14 +375,21 @@ export function AppShell({
                 </h1>
               </div>
             </div>
-            <div className="flex min-w-0 shrink-0 items-center gap-1.5">
+            <div
+              aria-label={`Workspace health: ${healthLabel}`}
+              className="flex min-w-0 shrink-0 items-center gap-1.5"
+              role="status"
+            >
               <div
                 className={cn(
                   "size-2 rounded-full",
                   isHealthy ? "bg-[var(--vpw-green)]" : "bg-[var(--vpw-amber)]",
                 )}
               />
-              <span className="max-w-[8.5rem] truncate text-sm text-[var(--vpw-text-muted)] sm:max-w-none">
+              <span className="text-sm text-[var(--vpw-text-muted)] sm:hidden">
+                {mobileHealthLabel}
+              </span>
+              <span className="hidden text-sm text-[var(--vpw-text-muted)] sm:inline">
                 {healthLabel}
               </span>
             </div>
@@ -481,53 +440,4 @@ export function AppShell({
       </div>
     </TooltipProvider>
   )
-}
-
-export function ProductAppShell({
-  activePath,
-  children,
-  currentUser,
-  eyebrow,
-  hideStatusStrip = false,
-  providerStatus,
-  status,
-  statusError,
-  title,
-}: ProductAppShellProps) {
-  const navigate = useNavigate()
-
-  async function signOut() {
-    try {
-      await LoginService.logoutCurrentToken()
-    } catch {
-      // Local logout should complete even if the server session already expired.
-    } finally {
-      clearAccessToken()
-      if (typeof window !== "undefined") {
-        window.location.assign("/login")
-      } else {
-        await navigate({ replace: true, search: {} as never, to: "/login" })
-      }
-    }
-  }
-
-  return (
-    <AppShell
-      activePath={activePath}
-      currentUserLabel={currentUserLabel(currentUser)}
-      eyebrow={eyebrow}
-      healthLabel={workspaceHealthLabel(status, statusError)}
-      hideStatusStrip={hideStatusStrip}
-      navigation={workbenchNavigation}
-      onSignOut={signOut}
-      statusItems={dataServicesSummary(status, providerStatus)}
-      title={title}
-    >
-      {children}
-    </AppShell>
-  )
-}
-
-function currentUserLabel(user: UserPublic | null) {
-  return user?.email ?? "Local workspace"
 }

--- a/frontend/src/components/app/index.ts
+++ b/frontend/src/components/app/index.ts
@@ -1,7 +1,5 @@
 export {
   AppShell,
-  ProductAppShell,
-  workbenchNavigation,
-  type WorkbenchPath,
-  type NavigationEntry,
+  type StatusSummaryItem,
 } from "./AppShell"
+export type { NavigationEntry, WorkbenchPath } from "../../lib/workbench-navigation"

--- a/frontend/src/components/finding-detail/FindingDetailHero.tsx
+++ b/frontend/src/components/finding-detail/FindingDetailHero.tsx
@@ -25,10 +25,10 @@ import {
   type FindingOccurrenceRow,
   findingAssetServiceDetailLabel,
   findingComponentDetailLabel,
+  findingHeroSummary,
   findingOwnerDetailLabel,
   findingRecommendedAction,
   findingSlaLabel,
-  findingWhyText,
 } from "./finding-detail-model"
 
 export type FindingDetailHeroProps = {
@@ -44,6 +44,10 @@ export function FindingDetailHero({
   isDemo,
   occurrences,
 }: FindingDetailHeroProps) {
+  const assetEnvironmentLabel = finding.asset_environment
+    ? labelize(finding.asset_environment)
+    : "Environment not recorded"
+
   return (
     <>
       {isDemo ? (
@@ -64,7 +68,7 @@ export function FindingDetailHero({
             Why this priority?
           </VpwBadge>
           <h2>{finding.cve_id}</h2>
-          <p>{findingWhyText(finding, explanation)}</p>
+          <p>{findingHeroSummary(finding, explanation)}</p>
           <div className="finding-decision-badges">
             <PriorityBadge priority={finding.priority} />
             <FindingStatusBadge status={finding.status} />
@@ -140,7 +144,7 @@ export function FindingDetailHero({
             </VpwSurfaceTitle>
           </VpwSurfaceHeader>
           <VpwSurfaceBody>
-            <p>{labelize(finding.asset_environment)}</p>
+            <p>{assetEnvironmentLabel}</p>
           </VpwSurfaceBody>
         </VpwSurface>
         <VpwSurface className="finding-fact-card finding-recommendation-card">

--- a/frontend/src/components/finding-detail/finding-detail-model.ts
+++ b/frontend/src/components/finding-detail/finding-detail-model.ts
@@ -142,6 +142,73 @@ export function findingWhyText(
   )
 }
 
+function summaryList(values: readonly string[]) {
+  if (values.length <= 1) {
+    return values[0] ?? ""
+  }
+  if (values.length === 2) {
+    return `${values[0]} and ${values[1]}`
+  }
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`
+}
+
+function firstCompactSentence(value: string, maxLength = 190) {
+  const trimmed = value.trim()
+  const firstSentence = trimmed.match(/^(.+?[.!?])(?:\s|$)/)?.[1] ?? trimmed
+  if (firstSentence.length <= maxLength) {
+    return firstSentence
+  }
+  const words = firstSentence.split(/\s+/)
+  let compact = ""
+  for (const word of words) {
+    const candidate = compact ? `${compact} ${word}` : word
+    if (candidate.length > maxLength - 3) {
+      break
+    }
+    compact = candidate
+  }
+  return `${compact || firstSentence.slice(0, maxLength - 3).trimEnd()}...`
+}
+
+export function findingHeroSummary(
+  finding: FindingDetailPublic | null,
+  explanation: FindingExplanationPublic | null,
+) {
+  if (!finding) {
+    return findingWhyText(finding, explanation)
+  }
+
+  const signals: string[] = []
+  if (finding.in_kev) {
+    signals.push("CISA KEV")
+  }
+  if (finding.epss !== null && finding.epss !== undefined) {
+    signals.push(`${formatEpss(finding.epss)} EPSS`)
+  }
+  if (
+    finding.cvss_base_score !== null &&
+    finding.cvss_base_score !== undefined
+  ) {
+    signals.push(`CVSS ${formatNullableNumber(finding.cvss_base_score)}`)
+  }
+  if (isInternetFacingExposure(finding.exposure)) {
+    signals.push(`${labelize(finding.exposure)} exposure`)
+  }
+  if (isProductionEnvironment(finding.asset_environment)) {
+    signals.push(`${labelize(finding.asset_environment)} environment`)
+  }
+
+  if (signals.length > 0) {
+    const priority =
+      finding.priority && labelize(finding.priority) !== "N.A."
+        ? `${labelize(finding.priority)} priority`
+        : "Priority"
+    return `${priority} combines ${summaryList(signals)}.`
+  }
+
+  return firstCompactSentence(findingWhyText(finding, explanation))
+}
+
 export function findingRecommendedAction(
   finding: FindingDetailPublic | null,
   explanation: FindingExplanationPublic | null,

--- a/frontend/src/components/findings/FindingsDataTable.tsx
+++ b/frontend/src/components/findings/FindingsDataTable.tsx
@@ -1,6 +1,7 @@
 import type { FindingPublic } from "@/api-client"
 import { VpwDataTable } from "@/components/vpw"
 import { buildFindingsDataTableColumns } from "./FindingsDataTableColumns"
+import { FindingsMobileCards } from "./FindingsMobileCards"
 import type { FindingsUrlSearch } from "./findings-search-state"
 import type { FindingsDirection, QueueSort } from "./remediation-queue-model"
 
@@ -35,18 +36,26 @@ export function FindingsDataTable({
   })
 
   return (
-    <div className="finding-table-scroll-shell">
-      <VpwDataTable
-        ariaLabel="Findings table scroll region"
-        caption="Findings remediation queue"
-        className="remediation-table-wrap shadow-none"
-        columns={columns}
-        data={findings}
-        density="standard"
-        getRowKey={(finding) => finding.id}
-        minWidth="clamp(1100px, 86vw, 1240px)"
-        tableClassName="table-fixed"
+    <>
+      <FindingsMobileCards
+        findingSearch={findingSearch}
+        findings={findings}
+        onOpenSheet={onOpenSheet}
+        onOpenWhy={onOpenWhy}
       />
-    </div>
+      <div className="finding-table-scroll-shell hidden sm:block">
+        <VpwDataTable
+          ariaLabel="Findings table scroll region"
+          caption="Findings remediation queue"
+          className="remediation-table-wrap shadow-none"
+          columns={columns}
+          data={findings}
+          density="standard"
+          getRowKey={(finding) => finding.id}
+          minWidth="960px"
+          tableClassName="table-fixed"
+        />
+      </div>
+    </>
   )
 }

--- a/frontend/src/components/findings/FindingsDataTableColumns.tsx
+++ b/frontend/src/components/findings/FindingsDataTableColumns.tsx
@@ -40,6 +40,7 @@ export type FindingsDataTableColumn = {
   ariaSort?: "ascending" | "descending"
   className?: string
   headerClassName?: string
+  width?: string
 }
 
 type BuildFindingsColumnsOptions = {
@@ -61,51 +62,39 @@ export function buildFindingsDataTableColumns({
 }: BuildFindingsColumnsOptions): readonly FindingsDataTableColumn[] {
   return [
     {
-      id: "priority",
+      id: "finding",
       header: (
-        <SortHeader
-          currentDirection={findingDirection}
-          currentSort={queueSort}
-          label="Priority"
-          onSort={onSort}
-          sort="priority"
-        />
+        <fieldset className="finding-sort-stack">
+          <legend className="sr-only">Finding sort controls</legend>
+          <SortHeader
+            currentDirection={findingDirection}
+            currentSort={queueSort}
+            label="Priority"
+            onSort={onSort}
+            sort="priority"
+          />
+          <SortHeader
+            currentDirection={findingDirection}
+            currentSort={queueSort}
+            label="Score"
+            onSort={onSort}
+            sort="score"
+          />
+          <SortHeader
+            currentDirection={findingDirection}
+            currentSort={queueSort}
+            label="CVE"
+            onSort={onSort}
+            sort="cve"
+          />
+        </fieldset>
       ),
-      ariaSort: sortAriaState(findingDirection, queueSort, "priority"),
-      cell: (finding) => <PriorityBadge priority={finding.priority} />,
-      className: "w-[6%]",
-      headerClassName: "w-[6%]",
-    },
-    {
-      id: "score",
-      header: (
-        <SortHeader
-          currentDirection={findingDirection}
-          currentSort={queueSort}
-          label="Score"
-          onSort={onSort}
-          sort="score"
-        />
-      ),
-      ariaSort: sortAriaState(findingDirection, queueSort, "score"),
-      cell: (finding) => <RiskScore value={finding.risk_score} />,
-      className: "w-[5%]",
-      headerClassName: "w-[5%]",
-    },
-    {
-      id: "cve",
-      header: (
-        <SortHeader
-          currentDirection={findingDirection}
-          currentSort={queueSort}
-          label="CVE"
-          onSort={onSort}
-          sort="cve"
-        />
-      ),
-      ariaSort: sortAriaState(findingDirection, queueSort, "cve"),
       cell: (finding) => (
-        <>
+        <div className="finding-primary-cell">
+          <div className="finding-primary-badges">
+            <PriorityBadge priority={finding.priority} />
+            <RiskScore value={finding.risk_score} />
+          </div>
           <Link
             className="finding-cve-link"
             params={{ findingId: finding.id }}
@@ -118,10 +107,11 @@ export function buildFindingsDataTableColumns({
           {finding.attack_mapped ? (
             <span className="remediation-subtext">ATT&amp;CK mapped</span>
           ) : null}
-        </>
+        </div>
       ),
-      className: "w-[8%]",
-      headerClassName: "w-[8%]",
+      className: "w-[22%]",
+      headerClassName: "w-[22%]",
+      width: "22%",
     },
     {
       id: "component",
@@ -148,8 +138,9 @@ export function buildFindingsDataTableColumns({
           </span>
         </div>
       ),
-      className: "w-[19%] min-w-0",
-      headerClassName: "w-[19%]",
+      className: "w-[20%] min-w-0",
+      headerClassName: "w-[20%]",
+      width: "20%",
     },
     {
       id: "owner",
@@ -173,8 +164,9 @@ export function buildFindingsDataTableColumns({
           ) : null}
         </>
       ),
-      className: "w-[10%]",
-      headerClassName: "w-[10%]",
+      className: "w-[12%]",
+      headerClassName: "w-[12%]",
+      width: "12%",
     },
     {
       id: "status",
@@ -199,8 +191,9 @@ export function buildFindingsDataTableColumns({
           </span>
         </div>
       ),
-      className: "w-[8%]",
-      headerClassName: "w-[8%]",
+      className: "w-[10%]",
+      headerClassName: "w-[10%]",
+      width: "10%",
     },
     {
       id: "signals",
@@ -231,8 +224,9 @@ export function buildFindingsDataTableColumns({
           <KevBadge matched={finding.in_kev} />
         </div>
       ),
-      className: "w-[13%]",
-      headerClassName: "w-[13%]",
+      className: "w-[15%]",
+      headerClassName: "w-[15%]",
+      width: "15%",
     },
     {
       id: "why",
@@ -251,8 +245,9 @@ export function buildFindingsDataTableColumns({
           </Button>
         </>
       ),
-      className: "w-[25%]",
-      headerClassName: "w-[25%]",
+      className: "w-[17%]",
+      headerClassName: "w-[17%]",
+      width: "17%",
     },
     {
       id: "view",
@@ -277,6 +272,7 @@ export function buildFindingsDataTableColumns({
         "sticky right-0 z-10 w-16 min-w-16 bg-[var(--vpw-bg-card)] pr-4 text-right",
       headerClassName:
         "sticky right-0 z-20 w-16 min-w-16 bg-[var(--vpw-bg-panel)] pr-4 text-right",
+      width: "4%",
     },
   ]
 }

--- a/frontend/src/components/findings/FindingsMobileCards.tsx
+++ b/frontend/src/components/findings/FindingsMobileCards.tsx
@@ -1,0 +1,156 @@
+import { Link } from "@tanstack/react-router"
+import { Eye } from "lucide-react"
+
+import type { FindingPublic } from "@/api-client"
+import {
+  CvssBadge,
+  EpssBadge,
+  FindingStatusBadge,
+  KevBadge,
+  PriorityBadge,
+  RiskScore,
+} from "@/components/risk"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { VpwBadge } from "@/components/vpw"
+import { formatLabel as labelize } from "@/lib/ui-copy"
+import {
+  assetLabel,
+  componentLabel,
+  findingWhyNow,
+  formatShortDate,
+  ownerLabel,
+  serviceLabel,
+} from "./FindingsDataTableModel"
+import type { FindingsUrlSearch } from "./findings-search-state"
+
+type FindingsMobileCardsProps = {
+  findings: readonly FindingPublic[]
+  findingSearch: FindingsUrlSearch
+  onOpenSheet: (finding: FindingPublic) => void
+  onOpenWhy: (finding: FindingPublic) => void
+}
+
+export function FindingsMobileCards({
+  findings,
+  findingSearch,
+  onOpenSheet,
+  onOpenWhy,
+}: FindingsMobileCardsProps) {
+  return (
+    <section
+      aria-label="Findings remediation cards"
+      className="findings-mobile-cards sm:hidden"
+      data-testid="findings-mobile-cards"
+    >
+      {findings.map((finding) => (
+        <article
+          aria-label={`Finding ${finding.cve_id}`}
+          className="findings-mobile-card"
+          data-testid="findings-mobile-card"
+          key={finding.id}
+        >
+          <div className="findings-mobile-card-header">
+            <div className="findings-mobile-card-title">
+              <PriorityBadge priority={finding.priority} />
+              <Link
+                className="finding-cve-link findings-mobile-cve"
+                params={{ findingId: finding.id }}
+                search={findingSearch}
+                title={`Open finding ${finding.cve_id}`}
+                to="/findings/$findingId"
+              >
+                {finding.cve_id}
+              </Link>
+            </div>
+            <RiskScore value={finding.risk_score} />
+          </div>
+
+          <div className="findings-mobile-component">
+            <strong
+              className="findings-mobile-component-name"
+              title={componentLabel(finding)}
+            >
+              {componentLabel(finding)}
+            </strong>
+            <span
+              className="findings-mobile-component-detail"
+              title={`${serviceLabel(finding)} / ${assetLabel(finding)}`}
+            >
+              {serviceLabel(finding)} / {assetLabel(finding)}
+            </span>
+          </div>
+
+          <div className="findings-mobile-meta-grid">
+            <div>
+              <span className="findings-mobile-label">Owner</span>
+              <strong className="findings-mobile-meta-value">
+                {ownerLabel(finding)}
+              </strong>
+              {finding.exposure ? (
+                <small className="findings-mobile-meta-detail">
+                  {labelize(finding.exposure)}
+                </small>
+              ) : null}
+            </div>
+            <div>
+              <span className="findings-mobile-label">Status</span>
+              <FindingStatusBadge status={finding.status} />
+              <small className="findings-mobile-meta-detail">
+                {formatShortDate(finding.last_seen_at)}
+              </small>
+            </div>
+          </div>
+
+          <div className="findings-mobile-signals">
+            <VpwBadge className="min-h-6 gap-1.5 px-2 text-[0.72rem]" tone="info">
+              <span>EPSS</span>
+              <strong className="font-black text-[var(--vpw-text-primary)]">
+                <EpssBadge value={finding.epss} />
+              </strong>
+            </VpwBadge>
+            <VpwBadge className="min-h-6 gap-1.5 px-2 text-[0.72rem]" tone="info">
+              <span>CVSS</span>
+              <strong className="font-black text-[var(--vpw-text-primary)]">
+                <CvssBadge value={finding.cvss_base_score} />
+              </strong>
+            </VpwBadge>
+            <KevBadge matched={finding.in_kev} />
+          </div>
+
+          <p className="findings-mobile-why">{findingWhyNow(finding)}</p>
+
+          <div className="findings-mobile-card-actions">
+            <Button
+              className="h-8 justify-start px-0 text-[0.78rem] font-extrabold text-[var(--vpw-text-primary)]"
+              onClick={() => onOpenWhy(finding)}
+              size="sm"
+              type="button"
+              variant="link"
+            >
+              Why now
+            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label={`Quick view ${finding.cve_id}`}
+                  className="finding-view-action"
+                  onClick={() => onOpenSheet(finding)}
+                  type="button"
+                  variant="ghost"
+                >
+                  <Eye aria-hidden="true" size={16} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="left">Quick view</TooltipContent>
+            </Tooltip>
+          </div>
+        </article>
+      ))}
+    </section>
+  )
+}

--- a/frontend/src/components/findings/RemediationQueueFilters.tsx
+++ b/frontend/src/components/findings/RemediationQueueFilters.tsx
@@ -19,6 +19,7 @@ import type { FindingFilters } from "./remediation-queue-model"
 
 type RemediationQueueFiltersProps = {
   activeFindingFilters: boolean
+  controlIdPrefix?: string
   filterCount: number
   findingAssetId: string | null
   findingAssetKey: string | null
@@ -43,6 +44,7 @@ type RemediationQueueFiltersProps = {
 
 export function RemediationQueueFilters({
   activeFindingFilters,
+  controlIdPrefix = "queue",
   filterCount,
   findingAssetId,
   findingAssetKey,
@@ -61,6 +63,8 @@ export function RemediationQueueFilters({
   showAdvancedFilters,
   signalFilterCount,
 }: RemediationQueueFiltersProps) {
+  const queueSearchId = `${controlIdPrefix}-search`
+
   return (
     <VpwPanel
       aria-label="Findings filters"
@@ -115,14 +119,14 @@ export function RemediationQueueFilters({
 
           <label
             className="flex min-w-56 flex-1 flex-col gap-1"
-            htmlFor="queue-search"
+            htmlFor={queueSearchId}
           >
             <span className="text-[11px] font-semibold uppercase text-muted-foreground">
               Owner / Service
             </span>
             <Input
               className="h-10 text-sm"
-              id="queue-search"
+              id={queueSearchId}
               onChange={(e) => setOwnerServiceDraft(e.target.value)}
               placeholder="payments, infra-team"
               value={ownerServiceDraft}

--- a/frontend/src/components/findings/RemediationQueueSummary.tsx
+++ b/frontend/src/components/findings/RemediationQueueSummary.tsx
@@ -22,14 +22,27 @@ export function DemoBanner() {
 }
 
 type SummaryChipProps = {
+  compact?: boolean
   label: string
   value: number | string
   tone?: "critical" | "warning" | "info" | "support"
 }
 
-function SummaryChip({ label, value, tone = "info" }: SummaryChipProps) {
+function SummaryChip({
+  compact = false,
+  label,
+  value,
+  tone = "info",
+}: SummaryChipProps) {
   return (
-    <VpwBadge tone={tone}>
+    <VpwBadge
+      className={
+        compact
+          ? "min-h-9 w-full justify-between gap-2 px-3 text-[0.72rem]"
+          : undefined
+      }
+      tone={tone}
+    >
       {label}: <span className="font-bold">{value}</span>
     </VpwBadge>
   )
@@ -78,7 +91,19 @@ export function RemediationQueueSummary({
           eyebrow="Remediation Queue"
           title="Findings"
         />
-        <VpwGrid columns={4}>
+        <fieldset className="m-0 grid grid-cols-2 gap-2 border-0 p-0 sm:hidden">
+          <legend className="sr-only">Queue signal summary</legend>
+          <SummaryChip
+            compact
+            label="Critical"
+            tone="critical"
+            value={criticalCount}
+          />
+          <SummaryChip compact label="High" tone="warning" value={highCount} />
+          <SummaryChip compact label="KEV" tone="support" value={kevCount} />
+          <SummaryChip compact label="Open" tone="info" value={openCount} />
+        </fieldset>
+        <VpwGrid className="hidden sm:grid" columns={4}>
           <VpwMetricCard
             description="highest urgency"
             icon={<AlertTriangle aria-hidden="true" className="h-4 w-4" />}
@@ -108,7 +133,7 @@ export function RemediationQueueSummary({
             value={openCount}
           />
         </VpwGrid>
-        <div className="flex flex-wrap gap-2">
+        <div className="hidden flex-wrap gap-2 sm:flex">
           <SummaryChip label="Critical" tone="critical" value={criticalCount} />
           <SummaryChip label="High" tone="warning" value={highCount} />
           <SummaryChip label="KEV" tone="support" value={kevCount} />

--- a/frontend/src/components/findings/RemediationQueueView.tsx
+++ b/frontend/src/components/findings/RemediationQueueView.tsx
@@ -1,4 +1,9 @@
-import type { Dispatch, SetStateAction } from "react"
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useState,
+} from "react"
 import type { FindingPublic, ProjectPublic } from "@/api-client"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import type { FindingsUrlSearch } from "./findings-search-state"
@@ -96,6 +101,30 @@ export function RemediationQueueView({
   const closeSheet = () => setSheetOpen(false)
   const closeWhy = () => setWhyOpen(false)
   const stableFindingSearch: FindingsUrlSearch = findingSearch
+  const mobileFilterLayout = useMobileFilterLayout()
+  const renderFilters = (controlIdPrefix: string) => (
+    <RemediationQueueFilters
+      activeFindingFilters={activeFindingFilters}
+      controlIdPrefix={controlIdPrefix}
+      filterCount={filterCount}
+      findingAssetId={findingAssetId}
+      findingAssetKey={findingAssetKey}
+      findingFilters={findingFilters}
+      isDemo={isDemo}
+      onClearAssetFilter={onClearAssetFilter}
+      onClearFilters={onClearFilters}
+      onFilterChange={onFilterChange}
+      onProjectChange={onProjectChange}
+      ownerServiceDraft={ownerServiceDraft}
+      projectListLoading={projectListLoading}
+      projects={projects}
+      selectedProjectId={selectedProjectId}
+      setAdvancedFiltersOpen={setAdvancedFiltersOpen}
+      setOwnerServiceDraft={setOwnerServiceDraft}
+      showAdvancedFilters={showAdvancedFilters}
+      signalFilterCount={signalFilterCount}
+    />
+  )
 
   return (
     <TooltipProvider>
@@ -112,26 +141,7 @@ export function RemediationQueueView({
           kevCount={kevCount}
           openCount={openCount}
         />
-        <RemediationQueueFilters
-          activeFindingFilters={activeFindingFilters}
-          filterCount={filterCount}
-          findingAssetId={findingAssetId}
-          findingAssetKey={findingAssetKey}
-          findingFilters={findingFilters}
-          isDemo={isDemo}
-          onClearAssetFilter={onClearAssetFilter}
-          onClearFilters={onClearFilters}
-          onFilterChange={onFilterChange}
-          onProjectChange={onProjectChange}
-          ownerServiceDraft={ownerServiceDraft}
-          projectListLoading={projectListLoading}
-          projects={projects}
-          selectedProjectId={selectedProjectId}
-          setAdvancedFiltersOpen={setAdvancedFiltersOpen}
-          setOwnerServiceDraft={setOwnerServiceDraft}
-          showAdvancedFilters={showAdvancedFilters}
-          signalFilterCount={signalFilterCount}
-        />
+        {!mobileFilterLayout ? renderFilters("queue-desktop") : null}
         <RemediationQueueStates
           activeFindingFilters={activeFindingFilters}
           displayFindings={displayFindings}
@@ -164,6 +174,7 @@ export function RemediationQueueView({
           queueSort={queueSort}
           totalCount={totalCount}
         />
+        {mobileFilterLayout ? renderFilters("queue-mobile") : null}
         <WhyDialog finding={whyFinding} onClose={closeWhy} open={whyOpen} />
         <QuickViewSheet
           finding={sheetFinding}
@@ -174,4 +185,22 @@ export function RemediationQueueView({
       </div>
     </TooltipProvider>
   )
+}
+
+function useMobileFilterLayout() {
+  const [mobileFilterLayout, setMobileFilterLayout] = useState(() => {
+    if (typeof window === "undefined") return false
+    return window.matchMedia("(max-width: 639px)").matches
+  })
+
+  useEffect(() => {
+    const media = window.matchMedia("(max-width: 639px)")
+    const update = () => setMobileFilterLayout(media.matches)
+
+    update()
+    media.addEventListener("change", update)
+    return () => media.removeEventListener("change", update)
+  }, [])
+
+  return mobileFilterLayout
 }

--- a/frontend/src/components/vpw/VpwDataTable.tsx
+++ b/frontend/src/components/vpw/VpwDataTable.tsx
@@ -18,6 +18,7 @@ export type VpwDataTableColumn<TData> = {
   ariaSort?: "ascending" | "descending" | "none"
   className?: string
   headerClassName?: string
+  width?: string
 }
 
 export type VpwDataTableDensity = "compact" | "standard" | "comfortable"
@@ -92,6 +93,14 @@ export function VpwDataTable<TData>({
         {caption ? (
           <TableCaption className="sr-only">{caption}</TableCaption>
         ) : null}
+        <colgroup>
+          {columns.map((column) => (
+            <col
+              key={column.id}
+              style={column.width ? { width: column.width } : undefined}
+            />
+          ))}
+        </colgroup>
         <TableHeader>
           <TableRow>
             {columns.map((column) => (
@@ -115,7 +124,10 @@ export function VpwDataTable<TData>({
               >
                 {columns.map((column) => (
                   <TableCell
-                    className={cn("vpw-table-cell", column.className)}
+                    className={cn(
+                      "vpw-table-cell !whitespace-normal",
+                      column.className,
+                    )}
                     key={column.id}
                   >
                     {column.cell(row)}

--- a/frontend/src/lib/app-route-config.ts
+++ b/frontend/src/lib/app-route-config.ts
@@ -1,4 +1,4 @@
-import type { WorkbenchPath } from "../components/app/AppShell"
+import type { WorkbenchPath } from "./workbench-navigation"
 
 type RouteDetail = {
   eyebrow: string

--- a/frontend/src/lib/workbench-navigation.ts
+++ b/frontend/src/lib/workbench-navigation.ts
@@ -1,0 +1,41 @@
+import {
+  Database,
+  FileArchive,
+  FileCheck2,
+  FileInput,
+  FolderKanban,
+  LayoutDashboard,
+  ListChecks,
+  type LucideIcon,
+  Settings,
+  ShieldCheck,
+} from "lucide-react"
+
+export type WorkbenchPath =
+  | "/"
+  | "/projects"
+  | "/imports"
+  | "/findings"
+  | "/waivers"
+  | "/assets"
+  | "/providers"
+  | "/reports"
+  | "/settings"
+
+export type NavigationEntry = {
+  icon: LucideIcon
+  label: string
+  to: WorkbenchPath
+}
+
+export const workbenchNavigation: readonly NavigationEntry[] = [
+  { label: "Dashboard", icon: LayoutDashboard, to: "/" },
+  { label: "Projects", icon: FolderKanban, to: "/projects" },
+  { label: "Imports", icon: FileInput, to: "/imports" },
+  { label: "Findings", icon: ListChecks, to: "/findings" },
+  { label: "Waivers", icon: FileCheck2, to: "/waivers" },
+  { label: "Assets", icon: ShieldCheck, to: "/assets" },
+  { label: "Providers", icon: Database, to: "/providers" },
+  { label: "Reports", icon: FileArchive, to: "/reports" },
+  { label: "Settings", icon: Settings, to: "/settings" },
+]

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -373,13 +373,38 @@
   line-height: 1.35;
 }
 
+.finding-sort-stack,
+.finding-primary-badges {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.finding-sort-stack {
+  margin-left: -4px;
+  border: 0;
+  padding: 0;
+}
+
+.finding-primary-cell {
+  display: grid;
+  min-width: 0;
+  gap: 8px;
+}
+
+.finding-primary-cell .finding-cve-link {
+  width: fit-content;
+}
+
 .remediation-why-now {
   display: block;
-  overflow: hidden;
+  max-width: 42ch;
+  overflow-wrap: anywhere;
   color: var(--vpw-text-secondary);
   font-size: 0.8rem;
-  line-height: 1.4;
-  max-width: 28ch;
+  line-height: 1.45;
 }
 
 .finding-view-action {
@@ -391,13 +416,13 @@
   border: 1px solid var(--vpw-text-primary);
   border-radius: 7px;
   padding: 0;
-  background: var(--vpw-navy);
+  background: var(--vpw-text-primary);
   color: var(--vpw-bg-card);
   text-decoration: none;
 }
 
 .finding-view-action:hover {
-  background: var(--vpw-text-primary);
+  background: var(--vpw-text-secondary);
   color: var(--vpw-bg-card);
 }
 

--- a/frontend/src/styles/findings.css
+++ b/frontend/src/styles/findings.css
@@ -132,3 +132,115 @@
     box-shadow: inset -16px 0 18px -18px var(--vpw-text-muted);
   }
 }
+
+.findings-mobile-cards {
+  display: grid;
+  gap: 12px;
+}
+
+.findings-mobile-card {
+  min-width: 0;
+  border: 1px solid var(--vpw-border-default);
+  border-radius: var(--vpw-radius-xl);
+  padding: 14px;
+  background: var(--vpw-bg-card);
+  box-shadow: var(--vpw-shadow-1);
+}
+
+.findings-mobile-card-header,
+.findings-mobile-card-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.findings-mobile-card-title,
+.findings-mobile-signals {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.findings-mobile-cve {
+  overflow-wrap: anywhere;
+  font-size: 0.95rem;
+}
+
+.findings-mobile-component {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+  margin-top: 12px;
+}
+
+.findings-mobile-component-name {
+  color: var(--vpw-text-primary);
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.findings-mobile-component-detail,
+.findings-mobile-meta-detail {
+  color: var(--vpw-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.findings-mobile-meta-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.findings-mobile-meta-grid > div {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 4px;
+  border: 1px solid var(--vpw-border-subtle);
+  border-radius: var(--vpw-radius-lg);
+  padding: 9px;
+  background: var(--vpw-bg-panel);
+}
+
+.findings-mobile-meta-value {
+  color: var(--vpw-text-primary);
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.findings-mobile-label {
+  color: var(--vpw-text-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.findings-mobile-signals {
+  margin-top: 12px;
+}
+
+.findings-mobile-why {
+  margin-top: 12px;
+  color: var(--vpw-text-secondary);
+  font-size: 0.83rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.findings-mobile-card-actions {
+  align-items: center;
+  margin-top: 8px;
+}
+
+@media (min-width: 640px) {
+  .findings-mobile-cards {
+    display: none;
+  }
+}

--- a/frontend/src/styles/vpw-components.css
+++ b/frontend/src/styles/vpw-components.css
@@ -155,6 +155,7 @@
     padding: 0.875rem 1rem;
     transition: background-color 120ms ease;
     vertical-align: top;
+    white-space: normal;
   }
 
   .vpw-table-row:hover > .vpw-table-cell {

--- a/frontend/src/workbench/ProductAppShell.tsx
+++ b/frontend/src/workbench/ProductAppShell.tsx
@@ -1,0 +1,80 @@
+import { useNavigate } from "@tanstack/react-router"
+import type { ReactNode } from "react"
+
+import {
+  LoginService,
+  type ProviderStatusPublic,
+  type UserPublic,
+  type WorkbenchStatus,
+} from "../api-client"
+import { clearAccessToken } from "../auth"
+import { AppShell } from "../components/app/AppShell"
+import {
+  dataServicesSummary,
+  workspaceHealthLabel,
+} from "../lib/provider-format"
+import {
+  type WorkbenchPath,
+  workbenchNavigation,
+} from "../lib/workbench-navigation"
+
+type ProductAppShellProps = {
+  activePath: WorkbenchPath | null
+  children: ReactNode
+  currentUser: UserPublic | null
+  eyebrow: string
+  hideStatusStrip?: boolean
+  providerStatus: ProviderStatusPublic | null
+  status: WorkbenchStatus | null
+  statusError: string
+  title: string
+}
+
+export function ProductAppShell({
+  activePath,
+  children,
+  currentUser,
+  eyebrow,
+  hideStatusStrip = false,
+  providerStatus,
+  status,
+  statusError,
+  title,
+}: ProductAppShellProps) {
+  const navigate = useNavigate()
+
+  async function signOut() {
+    try {
+      await LoginService.logoutCurrentToken()
+    } catch {
+      // Local logout should complete even if the server session already expired.
+    } finally {
+      clearAccessToken()
+      if (typeof window !== "undefined") {
+        window.location.assign("/login")
+      } else {
+        await navigate({ replace: true, search: {} as never, to: "/login" })
+      }
+    }
+  }
+
+  return (
+    <AppShell
+      activePath={activePath}
+      currentUserLabel={currentUserLabel(currentUser)}
+      eyebrow={eyebrow}
+      healthLabel={workspaceHealthLabel(status, statusError)}
+      hideStatusStrip={hideStatusStrip}
+      navigation={workbenchNavigation}
+      onSignOut={signOut}
+      statusItems={dataServicesSummary(status, providerStatus)}
+      title={title}
+    >
+      {children}
+    </AppShell>
+  )
+}
+
+function currentUserLabel(user: UserPublic | null) {
+  return user?.email ?? "Local workspace"
+}

--- a/frontend/src/workbench/WorkbenchShell.tsx
+++ b/frontend/src/workbench/WorkbenchShell.tsx
@@ -1,12 +1,13 @@
 import { type ReactNode, Suspense } from "react"
 import { useLocation } from "@tanstack/react-router"
-import { ProductAppShell, type WorkbenchPath } from "../components/app/AppShell"
 import { LoadingSkeleton } from "../components/states"
 import {
   routeDetails,
   unknownRouteDetail,
   workbenchPathFromPathname,
 } from "../lib/app-route-config"
+import type { WorkbenchPath } from "../lib/workbench-navigation"
+import { ProductAppShell } from "./ProductAppShell"
 import { useWorkbenchContext, WorkbenchProvider } from "./WorkbenchContext"
 
 type WorkbenchShellProps = {

--- a/frontend/src/workbench/useReportsRouteState.ts
+++ b/frontend/src/workbench/useReportsRouteState.ts
@@ -8,10 +8,10 @@ import {
   ReportsService,
   type ReportVerificationPublic,
 } from "../api-client"
-import type { WorkbenchPath } from "../components/app/AppShell"
 import type { WorkbenchReportFormat } from "../lib/app-defaults"
 import { apiErrorMessage, objectRecord } from "../lib/app-errors"
 import { isReportableRunStatus, reportFormatLabel } from "../lib/report-format"
+import type { WorkbenchPath } from "../lib/workbench-navigation"
 import { fetchReportDownload } from "./report-download"
 import { workbenchQueryKeys } from "./workbench-query-keys"
 

--- a/frontend/tests/findings-route-integration.spec.ts
+++ b/frontend/tests/findings-route-integration.spec.ts
@@ -308,8 +308,10 @@ test("findings detail, quick-view sheet, why dialog, and scroll evidence are cov
       scrollWidth: region.scrollWidth,
     }
   })
-  expect(scrollMetrics.scrollWidth).toBeGreaterThan(scrollMetrics.clientWidth)
-  expect(scrollMetrics.scrollLeft).toBeGreaterThan(0)
+  expect(scrollMetrics.scrollWidth).toBeLessThanOrEqual(
+    scrollMetrics.clientWidth + 2,
+  )
+  expect(scrollMetrics.scrollLeft).toBeLessThanOrEqual(1)
   await captureAuditScreenshot(
     page,
     "vpw-aud-204-findings-table-scroll-1440.png",

--- a/frontend/tests/responsive-shell.spec.ts
+++ b/frontend/tests/responsive-shell.spec.ts
@@ -56,13 +56,25 @@ async function expectFindingsTableScrollContainment(
   expect(metrics.regionClientWidth).toBeLessThanOrEqual(
     metrics.viewportWidth + 1,
   )
-  expect(metrics.tableScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
-    metrics.regionClientWidth,
-  )
-  expect(metrics.regionScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
-    metrics.regionClientWidth,
-  )
-  expect(metrics.regionScrollLeft, JSON.stringify(metrics)).toBeGreaterThan(0)
+  if (viewport.width >= 1200) {
+    expect(metrics.tableScrollWidth, JSON.stringify(metrics)).toBeLessThanOrEqual(
+      metrics.regionClientWidth + 2,
+    )
+    expect(metrics.regionScrollWidth, JSON.stringify(metrics)).toBeLessThanOrEqual(
+      metrics.regionClientWidth + 2,
+    )
+    expect(metrics.regionScrollLeft, JSON.stringify(metrics)).toBeLessThanOrEqual(
+      1,
+    )
+  } else {
+    expect(metrics.tableScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
+      metrics.regionClientWidth,
+    )
+    expect(metrics.regionScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
+      metrics.regionClientWidth,
+    )
+    expect(metrics.regionScrollLeft, JSON.stringify(metrics)).toBeGreaterThan(0)
+  }
 
   await page.screenshot({
     fullPage: true,
@@ -78,6 +90,60 @@ async function expectFindingsTableScrollContainment(
       "ui-productization",
       "screenshots",
       `vpw-aud-204-findings-table-scroll-${viewport.width}.png`,
+    ),
+  })
+}
+
+async function expectFindingsMobileCards(page: Page) {
+  const cardsRegion = page.getByRole("region", {
+    name: "Findings remediation cards",
+  })
+  await expect(cardsRegion).toBeVisible()
+  await expect(
+    page.getByRole("table", { name: "Findings remediation queue" }),
+  ).toBeHidden()
+
+  const metrics = await page
+    .locator('[data-testid="findings-mobile-cards"]')
+    .evaluate((region) => {
+      const cards = Array.from(
+        region.querySelectorAll('[data-testid="findings-mobile-card"]'),
+      )
+      const documentElement = document.documentElement
+      return {
+        bodyScrollWidth: document.body.scrollWidth,
+        cardCount: cards.length,
+        cardsFit: cards.every((card) => {
+          const rect = card.getBoundingClientRect()
+          return rect.left >= 0 && rect.right <= documentElement.clientWidth
+        }),
+        documentScrollWidth: documentElement.scrollWidth,
+        viewportWidth: documentElement.clientWidth,
+      }
+    })
+
+  expect(metrics.cardCount).toBeGreaterThan(0)
+  expect(metrics.cardsFit).toBe(true)
+  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+  expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
+    metrics.viewportWidth + 1,
+  )
+
+  await page.screenshot({
+    fullPage: true,
+    path: evidenceScreenshotPath(
+      "ui-productization",
+      "screenshots",
+      "vpw-aud-201-findings-390.png",
+    ),
+  })
+  await cardsRegion.screenshot({
+    path: evidenceScreenshotPath(
+      "ui-productization",
+      "screenshots",
+      "vpw-aud-204-findings-mobile-cards-390.png",
     ),
   })
 }
@@ -143,7 +209,16 @@ test("mobile status summary wraps without horizontal clipping", async ({
   await page.goto("/settings")
 
   const statusSummary = page.getByLabel("Workbench status summary")
+  const headerHealth = page.getByLabel("Workspace health: Data services healthy")
   await expect(statusSummary).toBeVisible()
+  const visibleHeaderHealthText = await headerHealth.evaluate((element) =>
+    Array.from(element.querySelectorAll("span"))
+      .filter((span) => getComputedStyle(span).display !== "none")
+      .map((span) => span.textContent?.trim())
+      .filter(Boolean)
+      .join(" "),
+  )
+  expect(visibleHeaderHealthText).toBe("Healthy")
 
   const metrics = await statusSummary.evaluate((element) => {
     const rect = element.getBoundingClientRect()
@@ -236,11 +311,15 @@ test("findings table keeps horizontal scroll contained at desktop, tablet, and m
   for (const viewport of [
     { height: 900, width: 1440 },
     { height: 1024, width: 768 },
-    { height: 844, width: 390 },
   ]) {
     await page.setViewportSize(viewport)
     await page.goto("/findings")
     await expect(page.getByRole("main")).toBeVisible()
     await expectFindingsTableScrollContainment(page, viewport)
   }
+
+  await page.setViewportSize({ height: 844, width: 390 })
+  await page.goto("/findings")
+  await expect(page.getByRole("main")).toBeVisible()
+  await expectFindingsMobileCards(page)
 })

--- a/frontend/tests/route-organization.test.ts
+++ b/frontend/tests/route-organization.test.ts
@@ -13,6 +13,10 @@ const routeDetailsFile = new URL(
   "../src/lib/app-route-config.ts",
   import.meta.url,
 )
+const workbenchNavigationFile = new URL(
+  "../src/lib/workbench-navigation.ts",
+  import.meta.url,
+)
 
 function text(url: URL) {
   return readFileSync(url, "utf8")
@@ -70,11 +74,12 @@ test("authenticated route adapters map to existing Workbench route containers", 
 })
 
 test("WorkbenchPath, navigation, route details, and route adapters stay in sync", () => {
-  const appShell = text(appShellFile)
   const routeDetails = text(routeDetailsFile)
-  const workbenchPaths = uniqueMatches(appShell, /\|\s+"([^"]+)"/g).sort()
+  const workbenchNavigation = text(workbenchNavigationFile)
+  const workbenchPaths = uniqueMatches(workbenchNavigation, /\|\s+"([^"]+)"/g)
+    .sort()
   const navigationPaths = uniqueMatches(
-    appShell,
+    workbenchNavigation,
     /\{\s*label:\s*"[^"]+",\s*icon:\s*[^,]+,\s*to:\s*"([^"]+)"/g,
   ).sort()
   const routeDetailPaths = uniqueMatches(routeDetails, /^\s+"([^"]+)":\s+\{/gm)
@@ -88,6 +93,8 @@ test("WorkbenchPath, navigation, route details, and route adapters stay in sync"
   assert.deepEqual(navigationPaths, workbenchPaths)
   assert.deepEqual(routeDetailPaths, workbenchPaths)
   assert.deepEqual(adapterPaths, workbenchPaths)
+  assert.doesNotMatch(routeDetails, /components\/app\/AppShell/)
+  assert.doesNotMatch(text(appShellFile), /workbenchNavigation|LoginService/)
 })
 
 test("Workbench shell is mounted once at the authenticated layout boundary", () => {

--- a/frontend/tests/ui-evidence-screenshots.spec.ts
+++ b/frontend/tests/ui-evidence-screenshots.spec.ts
@@ -43,8 +43,11 @@ const tabletViewport: EvidenceViewport = {
   label: "tablet-768",
   width: 768,
 }
-const baseViewports = [desktopViewport, mobileViewport] as const
-const tabletRouteIds = new Set(["findings", "assets", "waivers", "settings"])
+const evidenceViewports = [
+  desktopViewport,
+  mobileViewport,
+  tabletViewport,
+] as const
 
 const timestamp = "2026-05-10T10:00:00Z"
 const runId = "run-1"
@@ -472,6 +475,13 @@ const authenticatedRoutes: readonly EvidenceRoute[] = [
       await expect(
         page.getByRole("region", { name: "Findings filters" }),
       ).toBeVisible({ timeout: 15_000 })
+      if ((page.viewportSize()?.width ?? desktopViewport.width) < 640) {
+        await expect(
+          page.getByRole("region", { name: "Findings remediation cards" }),
+        ).toContainText(mockFinding.cve_id)
+        return
+      }
+
       await expect(
         page.getByRole("table", { name: "Findings remediation queue" }),
       ).toContainText(mockFinding.cve_id)
@@ -484,6 +494,14 @@ const authenticatedRoutes: readonly EvidenceRoute[] = [
       await expect(
         page.getByRole("heading", { name: new RegExp(mockFinding.cve_id) }),
       ).toBeVisible({ timeout: 15_000 })
+      await expect(
+        page.getByText(
+          "Critical priority combines CISA KEV, 92% EPSS, CVSS 10.0, and Internet Facing exposure.",
+        ),
+      ).toBeVisible()
+      await expect(
+        page.getByText(mockFinding.rationale, { exact: true }).first(),
+      ).toBeVisible()
       await expect(
         page.getByRole("region", { name: "Finding priority decision" }),
       ).toBeVisible()
@@ -629,12 +647,6 @@ function aliasKey(
   return `${routeId}:${theme}:${viewportLabel}`
 }
 
-function routeViewports(route: EvidenceRoute) {
-  return tabletRouteIds.has(route.id)
-    ? [...baseViewports, tabletViewport]
-    : [...baseViewports]
-}
-
 function explicitScreenshotName(
   routeId: string,
   theme: Theme,
@@ -757,7 +769,11 @@ async function captureRouteScreenshot({
   await page.evaluate(() => document.fonts.ready.then(() => undefined))
   await assertEvidenceLayout({ page, route, theme, viewport })
 
-  const screenshot = await page.screenshot({ fullPage: true })
+  const appShell = page.locator(".vpw-app-shell").first()
+  const screenshot =
+    (await appShell.count()) > 0
+      ? await appShell.screenshot()
+      : await page.screenshot({ fullPage: false })
   const fileNames = [
     explicitScreenshotName(route.id, theme, viewport.label),
     ...(legacyScreenshotAliases.get(
@@ -871,7 +887,7 @@ test("evidence: login route light and dark screenshots", async ({ page }) => {
   await routeLoginScreenshotApi(page)
 
   for (const theme of themes) {
-    for (const viewport of baseViewports) {
+    for (const viewport of evidenceViewports) {
       await captureRouteScreenshot({ page, route: loginRoute, theme, viewport })
     }
   }
@@ -885,7 +901,7 @@ for (const theme of themes) {
     await routeEvidenceScreenshotApi(page)
 
     for (const route of authenticatedRoutes) {
-      for (const viewport of routeViewports(route)) {
+      for (const viewport of evidenceViewports) {
         await captureRouteScreenshot({ page, route, theme, viewport })
       }
     }


### PR DESCRIPTION
## Summary
- split Workbench product shell/navigation concerns out of `AppShell` while keeping the app-first route model intact
- improve findings UI responsiveness with mobile remediation cards, tighter desktop/tablet table containment, and clearer status/summary behavior
- strengthen UI evidence coverage across desktop, tablet, mobile, light, and dark routes
- harden release safety around DB bootstrap and provider snapshot evidence bundle resolution
- update docs/release notes for the current release readiness and evidence expectations

## Review evidence
- Backend/security Explorer review found one release blocker in provider snapshot resolution; fixed by requiring safe relative paths plus provider-snapshot JSON shape validation.
- Backend/security re-review reported no remaining release blockers.
- Frontend UI/UX Explorer review reported no frontend UI/UX or test blockers.

## Validation
- `make release-readiness-check` passed locally.
- Backend: `1241 passed, 4 skipped`, coverage `96.57%` with configured `95%` gate.
- Frontend unit coverage: `68 pass`, line coverage `97.36%`, branch coverage `87.26%`, function coverage `96.04%`.
- Playwright: `39 passed`, covering accessibility, responsive shell, UI screenshots, findings, settings, waivers, smoke flows.
- Dependency audit: `pip-audit` no known vulnerabilities; `npm audit --omit=dev` found 0 vulnerabilities.
- Docker demo smoke passed.
- Docker production-like smoke passed with Postgres schema/Alembic verification and same-origin Workbench flow.
- Package/wheel/twine checks passed through the release gate.

## Notes
- Local demo containers were stopped for the release gates; ports 8000, 5173, and 5180 were free before commit.
- The only Docker build warnings observed are existing Dockerfile ENV secret-name lints for rate-limit/token-retention config names.
