### PR TITLE
[codex] Deep link reports to selected run

### DIFF
--- a/frontend/src/components/imports/ImportsWorkbenchResults.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchResults.tsx
@@ -24,6 +24,9 @@ export function ImportResult({
   const summaryRun = importRunSummary ?? importRun
   const status = summaryRun?.status ?? "pending"
   const runId = summaryRun?.id ?? importRun?.id ?? ""
+  const projectId = summaryRun?.project_id ?? importRun?.project_id ?? ""
+  const findingsSearch = { projectId }
+  const reportsSearch = { projectId, runId }
 
   return (
     <VpwSection>
@@ -79,10 +82,14 @@ export function ImportResult({
         ) : null}
         <div className="mt-5 flex flex-wrap gap-2">
           <Button asChild variant="outline">
-            <Link to="/findings">View Findings</Link>
+            <Link search={findingsSearch} to="/findings">
+              View Findings
+            </Link>
           </Button>
           <Button asChild variant="outline">
-            <Link to="/reports">Generate Evidence</Link>
+            <Link search={reportsSearch} to="/reports">
+              Generate Evidence
+            </Link>
           </Button>
         </div>
       </VpwPanel>

--- a/frontend/src/workbench/report-route-search.ts
+++ b/frontend/src/workbench/report-route-search.ts
@@ -1,0 +1,32 @@
+import type { ProjectUrlSearch } from "./selected-project-search"
+
+export function selectedReportRunIdFromSearch(searchStr: string): string {
+  const rawSearch = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr
+  return new URLSearchParams(rawSearch).get("runId") ?? ""
+}
+
+export function reportRunUrlSearch(
+  searchStr: string,
+  runId: string,
+): ProjectUrlSearch {
+  const rawSearch = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr
+  const params = new URLSearchParams(rawSearch)
+  if (runId) {
+    params.set("runId", runId)
+  } else {
+    params.delete("runId")
+  }
+  return Object.fromEntries(params.entries())
+}
+
+export function normalizeSelectedRunId(
+  candidates: readonly string[],
+  runIds: readonly string[],
+): string {
+  const availableRunIds = new Set(runIds)
+  return (
+    candidates.find((candidate) => candidate && availableRunIds.has(candidate)) ??
+    runIds[0] ??
+    ""
+  )
+}

--- a/frontend/src/workbench/routes/ReportsRoute.tsx
+++ b/frontend/src/workbench/routes/ReportsRoute.tsx
@@ -1,7 +1,14 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useLocation, useNavigate } from "@/lib/router"
 import { EvidenceCenter } from "../../components/reports/EvidenceCenter"
 import { apiErrorMessage } from "../../lib/app-errors"
 import { useWorkbenchContext } from "../WorkbenchContext"
+import {
+  normalizeSelectedRunId,
+  reportRunUrlSearch,
+  selectedReportRunIdFromSearch,
+} from "../report-route-search"
+import { searchStringFromUrlSearch } from "../selected-project-search"
 import {
   useProjectRunsQuery,
   useProjectSummaryQuery,
@@ -9,7 +16,13 @@ import {
 } from "../useWorkbenchQueries"
 import { useReportsRouteState } from "../useReportsRouteState"
 
+function activeSearchString(fallbackSearch: string) {
+  return typeof window === "undefined" ? fallbackSearch : window.location.search
+}
+
 function ReportsRouteContent() {
+  const location = useLocation()
+  const navigate = useNavigate()
   const {
     projectListLoading,
     projectListError,
@@ -19,7 +32,8 @@ function ReportsRouteContent() {
     selectedProjectId,
     setSelectedProjectId,
   } = useWorkbenchContext()
-  const [selectedRunId, setSelectedRunId] = useState("")
+  const routeRunId = selectedReportRunIdFromSearch(location.searchStr)
+  const [selectedRunId, setSelectedRunIdState] = useState(routeRunId)
   const projectRunsQuery = useProjectRunsQuery(selectedProjectId, true)
   const projectRuns = projectRunsQuery.data?.data ?? []
   const runDetailQuery = useRunDetailQuery(selectedRunId, true)
@@ -31,18 +45,50 @@ function ReportsRouteContent() {
     selectedReportRun,
     selectedRunId,
   })
+  const runIds = useMemo(() => projectRuns.map((run) => run.id), [projectRuns])
+
+  const selectRunId = useCallback(
+    (nextRunId: string, { replace }: { replace: boolean }) => {
+      setSelectedRunIdState(nextRunId)
+      const currentLocationSearch = activeSearchString(location.searchStr)
+      const nextSearch = reportRunUrlSearch(currentLocationSearch, nextRunId)
+      const currentSearch = currentLocationSearch.startsWith("?")
+        ? currentLocationSearch.slice(1)
+        : currentLocationSearch
+      if (searchStringFromUrlSearch(nextSearch) === currentSearch) {
+        return
+      }
+      void navigate({
+        replace,
+        search: () => nextSearch,
+      })
+    },
+    [location.searchStr, navigate],
+  )
 
   useEffect(() => {
-    setSelectedRunId((currentRunId) =>
-      projectRuns.some((run) => run.id === currentRunId)
-        ? currentRunId
-        : (projectRuns[0]?.id ?? ""),
+    if (projectRunsQuery.isLoading && runIds.length === 0) {
+      return
+    }
+    const nextRunId = normalizeSelectedRunId(
+      [routeRunId, selectedRunId],
+      runIds,
     )
-  }, [projectRuns])
+    if (nextRunId === selectedRunId && nextRunId === routeRunId) {
+      return
+    }
+    selectRunId(nextRunId, { replace: true })
+  }, [
+    projectRunsQuery.isLoading,
+    routeRunId,
+    runIds,
+    selectRunId,
+    selectedRunId,
+  ])
 
   function handleProjectChange(projectId: string) {
     setSelectedProjectId(projectId)
-    setSelectedRunId("")
+    selectRunId("", { replace: true })
   }
 
   return (
@@ -51,7 +97,7 @@ function ReportsRouteContent() {
       onCreateReport={reportsState.createReport}
       onDownloadReport={reportsState.downloadReport}
       onProjectChange={handleProjectChange}
-      onRunIdChange={setSelectedRunId}
+      onRunIdChange={(runId) => selectRunId(runId, { replace: false })}
       onVerifyReport={reportsState.verifyEvidenceReport}
       projectListError={projectListError}
       projectListLoading={projectListLoading}

--- a/frontend/tests/report-route-search.test.ts
+++ b/frontend/tests/report-route-search.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  normalizeSelectedRunId,
+  reportRunUrlSearch,
+  selectedReportRunIdFromSearch,
+} from "../src/workbench/report-route-search.ts"
+
+test("reads selected report run id from route search", () => {
+  assert.equal(selectedReportRunIdFromSearch("?runId=run-1"), "run-1")
+  assert.equal(selectedReportRunIdFromSearch("projectId=project-1"), "")
+})
+
+test("updates report run id while preserving project search", () => {
+  assert.deepEqual(
+    reportRunUrlSearch("?projectId=project-1&runId=old&tab=reports", "run-2"),
+    {
+      projectId: "project-1",
+      runId: "run-2",
+      tab: "reports",
+    },
+  )
+  assert.deepEqual(
+    reportRunUrlSearch("?projectId=project-1&runId=old", ""),
+    {
+      projectId: "project-1",
+    },
+  )
+})
+
+test("normalizes stale report run ids to an available run", () => {
+  assert.equal(
+    normalizeSelectedRunId(["missing", "run-2"], ["run-1", "run-2"]),
+    "run-2",
+  )
+  assert.equal(normalizeSelectedRunId(["missing"], ["run-1"]), "run-1")
+  assert.equal(normalizeSelectedRunId(["missing"], []), "")
+})


### PR DESCRIPTION
## Summary
- carry projectId/runId from Import Result links into Findings and Reports
- let Reports route read, normalize, and update runId in the URL
- add focused unit coverage for report run route search helpers

## Validation
- npm run test:unit -- report-route-search.test.ts imports-workbench-model.test.ts reporting-state.test.ts
- npm run lint
- npm run build
- make frontend-check
- git diff --check