### PR TITLE
[codex] Preserve project context in provider evidence link

### DIFF
--- a/frontend/src/components/providers/ProvidersRouteContainer.tsx
+++ b/frontend/src/components/providers/ProvidersRouteContainer.tsx
@@ -6,6 +6,7 @@ export type ProvidersRouteContainerProps = {
   providerStatus: ProviderStatusPublic | null
   providerStatusError: string
   providerStatusLoading: boolean
+  selectedProjectId: string
   onRefreshProviderStatus: () => Promise<void> | void
 }
 
@@ -14,6 +15,7 @@ export function ProvidersRouteContainer({
   providerStatus,
   providerStatusError,
   providerStatusLoading,
+  selectedProjectId,
 }: ProvidersRouteContainerProps) {
   return (
     <ProvidersWorkbench
@@ -21,6 +23,7 @@ export function ProvidersRouteContainer({
       providerStatus={providerStatus}
       providerStatusError={providerStatusError}
       providerStatusLoading={providerStatusLoading}
+      selectedProjectId={selectedProjectId}
     />
   )
 }

--- a/frontend/src/components/providers/ProvidersWorkbench.tsx
+++ b/frontend/src/components/providers/ProvidersWorkbench.tsx
@@ -20,6 +20,7 @@ export function ProvidersWorkbench({
   providerStatus,
   providerStatusError,
   providerStatusLoading,
+  selectedProjectId,
 }: ProvidersWorkbenchProps) {
   const showProviderDetails = !providerStatusError
   const rows = showProviderDetails ? sourceRows(providerStatus) : []
@@ -32,6 +33,7 @@ export function ProvidersWorkbench({
         providerStatus={providerStatus}
         providerStatusError={providerStatusError}
         providerStatusLoading={providerStatusLoading}
+        selectedProjectId={selectedProjectId}
       />
       <ProviderStatusAlerts
         providerStatus={providerStatus}

--- a/frontend/src/components/providers/ProvidersWorkbenchHero.tsx
+++ b/frontend/src/components/providers/ProvidersWorkbenchHero.tsx
@@ -14,6 +14,7 @@ import {
   VpwToolbarGroup,
 } from "@/components/vpw"
 import { providerSnapshotHealth } from "@/lib/provider-format"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   evidenceReadinessLabel,
   evidenceReadinessTone,
@@ -33,8 +34,10 @@ export function ProvidersHero({
   onRefreshProviderStatus,
   providerStatus,
   providerStatusLoading,
+  selectedProjectId,
 }: ProvidersWorkbenchProps) {
   const evidenceReadiness = evidenceReadinessLabel(providerStatus)
+  const projectSearch = selectedProjectRouteSearch(selectedProjectId)
 
   return (
     <VpwSection>
@@ -56,7 +59,9 @@ export function ProvidersHero({
               Refresh providers
             </Button>
             <Button asChild variant="outline">
-              <Link to="/reports">View Evidence Center</Link>
+              <Link search={projectSearch} to="/reports">
+                View Evidence Center
+              </Link>
             </Button>
           </VpwToolbarGroup>
           <VpwToolbarGroup>

--- a/frontend/src/components/providers/ProvidersWorkbenchHero.tsx
+++ b/frontend/src/components/providers/ProvidersWorkbenchHero.tsx
@@ -59,9 +59,7 @@ export function ProvidersHero({
               Refresh providers
             </Button>
             <Button asChild variant="outline">
-              <Link search={projectSearch} to="/reports">
-                View Evidence Center
-              </Link>
+              <Link search={projectSearch} to="/reports">View Evidence Center</Link>
             </Button>
           </VpwToolbarGroup>
           <VpwToolbarGroup>

--- a/frontend/src/components/providers/providers-workbench-model.ts
+++ b/frontend/src/components/providers/providers-workbench-model.ts
@@ -16,6 +16,7 @@ export type ProvidersWorkbenchProps = {
   providerStatus: ProviderStatusPublic | null
   providerStatusError: string
   providerStatusLoading: boolean
+  selectedProjectId: string
   onRefreshProviderStatus: () => void
 }
 

--- a/frontend/src/workbench/routes/ProvidersRoute.tsx
+++ b/frontend/src/workbench/routes/ProvidersRoute.tsx
@@ -7,6 +7,7 @@ function ProvidersRouteContent() {
     providerStatusError,
     providerStatusLoading,
     refreshProviderStatus,
+    selectedProjectId,
   } = useWorkbenchContext()
 
   return (
@@ -16,6 +17,7 @@ function ProvidersRouteContent() {
         providerStatus={providerStatus}
         providerStatusError={providerStatusError}
         providerStatusLoading={providerStatusLoading}
+        selectedProjectId={selectedProjectId}
       />
     </section>
   )


### PR DESCRIPTION
## Summary
- pass selectedProjectId through the providers route/container/workbench chain
- keep the Providers hero Evidence Center link on the active project

## Validation
- npm run test:unit -- selected-project-search.test.ts route-organization.test.ts
- npm run lint
- npm run build
- make frontend-check