### PR TITLE
[codex] Tighten import submit readiness

### DIFF
--- a/frontend/src/components/imports/ImportWizardSteps.tsx
+++ b/frontend/src/components/imports/ImportWizardSteps.tsx
@@ -1,0 +1,62 @@
+import { VpwGrid, VpwImportStepCard } from "@/components/vpw"
+
+import type {
+  ImportWizardStateLike,
+  SupportedImportFormat,
+} from "./imports-workbench-model"
+
+type ImportWizardStepsProps = {
+  format: SupportedImportFormat | undefined
+  importLoading: boolean
+  importWizard: ImportWizardStateLike
+  selectedProjectId: string
+}
+
+export function ImportWizardSteps({
+  format,
+  importLoading,
+  importWizard,
+  selectedProjectId,
+}: ImportWizardStepsProps) {
+  const stepCards = [
+    {
+      title: "Select project",
+      description: "Choose the workspace that owns the imported findings.",
+      status: selectedProjectId ? "Ready" : "Required",
+      statusTone: selectedProjectId ? "success" : "warning",
+    },
+    {
+      title: "Select input type",
+      description: "Match parser behavior to the file format.",
+      status: format?.label ?? "Required",
+      statusTone: "info",
+    },
+    {
+      title: "Upload file",
+      description: "Attach the source file that should become findings.",
+      status: importWizard.file ? "Ready" : "Required",
+      statusTone: importWizard.file ? "success" : "warning",
+    },
+    {
+      title: "Validate and import",
+      description:
+        "The backend validates format, parses input, and records run evidence.",
+      status: importLoading ? "Running" : "Ready",
+      statusTone: importLoading ? "info" : "neutral",
+    },
+  ] as const
+
+  return (
+    <VpwGrid columns={4}>
+      {stepCards.map((step) => (
+        <VpwImportStepCard
+          description={step.description}
+          key={step.title}
+          status={step.status}
+          statusTone={step.statusTone}
+          title={step.title}
+        />
+      ))}
+    </VpwGrid>
+  )
+}

