### PR TITLE
Fix release readiness Playwright install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ performance-smoke:
 	VPW_PERFORMANCE_SMOKE=1 VPW_PERFORMANCE_SMOKE_OUTPUT=build/vpw-072-performance-smoke.json $(PYTHON) -m pytest -q $(BACKEND_TESTS)/performance/test_vpw072_performance_smoke.py --no-cov
 
 playwright-install: frontend-install
-	cd frontend && npm --workspaces=false exec playwright install chromium
+	cd frontend && npm --workspaces=false exec playwright install --with-deps chromium
 
-playwright-check: frontend-install
+playwright-check: playwright-install
 	cd frontend && npm run test
 
 frontend-install:

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -488,12 +488,18 @@ def test_makefile_has_no_legacy_runtime_smoke_or_compose_path() -> None:
         "dependency-audit:",
         1,
     )[0]
+    playwright_install = makefile.split("playwright-install:", 1)[1].split(
+        "playwright-check:",
+        1,
+    )[0]
     playwright_check = makefile.split("playwright-check:", 1)[1].split("frontend-install:", 1)[0]
 
     assert "LEGACY_COMPOSE" not in makefile
     assert "docker-postgres-migration-smoke" not in makefile
     assert "api/test_workbench_api.py" not in makefile
     assert "$(BACKEND_TESTS)/playwright" not in makefile
+    assert "playwright install --with-deps chromium" in playwright_install
+    assert "playwright-check: playwright-install" in makefile
     assert "cd frontend && npm run test" in playwright_check
     assert "tests/ui-smoke.spec.ts tests/responsive-shell.spec.ts" not in playwright_check
     assert "frontend-test-unit-coverage" in makefile


### PR DESCRIPTION
## Summary
- make playwright-check install the Playwright Chromium browser first
- include Linux browser dependency installation for release-readiness workflows
- add a Makefile contract assertion for the dependency

## Test Plan
- python3 -m pytest -q backend/tests/test_backend_runtime_boundary.py backend/tests/test_v11_output_contracts.py --no-cov
- python3 -m ruff format --check backend
- python3 -m ruff check backend
- make -n playwright-check
- make workflow-check