### PR TITLE
[codex] Stabilize Workbench shell baseline

### DIFF
--- a/frontend/src/components/vpw/VpwDesignSystemShowcase.tsx
+++ b/frontend/src/components/vpw/VpwDesignSystemShowcase.tsx
@@ -510,9 +510,9 @@ export function VpwDesignSystemShowcase() {
           <VpwKeyValueList
             columns={2}
             items={[
-              { label: "Container", value: "1600px max", tone: "info" },
+              { label: "Container", value: "1920px max", tone: "info" },
               { label: "Density", value: "40px standard rows" },
-              { label: "Radius", value: "4 / 8 / 12 / 16" },
+              { label: "Radius", value: "4 / 6 / 8 / 8" },
               { label: "Overlay", value: "Shadow 3", tone: "support" },
             ]}
           />

--- a/frontend/src/components/vpw/VpwLayout.tsx
+++ b/frontend/src/components/vpw/VpwLayout.tsx
@@ -38,7 +38,9 @@ export function VpwSection({ children, className, ...props }: VpwSectionProps) {
 
 export function VpwGrid({ children, className, columns = 3 }: VpwGridProps) {
   return (
-    <div className={cn("grid gap-4", gridClass[columns], className)}>
+    <div
+      className={cn("grid min-w-0 gap-4 [&>*]:min-w-0", gridClass[columns], className)}
+    >
       {children}
     </div>
   )

--- a/frontend/src/lib/app-route-config.ts
+++ b/frontend/src/lib/app-route-config.ts
@@ -101,3 +101,11 @@ export function workbenchPathFromPathname(
   }
   return null
 }
+
+export function routeDetailFromPathname(
+  _pathname: string,
+  routePath: WorkbenchPath | null,
+): RouteDetail {
+  if (routePath) return routeDetails[routePath]
+  return unknownRouteDetail
+}

--- a/frontend/src/lib/vpw-tokens.json
+++ b/frontend/src/lib/vpw-tokens.json
@@ -42,9 +42,9 @@
   },
   "radius": {
     "sm": "4px",
-    "md": "8px",
-    "lg": "12px",
-    "xl": "16px",
+    "md": "6px",
+    "lg": "8px",
+    "xl": "8px",
     "pill": "9999px"
   },
   "shadow": {
@@ -54,7 +54,7 @@
     "3": "0 12px 24px rgba(2, 6, 23, 0.08)"
   },
   "layout": {
-    "maxWidth": "1600px",
+    "maxWidth": "1920px",
     "pagePadding": {
       "base": "1rem",
       "sm": "1.5rem",

--- a/frontend/src/lib/vpw-tokens.ts
+++ b/frontend/src/lib/vpw-tokens.ts
@@ -42,9 +42,9 @@ export const vpwTokens = {
   },
   radius: {
     sm: "4px",
-    md: "8px",
-    lg: "12px",
-    xl: "16px",
+    md: "6px",
+    lg: "8px",
+    xl: "8px",
     pill: "9999px",
   },
   shadow: {
@@ -54,7 +54,7 @@ export const vpwTokens = {
     3: "0 12px 24px rgba(2, 6, 23, 0.08)",
   },
   layout: {
-    maxWidth: "1600px",
+    maxWidth: "1920px",
     pagePadding: {
       base: "1rem",
       sm: "1.5rem",

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -144,7 +144,7 @@
   --vpw-shadow-1: 0 1px 2px rgba(2, 6, 23, 0.04);
   --vpw-shadow-2: 0 4px 12px rgba(2, 6, 23, 0.06);
   --vpw-shadow-3: 0 12px 24px rgba(2, 6, 23, 0.08);
-  --vpw-container-max: 1600px;
+  --vpw-container-max: 1920px;
   --vpw-container-padding: 1rem;
 
   color: var(--vpw-text-primary);

--- a/frontend/src/workbench/WorkbenchShell.tsx
+++ b/frontend/src/workbench/WorkbenchShell.tsx
@@ -2,8 +2,7 @@ import { type ReactNode, Suspense } from "react"
 import { useLocation } from "@tanstack/react-router"
 import { LoadingSkeleton } from "../components/states"
 import {
-  routeDetails,
-  unknownRouteDetail,
+  routeDetailFromPathname,
   workbenchPathFromPathname,
 } from "../lib/app-route-config"
 import type { WorkbenchPath } from "../lib/workbench-navigation"
@@ -15,8 +14,6 @@ type WorkbenchShellProps = {
   routePath?: WorkbenchPath | null
 }
 
-const routesWithStatusStrip = new Set<WorkbenchPath>(["/providers", "/settings"])
-
 function WorkbenchShellFrame({ children, routePath }: WorkbenchShellProps) {
   const location = useLocation()
   const {
@@ -26,20 +23,17 @@ function WorkbenchShellFrame({ children, routePath }: WorkbenchShellProps) {
     statusError,
   } = useWorkbenchContext()
   const activeRoutePath = routePath ?? workbenchPathFromPathname(location.pathname)
-  const routeDetail = activeRoutePath
-    ? routeDetails[activeRoutePath]
-    : unknownRouteDetail
-  const isFindingDetail =
-    activeRoutePath === "/findings" && /^\/findings\/[^/]+$/.test(location.pathname)
-  const hideStatusStrip =
-    !activeRoutePath || !routesWithStatusStrip.has(activeRoutePath)
+  const routeDetail = routeDetailFromPathname(
+    location.pathname,
+    activeRoutePath,
+  )
 
   return (
     <ProductAppShell
       activePath={activeRoutePath}
       currentUser={currentUser}
       eyebrow={routeDetail.eyebrow}
-      hideStatusStrip={hideStatusStrip || Boolean(isFindingDetail)}
+      hideStatusStrip
       providerStatus={providerStatus}
       status={status}
       statusError={statusError}

--- a/frontend/tests/design-system-contracts.test.ts
+++ b/frontend/tests/design-system-contracts.test.ts
@@ -238,6 +238,36 @@ test("retired compatibility and dark-mode override styles stay retired", () => {
   assert.deepEqual(offenders, [])
 })
 
+test("runtime CSS, TypeScript tokens, JSON tokens, and showcase copy stay synchronized", () => {
+  const tokenJson = JSON.parse(readProjectFile("src/lib/vpw-tokens.json")) as {
+    layout: { maxWidth: string }
+    radius: Record<string, string>
+  }
+  const tokenTs = readProjectFile("src/lib/vpw-tokens.ts")
+  const tokenCss = readProjectFile("src/styles/tokens.css")
+  const showcase = readProjectFile("src/components/vpw/VpwDesignSystemShowcase.tsx")
+  const expectedRadius = {
+    sm: "4px",
+    md: "6px",
+    lg: "8px",
+    xl: "8px",
+    pill: "9999px",
+  }
+
+  assert.equal(tokenJson.layout.maxWidth, "1920px")
+  assert.deepEqual(tokenJson.radius, expectedRadius)
+  assert.match(tokenTs, /maxWidth:\s*"1920px"/)
+  assert.match(tokenCss, /--vpw-container-max:\s*1920px;/)
+  assert.match(showcase, /1920px max/)
+
+  for (const [name, value] of Object.entries(expectedRadius)) {
+    assert.match(tokenTs, new RegExp(`${name}:\\s*"${value}"`))
+    assert.match(tokenCss, new RegExp(`--vpw-radius-${name}:\\s*${value};`))
+  }
+
+  assert.match(showcase, /4 \/ 6 \/ 8 \/ 8/)
+})
+
 test("cards and panels stay inside the eight-pixel radius system", () => {
   const offenders: string[] = []
 

--- a/frontend/tests/responsive-shell.spec.ts
+++ b/frontend/tests/responsive-shell.spec.ts
@@ -14,6 +14,32 @@ async function expectNoPageOverflow(page: Page) {
   )
 }
 
+async function expectNoGlobalStatusStrip(page: Page) {
+  await expect(page.getByLabel("Workbench status summary")).toHaveCount(0)
+}
+
+async function expectWqhdContainerBehavior(
+  page: Page,
+  viewport: { width: number; height: number },
+) {
+  const metrics = await page
+    .locator('section[aria-label="Workbench page content"] > .vpw-page-container')
+    .first()
+    .evaluate((container) => {
+      const rect = container.getBoundingClientRect()
+      return {
+        cssMaxWidth: getComputedStyle(container).maxWidth,
+        width: rect.width,
+      }
+    })
+
+  expect(metrics.cssMaxWidth).toBe("1920px")
+  expect(metrics.width).toBeLessThanOrEqual(1922)
+  if (viewport.width >= 2560) {
+    expect(metrics.width).toBeGreaterThanOrEqual(1918)
+  }
+}
+
 async function expectFindingsTableScrollContainment(
   page: Page,
   viewport: { width: number; height: number },
@@ -160,6 +186,16 @@ const authenticatedRoutes = [
   "/settings",
 ] as const
 
+const responsiveViewports = [
+  { height: 800, width: 360 },
+  { height: 667, width: 375 },
+  { height: 844, width: 390 },
+  { height: 1024, width: 768 },
+  { height: 900, width: 1440 },
+  { height: 1080, width: 1920 },
+  { height: 1440, width: 2560 },
+] as const
+
 test("mobile shell exposes drawer navigation without page-width overflow", async ({
   page,
 }) => {
@@ -182,14 +218,10 @@ test("mobile shell exposes drawer navigation without page-width overflow", async
 test("authenticated routes keep content within desktop, tablet, and mobile viewports", async ({
   page,
 }) => {
-  test.setTimeout(120_000)
+  test.setTimeout(180_000)
   await login(page)
 
-  for (const viewport of [
-    { height: 900, width: 1440 },
-    { height: 1024, width: 768 },
-    { height: 844, width: 390 },
-  ]) {
+  for (const viewport of responsiveViewports) {
     await page.setViewportSize(viewport)
     for (const route of authenticatedRoutes) {
       await page.goto(route)
@@ -197,20 +229,28 @@ test("authenticated routes keep content within desktop, tablet, and mobile viewp
       await page.keyboard.press("Tab")
       await expect(page.locator(":focus")).toBeVisible()
       await expectNoPageOverflow(page)
+      await expectNoGlobalStatusStrip(page)
+      await expectWqhdContainerBehavior(page, viewport)
     }
   }
 })
 
-test("mobile status summary wraps without horizontal clipping", async ({
+test("mobile shell keeps compact health status without duplicate summary strip", async ({
   page,
 }) => {
-  await login(page)
+  await routeWorkbenchShell(page, { projects: [mockProject] })
+  await page.route("**/api/v1/api-tokens/", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ data: [], count: 0 }),
+    }),
+  )
   await page.setViewportSize({ height: 844, width: 390 })
   await page.goto("/settings")
 
   const statusSummary = page.getByLabel("Workbench status summary")
   const headerHealth = page.getByLabel("Workspace health: Data services healthy")
-  await expect(statusSummary).toBeVisible()
+  await expect(statusSummary).toHaveCount(0)
   const visibleHeaderHealthText = await headerHealth.evaluate((element) =>
     Array.from(element.querySelectorAll("span"))
       .filter((span) => getComputedStyle(span).display !== "none")
@@ -219,31 +259,6 @@ test("mobile status summary wraps without horizontal clipping", async ({
       .join(" "),
   )
   expect(visibleHeaderHealthText).toBe("Healthy")
-
-  const metrics = await statusSummary.evaluate((element) => {
-    const rect = element.getBoundingClientRect()
-    const children = Array.from(element.children[0]?.children ?? []).map(
-      (child) => {
-        const childRect = child.getBoundingClientRect()
-        return {
-          left: childRect.left,
-          right: childRect.right,
-        }
-      },
-    )
-
-    return {
-      display: getComputedStyle(element.children[0] as Element).display,
-      fitsViewport: rect.left >= 0 && rect.right <= window.innerWidth,
-      childrenFit: children.every(
-        (child) => child.left >= 0 && child.right <= window.innerWidth,
-      ),
-    }
-  })
-
-  expect(metrics.display).toBe("grid")
-  expect(metrics.fitsViewport).toBe(true)
-  expect(metrics.childrenFit).toBe(true)
   await expectNoPageOverflow(page)
 })
 


### PR DESCRIPTION
## Summary
- Removes the duplicated route-level Workbench status strip from the shell baseline.
- Raises the Workbench page container max width to 1920px for WQHD use.
- Synchronizes VPW radius/container tokens across CSS, TS, JSON, and showcase copy.
- Adds contract/responsive coverage for token sync, removed status strip, and WQHD container behavior.

## Validation
- Commit hooks passed: end-of-file, trailing whitespace, merge conflict check, ruff hooks where applicable.
- Full frontend lint/build and responsive smoke were run on the follow-up redesign branch that includes this baseline.

## Notes
Direct push to main is blocked by branch protection, so this PR carries the requested main-bound baseline changes.
