### PR TITLE
[codex] Preserve project context in settings provider link

### DIFF
--- a/frontend/src/components/settings/SettingsWorkbench.tsx
+++ b/frontend/src/components/settings/SettingsWorkbench.tsx
@@ -21,6 +21,7 @@ export function SettingsWorkbench(props: SettingsWorkbenchProps) {
       <SettingsHero
         providerStatus={props.providerStatus}
         providerStatusError={props.providerStatusError}
+        selectedProjectId={props.selectedProjectId}
         statusError={props.statusError}
       />
       <SettingsAlerts

--- a/frontend/src/components/settings/SettingsWorkbenchHero.tsx
+++ b/frontend/src/components/settings/SettingsWorkbenchHero.tsx
@@ -6,6 +6,7 @@ import {
   type VpwBadgeTone,
   VpwSection,
 } from "@/components/vpw"
+import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   evidenceReadiness,
   providerHealth,
@@ -14,12 +15,13 @@ import {
 
 type SettingsHeroProps = Pick<
   SettingsWorkbenchProps,
-  "providerStatus" | "providerStatusError" | "statusError"
+  "providerStatus" | "providerStatusError" | "selectedProjectId" | "statusError"
 >
 
 export function SettingsHero({
   providerStatus,
   providerStatusError,
+  selectedProjectId,
   statusError,
 }: SettingsHeroProps) {
   const provider = providerHealth(providerStatus)
@@ -43,7 +45,12 @@ export function SettingsHero({
         </div>
         <div className="flex shrink-0">
           <Button asChild variant="outline">
-            <Link to="/providers">View providers</Link>
+            <Link
+              search={selectedProjectRouteSearch(selectedProjectId)}
+              to="/providers"
+            >
+              View providers
+            </Link>
           </Button>
         </div>
       </div>

--- a/frontend/src/components/settings/settings-workbench-model.ts
+++ b/frontend/src/components/settings/settings-workbench-model.ts
@@ -10,6 +10,7 @@ export type SettingsWorkbenchProps = {
   providerStatus: ProviderStatusPublic | null
   providerStatusError: string
   providerStatusLoading: boolean
+  selectedProjectId: string
   status: WorkbenchStatus | null
   statusError: string
   onSettingsTabChange: (tab: SettingsTab) => void

--- a/frontend/src/workbench/routes/SettingsRoute.tsx
+++ b/frontend/src/workbench/routes/SettingsRoute.tsx
@@ -14,6 +14,7 @@ function SettingsRouteContent() {
     providerStatus,
     providerStatusError,
     providerStatusLoading,
+    selectedProjectId,
     status,
     statusError,
   } = useWorkbenchContext()
@@ -49,6 +50,7 @@ function SettingsRouteContent() {
         providerStatus={providerStatus}
         providerStatusError={providerStatusError}
         providerStatusLoading={providerStatusLoading}
+        selectedProjectId={selectedProjectId}
         status={status}
         statusError={statusError}
       />

--- a/frontend/tests/settings-route-integration.spec.ts
+++ b/frontend/tests/settings-route-integration.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test"
+
+import { mockProject, routeWorkbenchShell } from "./workbench-route-mocks"
+
+test("settings provider link preserves selected project context", async ({
+  page,
+}) => {
+  await routeWorkbenchShell(page, { projects: [mockProject] })
+
+  await page.goto(`/settings?projectId=${mockProject.id}`)
+
+  const providersLink = page.getByRole("link", { name: "View providers" })
+  await expect(providersLink).toHaveAttribute(
+    "href",
+    `/providers?projectId=${mockProject.id}`,
+  )
+
+  await providersLink.click()
+
+  await expect(page).toHaveURL(
+    new RegExp(`/providers\\?projectId=${mockProject.id}`),
+  )
+})


### PR DESCRIPTION
## Summary
- Pass the selected project id into Settings so the Providers link keeps project context
- Add a mocked settings route Playwright test for the provider link href and navigation

## Validation
- npm run lint
- npm run build
- npx playwright test tests/settings-route-integration.spec.ts --project=chromium
- make frontend-check