--- a/frontend/src/components/imports/ImportsWorkbenchWizard.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchWizard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/vpw"
 import { ProviderAttackOptions } from "./ImportsWorkbenchProviderOptions"
 import {
+  importSubmitDisabled,
   type ImportsWorkbenchProps,
   selectedFormat,
   uploadProgress,
@@ -120,6 +121,13 @@ export function ImportWizard({
   | "supportedFormats"
 >) {
   const format = selectedFormat(supportedFormats, importWizard.inputType)
+  const submitDisabled = importSubmitDisabled({
+    importLoading,
+    projectListLoading,
+    projectCount: projects.length,
+    selectedProjectId,
+    wizard: importWizard,
+  })
   const stepCards = [
     {
       title: "Select project",
@@ -297,7 +305,7 @@ export function ImportWizard({
             ) : null}
             <Button
               aria-busy={importLoading}
-              disabled={importLoading || projects.length === 0}
+              disabled={submitDisabled}
               type="submit"
             >
               <Upload aria-hidden="true" data-icon="inline-start" />

--- a/frontend/src/components/imports/ImportsWorkbenchWizard.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchWizard.tsx
@@ -12,8 +12,6 @@ import {
   VpwBadge,
   VpwField,
   VpwFileInput,
-  VpwGrid,
-  VpwImportStepCard,
   VpwKeyValueList,
   VpwPanel,
   VpwProgress,
@@ -23,6 +21,7 @@ import {
   VpwToolbar,
   VpwToolbarGroup,
 } from "@/components/vpw"
+import { ImportWizardSteps } from "./ImportWizardSteps"
 import { ProviderAttackOptions } from "./ImportsWorkbenchProviderOptions"
 import {
   importSubmitDisabled,
@@ -128,51 +127,18 @@ export function ImportWizard({
     selectedProjectId,
     wizard: importWizard,
   })
-  const stepCards = [
-    {
-      title: "Select project",
-      description: "Choose the workspace that owns the imported findings.",
-      status: selectedProjectId ? "Ready" : "Required",
-      statusTone: selectedProjectId ? "success" : "warning",
-    },
-    {
-      title: "Select input type",
-      description: "Match parser behavior to the file format.",
-      status: format?.label ?? "Required",
-      statusTone: "info",
-    },
-    {
-      title: "Upload file",
-      description: "Attach the source file that should become findings.",
-      status: importWizard.file ? "Ready" : "Required",
-      statusTone: importWizard.file ? "success" : "warning",
-    },
-    {
-      title: "Validate and import",
-      description:
-        "The backend validates format, parses input, and records run evidence.",
-      status: importLoading ? "Running" : "Ready",
-      statusTone: importLoading ? "info" : "neutral",
-    },
-  ] as const
-
   return (
     <VpwSection>
       <VpwSectionHeader
         description="Step through project, format, files, and validation before import."
         title="Import Wizard"
       />
-      <VpwGrid columns={4}>
-        {stepCards.map((step) => (
-          <VpwImportStepCard
-            description={step.description}
-            key={step.title}
-            status={step.status}
-            statusTone={step.statusTone}
-            title={step.title}
-          />
-        ))}
-      </VpwGrid>
+      <ImportWizardSteps
+        format={format}
+        importLoading={importLoading}
+        importWizard={importWizard}
+        selectedProjectId={selectedProjectId}
+      />
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(20rem,0.75fr)]">
         <VpwPanel>
           <form className="flex flex-col gap-5" onSubmit={onSubmit}>

--- a/frontend/src/components/imports/imports-workbench-model.ts
+++ b/frontend/src/components/imports/imports-workbench-model.ts
@@ -177,3 +177,25 @@ export function uploadProgress(wizard: ImportWizardStateLike) {
   }
   return Math.min(value, 100)
 }
+
+export function importSubmitDisabled({
+  importLoading,
+  projectListLoading,
+  projectCount,
+  selectedProjectId,
+  wizard,
+}: {
+  importLoading: boolean
+  projectListLoading: boolean
+  projectCount: number
+  selectedProjectId: string
+  wizard: ImportWizardStateLike
+}) {
+  return (
+    importLoading ||
+    projectListLoading ||
+    projectCount === 0 ||
+    !selectedProjectId ||
+    !wizard.file
+  )
+}

--- a/frontend/tests/imports-workbench-model.test.ts
+++ b/frontend/tests/imports-workbench-model.test.ts
@@ -5,6 +5,7 @@ import {
   failedRunCause,
   formatDisplayType,
   formatExpectedFields,
+  importSubmitDisabled,
   jsonPreview,
   metadataRows,
   runFileLabel,
@@ -161,4 +162,52 @@ test("demo provider snapshot preset enables deterministic replay", () => {
 
   assert.equal(state.lockedProviderData, true)
   assert.equal(state.providerSnapshotFile, demoProviderSnapshotFile)
+})
+
+test("import submit stays disabled until project and source file are ready", () => {
+  const readyWizard = {
+    ...defaultImportWizardState,
+    file: {} as File,
+  }
+
+  assert.equal(
+    importSubmitDisabled({
+      importLoading: false,
+      projectListLoading: false,
+      projectCount: 1,
+      selectedProjectId: "project-1",
+      wizard: readyWizard,
+    }),
+    false,
+  )
+  assert.equal(
+    importSubmitDisabled({
+      importLoading: false,
+      projectListLoading: false,
+      projectCount: 1,
+      selectedProjectId: "",
+      wizard: readyWizard,
+    }),
+    true,
+  )
+  assert.equal(
+    importSubmitDisabled({
+      importLoading: false,
+      projectListLoading: false,
+      projectCount: 1,
+      selectedProjectId: "project-1",
+      wizard: defaultImportWizardState,
+    }),
+    true,
+  )
+  assert.equal(
+    importSubmitDisabled({
+      importLoading: true,
+      projectListLoading: false,
+      projectCount: 1,
+      selectedProjectId: "project-1",
+      wizard: readyWizard,
+    }),
+    true,
+  )
 })


### PR DESCRIPTION
## Summary
- disable Import Wizard submit until a project is selected and a source file is attached
- keep loading/no-project states covered by the same tested readiness helper
- add focused unit coverage for ready, missing project, missing file, and loading states

## Validation
- `npm run test:unit -- imports-workbench-model.test.ts`
- `make frontend-check`
- `git diff --check`
