### PR TITLE
[codex] Preserve project context in finding detail links

### DIFF
--- a/frontend/src/components/assets/AssetLinkedFindingsPanel.tsx
+++ b/frontend/src/components/assets/AssetLinkedFindingsPanel.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from "react"
 
 import type { AssetPublic, FindingPublic } from "../../api-client"
 import { formatLabel as labelize, optionalText } from "../../lib/ui-copy"
+import { selectedProjectRouteSearch } from "../../workbench/selected-project-search"
 import { Button } from "../ui/button"
 import {
   VpwAssetContextCard,
@@ -76,6 +77,7 @@ export function AssetLinkedFindingsPanel({
         <Link
           className="font-mono text-sm font-semibold text-[var(--vpw-blue)] hover:underline"
           params={{ findingId: finding.id }}
+          search={selectedProjectRouteSearch(finding.project_id)}
           to="/findings/$findingId"
         >
           {finding.cve_id}

--- a/frontend/src/components/dashboard/DashboardRemediationSection.tsx
+++ b/frontend/src/components/dashboard/DashboardRemediationSection.tsx
@@ -36,6 +36,7 @@ import {
   VpwSurfaceTitle,
 } from "@/components/vpw"
 import { optionalText } from "@/lib/ui-copy"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import { RiskBadge } from "../risk/RiskBadge"
 import { SeverityBadge } from "../risk/SeverityBadge"
 import { EmptyState, ErrorState } from "../states"
@@ -90,7 +91,11 @@ export function DashboardRemediationSection({
           className="h-auto px-0 font-mono text-sm"
           variant="link"
         >
-          <Link params={{ findingId: finding.id }} to="/findings/$findingId">
+          <Link
+            params={{ findingId: finding.id }}
+            search={selectedProjectRouteSearch(finding.project_id)}
+            to="/findings/$findingId"
+          >
             {finding.cve_id}
           </Link>
         </Button>
@@ -212,6 +217,7 @@ export function DashboardRemediationSection({
               <Button asChild className="w-full" size="sm" variant="outline">
                 <Link
                   params={{ findingId: finding.id }}
+                  search={selectedProjectRouteSearch(finding.project_id)}
                   to="/findings/$findingId"
                 >
                   Open full detail

--- a/frontend/src/components/waivers/WaiversWorkbenchRegisterColumns.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbenchRegisterColumns.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { VpwBadge, type VpwDataTableColumn } from "@/components/vpw"
 import { optionalText } from "@/lib/ui-copy"
 import { cn } from "@/lib/utils"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   daysLabel,
   formatDate,
@@ -147,8 +148,9 @@ function WaiverRegisterActions({
       {waiver.finding_id ? (
         <Button asChild size="sm" variant="outline">
           <Link
-            to="/findings/$findingId"
             params={{ findingId: waiver.finding_id }}
+            search={selectedProjectRouteSearch(waiver.project_id)}
+            to="/findings/$findingId"
           >
             View finding
           </Link>

--- a/frontend/tests/route-organization.test.ts
+++ b/frontend/tests/route-organization.test.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict"
 import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { dirname, join } from "node:path"
 import test from "node:test"
+import { fileURLToPath } from "node:url"
 
 import { workbenchPathFromPathname } from "../src/lib/app-route-config.ts"
 
+const frontendRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const appRouterFile = new URL("../src/AppRouter.tsx", import.meta.url)
 const oldRoutesDir = new URL("../src/routes/", import.meta.url)
 const workbenchRoutesDir = new URL("../src/workbench/routes/", import.meta.url)
+const componentsDir = join(frontendRoot, "src/components")
 const appShellFile = new URL("../src/components/app/AppShell.tsx", import.meta.url)
 const packageJsonFile = new URL("../package.json", import.meta.url)
 const routeDetailsFile = new URL(
@@ -24,6 +28,16 @@ function text(url: URL) {
 
 function uniqueMatches(source: string, pattern: RegExp) {
   return [...new Set([...source.matchAll(pattern)].map((match) => match[1]))]
+}
+
+function tsxFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) return tsxFiles(path)
+      return path.endsWith(".tsx") ? [path] : []
+    })
+    .sort()
 }
 
 test("AppRouter owns the active Workbench route table", () => {
@@ -121,4 +135,24 @@ test("frontend unit test scripts automatically include every unit test file", ()
     assert.doesNotMatch(script, /tests\/[\w-]+\.test\.ts/)
     assert.doesNotMatch(script, /\.spec\.ts/)
   }
+})
+
+test("finding detail links preserve selected project context", () => {
+  const sourceFiles = [
+    ...tsxFiles(componentsDir),
+    ...tsxFiles(fileURLToPath(workbenchRoutesDir)),
+  ]
+  const missingProjectSearch = sourceFiles.flatMap((file) => {
+    const source = readFileSync(file, "utf8")
+    const links = [
+      ...source.matchAll(
+        /<Link\b(?=[^>]*\bto="\/findings\/\$findingId")(?=[^>]*\bparams=\{\{\s*findingId:)[^>]*>/gs,
+      ),
+    ]
+    return links
+      .filter((match) => !/\bsearch=/.test(match[0]))
+      .map(() => file.replace(`${frontendRoot}/`, ""))
+  })
+
+  assert.deepEqual(missingProjectSearch, [])
 })


### PR DESCRIPTION
## Summary
- Add selected project search params to finding detail links from dashboard, assets, and waivers surfaces
- Add a frontend route-organization guard that prevents projectless finding detail links from reappearing

## Validation
- npm run lint
- npm run test:unit
- make frontend-check