### PR TITLE
[codex] Deep link imports to selected run

### DIFF
--- a/frontend/src/workbench/import-route-search.ts
+++ b/frontend/src/workbench/import-route-search.ts
@@ -6,5 +6,5 @@ import {
 
 export { normalizeSelectedRunId }
 
-export const selectedReportRunIdFromSearch = selectedRunIdFromSearch
-export const reportRunUrlSearch = runUrlSearch
+export const selectedImportRunIdFromSearch = selectedRunIdFromSearch
+export const importRunUrlSearch = runUrlSearch

--- a/frontend/src/workbench/routes/ImportsRoute.tsx
+++ b/frontend/src/workbench/routes/ImportsRoute.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { type FormEvent, useEffect, useState } from "react"
+import { useLocation, useNavigate } from "@/lib/router"
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react"
 import {
   type AnalysisRunPublic,
   type AnalysisRunSummaryPublic,
@@ -22,6 +23,12 @@ import {
   workbenchImportFormats,
 } from "../../lib/app-defaults"
 import { buildImportUploadFormData } from "../import-upload-payload"
+import {
+  importRunUrlSearch,
+  normalizeSelectedRunId,
+  selectedImportRunIdFromSearch,
+} from "../import-route-search"
+import { searchStringFromUrlSearch } from "../selected-project-search"
 import { useWorkbenchContext } from "../WorkbenchContext"
 import {
   useProjectRunsQuery,
@@ -40,7 +47,13 @@ const TERMINAL_RUN_STATUSES = new Set([
   "succeeded",
 ])
 
+function activeSearchString(fallbackSearch: string) {
+  return typeof window === "undefined" ? fallbackSearch : window.location.search
+}
+
 function ImportsRouteContainer() {
+  const location = useLocation()
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const {
     projectListLoading,
@@ -63,10 +76,20 @@ function ImportsRouteContainer() {
     ImportParseErrorPublic[]
   >([])
   const [selectedRunId, setSelectedRunId] = useState("")
+  const [pendingSelectableRunId, setPendingSelectableRunId] = useState("")
   const [refreshedTerminalRun, setRefreshedTerminalRun] = useState("")
+  const routeRunId = selectedImportRunIdFromSearch(location.searchStr)
   const projectRunsQuery = useProjectRunsQuery(selectedProjectId, true)
   const projectRuns = projectRunsQuery.data?.data ?? []
   const runDetailQuery = useRunDetailQuery(selectedRunId, true)
+  const runIds = useMemo(() => projectRuns.map((run) => run.id), [projectRuns])
+  const selectableRunIds = useMemo(
+    () =>
+      pendingSelectableRunId && !runIds.includes(pendingSelectableRunId)
+        ? [pendingSelectableRunId, ...runIds]
+        : runIds,
+    [pendingSelectableRunId, runIds],
+  )
   const importMutation = useMutation({
     mutationFn: ({
       body,
@@ -81,21 +104,60 @@ function ImportsRouteContainer() {
       }),
   })
 
+  const selectRunId = useCallback(
+    (nextRunId: string, { replace }: { replace: boolean }) => {
+      setSelectedRunId(nextRunId)
+      const currentLocationSearch = activeSearchString(location.searchStr)
+      const nextSearch = importRunUrlSearch(currentLocationSearch, nextRunId)
+      const currentSearch = currentLocationSearch.startsWith("?")
+        ? currentLocationSearch.slice(1)
+        : currentLocationSearch
+      if (searchStringFromUrlSearch(nextSearch) === currentSearch) {
+        return
+      }
+      void navigate({
+        replace,
+        search: () => nextSearch,
+      })
+    },
+    [location.searchStr, navigate],
+  )
+
   useEffect(() => {
-    setSelectedRunId((currentRunId) =>
-      projectRuns.some((run) => run.id === currentRunId)
-        ? currentRunId
-        : (projectRuns[0]?.id ?? ""),
+    if (projectRunsQuery.isLoading && runIds.length === 0) {
+      return
+    }
+    const nextRunId = normalizeSelectedRunId(
+      [routeRunId, selectedRunId],
+      selectableRunIds,
     )
-  }, [projectRuns])
+    if (nextRunId === selectedRunId && nextRunId === routeRunId) {
+      return
+    }
+    selectRunId(nextRunId, { replace: true })
+  }, [
+    projectRunsQuery.isLoading,
+    routeRunId,
+    runIds,
+    selectRunId,
+    selectableRunIds,
+    selectedRunId,
+  ])
+
+  useEffect(() => {
+    if (pendingSelectableRunId && runIds.includes(pendingSelectableRunId)) {
+      setPendingSelectableRunId("")
+    }
+  }, [pendingSelectableRunId, runIds])
 
   async function refreshProjectRuns(preferredRunId?: string) {
     if (!selectedProjectId) {
-      setSelectedRunId("")
+      selectRunId("", { replace: true })
       return
     }
     if (preferredRunId) {
-      setSelectedRunId(preferredRunId)
+      setPendingSelectableRunId(preferredRunId)
+      selectRunId(preferredRunId, { replace: false })
     }
     await queryClient.invalidateQueries({
       queryKey: workbenchQueryKeys.projectRuns(selectedProjectId),
@@ -194,7 +256,8 @@ function ImportsRouteContainer() {
       const summary = await RunsService.readRunSummary({ run_id: run.id })
       setImportRunSummary(summary)
       setImportParseErrors(summary.parse_errors ?? [])
-      setSelectedRunId(run.id)
+      setPendingSelectableRunId(run.id)
+      selectRunId(run.id, { replace: false })
       await refreshProjects(importProjectId)
       await refreshProjectRuns(run.id)
       await invalidateProjectScopedWorkbenchQueries(queryClient, importProjectId)
@@ -204,7 +267,8 @@ function ImportsRouteContainer() {
       const parseErrors = parseErrorsFromError(caught)
       setImportParseErrors(parseErrors)
       if (runId) {
-        setSelectedRunId(runId)
+        setPendingSelectableRunId(runId)
+        selectRunId(runId, { replace: false })
         try {
           const summary = await RunsService.readRunSummary({ run_id: runId })
           setImportRunSummary(summary)
@@ -217,6 +281,11 @@ function ImportsRouteContainer() {
       await refreshProjectRuns(runId ?? undefined)
       await invalidateProjectScopedWorkbenchQueries(queryClient, importProjectId)
     }
+  }
+
+  function handleProjectChange(projectId: string) {
+    setSelectedProjectId(projectId)
+    selectRunId("", { replace: true })
   }
 
   return (
@@ -251,9 +320,9 @@ function ImportsRouteContainer() {
       onUseDemoProviderSnapshot={() =>
         setImportWizard((state) => withDemoProviderSnapshot(state))
       }
-      onProjectChange={setSelectedProjectId}
+      onProjectChange={handleProjectChange}
       onRefreshRuns={() => void refreshProjectRuns(selectedRunId)}
-      onSelectRun={setSelectedRunId}
+      onSelectRun={(runId) => selectRunId(runId, { replace: false })}
       onSubmit={submitImport}
       onAttackMappingFileChange={(value) =>
         setImportWizard((state) => ({ ...state, attackMappingFile: value }))

--- a/frontend/src/workbench/run-route-search.ts
+++ b/frontend/src/workbench/run-route-search.ts
@@ -1,0 +1,32 @@
+import type { ProjectUrlSearch } from "./selected-project-search"
+
+export function selectedRunIdFromSearch(searchStr: string): string {
+  const rawSearch = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr
+  return new URLSearchParams(rawSearch).get("runId") ?? ""
+}
+
+export function runUrlSearch(
+  searchStr: string,
+  runId: string,
+): ProjectUrlSearch {
+  const rawSearch = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr
+  const params = new URLSearchParams(rawSearch)
+  if (runId) {
+    params.set("runId", runId)
+  } else {
+    params.delete("runId")
+  }
+  return Object.fromEntries(params.entries())
+}
+
+export function normalizeSelectedRunId(
+  candidates: readonly string[],
+  runIds: readonly string[],
+): string {
+  const availableRunIds = new Set(runIds)
+  return (
+    candidates.find((candidate) => candidate && availableRunIds.has(candidate)) ??
+    runIds[0] ??
+    ""
+  )
+}

--- a/frontend/tests/import-route-search.test.ts
+++ b/frontend/tests/import-route-search.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  importRunUrlSearch,
+  normalizeSelectedRunId,
+  selectedImportRunIdFromSearch,
+} from "../src/workbench/import-route-search.ts"
+
+test("reads selected import run id from route search", () => {
+  assert.equal(selectedImportRunIdFromSearch("?runId=run-1"), "run-1")
+  assert.equal(selectedImportRunIdFromSearch("projectId=project-1"), "")
+})
+
+test("updates import run id while preserving project search", () => {
+  assert.deepEqual(
+    importRunUrlSearch("?projectId=project-1&runId=old&tab=imports", "run-2"),
+    {
+      projectId: "project-1",
+      runId: "run-2",
+      tab: "imports",
+    },
+  )
+  assert.deepEqual(
+    importRunUrlSearch("?projectId=project-1&runId=old", ""),
+    {
+      projectId: "project-1",
+    },
+  )
+})
+
+test("normalizes stale import run ids to an available run", () => {
+  assert.equal(
+    normalizeSelectedRunId(["missing", "run-2"], ["run-1", "run-2"]),
+    "run-2",
+  )
+  assert.equal(normalizeSelectedRunId(["missing"], ["run-1"]), "run-1")
+  assert.equal(normalizeSelectedRunId(["missing"], []), "")
+})

--- a/frontend/tests/imports-route-integration.spec.ts
+++ b/frontend/tests/imports-route-integration.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test"
+import type { AnalysisRunPublic, AnalysisRunSummaryPublic } from "../src/api-client"
+import { mockProject, routeWorkbenchShell } from "./workbench-route-mocks"
+
+const runOne = importRun("run-1", "historical-import-one.txt")
+const runTwo = importRun("run-2", "historical-import-two.txt")
+
+test("imports route deep links selected run and preserves it across reload", async ({
+  page,
+}) => {
+  await routeWorkbenchShell(page, {
+    projects: [mockProject],
+    runSummaries: {
+      [runOne.id]: importRunSummary(runOne, 2),
+      [runTwo.id]: importRunSummary(runTwo, 4),
+    },
+    runs: [runOne, runTwo],
+  })
+
+  await page.goto(`/imports?projectId=${mockProject.id}&runId=${runTwo.id}`)
+
+  await expect(page.getByRole("heading", { name: runTwo.id })).toBeVisible()
+  await expect(
+    page.getByRole("cell", { name: "historical-import-two.txt" }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("link", { exact: true, name: "Evidence" }),
+  ).toHaveAttribute("href", `/reports?projectId=${mockProject.id}&runId=${runTwo.id}`)
+
+  await page.reload()
+
+  await expect(page).toHaveURL(new RegExp(`runId=${runTwo.id}`))
+  await expect(page.getByRole("heading", { name: runTwo.id })).toBeVisible()
+
+  await page
+    .getByRole("row", { name: /historical-import-one\.txt/ })
+    .getByRole("button", { name: "Inspect" })
+    .click()
+
+  await expect(page).toHaveURL(new RegExp(`runId=${runOne.id}`))
+  await expect(page.getByRole("heading", { name: runOne.id })).toBeVisible()
+})
+
+function importRun(id: string, filename: string): AnalysisRunPublic {
+  return {
+    filename,
+    finished_at: "2026-05-10T10:05:00Z",
+    id,
+    input_type: "cve-list",
+    project_id: mockProject.id,
+    provider_snapshot_id: "demo",
+    started_at: "2026-05-10T10:00:00Z",
+    status: "succeeded",
+    summary_json: {
+      input_upload: { filename },
+    },
+  }
+}
+
+function importRunSummary(
+  run: AnalysisRunPublic,
+  findingCount: number,
+): AnalysisRunSummaryPublic {
+  return {
+    created_findings: findingCount,
+    filename: run.filename ?? null,
+    finding_count: findingCount,
+    finished_at: run.finished_at ?? null,
+    id: run.id,
+    ignored_lines: 0,
+    input_type: run.input_type,
+    input_upload: { filename: run.filename },
+    parse_errors: [],
+    project_id: run.project_id,
+    provider_degraded: false,
+    provider_snapshot_id: run.provider_snapshot_id,
+    started_at: run.started_at ?? "2026-05-10T10:00:00Z",
+    status: run.status ?? "succeeded",
+    updated_findings: 0,
+  }
+}

--- a/frontend/tests/workbench-route-mocks.ts
+++ b/frontend/tests/workbench-route-mocks.ts
@@ -1,4 +1,8 @@
 import type { Page } from "@playwright/test"
+import type {
+  AnalysisRunPublic,
+  AnalysisRunSummaryPublic,
+} from "../src/api-client"
 
 type MockProject = {
   created_at: string
@@ -44,6 +48,8 @@ type RouteWorkbenchShellOptions = {
   providerStatusDelayMs?: number
   providerStatusError?: boolean
   projects?: MockProject[]
+  runSummaries?: Record<string, AnalysisRunSummaryPublic>
+  runs?: AnalysisRunPublic[]
 }
 
 export const mockProject: MockProject = {
@@ -89,6 +95,8 @@ export async function routeWorkbenchShell(
 ) {
   const projects = options.projects ?? []
   const findings = options.findings ?? []
+  const runs = options.runs ?? []
+  const runSummaries = options.runSummaries ?? {}
   const findingsDelayMs = options.findingsDelayMs ?? 0
   const onFindingsRequest = options.onFindingsRequest
   const providerStatusDelayMs = options.providerStatusDelayMs ?? 0
@@ -197,6 +205,7 @@ export async function routeWorkbenchShell(
     }),
   )
   for (const project of projects) {
+    const projectRuns = runs.filter((run) => run.project_id === project.id)
     const projectSummary = {
       counts_by_priority: { critical: findings.length },
       counts_by_status: { open: findings.length },
@@ -204,8 +213,8 @@ export async function routeWorkbenchShell(
       epss_hits: findings.filter((finding) => finding.epss > 0).length,
       finding_count: findings.length,
       kev_hits: findings.filter((finding) => finding.in_kev).length,
-      latest_run_id: null,
-      latest_run_status: null,
+      latest_run_id: projectRuns[0]?.id ?? null,
+      latest_run_status: projectRuns[0]?.status ?? null,
       latest_run_summary: {},
       open_finding_count: findings.length,
       project_id: project.id,
@@ -257,9 +266,21 @@ export async function routeWorkbenchShell(
             top_services_by_risk: [],
           },
           project_id: project.id,
-          runs: { data: [], count: 0 },
+          runs: { data: projectRuns, count: projectRuns.length },
           summary: projectSummary,
         }),
+      }),
+    )
+    await page.route(`**/api/v1/projects/${project.id}/runs/`, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ data: projectRuns, count: projectRuns.length }),
+      }),
+    )
+    await page.route(`**/api/v1/projects/${project.id}/runs/?*`, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ data: projectRuns, count: projectRuns.length }),
       }),
     )
     await page.route(
@@ -277,6 +298,40 @@ export async function routeWorkbenchShell(
         })
       },
     )
+  }
+  for (const run of runs) {
+    await page.route(`**/api/v1/runs/${run.id}`, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(run),
+      }),
+    )
+    await page.route(`**/api/v1/runs/${run.id}/summary`, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(runSummaries[run.id] ?? runSummaryFromRun(run)),
+      }),
+    )
+  }
+}
+
+function runSummaryFromRun(run: AnalysisRunPublic): AnalysisRunSummaryPublic {
+  return {
+    created_findings: 0,
+    filename: run.filename ?? null,
+    finding_count: 0,
+    finished_at: run.finished_at ?? null,
+    id: run.id,
+    ignored_lines: 0,
+    input_type: run.input_type,
+    parse_errors: [],
+    project_id: run.project_id,
+    provider_degraded: false,
+    provider_snapshot_id: run.provider_snapshot_id,
+    started_at: run.started_at ?? "2025-01-01T00:00:00Z",
+    status: run.status ?? "pending",
+    summary_json: run.summary_json,
+    updated_findings: 0,
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared runId route-search helpers for Workbench routes
- keep Imports selected run in the URL as runId for reload/shareable history detail
- extend route mocks and browser coverage for importing run deep links

## Validation
- npm run test:unit -- import-route-search.test.ts report-route-search.test.ts selected-project-search.test.ts
- npm run lint
- npm run build
- python3 -m pytest -q backend/tests/test_refactor_hygiene.py::test_workbench_reports_route_state_is_split_from_shell backend/tests/test_refactor_hygiene.py::test_frontend_routes_use_workbench_route_containers_instead_of_app_facade backend/tests/test_refactor_hygiene.py::test_workbench_shell_is_frame_only_and_routes_own_product_surfaces --no-cov
- npx playwright test tests/imports-route-integration.spec.ts --project=chromium
- make frontend-check