### PR TITLE
[codex] Clarify Workbench provider snapshot input

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ Suggested demo path:
 
 1. Create or select a project.
 2. Import `data/sample_cves.txt` as a CVE list.
-3. Use `data/demo_provider_snapshot.json` with locked provider data enabled.
+3. Enter `demo_provider_snapshot.json` in the provider snapshot field and keep
+   locked provider data enabled. The checked-in source file is
+   `data/demo_provider_snapshot.json`.
 4. Review Findings, Finding Detail, TTP Context, Waivers, and Evidence Center.
 
 The demo path uses local checked-in fixtures and provider replay. Do not reuse

--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -201,6 +201,24 @@ def test_docs_examples_do_not_use_template_named_artifacts() -> None:
     assert template_named_examples == []
 
 
+def test_workbench_demo_docs_use_managed_snapshot_filename_in_import_field() -> None:
+    active_demo_docs = {
+        "README.md": README_FILE,
+        "docs/index.md": REPO_ROOT / "docs" / "index.md",
+        "docs/workbench-offline-demo.md": WORKBENCH_OFFLINE_DEMO_FILE,
+    }
+    violations = {
+        name: [
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if "provider snapshot" in line.lower() and "data/demo_provider_snapshot.json" in line
+        ]
+        for name, path in active_demo_docs.items()
+    }
+
+    assert violations == {name: [] for name in active_demo_docs}
+
+
 def test_gitignore_covers_workbench_runtime_artifacts() -> None:
     gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
     required_runtime_roots = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,9 +55,11 @@ curl http://127.0.0.1:8000/api/v1/workbench/health
 ```
 
 Open `http://127.0.0.1:5173`, create or select a project, and import
-`data/sample_cves.txt` with `data/demo_provider_snapshot.json` plus locked
-provider data enabled. The current local Workbench is single-user and does not
-require a login step. This path works without live provider API keys.
+`data/sample_cves.txt`. In the provider snapshot field, enter
+`demo_provider_snapshot.json` and enable locked provider data. The checked-in
+snapshot source is `data/demo_provider_snapshot.json`. The current local
+Workbench is single-user and does not require a login step. This path works
+without live provider API keys.
 
 The Compose path starts the current FastAPI backend and React frontend. The
 Workbench remains local-first and uses the import-format matrix documented in

--- a/docs/workbench-offline-demo.md
+++ b/docs/workbench-offline-demo.md
@@ -38,7 +38,8 @@ If `pip-audit`, npm, or advisory data is unavailable, record that as a release-c
 1. Open **Import**.
 2. Select `CVE list`.
 3. Upload `data/sample_cves.txt`.
-4. Set provider snapshot to `data/demo_provider_snapshot.json`.
+4. Set provider snapshot to `demo_provider_snapshot.json`; the checked-in source
+   file is `data/demo_provider_snapshot.json`.
 5. Enable locked provider data.
 6. Submit the import and open the generated reports page.
 7. Return to the dashboard and confirm provider freshness is visible.


### PR DESCRIPTION
## Summary
- clarify that Workbench imports expect the managed snapshot filename `demo_provider_snapshot.json`, not the repository path `data/demo_provider_snapshot.json`
- keep the checked-in source file path documented separately
- add a docs hygiene test so active demo docs do not reintroduce the wrong import-field value

## Validation
- `python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov`
- `python3 -m pytest -q backend/tests/api/test_workbench_import_upload_api.py::test_workbench_import_uses_demo_snapshot_without_network_or_keys backend/tests/api/test_workbench_import_upload_api.py::test_upload_rejects_unsafe_or_unsupported_sidecar_uploads --no-cov`
- `make docs-check`
- `git diff --check`
