### PR TITLE
[codex] Add import demo snapshot preset

### DIFF
--- a/frontend/src/components/imports/ImportsWorkbenchProviderOptions.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchProviderOptions.tsx
@@ -1,3 +1,5 @@
+import { FileJson } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -8,7 +10,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { VpwField, VpwPanel, VpwSectionHeader } from "@/components/vpw"
-import { attackImportSourceOptions } from "@/lib/app-defaults"
+import {
+  attackImportSourceOptions,
+  demoProviderSnapshotFile,
+} from "@/lib/app-defaults"
 import type { ImportsWorkbenchProps } from "./imports-workbench-model"
 
 export function ProviderAttackOptions({
@@ -18,6 +23,7 @@ export function ProviderAttackOptions({
   onAttackTechniqueMetadataFileChange,
   onLockedProviderDataChange,
   onProviderSnapshotFileChange,
+  onUseDemoProviderSnapshot,
 }: Pick<
   ImportsWorkbenchProps,
   | "importWizard"
@@ -26,6 +32,7 @@ export function ProviderAttackOptions({
   | "onAttackTechniqueMetadataFileChange"
   | "onLockedProviderDataChange"
   | "onProviderSnapshotFileChange"
+  | "onUseDemoProviderSnapshot"
 >) {
   return (
     <VpwPanel className="flex flex-col gap-4 border-[var(--vpw-border-default)] bg-[var(--vpw-bg-card)] p-4">
@@ -35,19 +42,31 @@ export function ProviderAttackOptions({
       />
       <div className="grid gap-4 lg:grid-cols-2">
         <VpwField
-          description="Filename under the configured provider snapshot directory, for example demo_provider_snapshot.json."
+          description={`Filename under the configured provider snapshot directory, for example ${demoProviderSnapshotFile}.`}
           htmlFor="provider-snapshot-file"
           label="Provider snapshot file"
         >
-          <Input
-            id="provider-snapshot-file"
-            name="providerSnapshotFile"
-            onChange={(event) =>
-              onProviderSnapshotFileChange(event.target.value)
-            }
-            placeholder="demo_provider_snapshot.json"
-            value={importWizard.providerSnapshotFile}
-          />
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              id="provider-snapshot-file"
+              name="providerSnapshotFile"
+              onChange={(event) =>
+                onProviderSnapshotFileChange(event.target.value)
+              }
+              placeholder={demoProviderSnapshotFile}
+              value={importWizard.providerSnapshotFile}
+            />
+            <Button
+              className="sm:w-auto"
+              onClick={onUseDemoProviderSnapshot}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <FileJson aria-hidden="true" data-icon="inline-start" />
+              Use demo snapshot
+            </Button>
+          </div>
         </VpwField>
         <label
           className="flex min-h-10 items-start gap-3 rounded-[var(--vpw-radius-md)] border border-[var(--vpw-border-default)] bg-[var(--vpw-bg-panel)] p-3 text-sm"

--- a/frontend/src/components/imports/ImportsWorkbenchWizard.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchWizard.tsx
@@ -88,6 +88,7 @@ export function ImportWizard({
   onProviderSnapshotFileChange,
   onProjectChange,
   onSubmit,
+  onUseDemoProviderSnapshot,
   onAttackMappingFileChange,
   onAttackSourceChange,
   onAttackTechniqueMetadataFileChange,
@@ -108,6 +109,7 @@ export function ImportWizard({
   | "onProviderSnapshotFileChange"
   | "onProjectChange"
   | "onSubmit"
+  | "onUseDemoProviderSnapshot"
   | "onAttackMappingFileChange"
   | "onAttackSourceChange"
   | "onAttackTechniqueMetadataFileChange"
@@ -276,6 +278,7 @@ export function ImportWizard({
               }
               onLockedProviderDataChange={onLockedProviderDataChange}
               onProviderSnapshotFileChange={onProviderSnapshotFileChange}
+              onUseDemoProviderSnapshot={onUseDemoProviderSnapshot}
             />
             <VpwProgress
               label="Import readiness"

--- a/frontend/src/components/imports/imports-workbench-model.ts
+++ b/frontend/src/components/imports/imports-workbench-model.ts
@@ -43,6 +43,7 @@ export type ImportsWorkbenchProps = {
   onRefreshRuns: () => void
   onSelectRun: (runId: string) => void
   onSubmit: FormEventHandler<HTMLFormElement>
+  onUseDemoProviderSnapshot: () => void
   onAttackMappingFileChange: (value: string) => void
   onAttackSourceChange: (value: string) => void
   onAttackTechniqueMetadataFileChange: (value: string) => void

--- a/frontend/src/lib/app-defaults.ts
+++ b/frontend/src/lib/app-defaults.ts
@@ -209,6 +209,8 @@ export type ImportWizardState = {
   vexFile: File | null
 }
 
+export const demoProviderSnapshotFile = "demo_provider_snapshot.json"
+
 export const defaultImportWizardState: ImportWizardState = {
   attackMappingFile: "",
   attackSource: "none",
@@ -219,6 +221,16 @@ export const defaultImportWizardState: ImportWizardState = {
   lockedProviderData: false,
   providerSnapshotFile: "",
   vexFile: null,
+}
+
+export function withDemoProviderSnapshot(
+  state: ImportWizardState,
+): ImportWizardState {
+  return {
+    ...state,
+    lockedProviderData: true,
+    providerSnapshotFile: demoProviderSnapshotFile,
+  }
 }
 
 export type ImportUploadFormData = Parameters<

--- a/frontend/src/workbench/routes/ImportsRoute.tsx
+++ b/frontend/src/workbench/routes/ImportsRoute.tsx
@@ -18,6 +18,7 @@ import {
   type ImportFormat,
   type ImportUploadFormData,
   type ImportWizardState,
+  withDemoProviderSnapshot,
   workbenchImportFormats,
 } from "../../lib/app-defaults"
 import { buildImportUploadFormData } from "../import-upload-payload"
@@ -246,6 +247,9 @@ function ImportsRouteContainer() {
       }
       onProviderSnapshotFileChange={(value) =>
         setImportWizard((state) => ({ ...state, providerSnapshotFile: value }))
+      }
+      onUseDemoProviderSnapshot={() =>
+        setImportWizard((state) => withDemoProviderSnapshot(state))
       }
       onProjectChange={setSelectedProjectId}
       onRefreshRuns={() => void refreshProjectRuns(selectedRunId)}

--- a/frontend/tests/imports-workbench-model.test.ts
+++ b/frontend/tests/imports-workbench-model.test.ts
@@ -12,7 +12,11 @@ import {
   selectedFormat,
   uploadProgress,
 } from "../src/components/imports/imports-workbench-model.ts"
-import { defaultImportWizardState } from "../src/lib/app-defaults.ts"
+import {
+  defaultImportWizardState,
+  demoProviderSnapshotFile,
+  withDemoProviderSnapshot,
+} from "../src/lib/app-defaults.ts"
 import { buildImportUploadFormData } from "../src/workbench/import-upload-payload.ts"
 
 test("import model derives display labels and format metadata", () => {
@@ -146,4 +150,15 @@ test("import upload payload omits empty optional file-name fields", () => {
     input_type: defaultImportWizardState.inputType,
     locked_provider_data: false,
   })
+})
+
+test("demo provider snapshot preset enables deterministic replay", () => {
+  const state = withDemoProviderSnapshot({
+    ...defaultImportWizardState,
+    file: {} as File,
+    providerSnapshotFile: "",
+  })
+
+  assert.equal(state.lockedProviderData, true)
+  assert.equal(state.providerSnapshotFile, demoProviderSnapshotFile)
 })

--- a/frontend/tests/ui-smoke.spec.ts
+++ b/frontend/tests/ui-smoke.spec.ts
@@ -20,6 +20,11 @@ test("smoke: imports renders", async ({ page }) => {
   await expect(page.getByText("Provider and ATT&CK options")).toBeVisible()
   await expect(page.getByLabel("Provider snapshot file")).toBeVisible()
   await expect(page.getByLabel("ATT&CK source")).toBeVisible()
+  await page.getByRole("button", { name: "Use demo snapshot" }).click()
+  await expect(page.getByLabel("Provider snapshot file")).toHaveValue(
+    "demo_provider_snapshot.json",
+  )
+  await expect(page.getByLabel("Locked provider data")).toBeChecked()
   await page.getByRole("combobox", { name: "Input type" }).click()
   await expect(page.getByRole("option", { name: "CycloneDX SBOM JSON" })).toBeVisible()
   await expect(page.getByRole("option", { name: "Nessus XML" })).toBeVisible()


### PR DESCRIPTION
## Summary
- add an Import Wizard preset button that fills `demo_provider_snapshot.json` and enables locked provider data
- keep the preset as an explicit user action so ordinary imports remain neutral
- cover the preset in unit tests and the imports Playwright smoke

## Validation
- `npm run test:unit -- imports-workbench-model.test.ts`
- `npm run test -- tests/ui-smoke.spec.ts --grep "imports renders"`
- `make frontend-check`
- `git diff --check`
