### PR TITLE
[codex] Preserve project context in dashboard and waiver links

### DIFF
--- a/frontend/src/components/dashboard/DashboardSignalOverview.tsx
+++ b/frontend/src/components/dashboard/DashboardSignalOverview.tsx
@@ -13,6 +13,7 @@ import {
 } from "recharts"
 import { ChartCard } from "@/components/charts/ChartCard"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   Select,
   SelectContent,
@@ -39,6 +40,7 @@ type DashboardSignalOverviewProps = {
   onRunRangeChange: (value: DashboardRunRange) => void
   priorityItems: readonly ChartDatum[]
   runsLoading: boolean
+  selectedProjectId: string
   selectedRunRange: DashboardRunRange
   serviceItems: readonly ChartDatum[]
   summaryLoading: boolean
@@ -102,12 +104,15 @@ export function DashboardSignalOverview({
   onRunRangeChange,
   priorityItems,
   runsLoading,
+  selectedProjectId,
   selectedRunRange,
   serviceItems,
   summaryLoading,
   topServiceSource,
   trendItems,
 }: DashboardSignalOverviewProps) {
+  const projectSearch = selectedProjectRouteSearch(selectedProjectId)
+
   return (
     <VpwSurface className="gap-2 py-4">
       <VpwSurfaceHeader>
@@ -149,7 +154,9 @@ export function DashboardSignalOverview({
                 <EmptyState
                   action={
                     <Button asChild size="sm" variant="outline">
-                      <Link to="/imports">Import findings</Link>
+                      <Link search={projectSearch} to="/imports">
+                        Import findings
+                      </Link>
                     </Button>
                   }
                   ariaLabel="No priority data"
@@ -199,7 +206,9 @@ export function DashboardSignalOverview({
                 <EmptyState
                   action={
                     <Button asChild size="sm" variant="outline">
-                      <Link to="/imports">Run import</Link>
+                      <Link search={projectSearch} to="/imports">
+                        Run import
+                      </Link>
                     </Button>
                   }
                   ariaLabel="No EPSS data"
@@ -256,7 +265,9 @@ export function DashboardSignalOverview({
                 <EmptyState
                   action={
                     <Button asChild size="sm" variant="outline">
-                      <Link to="/findings">Review findings</Link>
+                      <Link search={projectSearch} to="/findings">
+                        Review findings
+                      </Link>
                     </Button>
                   }
                   ariaLabel="No service risk data"
@@ -319,7 +330,9 @@ export function DashboardSignalOverview({
                 <EmptyState
                   action={
                     <Button asChild size="sm" variant="outline">
-                      <Link to="/imports">Create first import</Link>
+                      <Link search={projectSearch} to="/imports">
+                        Create first import
+                      </Link>
                     </Button>
                   }
                   ariaLabel="No trend data"

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -373,6 +373,7 @@ export function RiskOperationsDashboard({
                   }
                   priorityItems={priorityItems}
                   runsLoading={runsLoading}
+                  selectedProjectId={isDemoMode ? "" : selectedProjectId}
                   selectedRunRange={filters.selectedRunRange}
                   serviceItems={serviceItems}
                   summaryLoading={summaryLoading}

--- a/frontend/src/components/waivers/WaiversWorkbench.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbench.tsx
@@ -76,6 +76,7 @@ export function WaiversWorkbench(props: WaiversWorkbenchProps) {
       <WaiverRegister
         onExpireWaiver={props.onExpireWaiver}
         onRefreshWaivers={props.onRefreshWaivers}
+        selectedProjectId={props.selectedProjectId}
         waiverActionLoading={props.waiverActionLoading}
         waivers={props.waivers}
         waiversLoading={props.waiversLoading}
@@ -89,6 +90,7 @@ export function WaiversWorkbench(props: WaiversWorkbenchProps) {
         projects={props.projects}
         reviewDue={reviewDue}
         selectedProject={props.selectedProject}
+        selectedProjectId={props.selectedProjectId}
         waiverActionLoading={props.waiverActionLoading}
         waiverForm={props.waiverForm}
       />

--- a/frontend/src/components/waivers/WaiversWorkbenchCreate.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbenchCreate.tsx
@@ -2,6 +2,7 @@ import { Link } from "@/lib/router"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwField,
   VpwGrid,
@@ -22,6 +23,7 @@ export function CreateWaiverSection({
   projects,
   reviewDue,
   selectedProject,
+  selectedProjectId,
   waiverActionLoading,
   waiverForm,
 }: Pick<
@@ -32,12 +34,17 @@ export function CreateWaiverSection({
   | "projectSummary"
   | "projects"
   | "selectedProject"
+  | "selectedProjectId"
   | "waiverActionLoading"
   | "waiverForm"
 > & {
   completeness: number
   reviewDue: string
 }) {
+  const projectSearch = selectedProjectRouteSearch(
+    selectedProject?.id ?? selectedProjectId,
+  )
+
   return (
     <VpwGrid columns={2}>
       <div id="create-waiver">
@@ -196,7 +203,9 @@ export function CreateWaiverSection({
                 {waiverActionLoading ? "Creating" : "Create waiver"}
               </Button>
               <Button asChild type="button" variant="outline">
-                <Link to="/findings">View findings</Link>
+                <Link search={projectSearch} to="/findings">
+                  View findings
+                </Link>
               </Button>
             </div>
           </form>

--- a/frontend/src/components/waivers/WaiversWorkbenchHero.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbenchHero.tsx
@@ -7,6 +7,7 @@ import {
   ShieldCheck,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   Select,
   SelectContent,
@@ -50,6 +51,8 @@ export function WaiversHero({
   expired: string
   expiringSoon: string
 }) {
+  const projectSearch = selectedProjectRouteSearch(selectedProjectId)
+
   return (
     <VpwSection>
       <VpwPanel className="flex flex-col gap-5 p-5">
@@ -60,7 +63,9 @@ export function WaiversHero({
                 <a href="#create-waiver">Create waiver</a>
               </Button>
               <Button asChild variant="outline">
-                <Link to="/findings">View findings</Link>
+                <Link search={projectSearch} to="/findings">
+                  View findings
+                </Link>
               </Button>
             </>
           }

--- a/frontend/src/components/waivers/WaiversWorkbenchRegister.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbenchRegister.tsx
@@ -2,6 +2,7 @@ import { Link } from "@/lib/router"
 import { RefreshCw } from "lucide-react"
 import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwDataTable,
   VpwEmptyState,
@@ -16,6 +17,7 @@ import type { WaiversWorkbenchProps } from "./waivers-workbench-model"
 export function WaiverRegister({
   onExpireWaiver,
   onRefreshWaivers,
+  selectedProjectId,
   waiverActionLoading,
   waivers,
   waiversLoading,
@@ -23,11 +25,13 @@ export function WaiverRegister({
   WaiversWorkbenchProps,
   | "onExpireWaiver"
   | "onRefreshWaivers"
+  | "selectedProjectId"
   | "waiverActionLoading"
   | "waivers"
   | "waiversLoading"
 >) {
   const [confirmExpireId, setConfirmExpireId] = useState<string | null>(null)
+  const projectSearch = selectedProjectRouteSearch(selectedProjectId)
 
   useEffect(() => {
     if (
@@ -84,7 +88,9 @@ export function WaiverRegister({
                     <a href="#create-waiver">Create waiver</a>
                   </Button>
                   <Button asChild variant="outline">
-                    <Link to="/findings">View findings</Link>
+                    <Link search={projectSearch} to="/findings">
+                      View findings
+                    </Link>
                   </Button>
                 </div>
               }


### PR DESCRIPTION
## Summary
- keep selected project search params on dashboard empty-state navigation
- keep selected project context on waiver links back to findings

## Validation
- npm run test:unit -- selected-project-search.test.ts route-organization.test.ts
- npm run lint
- npm run build
- make frontend-check