### PR TITLE
[codex] Preserve project context in navigation

### DIFF
--- a/frontend/src/components/assets/AssetsRoute.tsx
+++ b/frontend/src/components/assets/AssetsRoute.tsx
@@ -9,6 +9,7 @@ import type {
   ProviderStatusPublic,
 } from "../../api-client"
 import { Button } from "../ui/button"
+import { selectedProjectRouteSearch } from "../../workbench/selected-project-search"
 import {
   VpwBadge,
   VpwPageContainer,
@@ -77,6 +78,8 @@ export type AssetsWorkbenchProps = {
 }
 
 export function AssetsWorkbench(state: AssetsWorkbenchProps) {
+  const projectSearch = selectedProjectRouteSearch(state.selectedProjectId)
+
   return (
     <VpwPageContainer className="flex flex-col gap-6 px-0 py-0">
         <VpwSection>
@@ -95,7 +98,9 @@ export function AssetsWorkbench(state: AssetsWorkbenchProps) {
                   </a>
                 </Button>
                 <Button asChild variant="outline">
-                  <Link to="/findings">View findings</Link>
+                  <Link search={projectSearch} to="/findings">
+                    View findings
+                  </Link>
                 </Button>
                 <Button
                   aria-label="Refresh assets"

--- a/frontend/src/components/dashboard/DashboardHero.tsx
+++ b/frontend/src/components/dashboard/DashboardHero.tsx
@@ -2,6 +2,7 @@ import { Link } from "@/lib/router"
 import { BellRing, Import, RefreshCw, ShieldCheck } from "lucide-react"
 import type { ProjectPublic, ProviderStatusPublic } from "@/api-client"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   Select,
   SelectContent,
@@ -38,6 +39,10 @@ export function DashboardHero({
   providerStatusLoading,
   selectedProjectId,
 }: DashboardHeroProps) {
+  const projectSearch = selectedProjectRouteSearch(
+    isDemoMode ? "" : selectedProjectId,
+  )
+
   return (
     <div className="dashboard-analyst-hero">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -94,7 +99,7 @@ export function DashboardHero({
             asChild
             className="w-full justify-center font-semibold sm:w-auto"
           >
-            <Link to="/imports">
+            <Link search={projectSearch} to="/imports">
               <Import aria-hidden="true" data-icon="inline-start" />
               Import findings
             </Link>
@@ -104,7 +109,7 @@ export function DashboardHero({
             className="w-full justify-center sm:w-auto"
             variant="ghost"
           >
-            <Link to="/reports">
+            <Link search={projectSearch} to="/reports">
               <BellRing aria-hidden="true" data-icon="inline-start" />
               Generate evidence
             </Link>

--- a/frontend/src/components/dashboard/DashboardSidePanel.tsx
+++ b/frontend/src/components/dashboard/DashboardSidePanel.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@/api-client"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwBadge,
   type VpwBadgeTone,
@@ -31,6 +32,7 @@ type DashboardSidePanelProps = {
   latestRun: AnalysisRunPublic | null
   latestRunFactsRows: readonly DashboardRunFact[]
   providerStatusLoading: boolean
+  selectedProjectId: string
   staleProvider: boolean
 }
 
@@ -44,11 +46,13 @@ export function DashboardSidePanel({
   latestRun,
   latestRunFactsRows,
   providerStatusLoading,
+  selectedProjectId,
   staleProvider,
 }: DashboardSidePanelProps) {
   const qualityIssueCount =
     dataQualityWarnings.length + (dataQualityError ? 1 : 0)
   const readinessTone: VpwBadgeTone = staleProvider ? "warning" : "success"
+  const projectSearch = selectedProjectRouteSearch(selectedProjectId)
 
   return (
     <div className="flex flex-col gap-4 lg:sticky lg:top-20">
@@ -182,7 +186,9 @@ export function DashboardSidePanel({
             </div>
           )}
           <Button asChild className="mt-3 w-full" size="sm" variant="outline">
-            <Link to="/imports">View all imports</Link>
+            <Link search={projectSearch} to="/imports">
+              View all imports
+            </Link>
           </Button>
         </VpwSurfaceBody>
       </VpwSurface>

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -404,6 +404,7 @@ export function RiskOperationsDashboard({
               latestRun={latestRun}
               latestRunFactsRows={latestRunFactsRows}
               providerStatusLoading={providerStatusLoading}
+              selectedProjectId={isDemoMode ? "" : selectedProjectId}
               staleProvider={staleProvider}
             />
           </div>

--- a/frontend/src/components/findings/RemediationQueueStates.tsx
+++ b/frontend/src/components/findings/RemediationQueueStates.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@/lib/router"
 import type { FindingPublic, ProjectPublic } from "@/api-client"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwEmptyState,
   VpwPanel,
@@ -31,6 +32,8 @@ export function RemediationQueueStates({
   projects,
   selectedProject,
 }: RemediationQueueStatesProps) {
+  const projectSearch = selectedProjectRouteSearch(selectedProject?.id ?? "")
+
   return (
     <>
       {hasError ? (
@@ -66,7 +69,9 @@ export function RemediationQueueStates({
         <VpwEmptyState
           action={
             <Button asChild>
-              <Link to="/imports">Import data</Link>
+              <Link search={projectSearch} to="/imports">
+                Import data
+              </Link>
             </Button>
           }
           ariaLabel="No findings empty state"

--- a/frontend/src/components/findings/RemediationQueueSummary.tsx
+++ b/frontend/src/components/findings/RemediationQueueSummary.tsx
@@ -2,6 +2,7 @@ import { Link } from "@/lib/router"
 import { AlertTriangle, ArrowUp, Eye, FileDown, Upload } from "lucide-react"
 import type { ProjectPublic } from "@/api-client"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwBadge,
   VpwDemoBanner,
@@ -63,6 +64,8 @@ export function RemediationQueueSummary({
   kevCount,
   openCount,
 }: RemediationQueueSummaryProps) {
+  const projectSearch = selectedProjectRouteSearch(displayProject?.id ?? "")
+
   return (
     <VpwSection>
       <VpwPanel className="findings-analyst-summary flex flex-col gap-5 bg-[var(--vpw-bg-card)]">
@@ -70,13 +73,13 @@ export function RemediationQueueSummary({
           actions={
             <>
               <Button asChild size="sm" variant="outline">
-                <Link to="/reports">
+                <Link search={projectSearch} to="/reports">
                   <FileDown aria-hidden="true" className="mr-1.5" size={14} />
                   Generate evidence
                 </Link>
               </Button>
               <Button asChild size="sm">
-                <Link to="/imports">
+                <Link search={projectSearch} to="/imports">
                   <Upload aria-hidden="true" className="mr-1.5" size={14} />
                   Import findings
                 </Link>

--- a/frontend/src/components/imports/ImportsWorkbenchHistory.tsx
+++ b/frontend/src/components/imports/ImportsWorkbenchHistory.tsx
@@ -220,6 +220,11 @@ export function RunDetail({
     }),
   )
   const selectedParseErrors = selectedRunSummary.parse_errors ?? []
+  const findingsSearch = { projectId: selectedRunSummary.project_id }
+  const reportsSearch = {
+    projectId: selectedRunSummary.project_id,
+    runId: selectedRunSummary.id,
+  }
 
   return (
     <VpwPanel className="flex flex-col gap-5">
@@ -230,9 +235,18 @@ export function RunDetail({
             {selectedRunId.slice(0, 8)}
           </h3>
         </div>
-        <Button asChild size="sm" variant="outline">
-          <Link to="/findings">Findings</Link>
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild size="sm" variant="outline">
+            <Link search={findingsSearch} to="/findings">
+              Findings
+            </Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link search={reportsSearch} to="/reports">
+              Evidence
+            </Link>
+          </Button>
+        </div>
       </div>
       <VpwKeyValueList
         columns={2}

--- a/frontend/src/components/projects/ProjectsWorkbenchActive.tsx
+++ b/frontend/src/components/projects/ProjectsWorkbenchActive.tsx
@@ -3,6 +3,7 @@ import { Archive, FolderKanban, PlayCircle, Upload } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwBadge,
   VpwEmptyState,
@@ -66,6 +67,7 @@ function ActiveProjectPanel({
 
   const evidence = evidenceState(projectSummary)
   const readiness = readinessProgress(selectedProject, projectSummary)
+  const projectSearch = selectedProjectRouteSearch(selectedProject.id)
 
   return (
     <VpwPanel className="flex flex-col gap-5 border-[color-mix(in_srgb,var(--vpw-blue)_24%,var(--vpw-border-subtle))] bg-[var(--vpw-bg-card)]">
@@ -87,13 +89,13 @@ function ActiveProjectPanel({
             Edit
           </Button>
           <Button asChild variant="outline">
-            <Link to="/imports">
+            <Link search={projectSearch} to="/imports">
               <Upload aria-hidden="true" />
               Import findings
             </Link>
           </Button>
           <Button asChild>
-            <Link to="/reports">
+            <Link search={projectSearch} to="/reports">
               <PlayCircle aria-hidden="true" />
               Generate evidence
             </Link>

--- a/frontend/src/components/projects/ProjectsWorkbenchOverview.tsx
+++ b/frontend/src/components/projects/ProjectsWorkbenchOverview.tsx
@@ -9,6 +9,7 @@ import {
   Upload,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwBadge,
   VpwGrid,
@@ -38,6 +39,7 @@ export function ProjectHero({
   "projectSummary" | "projects" | "selectedProject"
 >) {
   const evidence = evidenceState(projectSummary)
+  const projectSearch = selectedProjectRouteSearch(selectedProject?.id ?? "")
 
   return (
     <VpwSection>
@@ -55,7 +57,7 @@ export function ProjectHero({
             </a>
           </Button>
           <Button asChild variant="outline">
-            <Link to="/imports">
+            <Link search={projectSearch} to="/imports">
               <Upload aria-hidden="true" />
               Import findings
             </Link>

--- a/frontend/src/workbench/selected-project-search.ts
+++ b/frontend/src/workbench/selected-project-search.ts
@@ -19,6 +19,10 @@ export function selectedProjectUrlSearch(
   return Object.fromEntries(params.entries())
 }
 
+export function selectedProjectRouteSearch(projectId: string): ProjectUrlSearch {
+  return projectId ? { projectId } : {}
+}
+
 export function searchStringFromUrlSearch(search: ProjectUrlSearch): string {
   const params = new URLSearchParams()
   for (const [key, value] of Object.entries(search)) {

--- a/frontend/tests/selected-project-search.test.ts
+++ b/frontend/tests/selected-project-search.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeSelectedProjectId,
   searchStringFromUrlSearch,
   selectedProjectIdFromSearch,
+  selectedProjectRouteSearch,
   selectedProjectUrlSearch,
 } from "../src/workbench/selected-project-search.ts"
 
@@ -29,6 +30,13 @@ test("updates project id in route search while preserving other keys", () => {
     ),
     "status=open",
   )
+})
+
+test("builds route search for project-aware navigation", () => {
+  assert.deepEqual(selectedProjectRouteSearch("project-1"), {
+    projectId: "project-1",
+  })
+  assert.deepEqual(selectedProjectRouteSearch(""), {})
 })
 
 test("normalizes stale selected project ids to an available project", () => {


### PR DESCRIPTION
## Summary
- keep projectId on main workflow links from dashboard, projects, findings, imports, and assets
- add a small selectedProjectRouteSearch helper for project-aware links
- add an Evidence shortcut from import run detail to the selected run's Reports view

## Validation
- npm run test:unit -- selected-project-search.test.ts report-route-search.test.ts
- npm run lint
- npm run build
- make frontend-check
- git diff --check