### PR TITLE
[codex] Refactor settings workspace UX

### DIFF
--- a/frontend/src/components/settings/SettingsDiagnosticsPanel.tsx
+++ b/frontend/src/components/settings/SettingsDiagnosticsPanel.tsx
@@ -1,0 +1,127 @@
+import type { ProviderStatusPublic, WorkbenchStatus } from "@/api-client"
+import { ShieldAlert } from "lucide-react"
+import type { ReactNode } from "react"
+
+import {
+  VpwBadge,
+  type VpwBadgeTone,
+  VpwCodeBlock,
+  VpwPanel,
+  VpwSectionHeader,
+} from "@/components/vpw"
+import { providerSnapshotSummary } from "@/lib/provider-format"
+import {
+  type evidenceReadiness,
+  safeDiagnosticsCode,
+} from "./settings-workbench-model"
+
+type SettingsDiagnosticsPanelProps = {
+  evidence: ReturnType<typeof evidenceReadiness>
+  providerStatus: ProviderStatusPublic | null
+  status: WorkbenchStatus | null
+  statusError: string
+}
+
+export function SettingsDiagnosticsPanel({
+  evidence,
+  providerStatus,
+  status,
+  statusError,
+}: SettingsDiagnosticsPanelProps) {
+  const diagnosticsCode = safeDiagnosticsCode({
+    providerStatus,
+    status,
+    statusError,
+  })
+
+  return (
+    <VpwPanel className="overflow-hidden p-0">
+      <div className="border-b border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] px-5 py-4">
+        <VpwSectionHeader
+          description="Support-only facts for troubleshooting. Expand JSON only when you need to share safe diagnostics."
+          title="Diagnostics"
+        />
+      </div>
+      <SettingsDiagnosticRows
+        items={[
+          { label: "Frontend", value: "Vite app" },
+          { label: "Backend version", value: status?.core_version ?? "Not reported" },
+          {
+            label: "Provider freshness",
+            value: providerSnapshotSummary(providerStatus),
+          },
+          {
+            label: "Evidence readiness",
+            value: evidence.label,
+            tone: evidence.tone,
+          },
+        ]}
+      />
+      <details className="group border-t border-[var(--vpw-border-subtle)] bg-[var(--vpw-bg-card)]">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-[var(--vpw-text-primary)] marker:hidden">
+          Safe diagnostics payload
+          <span className="font-mono text-xs text-[var(--vpw-text-muted)] group-open:hidden">
+            Expand
+          </span>
+          <span className="hidden font-mono text-xs text-[var(--vpw-text-muted)] group-open:inline">
+            Collapse
+          </span>
+        </summary>
+        <div className="border-t border-[var(--vpw-border-subtle)] p-3">
+          <VpwCodeBlock
+            code={diagnosticsCode}
+            label="Safe diagnostics"
+            onCopy={() => void navigator.clipboard?.writeText(diagnosticsCode)}
+          />
+        </div>
+      </details>
+      <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-amber)_9%,var(--vpw-bg-card))] px-5 py-3">
+        <p className="flex gap-2 text-sm leading-6 text-[var(--vpw-text-secondary)]">
+          <ShieldAlert
+            aria-hidden="true"
+            className="mt-1 h-4 w-4 shrink-0 text-[var(--vpw-amber)]"
+          />
+          <span>
+            <span className="font-medium text-[var(--vpw-text-primary)]">
+              Generated client stays managed.
+            </span>{" "}
+            API contracts are consumed through the generated client and should
+            not be edited by hand.
+          </span>
+        </p>
+      </div>
+    </VpwPanel>
+  )
+}
+
+type SettingsDiagnosticRow = {
+  label: string
+  value: ReactNode
+  tone?: VpwBadgeTone
+}
+
+function SettingsDiagnosticRows({
+  items,
+}: {
+  items: readonly SettingsDiagnosticRow[]
+}) {
+  return (
+    <dl className="grid divide-y divide-[var(--vpw-border-subtle)] lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+      {items.map((item) => (
+        <div
+          className="min-w-0 px-5 py-4 odd:lg:border-b odd:lg:border-[var(--vpw-border-subtle)] even:lg:border-b even:lg:border-[var(--vpw-border-subtle)]"
+          key={item.label}
+        >
+          <dt className="vpw-label">{item.label}</dt>
+          <dd className="mt-2 min-w-0 font-medium text-[var(--vpw-text-primary)] [overflow-wrap:anywhere]">
+            {item.tone ? (
+              <VpwBadge tone={item.tone}>{item.value}</VpwBadge>
+            ) : (
+              item.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/frontend/src/components/settings/SettingsFactRows.tsx
+++ b/frontend/src/components/settings/SettingsFactRows.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react"
+
+import { VpwBadge, type VpwBadgeTone } from "@/components/vpw"
+
+type SettingsFactRow = {
+  label: string
+  value: ReactNode
+  tone?: VpwBadgeTone
+}
+
+export function SettingsFactRows({
+  items,
+}: {
+  items: readonly SettingsFactRow[]
+}) {
+  return (
+    <dl className="divide-y divide-[var(--vpw-border-subtle)]">
+      {items.map((item) => (
+        <div
+          className="grid gap-1 px-5 py-3.5 sm:grid-cols-[minmax(8rem,0.38fr)_minmax(0,1fr)] sm:items-center"
+          key={item.label}
+        >
+          <dt className="vpw-label">{item.label}</dt>
+          <dd className="min-w-0 font-medium text-[var(--vpw-text-primary)] [overflow-wrap:anywhere]">
+            {item.tone ? (
+              <VpwBadge tone={item.tone}>{item.value}</VpwBadge>
+            ) : (
+              item.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/frontend/src/components/settings/SettingsRuntimeProviderPanel.tsx
+++ b/frontend/src/components/settings/SettingsRuntimeProviderPanel.tsx
@@ -1,0 +1,81 @@
+import type { ProviderStatusPublic } from "@/api-client"
+import { Info } from "lucide-react"
+
+import {
+  VpwBadge,
+  VpwDataTable,
+  type VpwDataTableColumn,
+  VpwPanel,
+  VpwSectionHeader,
+} from "@/components/vpw"
+import {
+  type ProviderConfigRow,
+  providerConfigRows,
+} from "./settings-workbench-model"
+
+const providerColumns: VpwDataTableColumn<ProviderConfigRow>[] = [
+  {
+    id: "setting",
+    header: "Setting",
+    cell: (row) => (
+      <p className="font-medium text-[var(--vpw-text-primary)]">
+        {row.setting}
+      </p>
+    ),
+  },
+  {
+    id: "value",
+    header: "Value",
+    cell: (row) => <VpwBadge tone={row.tone}>{row.value}</VpwBadge>,
+  },
+  {
+    id: "detail",
+    header: "Details",
+    cell: (row) => (
+      <span className="text-sm text-[var(--vpw-text-secondary)]">
+        {row.detail}
+      </span>
+    ),
+  },
+]
+
+export function SettingsRuntimeProviderPanel({
+  providerStatus,
+}: {
+  providerStatus: ProviderStatusPublic | null
+}) {
+  return (
+    <VpwPanel className="overflow-hidden p-0">
+      <div className="border-b border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] px-5 py-4">
+        <VpwSectionHeader
+          description="Safe provider configuration values reported by existing APIs."
+          title="Runtime & providers"
+        />
+      </div>
+      <div className="p-4">
+        <VpwDataTable
+          caption="Provider runtime configuration"
+          columns={providerColumns}
+          data={providerConfigRows(providerStatus)}
+          density="compact"
+          getRowKey={(row) => row.id}
+        />
+      </div>
+      <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-blue)_6%,var(--vpw-bg-card))] px-5 py-3">
+        <p className="flex gap-2 text-sm leading-6 text-[var(--vpw-text-secondary)]">
+          <Info
+            aria-hidden="true"
+            className="mt-1 h-4 w-4 shrink-0 text-[var(--vpw-blue)]"
+          />
+          <span>
+            <span className="font-medium text-[var(--vpw-text-primary)]">
+              Secrets are not displayed.
+            </span>{" "}
+            Provider keys, environment secrets, and stored token secrets stay
+            outside Settings.
+          </span>
+        </p>
+      </div>
+    </VpwPanel>
+  )
+}

--- a/frontend/src/components/settings/SettingsTokenCreateSheet.tsx
+++ b/frontend/src/components/settings/SettingsTokenCreateSheet.tsx
@@ -1,0 +1,201 @@
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import {
+  VpwField,
+  VpwSectionHeader,
+  VpwSelectionCard,
+  VpwStatusBanner,
+} from "@/components/vpw"
+import { Button } from "@/components/ui/button"
+import { SettingsTokenCreationResult } from "./SettingsTokenCreationResult"
+import type { SettingsWorkbenchProps } from "./settings-workbench-model"
+
+type SettingsTokenCreateSheetProps = Pick<
+  SettingsWorkbenchProps,
+  | "apiTokenActionLoading"
+  | "apiTokenName"
+  | "apiTokenProjectId"
+  | "apiTokenProjectOptions"
+  | "apiTokenScopeOptions"
+  | "apiTokenScopes"
+  | "createdApiToken"
+  | "onApiTokenNameChange"
+  | "onApiTokenProjectChange"
+  | "onCreateApiToken"
+  | "onToggleApiTokenScope"
+> & {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SettingsTokenCreateSheet({
+  apiTokenActionLoading,
+  apiTokenName,
+  apiTokenProjectId,
+  apiTokenProjectOptions,
+  apiTokenScopeOptions,
+  apiTokenScopes,
+  createdApiToken,
+  onApiTokenNameChange,
+  onApiTokenProjectChange,
+  onCreateApiToken,
+  onOpenChange,
+  onToggleApiTokenScope,
+  open,
+}: SettingsTokenCreateSheetProps) {
+  const tokenHasAdminScope = apiTokenScopes.includes("admin")
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-[min(40rem,calc(100vw-2rem))] overflow-y-auto bg-[var(--vpw-bg-card)] p-0 text-[var(--vpw-text-primary)] sm:max-w-[40rem]">
+        <SheetHeader className="border-b border-[var(--vpw-border-default)] px-5 py-5 text-left">
+          <SheetTitle className="text-xl text-[var(--vpw-text-primary)]">
+            Create API token
+          </SheetTitle>
+          <SheetDescription className="text-sm leading-6 text-[var(--vpw-text-secondary)]">
+            Generate a scoped service token for automation. The cleartext secret
+            is only available in this drawer after creation.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-6 px-5 py-5">
+          <div className="flex flex-col gap-5">
+            <VpwSectionHeader
+              description="Select the least-privilege scopes required by the service account."
+              eyebrow="Access"
+              title="Service Token"
+            />
+            {tokenHasAdminScope ? (
+              <VpwStatusBanner title="Admin scope is global" tone="warning">
+                Admin tokens bypass the project boundary. Use only for trusted
+                break-glass automation.
+              </VpwStatusBanner>
+            ) : null}
+            <form className="flex flex-col gap-5" onSubmit={onCreateApiToken}>
+              <VpwField
+                description="Use a short automation or integration name."
+                htmlFor="api-token-name"
+                label="Name"
+                required
+              >
+                <Input
+                  id="api-token-name"
+                  maxLength={200}
+                  onChange={(event) =>
+                    onApiTokenNameChange(event.target.value)
+                  }
+                  value={apiTokenName}
+                />
+              </VpwField>
+
+              <VpwField label="Scopes" required>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {apiTokenScopeOptions.map((scope) => {
+                    const checked = apiTokenScopes.includes(scope)
+                    const scopeId = `api-token-scope-${scope}`
+                    return (
+                      <label
+                        className="block cursor-pointer"
+                        htmlFor={scopeId}
+                        key={scope}
+                      >
+                        <Checkbox
+                          checked={checked}
+                          className="peer sr-only"
+                          id={scopeId}
+                          onCheckedChange={() => onToggleApiTokenScope(scope)}
+                        />
+                        <VpwSelectionCard
+                          as="span"
+                          checked={checked}
+                          className="cursor-pointer peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--vpw-blue)] peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--vpw-bg-default)]"
+                          meta={scope === "admin" ? "Privileged" : "Service"}
+                          title={scope.toUpperCase()}
+                        >
+                          {scopeDescription(scope)}
+                        </VpwSelectionCard>
+                      </label>
+                    )
+                  })}
+                </div>
+              </VpwField>
+
+              <VpwField
+                description={
+                  tokenHasAdminScope
+                    ? "Admin tokens are root-equivalent and global."
+                    : "Required project boundary for service tokens."
+                }
+                htmlFor="api-token-project"
+                label="Project scope"
+                required={!tokenHasAdminScope}
+              >
+                <Select
+                  disabled={
+                    tokenHasAdminScope || apiTokenProjectOptions.length === 0
+                  }
+                  onValueChange={onApiTokenProjectChange}
+                  value={apiTokenProjectId}
+                >
+                  <SelectTrigger id="api-token-project">
+                    <SelectValue placeholder="Select project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {apiTokenProjectOptions.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </VpwField>
+
+              <Button
+                aria-busy={apiTokenActionLoading}
+                disabled={
+                  apiTokenActionLoading ||
+                  (!tokenHasAdminScope && apiTokenProjectOptions.length === 0)
+                }
+                type="submit"
+              >
+                {apiTokenActionLoading ? "Creating" : "Create token"}
+              </Button>
+            </form>
+          </div>
+
+          <div className="border-t border-[var(--vpw-border-subtle)] pt-5">
+            <VpwSectionHeader
+              description="Token secrets are masked by default and only available during the one-time creation response."
+              eyebrow="One-time secret"
+              title="Creation result"
+            />
+            <div className="mt-5">
+              <SettingsTokenCreationResult createdApiToken={createdApiToken} />
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function scopeDescription(scope: string) {
+  if (scope === "read") return "Read workbench findings and evidence metadata."
+  if (scope === "import") return "Create import runs and normalize supplied inputs."
+  if (scope === "report") return "Generate and download report artifacts."
+  return "Root-equivalent global access for trusted operators."
+}

--- a/frontend/src/components/settings/SettingsTokenCreationResult.tsx
+++ b/frontend/src/components/settings/SettingsTokenCreationResult.tsx
@@ -40,7 +40,7 @@ export function SettingsTokenCreationResult({
         tone="success"
       >
         Save this one-time token now. It will be cleared when you leave Settings
-        and is not listed again.
+        or close this drawer and is not listed again.
       </VpwStatusBanner>
       <VpwField
         description="Reveal only long enough to store it in your secret manager."

--- a/frontend/src/components/settings/SettingsWorkbench.tsx
+++ b/frontend/src/components/settings/SettingsWorkbench.tsx
@@ -1,20 +1,24 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { VpwPageContainer } from "@/components/vpw"
 import {
   SettingsAccountHealth,
   SettingsAlerts,
   SettingsApiTokensSection,
   SettingsHero,
-  SettingsMetrics,
-  SettingsRuntimeDiagnostics,
-  SettingsSecurityNotes,
+  SettingsDiagnostics,
+  SettingsRuntimeProviders,
 } from "./SettingsWorkbenchSections"
-import type { SettingsWorkbenchProps } from "./settings-workbench-model"
+import {
+  normalizeSettingsTab,
+  settingsTabOptions,
+  type SettingsWorkbenchProps,
+} from "./settings-workbench-model"
 
 export type { SettingsWorkbenchProps } from "./settings-workbench-model"
 
 export function SettingsWorkbench(props: SettingsWorkbenchProps) {
   return (
-    <VpwPageContainer className="flex flex-col gap-8 px-0 py-0">
+    <VpwPageContainer className="flex flex-col gap-5 px-0 py-0">
       <SettingsHero
         apiTokens={props.apiTokens}
         currentUser={props.currentUser}
@@ -28,46 +32,75 @@ export function SettingsWorkbench(props: SettingsWorkbenchProps) {
         providerStatusError={props.providerStatusError}
         statusError={props.statusError}
       />
-      <SettingsMetrics
-        apiTokens={props.apiTokens}
-        apiTokensLoading={props.apiTokensLoading}
-        currentUser={props.currentUser}
-        providerStatus={props.providerStatus}
-        providerStatusError={props.providerStatusError}
-        statusError={props.statusError}
-      />
-      <SettingsAccountHealth
-        apiTokens={props.apiTokens}
-        currentUser={props.currentUser}
-        providerStatus={props.providerStatus}
-        providerStatusError={props.providerStatusError}
-        providerStatusLoading={props.providerStatusLoading}
-        status={props.status}
-        statusError={props.statusError}
-      />
-      <SettingsApiTokensSection
-        apiTokenActionLoading={props.apiTokenActionLoading}
-        apiTokenName={props.apiTokenName}
-        apiTokenProjectId={props.apiTokenProjectId}
-        apiTokenProjectOptions={props.apiTokenProjectOptions}
-        apiTokenScopeOptions={props.apiTokenScopeOptions}
-        apiTokenScopes={props.apiTokenScopes}
-        apiTokens={props.apiTokens}
-        apiTokensLoading={props.apiTokensLoading}
-        createdApiToken={props.createdApiToken}
-        onApiTokenNameChange={props.onApiTokenNameChange}
-        onApiTokenProjectChange={props.onApiTokenProjectChange}
-        onCreateApiToken={props.onCreateApiToken}
-        onRevokeApiToken={props.onRevokeApiToken}
-        onToggleApiTokenScope={props.onToggleApiTokenScope}
-      />
-      <SettingsRuntimeDiagnostics
-        providerStatus={props.providerStatus}
-        providerStatusError={props.providerStatusError}
-        status={props.status}
-        statusError={props.statusError}
-      />
-      <SettingsSecurityNotes />
+      <Tabs
+        className="min-w-0"
+        onValueChange={(value) =>
+          props.onSettingsTabChange(normalizeSettingsTab(value))
+        }
+        value={props.activeSettingsTab}
+      >
+        <div className="flex min-w-0 border-b border-[var(--vpw-border-default)] pb-3">
+          <TabsList
+            aria-label="Settings sections"
+            className="grid h-auto w-full min-w-0 grid-cols-2 gap-1 rounded-[var(--vpw-radius-lg)] border border-[var(--vpw-border-subtle)] bg-[var(--vpw-bg-panel)] p-1 sm:inline-grid sm:w-auto sm:grid-cols-4"
+          >
+            {settingsTabOptions.map((option) => (
+              <TabsTrigger
+                className="min-h-9 min-w-0 rounded-[var(--vpw-radius-md)] border border-transparent px-2 py-2 text-center text-xs font-medium leading-tight text-[var(--vpw-text-secondary)] data-[state=active]:border-[var(--vpw-border-default)] data-[state=active]:bg-[var(--vpw-bg-card)] data-[state=active]:text-[var(--vpw-text-primary)] data-[state=active]:shadow-[var(--vpw-shadow-1)] sm:px-4 sm:text-sm"
+                key={option.value}
+                value={option.value}
+              >
+                {option.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
+
+        <TabsContent className="mt-5" value="overview">
+          <SettingsAccountHealth
+            apiTokens={props.apiTokens}
+            currentUser={props.currentUser}
+            providerStatus={props.providerStatus}
+            providerStatusError={props.providerStatusError}
+            providerStatusLoading={props.providerStatusLoading}
+            status={props.status}
+            statusError={props.statusError}
+          />
+        </TabsContent>
+
+        <TabsContent className="mt-5" value="tokens">
+          <SettingsApiTokensSection
+            apiTokenActionLoading={props.apiTokenActionLoading}
+            apiTokenName={props.apiTokenName}
+            apiTokenProjectId={props.apiTokenProjectId}
+            apiTokenProjectOptions={props.apiTokenProjectOptions}
+            apiTokenScopeOptions={props.apiTokenScopeOptions}
+            apiTokenScopes={props.apiTokenScopes}
+            apiTokens={props.apiTokens}
+            apiTokensLoading={props.apiTokensLoading}
+            createdApiToken={props.createdApiToken}
+            onClearCreatedApiToken={props.onClearCreatedApiToken}
+            onApiTokenNameChange={props.onApiTokenNameChange}
+            onApiTokenProjectChange={props.onApiTokenProjectChange}
+            onCreateApiToken={props.onCreateApiToken}
+            onRevokeApiToken={props.onRevokeApiToken}
+            onToggleApiTokenScope={props.onToggleApiTokenScope}
+          />
+        </TabsContent>
+
+        <TabsContent className="mt-5" value="runtime">
+          <SettingsRuntimeProviders providerStatus={props.providerStatus} />
+        </TabsContent>
+
+        <TabsContent className="mt-5" value="diagnostics">
+          <SettingsDiagnostics
+            providerStatus={props.providerStatus}
+            providerStatusError={props.providerStatusError}
+            status={props.status}
+            statusError={props.statusError}
+          />
+        </TabsContent>
+      </Tabs>
     </VpwPageContainer>
   )
 }

--- a/frontend/src/components/settings/SettingsWorkbenchAlerts.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchAlerts.tsx
@@ -1,0 +1,42 @@
+import { VpwStatusBanner } from "@/components/vpw"
+import type { SettingsWorkbenchProps } from "./settings-workbench-model"
+
+type SettingsAlertsProps = Pick<
+  SettingsWorkbenchProps,
+  "apiTokenError" | "apiTokenMessage" | "providerStatusError" | "statusError"
+>
+
+export function SettingsAlerts({
+  apiTokenError,
+  apiTokenMessage,
+  providerStatusError,
+  statusError,
+}: SettingsAlertsProps) {
+  return (
+    <>
+      {statusError ? (
+        <VpwStatusBanner title="Workbench status unavailable" tone="critical">
+          {statusError}
+        </VpwStatusBanner>
+      ) : null}
+
+      {providerStatusError ? (
+        <VpwStatusBanner title="Provider status unavailable" tone="warning">
+          {providerStatusError}
+        </VpwStatusBanner>
+      ) : null}
+
+      {apiTokenError ? (
+        <VpwStatusBanner title="API token action failed" tone="critical">
+          {apiTokenError}
+        </VpwStatusBanner>
+      ) : null}
+
+      {apiTokenMessage ? (
+        <VpwStatusBanner title="API token action complete" tone="success">
+          {apiTokenMessage}
+        </VpwStatusBanner>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/settings/SettingsWorkbenchHero.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchHero.tsx
@@ -3,12 +3,9 @@ import { Link } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 import {
   VpwBadge,
-  VpwPanel,
+  type VpwBadgeTone,
   VpwSection,
-  VpwSectionHeader,
   VpwStatusBanner,
-  VpwToolbar,
-  VpwToolbarGroup,
 } from "@/components/vpw"
 import {
   evidenceReadiness,
@@ -47,33 +44,64 @@ export function SettingsHero({
 
   return (
     <VpwSection aria-label="User Settings">
-      <VpwPanel className="flex flex-col gap-5 p-5">
-        <VpwSectionHeader
-          actions={
-            <Button asChild variant="outline">
-              <Link to="/providers">View providers</Link>
-            </Button>
-          }
-          description="Manage workspace access, API tokens, runtime configuration and diagnostics."
-          eyebrow="Workspace configuration"
-          title="Settings"
+      <div className="flex flex-col gap-4 border-b border-[var(--vpw-border-default)] pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          <p className="vpw-label text-[var(--vpw-teal)]">Settings console</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-[-0.01em] text-[var(--vpw-text-primary)]">
+            Workspace controls
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-[var(--vpw-text-secondary)]">
+            Access, automation tokens, provider state, and safe diagnostics.
+          </p>
+        </div>
+        <div className="flex shrink-0">
+          <Button asChild variant="outline">
+            <Link to="/providers">View providers</Link>
+          </Button>
+        </div>
+      </div>
+      <div className="mt-3 flex min-w-0 flex-wrap gap-2">
+        <SettingsHeroFact
+          label="Account"
+          tone={currentUser ? "success" : "warning"}
+          value={userLabel(currentUser)}
         />
-        <VpwToolbar label="Settings context" variant="plain">
-          <VpwToolbarGroup>
-            <VpwBadge tone={currentUser ? "success" : "warning"}>
-              {userLabel(currentUser)}
-            </VpwBadge>
-            <VpwBadge tone={apiTokens.length > 0 ? "info" : "neutral"}>
-              API tokens: {apiTokens.length}
-            </VpwBadge>
-            <VpwBadge tone={provider.tone}>
-              Snapshot: {providerStatus?.snapshot_mode ?? "loading"}
-            </VpwBadge>
-            <VpwBadge tone={evidence.tone}>Evidence: {evidence.label}</VpwBadge>
-          </VpwToolbarGroup>
-        </VpwToolbar>
-      </VpwPanel>
+        <SettingsHeroFact
+          label="API tokens"
+          tone={apiTokens.length > 0 ? "info" : "neutral"}
+          value={apiTokens.length}
+        />
+        <SettingsHeroFact
+          label="Snapshot"
+          tone={provider.tone}
+          value={providerStatus?.snapshot_mode ?? "loading"}
+        />
+        <SettingsHeroFact
+          label="Evidence"
+          tone={evidence.tone}
+          value={evidence.label}
+        />
+      </div>
     </VpwSection>
+  )
+}
+
+function SettingsHeroFact({
+  label,
+  tone,
+  value,
+}: {
+  label: string
+  tone: VpwBadgeTone
+  value: string | number
+}) {
+  return (
+    <div className="inline-flex min-w-0 items-center gap-2 rounded-[var(--vpw-radius-md)] border border-[var(--vpw-border-subtle)] bg-[var(--vpw-bg-card)] px-3 py-2 shadow-[var(--vpw-shadow-0)]">
+      <p className="vpw-label">{label}</p>
+      <div className="min-w-0">
+        <VpwBadge tone={tone}>{value}</VpwBadge>
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/components/settings/SettingsWorkbenchHero.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchHero.tsx
@@ -5,7 +5,6 @@ import {
   VpwBadge,
   type VpwBadgeTone,
   VpwSection,
-  VpwStatusBanner,
 } from "@/components/vpw"
 import {
   evidenceReadiness,
@@ -21,11 +20,6 @@ type SettingsHeroProps = Pick<
   | "providerStatus"
   | "providerStatusError"
   | "statusError"
->
-
-type SettingsAlertsProps = Pick<
-  SettingsWorkbenchProps,
-  "apiTokenError" | "apiTokenMessage" | "providerStatusError" | "statusError"
 >
 
 export function SettingsHero({
@@ -102,40 +96,5 @@ function SettingsHeroFact({
         <VpwBadge tone={tone}>{value}</VpwBadge>
       </div>
     </div>
-  )
-}
-
-export function SettingsAlerts({
-  apiTokenError,
-  apiTokenMessage,
-  providerStatusError,
-  statusError,
-}: SettingsAlertsProps) {
-  return (
-    <>
-      {statusError ? (
-        <VpwStatusBanner title="Workbench status unavailable" tone="critical">
-          {statusError}
-        </VpwStatusBanner>
-      ) : null}
-
-      {providerStatusError ? (
-        <VpwStatusBanner title="Provider status unavailable" tone="warning">
-          {providerStatusError}
-        </VpwStatusBanner>
-      ) : null}
-
-      {apiTokenError ? (
-        <VpwStatusBanner title="API token action failed" tone="critical">
-          {apiTokenError}
-        </VpwStatusBanner>
-      ) : null}
-
-      {apiTokenMessage ? (
-        <VpwStatusBanner title="API token action complete" tone="success">
-          {apiTokenMessage}
-        </VpwStatusBanner>
-      ) : null}
-    </>
   )
 }

--- a/frontend/src/components/settings/SettingsWorkbenchOverview.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchOverview.tsx
@@ -1,11 +1,13 @@
 import { Database, KeyRound, ShieldCheck, UserRound } from "lucide-react"
+import type { ReactNode } from "react"
 
 import {
   VpwGrid,
-  VpwKeyValueList,
   VpwMetricCard,
   VpwPanel,
   VpwProgress,
+  VpwBadge,
+  type VpwBadgeTone,
   VpwSectionHeader,
   VpwSkeletonStack,
 } from "@/components/vpw"
@@ -111,14 +113,15 @@ export function SettingsAccountHealth({
   const provider = providerHealth(providerStatus)
 
   return (
-    <VpwGrid columns={2}>
-      <VpwPanel className="flex flex-col gap-5 p-5">
-        <VpwSectionHeader
-          description="Current authenticated account and workspace runtime state."
-          title="Account and session"
-        />
-        <VpwKeyValueList
-          columns={2}
+    <VpwGrid className="items-start" columns={2}>
+      <VpwPanel className="overflow-hidden p-0">
+        <div className="border-b border-[var(--vpw-border-subtle)] px-5 py-4">
+          <VpwSectionHeader
+            description="Current account and session state."
+            title="Account and session"
+          />
+        </div>
+        <SettingsFactRows
           items={[
             {
               label: "Signed-in user",
@@ -144,16 +147,19 @@ export function SettingsAccountHealth({
         />
       </VpwPanel>
 
-      <VpwPanel className="flex flex-col gap-5 p-5">
-        <VpwSectionHeader
-          description="Token inventory, provider health, and reproducibility signals."
-          title="Setup health"
-        />
+      <VpwPanel className="overflow-hidden p-0">
+        <div className="border-b border-[var(--vpw-border-subtle)] px-5 py-4">
+          <VpwSectionHeader
+            description="Token inventory, provider health, and reproducibility signals."
+            title="Setup health"
+          />
+        </div>
         {providerStatusLoading ? (
-          <VpwSkeletonStack rows={4} />
+          <div className="p-5">
+            <VpwSkeletonStack rows={4} />
+          </div>
         ) : (
-          <VpwKeyValueList
-            columns={2}
+          <SettingsFactRows
             items={[
               {
                 label: "Backend status",
@@ -186,12 +192,42 @@ export function SettingsAccountHealth({
             ]}
           />
         )}
-        <VpwProgress
-          label="Active token coverage"
-          tone={apiTokens.length > 0 ? "info" : "neutral"}
-          value={tokenActivityPercent(apiTokens)}
-        />
+        <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_58%,var(--vpw-bg-card))] px-5 py-4">
+          <VpwProgress
+            label="Active token coverage"
+            tone={apiTokens.length > 0 ? "info" : "neutral"}
+            value={tokenActivityPercent(apiTokens)}
+          />
+        </div>
       </VpwPanel>
     </VpwGrid>
+  )
+}
+
+type SettingsFactRow = {
+  label: string
+  value: ReactNode
+  tone?: VpwBadgeTone
+}
+
+function SettingsFactRows({ items }: { items: readonly SettingsFactRow[] }) {
+  return (
+    <dl className="divide-y divide-[var(--vpw-border-subtle)]">
+      {items.map((item) => (
+        <div
+          className="grid gap-1 px-5 py-3.5 sm:grid-cols-[minmax(8rem,0.38fr)_minmax(0,1fr)] sm:items-center"
+          key={item.label}
+        >
+          <dt className="vpw-label">{item.label}</dt>
+          <dd className="min-w-0 font-medium text-[var(--vpw-text-primary)] [overflow-wrap:anywhere]">
+            {item.tone ? (
+              <VpwBadge tone={item.tone}>{item.value}</VpwBadge>
+            ) : (
+              item.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
   )
 }

--- a/frontend/src/components/settings/SettingsWorkbenchOverview.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchOverview.tsx
@@ -1,13 +1,10 @@
 import { Database, KeyRound, ShieldCheck, UserRound } from "lucide-react"
-import type { ReactNode } from "react"
 
 import {
   VpwGrid,
   VpwMetricCard,
   VpwPanel,
   VpwProgress,
-  VpwBadge,
-  type VpwBadgeTone,
   VpwSectionHeader,
   VpwSkeletonStack,
 } from "@/components/vpw"
@@ -22,6 +19,7 @@ import {
   providerHealth,
   type SettingsWorkbenchProps,
 } from "./settings-workbench-model"
+import { SettingsFactRows } from "./SettingsFactRows"
 
 type SettingsMetricsProps = Pick<
   SettingsWorkbenchProps,
@@ -201,33 +199,5 @@ export function SettingsAccountHealth({
         </div>
       </VpwPanel>
     </VpwGrid>
-  )
-}
-
-type SettingsFactRow = {
-  label: string
-  value: ReactNode
-  tone?: VpwBadgeTone
-}
-
-function SettingsFactRows({ items }: { items: readonly SettingsFactRow[] }) {
-  return (
-    <dl className="divide-y divide-[var(--vpw-border-subtle)]">
-      {items.map((item) => (
-        <div
-          className="grid gap-1 px-5 py-3.5 sm:grid-cols-[minmax(8rem,0.38fr)_minmax(0,1fr)] sm:items-center"
-          key={item.label}
-        >
-          <dt className="vpw-label">{item.label}</dt>
-          <dd className="min-w-0 font-medium text-[var(--vpw-text-primary)] [overflow-wrap:anywhere]">
-            {item.tone ? (
-              <VpwBadge tone={item.tone}>{item.value}</VpwBadge>
-            ) : (
-              item.value
-            )}
-          </dd>
-        </div>
-      ))}
-    </dl>
   )
 }

--- a/frontend/src/components/settings/SettingsWorkbenchRuntime.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchRuntime.tsx
@@ -1,211 +1,16 @@
-import type { ProviderStatusPublic, WorkbenchStatus } from "@/api-client"
-import { Info, ShieldAlert } from "lucide-react"
-import type { ReactNode } from "react"
-import {
-  VpwBadge,
-  type VpwBadgeTone,
-  VpwCodeBlock,
-  VpwDataTable,
-  type VpwDataTableColumn,
-  VpwPanel,
-  VpwSection,
-  VpwSectionHeader,
-} from "@/components/vpw"
-import { providerSnapshotSummary } from "@/lib/provider-format"
+import type { ProviderStatusPublic } from "@/api-client"
+import { VpwSection } from "@/components/vpw"
+import { SettingsDiagnosticsPanel } from "./SettingsDiagnosticsPanel"
+import { SettingsRuntimeProviderPanel } from "./SettingsRuntimeProviderPanel"
 import {
   evidenceReadiness,
-  type ProviderConfigRow,
-  providerConfigRows,
   type SettingsWorkbenchProps,
-  safeDiagnosticsCode,
 } from "./settings-workbench-model"
 
 type SettingsDiagnosticsProps = Pick<
   SettingsWorkbenchProps,
   "providerStatus" | "providerStatusError" | "status" | "statusError"
 >
-
-const providerColumns: VpwDataTableColumn<ProviderConfigRow>[] = [
-  {
-    id: "setting",
-    header: "Setting",
-    cell: (row) => (
-      <p className="font-medium text-[var(--vpw-text-primary)]">
-        {row.setting}
-      </p>
-    ),
-  },
-  {
-    id: "value",
-    header: "Value",
-    cell: (row) => <VpwBadge tone={row.tone}>{row.value}</VpwBadge>,
-  },
-  {
-    id: "detail",
-    header: "Details",
-    cell: (row) => (
-      <span className="text-sm text-[var(--vpw-text-secondary)]">
-        {row.detail}
-      </span>
-    ),
-  },
-]
-
-function ProviderRuntimeConfiguration({
-  providerStatus,
-}: {
-  providerStatus: ProviderStatusPublic | null
-}) {
-  return (
-    <VpwPanel className="overflow-hidden p-0">
-      <div className="border-b border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] px-5 py-4">
-        <VpwSectionHeader
-          description="Safe provider configuration values reported by existing APIs."
-          title="Runtime & providers"
-        />
-      </div>
-      <div className="p-4">
-        <VpwDataTable
-          caption="Provider runtime configuration"
-          columns={providerColumns}
-          data={providerConfigRows(providerStatus)}
-          density="compact"
-          getRowKey={(row) => row.id}
-        />
-      </div>
-      <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-blue)_6%,var(--vpw-bg-card))] px-5 py-3">
-        <p className="flex gap-2 text-sm leading-6 text-[var(--vpw-text-secondary)]">
-          <Info
-            aria-hidden="true"
-            className="mt-1 h-4 w-4 shrink-0 text-[var(--vpw-blue)]"
-          />
-          <span>
-            <span className="font-medium text-[var(--vpw-text-primary)]">
-              Secrets are not displayed.
-            </span>{" "}
-            Provider keys, environment secrets, and stored token secrets stay
-            outside Settings.
-          </span>
-        </p>
-      </div>
-    </VpwPanel>
-  )
-}
-
-function DiagnosticsPanel({
-  evidence,
-  providerStatus,
-  status,
-  statusError,
-}: {
-  evidence: ReturnType<typeof evidenceReadiness>
-  providerStatus: ProviderStatusPublic | null
-  status: WorkbenchStatus | null
-  statusError: string
-}) {
-  const diagnosticsCode = safeDiagnosticsCode({
-    providerStatus,
-    status,
-    statusError,
-  })
-
-  return (
-    <VpwPanel className="overflow-hidden p-0">
-      <div className="border-b border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] px-5 py-4">
-        <VpwSectionHeader
-          description="Support-only facts for troubleshooting. Expand JSON only when you need to share safe diagnostics."
-          title="Diagnostics"
-        />
-      </div>
-      <SettingsDiagnosticRows
-        items={[
-          {
-            label: "Frontend",
-            value: "Vite app",
-          },
-          {
-            label: "Backend version",
-            value: status?.core_version ?? "Not reported",
-          },
-          {
-            label: "Provider freshness",
-            value: providerSnapshotSummary(providerStatus),
-          },
-          {
-            label: "Evidence readiness",
-            value: evidence.label,
-            tone: evidence.tone,
-          },
-        ]}
-      />
-      <details className="group border-t border-[var(--vpw-border-subtle)] bg-[var(--vpw-bg-card)]">
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-[var(--vpw-text-primary)] marker:hidden">
-          Safe diagnostics payload
-          <span className="font-mono text-xs text-[var(--vpw-text-muted)] group-open:hidden">
-            Expand
-          </span>
-          <span className="hidden font-mono text-xs text-[var(--vpw-text-muted)] group-open:inline">
-            Collapse
-          </span>
-        </summary>
-        <div className="border-t border-[var(--vpw-border-subtle)] p-3">
-          <VpwCodeBlock
-            code={diagnosticsCode}
-            label="Safe diagnostics"
-            onCopy={() => void navigator.clipboard?.writeText(diagnosticsCode)}
-          />
-        </div>
-      </details>
-      <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-amber)_9%,var(--vpw-bg-card))] px-5 py-3">
-        <p className="flex gap-2 text-sm leading-6 text-[var(--vpw-text-secondary)]">
-          <ShieldAlert
-            aria-hidden="true"
-            className="mt-1 h-4 w-4 shrink-0 text-[var(--vpw-amber)]"
-          />
-          <span>
-            <span className="font-medium text-[var(--vpw-text-primary)]">
-              Generated client stays managed.
-            </span>{" "}
-            API contracts are consumed through the generated client and should
-            not be edited by hand.
-          </span>
-        </p>
-      </div>
-    </VpwPanel>
-  )
-}
-
-type SettingsDiagnosticRow = {
-  label: string
-  value: ReactNode
-  tone?: VpwBadgeTone
-}
-
-function SettingsDiagnosticRows({
-  items,
-}: {
-  items: readonly SettingsDiagnosticRow[]
-}) {
-  return (
-    <dl className="grid divide-y divide-[var(--vpw-border-subtle)] lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-      {items.map((item) => (
-        <div
-          className="min-w-0 px-5 py-4 odd:lg:border-b odd:lg:border-[var(--vpw-border-subtle)] even:lg:border-b even:lg:border-[var(--vpw-border-subtle)]"
-          key={item.label}
-        >
-          <dt className="vpw-label">{item.label}</dt>
-          <dd className="mt-2 min-w-0 font-medium text-[var(--vpw-text-primary)] [overflow-wrap:anywhere]">
-            {item.tone ? (
-              <VpwBadge tone={item.tone}>{item.value}</VpwBadge>
-            ) : (
-              item.value
-            )}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  )
-}
 
 export function SettingsRuntimeProviders({
   providerStatus,
@@ -214,7 +19,7 @@ export function SettingsRuntimeProviders({
 }) {
   return (
     <VpwSection aria-label="Runtime and providers">
-      <ProviderRuntimeConfiguration providerStatus={providerStatus} />
+      <SettingsRuntimeProviderPanel providerStatus={providerStatus} />
     </VpwSection>
   )
 }
@@ -233,7 +38,7 @@ export function SettingsDiagnostics({
 
   return (
     <VpwSection aria-label="Diagnostics">
-      <DiagnosticsPanel
+      <SettingsDiagnosticsPanel
         evidence={evidence}
         providerStatus={providerStatus}
         status={status}

--- a/frontend/src/components/settings/SettingsWorkbenchRuntime.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchRuntime.tsx
@@ -1,15 +1,15 @@
 import type { ProviderStatusPublic, WorkbenchStatus } from "@/api-client"
+import { Info, ShieldAlert } from "lucide-react"
+import type { ReactNode } from "react"
 import {
   VpwBadge,
+  type VpwBadgeTone,
   VpwCodeBlock,
   VpwDataTable,
   type VpwDataTableColumn,
-  VpwGrid,
-  VpwKeyValueList,
   VpwPanel,
   VpwSection,
   VpwSectionHeader,
-  VpwStatusBanner,
 } from "@/components/vpw"
 import { providerSnapshotSummary } from "@/lib/provider-format"
 import {
@@ -20,7 +20,7 @@ import {
   safeDiagnosticsCode,
 } from "./settings-workbench-model"
 
-type SettingsRuntimeDiagnosticsProps = Pick<
+type SettingsDiagnosticsProps = Pick<
   SettingsWorkbenchProps,
   "providerStatus" | "providerStatusError" | "status" | "statusError"
 >
@@ -57,22 +57,37 @@ function ProviderRuntimeConfiguration({
   providerStatus: ProviderStatusPublic | null
 }) {
   return (
-    <VpwPanel className="flex flex-col gap-5 p-5">
-      <VpwSectionHeader
-        description="Safe runtime and provider configuration values reported by existing APIs."
-        title="Provider and runtime configuration"
-      />
-      <VpwDataTable
-        caption="Provider runtime configuration"
-        columns={providerColumns}
-        data={providerConfigRows(providerStatus)}
-        density="compact"
-        getRowKey={(row) => row.id}
-      />
-      <VpwStatusBanner title="Secrets are not displayed" tone="info">
-        Provider keys, environment secrets, and stored token secrets are not
-        rendered in Settings. Use environment variables for provider keys.
-      </VpwStatusBanner>
+    <VpwPanel className="overflow-hidden p-0">
+      <div className="border-b border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] px-5 py-4">
+        <VpwSectionHeader
+          description="Safe provider configuration values reported by existing APIs."
+          title="Runtime & providers"
+        />
+      </div>
+      <div className="p-4">
+        <VpwDataTable
+          caption="Provider runtime configuration"
+          columns={providerColumns}
+          data={providerConfigRows(providerStatus)}
+          density="compact"
+          getRowKey={(row) => row.id}
+        />
+      </div>
+      <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-blue)_6%,var(--vpw-bg-card))] px-5 py-3">
+        <p className="flex gap-2 text-sm leading-6 text-[var(--vpw-text-secondary)]">
+          <Info
+            aria-hidden="true"
+            className="mt-1 h-4 w-4 shrink-0 text-[var(--vpw-blue)]"
+          />
+          <span>
+            <span className="font-medium text-[var(--vpw-text-primary)]">
+              Secrets are not displayed.
+            </span>{" "}
+            Provider keys, environment secrets, and stored token secrets stay
+            outside Settings.
+          </span>
+        </p>
+      </div>
     </VpwPanel>
   )
 }
@@ -88,14 +103,21 @@ function DiagnosticsPanel({
   status: WorkbenchStatus | null
   statusError: string
 }) {
+  const diagnosticsCode = safeDiagnosticsCode({
+    providerStatus,
+    status,
+    statusError,
+  })
+
   return (
-    <VpwPanel className="flex flex-col gap-5 p-5">
-      <VpwSectionHeader
-        description="Compact troubleshooting facts for support and evidence checks."
-        title="Diagnostics"
-      />
-      <VpwKeyValueList
-        columns={2}
+    <VpwPanel className="overflow-hidden p-0">
+      <div className="border-b border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] px-5 py-4">
+        <VpwSectionHeader
+          description="Support-only facts for troubleshooting. Expand JSON only when you need to share safe diagnostics."
+          title="Diagnostics"
+        />
+      </div>
+      <SettingsDiagnosticRows
         items={[
           {
             label: "Frontend",
@@ -116,24 +138,93 @@ function DiagnosticsPanel({
           },
         ]}
       />
-      <VpwCodeBlock
-        code={safeDiagnosticsCode({ providerStatus, status, statusError })}
-        label="Safe diagnostics"
-      />
-      <VpwStatusBanner title="Generated client stays managed" tone="warning">
-        API contracts are consumed through the generated client and should not
-        be edited by hand.
-      </VpwStatusBanner>
+      <details className="group border-t border-[var(--vpw-border-subtle)] bg-[var(--vpw-bg-card)]">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-[var(--vpw-text-primary)] marker:hidden">
+          Safe diagnostics payload
+          <span className="font-mono text-xs text-[var(--vpw-text-muted)] group-open:hidden">
+            Expand
+          </span>
+          <span className="hidden font-mono text-xs text-[var(--vpw-text-muted)] group-open:inline">
+            Collapse
+          </span>
+        </summary>
+        <div className="border-t border-[var(--vpw-border-subtle)] p-3">
+          <VpwCodeBlock
+            code={diagnosticsCode}
+            label="Safe diagnostics"
+            onCopy={() => void navigator.clipboard?.writeText(diagnosticsCode)}
+          />
+        </div>
+      </details>
+      <div className="border-t border-[var(--vpw-border-subtle)] bg-[color-mix(in_srgb,var(--vpw-amber)_9%,var(--vpw-bg-card))] px-5 py-3">
+        <p className="flex gap-2 text-sm leading-6 text-[var(--vpw-text-secondary)]">
+          <ShieldAlert
+            aria-hidden="true"
+            className="mt-1 h-4 w-4 shrink-0 text-[var(--vpw-amber)]"
+          />
+          <span>
+            <span className="font-medium text-[var(--vpw-text-primary)]">
+              Generated client stays managed.
+            </span>{" "}
+            API contracts are consumed through the generated client and should
+            not be edited by hand.
+          </span>
+        </p>
+      </div>
     </VpwPanel>
   )
 }
 
-export function SettingsRuntimeDiagnostics({
+type SettingsDiagnosticRow = {
+  label: string
+  value: ReactNode
+  tone?: VpwBadgeTone
+}
+
+function SettingsDiagnosticRows({
+  items,
+}: {
+  items: readonly SettingsDiagnosticRow[]
+}) {
+  return (
+    <dl className="grid divide-y divide-[var(--vpw-border-subtle)] lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+      {items.map((item) => (
+        <div
+          className="min-w-0 px-5 py-4 odd:lg:border-b odd:lg:border-[var(--vpw-border-subtle)] even:lg:border-b even:lg:border-[var(--vpw-border-subtle)]"
+          key={item.label}
+        >
+          <dt className="vpw-label">{item.label}</dt>
+          <dd className="mt-2 min-w-0 font-medium text-[var(--vpw-text-primary)] [overflow-wrap:anywhere]">
+            {item.tone ? (
+              <VpwBadge tone={item.tone}>{item.value}</VpwBadge>
+            ) : (
+              item.value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+export function SettingsRuntimeProviders({
+  providerStatus,
+}: {
+  providerStatus: ProviderStatusPublic | null
+}) {
+  return (
+    <VpwSection aria-label="Runtime and providers">
+      <ProviderRuntimeConfiguration providerStatus={providerStatus} />
+    </VpwSection>
+  )
+}
+
+export function SettingsDiagnostics({
   providerStatus,
   providerStatusError,
   status,
   statusError,
-}: SettingsRuntimeDiagnosticsProps) {
+}: SettingsDiagnosticsProps) {
   const evidence = evidenceReadiness(
     providerStatus,
     providerStatusError,
@@ -141,37 +232,13 @@ export function SettingsRuntimeDiagnostics({
   )
 
   return (
-    <VpwGrid columns={2}>
-      <ProviderRuntimeConfiguration providerStatus={providerStatus} />
+    <VpwSection aria-label="Diagnostics">
       <DiagnosticsPanel
         evidence={evidence}
         providerStatus={providerStatus}
         status={status}
         statusError={statusError}
       />
-    </VpwGrid>
-  )
-}
-
-export function SettingsSecurityNotes() {
-  return (
-    <VpwSection>
-      <VpwSectionHeader
-        description="Operational guardrails for access and troubleshooting."
-        title="Security notes"
-      />
-      <VpwGrid columns={3}>
-        <VpwStatusBanner title="Do not share API tokens" tone="critical">
-          Treat service tokens like passwords and revoke unused tokens.
-        </VpwStatusBanner>
-        <VpwStatusBanner title="Accepted diagnostics only" tone="info">
-          Diagnostics show status and version metadata, not provider secrets.
-        </VpwStatusBanner>
-        <VpwStatusBanner title="Evidence remains reproducible" tone="success">
-          Provider snapshot state is visible so generated reports can explain
-          their data sources.
-        </VpwStatusBanner>
-      </VpwGrid>
     </VpwSection>
   )
 }

--- a/frontend/src/components/settings/SettingsWorkbenchSections.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchSections.tsx
@@ -1,4 +1,5 @@
-export { SettingsAlerts, SettingsHero } from "./SettingsWorkbenchHero"
+export { SettingsAlerts } from "./SettingsWorkbenchAlerts"
+export { SettingsHero } from "./SettingsWorkbenchHero"
 export {
   SettingsAccountHealth,
   SettingsMetrics,

--- a/frontend/src/components/settings/SettingsWorkbenchSections.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchSections.tsx
@@ -4,7 +4,7 @@ export {
   SettingsMetrics,
 } from "./SettingsWorkbenchOverview"
 export {
-  SettingsRuntimeDiagnostics,
-  SettingsSecurityNotes,
+  SettingsDiagnostics,
+  SettingsRuntimeProviders,
 } from "./SettingsWorkbenchRuntime"
 export { SettingsApiTokensSection } from "./SettingsWorkbenchTokens"

--- a/frontend/src/components/settings/SettingsWorkbenchTokens.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchTokens.tsx
@@ -1,5 +1,5 @@
-import { Link } from "@tanstack/react-router"
-import { KeyRound, ShieldAlert } from "lucide-react"
+import { KeyRound, Plus, ShieldAlert } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -12,11 +12,17 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import {
   VpwBadge,
   VpwDataTable,
   VpwEmptyState,
   VpwField,
-  VpwGrid,
   VpwPanel,
   VpwSection,
   VpwSectionHeader,
@@ -41,6 +47,7 @@ type SettingsApiTokensSectionProps = Pick<
   | "createdApiToken"
   | "onApiTokenNameChange"
   | "onApiTokenProjectChange"
+  | "onClearCreatedApiToken"
   | "onCreateApiToken"
   | "onRevokeApiToken"
   | "onToggleApiTokenScope"
@@ -58,186 +65,290 @@ export function SettingsApiTokensSection({
   createdApiToken,
   onApiTokenNameChange,
   onApiTokenProjectChange,
+  onClearCreatedApiToken,
   onCreateApiToken,
   onRevokeApiToken,
   onToggleApiTokenScope,
 }: SettingsApiTokensSectionProps) {
+  const [tokenSheetOpen, setTokenSheetOpen] = useState(false)
   const activeTokens = activeTokenCount(apiTokens)
-  const tokenHasAdminScope = apiTokenScopes.includes("admin")
   const tokenColumns = buildApiTokenColumns({
     actionLoading: apiTokenActionLoading,
     projects: apiTokenProjectOptions,
     onRevokeApiToken,
   })
 
+  useEffect(() => {
+    if (createdApiToken) {
+      setTokenSheetOpen(true)
+    }
+  }, [createdApiToken])
+
+  function handleTokenSheetOpenChange(open: boolean) {
+    setTokenSheetOpen(open)
+    if (!open) {
+      onClearCreatedApiToken()
+    }
+  }
+
   return (
     <VpwSection aria-label="API tokens">
-      <VpwSectionHeader
-        actions={
-          <VpwBadge tone={activeTokens > 0 ? "success" : "neutral"}>
-            Active tokens: {activeTokens}
-          </VpwBadge>
-        }
-        description="Create service tokens for automation and revoke tokens that should no longer access the Workbench."
-        title="API tokens"
-      />
-      <VpwGrid columns={2}>
-        <VpwPanel className="flex flex-col gap-5 p-5">
-          <VpwSectionHeader
-            description="Select the least-privilege scopes required by the service account."
-            eyebrow="Access"
-            title="Service Token"
-          />
-          {tokenHasAdminScope ? (
-            <VpwStatusBanner title="Admin scope is global" tone="warning">
-              Admin tokens bypass the project boundary. Use only for trusted
-              break-glass automation.
-            </VpwStatusBanner>
-          ) : null}
-          <form className="flex flex-col gap-5" onSubmit={onCreateApiToken}>
-            <VpwField
-              description="Use a short automation or integration name."
-              htmlFor="api-token-name"
-              label="Name"
-              required
-            >
-              <Input
-                id="api-token-name"
-                maxLength={200}
-                onChange={(event) => onApiTokenNameChange(event.target.value)}
-                value={apiTokenName}
-              />
-            </VpwField>
-
-            <VpwField label="Scopes" required>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {apiTokenScopeOptions.map((scope) => {
-                  const checked = apiTokenScopes.includes(scope)
-                  const scopeId = `api-token-scope-${scope}`
-                  return (
-                    <label
-                      className="block cursor-pointer"
-                      htmlFor={scopeId}
-                      key={scope}
-                    >
-                      <Checkbox
-                        checked={checked}
-                        className="peer sr-only"
-                        id={scopeId}
-                        onCheckedChange={() => onToggleApiTokenScope(scope)}
-                      />
-                      <VpwSelectionCard
-                        as="span"
-                        checked={checked}
-                        className="cursor-pointer peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--vpw-blue)] peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--vpw-bg-default)]"
-                        meta={scope === "admin" ? "Privileged" : "Service"}
-                        title={scope.toUpperCase()}
-                      >
-                        {scope === "read"
-                          ? "Read workbench findings and evidence metadata."
-                          : scope === "import"
-                            ? "Create import runs and normalize supplied inputs."
-                            : scope === "report"
-                              ? "Generate and download report artifacts."
-                              : "Root-equivalent global access for trusted operators."}
-                      </VpwSelectionCard>
-                    </label>
-                  )
-                })}
-              </div>
-            </VpwField>
-
-            <VpwField
-              description={
-                tokenHasAdminScope
-                  ? "Admin tokens are root-equivalent and global."
-                  : "Required project boundary for service tokens."
-              }
-              htmlFor="api-token-project"
-              label="Project scope"
-              required={!tokenHasAdminScope}
-            >
-              <Select
-                disabled={
-                  tokenHasAdminScope || apiTokenProjectOptions.length === 0
-                }
-                onValueChange={onApiTokenProjectChange}
-                value={apiTokenProjectId}
-              >
-                <SelectTrigger id="api-token-project">
-                  <SelectValue placeholder="Select project" />
-                </SelectTrigger>
-                <SelectContent>
-                  {apiTokenProjectOptions.map((project) => (
-                    <SelectItem key={project.id} value={project.id}>
-                      {project.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </VpwField>
-
-            <Button
-              aria-busy={apiTokenActionLoading}
-              disabled={
-                apiTokenActionLoading ||
-                (!tokenHasAdminScope && apiTokenProjectOptions.length === 0)
-              }
-              type="submit"
-            >
-              {apiTokenActionLoading ? "Creating" : "Create Token"}
-            </Button>
-          </form>
-        </VpwPanel>
-
-        <VpwPanel className="flex flex-col gap-5 p-5">
-          <VpwSectionHeader
-            description="Token secrets are masked by default and only available during the one-time creation response."
-            eyebrow="One-time secret"
-            title="Creation result"
-          />
-          <SettingsTokenCreationResult createdApiToken={createdApiToken} />
-        </VpwPanel>
-      </VpwGrid>
-
       <VpwPanel className="p-0">
-        {activeTokens > 0 ? (
-          <div className="border-b border-[var(--vpw-border-default)] p-4">
-            <VpwStatusBanner title="Revocation is immediate" tone="warning">
-              <span className="inline-flex items-center gap-2">
-                <ShieldAlert aria-hidden="true" className="h-4 w-4" />
-                Revoke tokens before deleting automation credentials or rotating
-                project access.
-              </span>
-            </VpwStatusBanner>
+        <div className="flex flex-col gap-4 border-b border-[var(--vpw-border-default)] bg-[color-mix(in_srgb,var(--vpw-bg-panel)_52%,var(--vpw-bg-card))] p-5 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <p className="vpw-label">Token inventory</p>
+            <h2 className="mt-1 text-xl font-semibold tracking-[-0.01em] text-[var(--vpw-text-primary)]">
+              API tokens
+            </h2>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-[var(--vpw-text-secondary)]">
+              Existing tokens are shown without secrets. Create new secrets only
+              when automation needs scoped Workbench API access.
+            </p>
+            {activeTokens > 0 ? (
+              <div className="mt-3 inline-flex max-w-full items-start gap-2 rounded-[var(--vpw-radius-md)] border border-[color-mix(in_srgb,var(--vpw-amber)_30%,var(--vpw-bg-card))] bg-[var(--vpw-bg-warning)] px-3 py-2 text-sm text-[color-mix(in_srgb,var(--vpw-amber)_58%,var(--vpw-text-primary))]">
+                <ShieldAlert
+                  aria-hidden="true"
+                  className="mt-0.5 h-4 w-4 shrink-0"
+                />
+                <span className="leading-5">
+                  Revocation is immediate. Rotate automation credentials before
+                  deleting project access.
+                </span>
+              </div>
+            ) : null}
           </div>
-        ) : null}
-        {apiTokensLoading ? (
-          <div className="p-5">
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <VpwBadge tone={activeTokens > 0 ? "success" : "neutral"}>
+              Active tokens: {activeTokens}
+            </VpwBadge>
+            <Button onClick={() => setTokenSheetOpen(true)} type="button">
+              <Plus aria-hidden="true" className="h-4 w-4" />
+              Create token
+            </Button>
+          </div>
+        </div>
+        <div className="p-4">
+          {apiTokensLoading ? (
             <VpwSkeletonStack rows={6} />
-          </div>
-        ) : (
-          <VpwDataTable
-            caption="API tokens table"
-            columns={tokenColumns}
-            data={apiTokens}
-            density="compact"
-            emptyState={
-              <VpwEmptyState
-                action={
-                  <Button asChild variant="outline">
-                    <Link to="/findings">View findings</Link>
-                  </Button>
-                }
-                description="Create a token when automation needs scoped access to Workbench APIs."
-                icon={<KeyRound aria-hidden="true" className="h-5 w-5" />}
-                title="No API tokens yet"
-              />
-            }
-            getRowKey={(token) => token.id}
-          />
-        )}
+          ) : (
+            <VpwDataTable
+              caption="API tokens table"
+              columns={tokenColumns}
+              data={apiTokens}
+              density="compact"
+              emptyState={
+                <VpwEmptyState
+                  action={
+                    <Button
+                      onClick={() => setTokenSheetOpen(true)}
+                      type="button"
+                      variant="outline"
+                    >
+                      <Plus aria-hidden="true" className="h-4 w-4" />
+                      Create token
+                    </Button>
+                  }
+                  description="Create a token when automation needs scoped access to Workbench APIs."
+                  icon={<KeyRound aria-hidden="true" className="h-5 w-5" />}
+                  title="No API tokens yet"
+                />
+              }
+              getRowKey={(token) => token.id}
+              minWidth="920px"
+            />
+          )}
+        </div>
       </VpwPanel>
+      <SettingsTokenCreateSheet
+        apiTokenActionLoading={apiTokenActionLoading}
+        apiTokenName={apiTokenName}
+        apiTokenProjectId={apiTokenProjectId}
+        apiTokenProjectOptions={apiTokenProjectOptions}
+        apiTokenScopeOptions={apiTokenScopeOptions}
+        apiTokenScopes={apiTokenScopes}
+        createdApiToken={createdApiToken}
+        onApiTokenNameChange={onApiTokenNameChange}
+        onApiTokenProjectChange={onApiTokenProjectChange}
+        onCreateApiToken={onCreateApiToken}
+        onOpenChange={handleTokenSheetOpenChange}
+        onToggleApiTokenScope={onToggleApiTokenScope}
+        open={tokenSheetOpen}
+      />
     </VpwSection>
+  )
+}
+
+type SettingsTokenCreateSheetProps = Pick<
+  SettingsApiTokensSectionProps,
+  | "apiTokenActionLoading"
+  | "apiTokenName"
+  | "apiTokenProjectId"
+  | "apiTokenProjectOptions"
+  | "apiTokenScopeOptions"
+  | "apiTokenScopes"
+  | "createdApiToken"
+  | "onApiTokenNameChange"
+  | "onApiTokenProjectChange"
+  | "onCreateApiToken"
+  | "onToggleApiTokenScope"
+> & {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function SettingsTokenCreateSheet({
+  apiTokenActionLoading,
+  apiTokenName,
+  apiTokenProjectId,
+  apiTokenProjectOptions,
+  apiTokenScopeOptions,
+  apiTokenScopes,
+  createdApiToken,
+  onApiTokenNameChange,
+  onApiTokenProjectChange,
+  onCreateApiToken,
+  onOpenChange,
+  onToggleApiTokenScope,
+  open,
+}: SettingsTokenCreateSheetProps) {
+  const tokenHasAdminScope = apiTokenScopes.includes("admin")
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-[min(40rem,calc(100vw-2rem))] overflow-y-auto bg-[var(--vpw-bg-card)] p-0 text-[var(--vpw-text-primary)] sm:max-w-[40rem]">
+        <SheetHeader className="border-b border-[var(--vpw-border-default)] px-5 py-5 text-left">
+          <SheetTitle className="text-xl text-[var(--vpw-text-primary)]">
+            Create API token
+          </SheetTitle>
+          <SheetDescription className="text-sm leading-6 text-[var(--vpw-text-secondary)]">
+            Generate a scoped service token for automation. The cleartext secret
+            is only available in this drawer after creation.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-6 px-5 py-5">
+          <div className="flex flex-col gap-5">
+            <VpwSectionHeader
+              description="Select the least-privilege scopes required by the service account."
+              eyebrow="Access"
+              title="Service Token"
+            />
+            {tokenHasAdminScope ? (
+              <VpwStatusBanner title="Admin scope is global" tone="warning">
+                Admin tokens bypass the project boundary. Use only for trusted
+                break-glass automation.
+              </VpwStatusBanner>
+            ) : null}
+            <form className="flex flex-col gap-5" onSubmit={onCreateApiToken}>
+              <VpwField
+                description="Use a short automation or integration name."
+                htmlFor="api-token-name"
+                label="Name"
+                required
+              >
+                <Input
+                  id="api-token-name"
+                  maxLength={200}
+                  onChange={(event) =>
+                    onApiTokenNameChange(event.target.value)
+                  }
+                  value={apiTokenName}
+                />
+              </VpwField>
+
+              <VpwField label="Scopes" required>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {apiTokenScopeOptions.map((scope) => {
+                    const checked = apiTokenScopes.includes(scope)
+                    const scopeId = `api-token-scope-${scope}`
+                    return (
+                      <label
+                        className="block cursor-pointer"
+                        htmlFor={scopeId}
+                        key={scope}
+                      >
+                        <Checkbox
+                          checked={checked}
+                          className="peer sr-only"
+                          id={scopeId}
+                          onCheckedChange={() => onToggleApiTokenScope(scope)}
+                        />
+                        <VpwSelectionCard
+                          as="span"
+                          checked={checked}
+                          className="cursor-pointer peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--vpw-blue)] peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--vpw-bg-default)]"
+                          meta={scope === "admin" ? "Privileged" : "Service"}
+                          title={scope.toUpperCase()}
+                        >
+                          {scope === "read"
+                            ? "Read workbench findings and evidence metadata."
+                            : scope === "import"
+                              ? "Create import runs and normalize supplied inputs."
+                              : scope === "report"
+                                ? "Generate and download report artifacts."
+                                : "Root-equivalent global access for trusted operators."}
+                        </VpwSelectionCard>
+                      </label>
+                    )
+                  })}
+                </div>
+              </VpwField>
+
+              <VpwField
+                description={
+                  tokenHasAdminScope
+                    ? "Admin tokens are root-equivalent and global."
+                    : "Required project boundary for service tokens."
+                }
+                htmlFor="api-token-project"
+                label="Project scope"
+                required={!tokenHasAdminScope}
+              >
+                <Select
+                  disabled={
+                    tokenHasAdminScope || apiTokenProjectOptions.length === 0
+                  }
+                  onValueChange={onApiTokenProjectChange}
+                  value={apiTokenProjectId}
+                >
+                  <SelectTrigger id="api-token-project">
+                    <SelectValue placeholder="Select project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {apiTokenProjectOptions.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </VpwField>
+
+              <Button
+                aria-busy={apiTokenActionLoading}
+                disabled={
+                  apiTokenActionLoading ||
+                  (!tokenHasAdminScope && apiTokenProjectOptions.length === 0)
+                }
+                type="submit"
+              >
+                {apiTokenActionLoading ? "Creating" : "Create token"}
+              </Button>
+            </form>
+          </div>
+
+          <div className="border-t border-[var(--vpw-border-subtle)] pt-5">
+            <VpwSectionHeader
+              description="Token secrets are masked by default and only available during the one-time creation response."
+              eyebrow="One-time secret"
+              title="Creation result"
+            />
+            <div className="mt-5">
+              <SettingsTokenCreationResult createdApiToken={createdApiToken} />
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/frontend/src/components/settings/SettingsWorkbenchTokens.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchTokens.tsx
@@ -2,35 +2,15 @@ import { KeyRound, Plus, ShieldAlert } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet"
 import {
   VpwBadge,
   VpwDataTable,
   VpwEmptyState,
-  VpwField,
   VpwPanel,
   VpwSection,
-  VpwSectionHeader,
-  VpwSelectionCard,
   VpwSkeletonStack,
-  VpwStatusBanner,
 } from "@/components/vpw"
-import { SettingsTokenCreationResult } from "./SettingsTokenCreationResult"
+import { SettingsTokenCreateSheet } from "./SettingsTokenCreateSheet"
 import { activeTokenCount, buildApiTokenColumns } from "./settings-token-model"
 import type { SettingsWorkbenchProps } from "./settings-workbench-model"
 
@@ -175,180 +155,5 @@ export function SettingsApiTokensSection({
         open={tokenSheetOpen}
       />
     </VpwSection>
-  )
-}
-
-type SettingsTokenCreateSheetProps = Pick<
-  SettingsApiTokensSectionProps,
-  | "apiTokenActionLoading"
-  | "apiTokenName"
-  | "apiTokenProjectId"
-  | "apiTokenProjectOptions"
-  | "apiTokenScopeOptions"
-  | "apiTokenScopes"
-  | "createdApiToken"
-  | "onApiTokenNameChange"
-  | "onApiTokenProjectChange"
-  | "onCreateApiToken"
-  | "onToggleApiTokenScope"
-> & {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}
-
-function SettingsTokenCreateSheet({
-  apiTokenActionLoading,
-  apiTokenName,
-  apiTokenProjectId,
-  apiTokenProjectOptions,
-  apiTokenScopeOptions,
-  apiTokenScopes,
-  createdApiToken,
-  onApiTokenNameChange,
-  onApiTokenProjectChange,
-  onCreateApiToken,
-  onOpenChange,
-  onToggleApiTokenScope,
-  open,
-}: SettingsTokenCreateSheetProps) {
-  const tokenHasAdminScope = apiTokenScopes.includes("admin")
-
-  return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-[min(40rem,calc(100vw-2rem))] overflow-y-auto bg-[var(--vpw-bg-card)] p-0 text-[var(--vpw-text-primary)] sm:max-w-[40rem]">
-        <SheetHeader className="border-b border-[var(--vpw-border-default)] px-5 py-5 text-left">
-          <SheetTitle className="text-xl text-[var(--vpw-text-primary)]">
-            Create API token
-          </SheetTitle>
-          <SheetDescription className="text-sm leading-6 text-[var(--vpw-text-secondary)]">
-            Generate a scoped service token for automation. The cleartext secret
-            is only available in this drawer after creation.
-          </SheetDescription>
-        </SheetHeader>
-
-        <div className="flex flex-col gap-6 px-5 py-5">
-          <div className="flex flex-col gap-5">
-            <VpwSectionHeader
-              description="Select the least-privilege scopes required by the service account."
-              eyebrow="Access"
-              title="Service Token"
-            />
-            {tokenHasAdminScope ? (
-              <VpwStatusBanner title="Admin scope is global" tone="warning">
-                Admin tokens bypass the project boundary. Use only for trusted
-                break-glass automation.
-              </VpwStatusBanner>
-            ) : null}
-            <form className="flex flex-col gap-5" onSubmit={onCreateApiToken}>
-              <VpwField
-                description="Use a short automation or integration name."
-                htmlFor="api-token-name"
-                label="Name"
-                required
-              >
-                <Input
-                  id="api-token-name"
-                  maxLength={200}
-                  onChange={(event) =>
-                    onApiTokenNameChange(event.target.value)
-                  }
-                  value={apiTokenName}
-                />
-              </VpwField>
-
-              <VpwField label="Scopes" required>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {apiTokenScopeOptions.map((scope) => {
-                    const checked = apiTokenScopes.includes(scope)
-                    const scopeId = `api-token-scope-${scope}`
-                    return (
-                      <label
-                        className="block cursor-pointer"
-                        htmlFor={scopeId}
-                        key={scope}
-                      >
-                        <Checkbox
-                          checked={checked}
-                          className="peer sr-only"
-                          id={scopeId}
-                          onCheckedChange={() => onToggleApiTokenScope(scope)}
-                        />
-                        <VpwSelectionCard
-                          as="span"
-                          checked={checked}
-                          className="cursor-pointer peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--vpw-blue)] peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--vpw-bg-default)]"
-                          meta={scope === "admin" ? "Privileged" : "Service"}
-                          title={scope.toUpperCase()}
-                        >
-                          {scope === "read"
-                            ? "Read workbench findings and evidence metadata."
-                            : scope === "import"
-                              ? "Create import runs and normalize supplied inputs."
-                              : scope === "report"
-                                ? "Generate and download report artifacts."
-                                : "Root-equivalent global access for trusted operators."}
-                        </VpwSelectionCard>
-                      </label>
-                    )
-                  })}
-                </div>
-              </VpwField>
-
-              <VpwField
-                description={
-                  tokenHasAdminScope
-                    ? "Admin tokens are root-equivalent and global."
-                    : "Required project boundary for service tokens."
-                }
-                htmlFor="api-token-project"
-                label="Project scope"
-                required={!tokenHasAdminScope}
-              >
-                <Select
-                  disabled={
-                    tokenHasAdminScope || apiTokenProjectOptions.length === 0
-                  }
-                  onValueChange={onApiTokenProjectChange}
-                  value={apiTokenProjectId}
-                >
-                  <SelectTrigger id="api-token-project">
-                    <SelectValue placeholder="Select project" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {apiTokenProjectOptions.map((project) => (
-                      <SelectItem key={project.id} value={project.id}>
-                        {project.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </VpwField>
-
-              <Button
-                aria-busy={apiTokenActionLoading}
-                disabled={
-                  apiTokenActionLoading ||
-                  (!tokenHasAdminScope && apiTokenProjectOptions.length === 0)
-                }
-                type="submit"
-              >
-                {apiTokenActionLoading ? "Creating" : "Create token"}
-              </Button>
-            </form>
-          </div>
-
-          <div className="border-t border-[var(--vpw-border-subtle)] pt-5">
-            <VpwSectionHeader
-              description="Token secrets are masked by default and only available during the one-time creation response."
-              eyebrow="One-time secret"
-              title="Creation result"
-            />
-            <div className="mt-5">
-              <SettingsTokenCreationResult createdApiToken={createdApiToken} />
-            </div>
-          </div>
-        </div>
-      </SheetContent>
-    </Sheet>
   )
 }

--- a/frontend/src/components/settings/settings-token-model.tsx
+++ b/frontend/src/components/settings/settings-token-model.tsx
@@ -90,51 +90,51 @@ export function buildApiTokenColumns({
       cell: (token) => projectScopeLabel(token.project_id, projects),
     },
     {
-      id: "created",
-      header: "Created",
-      cell: (token) => formatDateTime(token.created_at),
-      className: "whitespace-nowrap",
-    },
-    {
-      id: "last-used",
-      header: "Last used",
-      cell: (token) => formatDateTime(token.last_used_at),
-      className: "whitespace-nowrap",
+      id: "activity",
+      header: "Activity",
+      cell: (token) => (
+        <div className="min-w-36 space-y-1 text-sm">
+          <p className="text-[var(--vpw-text-primary)]">
+            <span className="vpw-label mr-2">Created</span>
+            {formatDateTime(token.created_at)}
+          </p>
+          <p className="text-[var(--vpw-text-secondary)]">
+            <span className="vpw-label mr-2">Last used</span>
+            {formatDateTime(token.last_used_at)}
+          </p>
+        </div>
+      ),
     },
     {
       id: "expires",
       header: "Expires",
       cell: (token) => formatDateTime(token.expires_at),
-      className: "whitespace-nowrap",
     },
     {
-      id: "status",
-      header: "Status",
+      id: "access",
+      header: "Access",
       cell: (token) => (
-        <VpwBadge tone={statusBadgeTone(token.active)}>
-          {statusLabel(token.active)}
-        </VpwBadge>
+        <div className="flex min-w-28 flex-col items-start gap-2">
+          <VpwBadge tone={statusBadgeTone(token.active)}>
+            {statusLabel(token.active)}
+          </VpwBadge>
+          {token.active ? (
+            <Button
+              aria-busy={actionLoading}
+              disabled={actionLoading}
+              onClick={() => void onRevokeApiToken(token)}
+              size="sm"
+              type="button"
+              variant="destructive"
+            >
+              <Trash2 aria-hidden="true" className="h-4 w-4" />
+              Revoke
+            </Button>
+          ) : (
+            <span className="text-sm text-[var(--vpw-text-muted)]">N.A.</span>
+          )}
+        </div>
       ),
-    },
-    {
-      id: "actions",
-      header: "Actions",
-      cell: (token) =>
-        token.active ? (
-          <Button
-            aria-busy={actionLoading}
-            disabled={actionLoading}
-            onClick={() => void onRevokeApiToken(token)}
-            size="sm"
-            type="button"
-            variant="destructive"
-          >
-            <Trash2 aria-hidden="true" className="h-4 w-4" />
-            Revoke
-          </Button>
-        ) : (
-          <span className="text-sm text-[var(--vpw-text-muted)]">N.A.</span>
-        ),
     },
   ]
 }

--- a/frontend/src/components/settings/settings-token-model.tsx
+++ b/frontend/src/components/settings/settings-token-model.tsx
@@ -93,7 +93,7 @@ export function buildApiTokenColumns({
       id: "activity",
       header: "Activity",
       cell: (token) => (
-        <div className="min-w-36 space-y-1 text-sm">
+        <div className="flex min-w-36 flex-col gap-1 text-sm">
           <p className="text-[var(--vpw-text-primary)]">
             <span className="vpw-label mr-2">Created</span>
             {formatDateTime(token.created_at)}

--- a/frontend/src/components/settings/settings-workbench-model.ts
+++ b/frontend/src/components/settings/settings-workbench-model.ts
@@ -13,6 +13,7 @@ import { formatCacheAge, providerSnapshotSummary } from "@/lib/provider-format"
 import type { ApiTokenScope } from "./settings-token-model"
 
 export type SettingsWorkbenchProps = {
+  activeSettingsTab: SettingsTab
   apiTokenActionLoading: boolean
   apiTokenError: string
   apiTokenMessage: string
@@ -30,11 +31,34 @@ export type SettingsWorkbenchProps = {
   providerStatusLoading: boolean
   status: WorkbenchStatus | null
   statusError: string
+  onClearCreatedApiToken: () => void
   onApiTokenNameChange: (value: string) => void
   onApiTokenProjectChange: (value: string) => void
   onCreateApiToken: (event: FormEvent<HTMLFormElement>) => void | Promise<void>
   onRevokeApiToken: (token: ApiTokenPublic) => void | Promise<void>
+  onSettingsTabChange: (tab: SettingsTab) => void
   onToggleApiTokenScope: (scope: ApiTokenScope) => void
+}
+
+export const settingsTabOptions = [
+  { label: "Overview", value: "overview" },
+  { label: "API Tokens", value: "tokens" },
+  { label: "Runtime & Providers", value: "runtime" },
+  { label: "Diagnostics", value: "diagnostics" },
+] as const
+
+export type SettingsTab = (typeof settingsTabOptions)[number]["value"]
+
+const settingsTabValues = new Set<string>(
+  settingsTabOptions.map((option) => option.value),
+)
+
+export function normalizeSettingsTab(
+  value: string | null | undefined,
+): SettingsTab {
+  return value && settingsTabValues.has(value)
+    ? (value as SettingsTab)
+    : "overview"
 }
 
 export type ProviderConfigRow = {

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -20,7 +20,7 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     data-slot="sheet-overlay"
     className={cn(
-      "fixed inset-0 bg-foreground/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-foreground/50 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:opacity-0 data-[state=open]:!opacity-100 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -30,16 +30,16 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed isolate flex flex-col gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 isolate flex flex-col gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:!translate-y-0 data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:!translate-y-0 data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:!translate-x-0 data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:!translate-x-0 data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {

--- a/frontend/src/workbench/routes/SettingsRoute.tsx
+++ b/frontend/src/workbench/routes/SettingsRoute.tsx
@@ -1,3 +1,4 @@
+import { useLocation, useNavigate } from "@tanstack/react-router"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { type FormEvent, useEffect, useState } from "react"
 import {
@@ -6,6 +7,10 @@ import {
   type ApiTokenPublic,
 } from "../../api-client"
 import { SettingsRouteContainer } from "../../components/settings/SettingsRouteContainer"
+import {
+  normalizeSettingsTab,
+  type SettingsTab,
+} from "../../components/settings/settings-workbench-model"
 import { apiErrorMessage } from "../../lib/app-errors"
 import {
   type ApiTokenScope,
@@ -18,6 +23,8 @@ import { useApiTokensQuery } from "../useWorkbenchQueries"
 import { workbenchQueryKeys } from "../workbench-query-keys"
 
 function SettingsRouteContent() {
+  const location = useLocation()
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const {
     currentUser,
@@ -38,6 +45,12 @@ function SettingsRouteContent() {
   const [apiTokenProjectId, setApiTokenProjectId] = useState("")
   const [createdApiToken, setCreatedApiToken] =
     useState<ApiTokenCreatePublic | null>(null)
+  const routeSearch = activeSearchString(location.searchStr)
+  const activeSettingsTab = normalizeSettingsTab(
+    new URLSearchParams(
+      routeSearch.startsWith("?") ? routeSearch.slice(1) : routeSearch,
+    ).get("tab"),
+  )
   const apiTokensQuery = useApiTokensQuery(true)
   const createApiTokenMutation = useMutation({
     mutationFn: (apiTokenCreate: {
@@ -66,6 +79,22 @@ function SettingsRouteContent() {
       return projects[0]?.id ?? ""
     })
   }, [apiTokenScopes, projects, selectedProjectId])
+
+  useEffect(() => {
+    if (activeSettingsTab !== "tokens") {
+      setCreatedApiToken(null)
+    }
+  }, [activeSettingsTab])
+
+  function updateSettingsTab(tab: SettingsTab) {
+    if (tab !== "tokens") {
+      setCreatedApiToken(null)
+    }
+    void navigate({
+      search: settingsRouteSearch(activeSearchString(location.searchStr), tab),
+      to: "/settings",
+    })
+  }
 
   function toggleApiTokenScope(scope: ApiTokenScope) {
     setApiTokenScopes((previousScopes) => {
@@ -135,6 +164,7 @@ function SettingsRouteContent() {
   return (
     <section className="w-full">
       <SettingsRouteContainer
+        activeSettingsTab={activeSettingsTab}
         apiTokenActionLoading={
           createApiTokenMutation.isPending || revokeApiTokenMutation.isPending
         }
@@ -154,10 +184,12 @@ function SettingsRouteContent() {
         apiTokensLoading={apiTokensQuery.isLoading || apiTokensQuery.isFetching}
         createdApiToken={createdApiToken}
         currentUser={currentUser}
+        onClearCreatedApiToken={() => setCreatedApiToken(null)}
         onApiTokenNameChange={setApiTokenName}
         onApiTokenProjectChange={setApiTokenProjectId}
         onCreateApiToken={createApiToken}
         onRevokeApiToken={(token) => void revokeApiToken(token)}
+        onSettingsTabChange={updateSettingsTab}
         onToggleApiTokenScope={toggleApiTokenScope}
         providerStatus={providerStatus}
         providerStatusError={providerStatusError}
@@ -171,4 +203,19 @@ function SettingsRouteContent() {
 
 export function SettingsRoute() {
   return <SettingsRouteContent />
+}
+
+function settingsRouteSearch(searchStr: string, tab: SettingsTab) {
+  const rawSearch = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr
+  const params = new URLSearchParams(rawSearch)
+  if (tab === "overview") {
+    params.delete("tab")
+  } else {
+    params.set("tab", tab)
+  }
+  return Object.fromEntries(params.entries())
+}
+
+function activeSearchString(fallbackSearch: string) {
+  return typeof window === "undefined" ? fallbackSearch : window.location.search
 }

--- a/frontend/tests/settings-token.spec.ts
+++ b/frontend/tests/settings-token.spec.ts
@@ -21,21 +21,31 @@ test("workbench settings clears one-time API token when leaving settings", async
   expect(projectResponse.ok(), await projectResponse.text()).toBeTruthy()
   const project = (await projectResponse.json()) as { id: string; name: string }
 
-  await page.goto(`/settings?projectId=${project.id}`)
+  await page.goto(`/settings?projectId=${project.id}&tab=tokens`)
   await expect(
-    page.getByRole("heading", { name: "Service Token" }),
+    page.getByRole("region", { exact: true, name: "API tokens" }),
   ).toBeVisible()
-  const projectScope = page.getByRole("combobox", { name: "Project scope" })
+  await page.getByRole("button", { name: "Create token" }).first().click()
+  const tokenDrawer = page.getByRole("dialog", { name: "Create API token" })
+  await expect(tokenDrawer).toBeVisible()
+  await expect(
+    tokenDrawer.getByRole("heading", { name: "Service Token" }),
+  ).toBeVisible()
+  const projectScope = tokenDrawer.getByRole("combobox", {
+    name: "Project scope",
+  })
   await expect(projectScope).toBeEnabled()
   await expect(projectScope).toContainText(project.name)
-  const tokenForm = page.getByLabel("Name").locator("xpath=ancestor::form[1]")
+  const tokenForm = tokenDrawer
+    .getByLabel("Name")
+    .locator("xpath=ancestor::form[1]")
   const writeScope = tokenForm.getByRole("checkbox", { name: /WRITE/i })
   await expect(writeScope).not.toBeChecked()
   await tokenForm.getByText("WRITE", { exact: true }).click()
   await expect(writeScope).toBeChecked()
   await tokenForm.getByText("WRITE", { exact: true }).click()
   await expect(writeScope).not.toBeChecked()
-  await page.getByLabel("Name").fill(`automation-${testRunSuffix}`)
+  await tokenDrawer.getByLabel("Name").fill(`automation-${testRunSuffix}`)
   const importScope = tokenForm.getByRole("checkbox", { name: /IMPORT/i })
   await importScope.focus()
   await page.keyboard.press("Space")
@@ -44,14 +54,16 @@ test("workbench settings clears one-time API token when leaving settings", async
   await reportScope.focus()
   await page.keyboard.press("Space")
   await expect(reportScope).toBeChecked()
-  await page.getByRole("button", { name: "Create Token" }).click()
+  await tokenForm.getByRole("button", { name: "Create token" }).click()
 
-  const createdTokenPanel = page.getByRole("region", {
+  const createdTokenPanel = tokenDrawer.getByRole("region", {
     name: "Created API token",
   })
   await expect(createdTokenPanel).toBeVisible()
   await expect(createdTokenPanel.getByLabel("Token")).toHaveValue(/^vpr_/)
   await expect(createdTokenPanel).toContainText("READ, IMPORT, REPORT")
+  await tokenDrawer.getByRole("button", { name: "Close" }).click()
+  await expect(createdTokenPanel).toHaveCount(0)
 
   await page.getByRole("link", { name: "Dashboard" }).click()
   await expect(page).toHaveURL(/\/(?:\?.*)?$/)
@@ -65,6 +77,7 @@ test("workbench settings clears one-time API token when leaving settings", async
 
   await expect(createdTokenPanel).toHaveCount(0)
   await expect(page.getByRole("textbox", { name: "Token" })).toHaveCount(0)
+  await page.getByRole("tab", { name: "API Tokens" }).click()
   await expect(
     page.getByRole("table", { name: "API tokens table" }),
   ).toContainText(/READ\s*IMPORT\s*REPORT/)

--- a/frontend/tests/ui-evidence-screenshots.spec.ts
+++ b/frontend/tests/ui-evidence-screenshots.spec.ts
@@ -558,10 +558,14 @@ const authenticatedRoutes: readonly EvidenceRoute[] = [
   {
     assertReady: async (page) => {
       await expect(
-        page.getByRole("heading", { level: 2, name: "Settings" }),
+        page.getByRole("heading", { level: 2, name: "Workspace controls" }),
       ).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible()
       await expect(
-        page.getByRole("region", { exact: true, name: "API tokens" }),
+        page.getByRole("heading", { name: "Account and session" }),
+      ).toBeVisible()
+      await expect(
+        page.getByRole("tab", { name: "API Tokens" }),
       ).toBeVisible()
     },
     id: "settings",

--- a/frontend/tests/ui-smoke.spec.ts
+++ b/frontend/tests/ui-smoke.spec.ts
@@ -57,8 +57,10 @@ test("smoke: settings renders", async ({ page }) => {
   test.setTimeout(30_000)
   await login(page)
   await page.goto("/settings")
+  await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible()
+  await expect(page.getByRole("tab", { name: "API Tokens" })).toBeVisible()
   await expect(
-    page.getByRole("region", { exact: true, name: "API tokens" }),
+    page.getByRole("heading", { name: "Account and session" }),
   ).toBeVisible()
 })
 


### PR DESCRIPTION
## Summary
- Refactors `/settings` into a tabbed, task-oriented settings console.
- Moves API token creation into a right-side drawer and keeps one-time secrets scoped to that flow.
- Polishes Settings visual density, responsive tabs, Runtime/Diagnostics panels, and token table spacing for consistency.

## Why
The previous settings page exposed account, token, runtime, diagnostics, and security content as one long page, which made the workflow harder to scan and maintain.

## Validation
- `npm run lint`
- `npm --prefix frontend run build`
- `VPW_PLAYWRIGHT_REUSE_EXISTING_SERVER=1 npm --prefix frontend run test -- settings-token.spec.ts ui-smoke.spec.ts --project=chromium`
- `VPW_PLAYWRIGHT_REUSE_EXISTING_SERVER=1 npm --prefix frontend run test -- ui-evidence-screenshots.spec.ts --project=chromium --grep "productive scoped route screenshots"`
- `VPW_PLAYWRIGHT_REUSE_EXISTING_SERVER=1 npm --prefix frontend run test -- settings-token.spec.ts --project=chromium`