### PR TITLE
[codex] Clarify historical release docs for local Workbench

### DIFF
--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -332,13 +332,25 @@ def test_current_docs_do_not_reframe_workbench_as_cli_or_release_gate() -> None:
     reference_gap = REFERENCE_GAP_FILE.read_text(encoding="utf-8")
     offline_demo = WORKBENCH_OFFLINE_DEMO_FILE.read_text(encoding="utf-8")
     docs_index = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+    release_notes = (REPO_ROOT / "docs" / "releases" / "v1.1.0.md").read_text(encoding="utf-8")
+    workbench_release_notes = (REPO_ROOT / "docs" / "releases" / "workbench-v1.0.0.md").read_text(
+        encoding="utf-8"
+    )
     normalized_reference_gap = " ".join(reference_gap.split())
+    normalized_release_notes = " ".join(release_notes.split())
+    normalized_workbench_release_notes = " ".join(workbench_release_notes.split())
 
     assert "broader CLI/CI workflow tool" not in normalized_reference_gap
     assert "old CLI/CI-oriented surfaces are historical" in normalized_reference_gap
     assert "release-readiness path" not in offline_demo
     assert "reproducible local demo path" in offline_demo
     assert "not part of the normal local Workbench development path" in docs_index
+    assert "current Workbench-ready tree" not in normalized_release_notes
+    assert "historical public package release" in normalized_release_notes
+    assert "not current product surfaces" in normalized_release_notes
+    assert "does not expose API-token gating" in normalized_release_notes
+    assert "post-v1.0 package-line work" in normalized_workbench_release_notes
+    assert "does not expose API-token gating" in normalized_workbench_release_notes
 
 
 def test_active_docs_do_not_publish_removed_cli_report_examples() -> None:

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -2,10 +2,18 @@
 
 ## Focus
 
-`v1.1.0` is the public package release for the current Workbench-ready tree.
-It turns the stable prioritization core into a local-first CLI plus self-hosted Workbench release line. The scoring model stays transparent and rule-based, while the workflow surface grows around it.
+`v1.1.0` is the historical public package release for the tag-time
+Workbench-ready tree. At that tag, the stable prioritization core still shipped
+as a local-first CLI plus a self-hosted Workbench release line. Current `main`
+has since moved to a local single-user Workbench: the old CLI entrypoint,
+composite GitHub Action surface, active API-token gating, RBAC, login, and
+session flows are not current product surfaces.
 
-## Highlights
+The scoring model stays transparent and rule-based, while the active Workbench
+surface focuses on importing known vulnerability evidence, prioritizing it, and
+producing reports from local project data.
+
+## Tag-Time Highlights
 
 - Added first-class runtime config discovery via `vuln-prioritizer.yml`, plus `--config` and `--no-config`.
 - Added `doctor` for local diagnostics and optional live-source reachability probes.
@@ -20,7 +28,12 @@ It turns the stable prioritization core into a local-first CLI plus self-hosted 
 - Refreshed README, docs navigation, and committed screenshots/static preview media for public-facing use cases, including clearer command-specific output support.
 - Added the Workbench local app surface for projects, imports, dashboard, findings, vulnerability intelligence, reports, evidence bundles, assets, waivers, and settings.
 - Added advanced ATT&CK Workbench surfaces for detection controls, coverage gaps, defensive Navigator exports, and technique detail pages.
-- Added local automation and integration surfaces: API-token gating, optional PostgreSQL profile, scheduled provider snapshot refresh, GitHub Action report/SARIF workflows, GitHub issue export, and config-as-code settings.
+- Added local automation and integration surfaces in the tag-time package line:
+  API-token gating, optional PostgreSQL profile, scheduled provider snapshot
+  refresh, GitHub Action report/SARIF workflows, GitHub issue export, and
+  config-as-code settings. Current `main` keeps GitHub issue export as an
+  active Workbench feature, but does not expose API-token gating or the old
+  composite Action/CLI product surface.
 
 ## Release Assets And Documentation
 
@@ -36,8 +49,11 @@ The GitHub Release assets are the attached `vuln_prioritizer-1.1.0-py3-none-any.
 - [docs/examples/media/workbench-reports-evidence.png](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/media/workbench-reports-evidence.png)
 - [docs/examples/example_report.html](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/examples/example_report.html)
 
-Current post-release documentation and security-hygiene status is tracked on `main`:
+Current post-release documentation and local Workbench status is tracked on
+`main`:
 
+- [docs/current-product-state.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/current-product-state.md)
+- [docs/support_matrix.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/support_matrix.md)
 - [docs/workbench-v1-release-checklist.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/workbench-v1-release-checklist.md)
 - [docs/roadmap.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/roadmap.md)
 - [docs/dependency-and-package-policy.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/main/docs/dependency-and-package-policy.md)
@@ -65,7 +81,7 @@ The locked-provider demo evidence bundle is generated with `VULN_PRIORITIZER_FIX
 
 ## Notes
 
-- The existing `analyze`, `compare`, and `explain` JSON contracts remain on `metadata.schema_version = 1.0.0`.
+- At tag time, the existing `analyze`, `compare`, and `explain` JSON contracts remained on `metadata.schema_version = 1.0.0`.
 - The new helper contracts introduced in this release use `1.1.0`.
 - The wheel and sdist include the tag-time README from `v1.1.0`; current `main` contains post-publication README wording updates. A patch release should be cut if package metadata wording itself needs to be republished.
 - Use [docs/releases/v1.0.0.md](https://github.com/Noetheon/vuln-prioritizer-workbench/blob/v1.1.0/docs/releases/v1.0.0.md) for the first stable baseline release notes.

--- a/docs/releases/workbench-v1.0.0.md
+++ b/docs/releases/workbench-v1.0.0.md
@@ -128,6 +128,13 @@ Record the release commit with `git rev-parse HEAD`, the date of the run, and th
 
 ## Post-Milestone Status
 
-- The pinned ATT&CK STIX import, ATT&CK version/hash tracking, CTID provider provenance, and detection coverage work were completed on `main` after this Workbench v1.0 readiness milestone.
-- Local API-token gating, optional PostgreSQL profile, scheduled provider update jobs, SARIF/Action workflow expansion, GitHub issue export, config-as-code, and CI/CD docs were completed on `main` after this Workbench v1.0 readiness milestone.
+- The pinned ATT&CK STIX import, ATT&CK version/hash tracking, CTID provider
+  provenance, and detection coverage work landed after this Workbench v1.0
+  readiness milestone and remain part of the current Workbench evidence model.
+- API-token gating, optional PostgreSQL profile, scheduled provider update jobs,
+  SARIF/Action workflow expansion, GitHub issue export, config-as-code, and
+  CI/CD docs belonged to post-v1.0 package-line work in the historical
+  `v1.1.0` tree. Current `main` has since narrowed the active product to the
+  local single-user Workbench and does not expose API-token gating, RBAC,
+  login/session flows, or the old CLI/Action product surface.
 - The `v1.1.0` package tag and GitHub Release now carry the completed Workbench scope from `main`; future Workbench work should be tracked as new issues rather than as unfinished v1.0 follow-up.


### PR DESCRIPTION
## Summary
- Reframe v1.1.0 release notes as tag-time historical package docs, not current product scope
- Clarify that current main is local single-user Workbench without active CLI/API-token/RBAC/login/session surfaces
- Add docs hygiene assertions to prevent release notes from reintroducing misleading current-scope wording

## Validation
- python3 -m pytest -q backend/tests/test_docs_hygiene.py --no-cov
- git diff --check