### PR TITLE
[codex] Harden backend operational edges

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
+from sqlalchemy.engine import Engine
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
@@ -74,12 +75,9 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
     app.state.rate_limiter = create_rate_limiter(selected_settings, active_engine)
     if selected_settings.ENVIRONMENT != "local":
         app.router.on_startup.append(lambda: assert_migrated_schema(active_engine))
-        app.router.on_startup.append(
-            lambda: reconcile_stale_background_import_runs(
-                engine=active_engine,
-                settings=selected_settings,
-            )
-        )
+    app.router.on_startup.append(
+        lambda: _reconcile_stale_import_runs_on_startup(active_engine, selected_settings)
+    )
     app.add_middleware(
         TrustedHostMiddleware,
         allowed_hosts=list(selected_settings.ALLOWED_HOSTS),
@@ -101,6 +99,22 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
     app.add_exception_handler(Exception, unhandled_exception_handler)
     install_error_openapi_schema(app)
     return app
+
+
+def _reconcile_stale_import_runs_on_startup(
+    active_engine: Engine,
+    selected_settings: Settings,
+) -> int:
+    """Reconcile background imports without breaking first-run local schema setup."""
+    try:
+        return reconcile_stale_background_import_runs(
+            engine=active_engine,
+            settings=selected_settings,
+        )
+    except Exception:
+        if selected_settings.ENVIRONMENT == "local":
+            return 0
+        raise
 
 
 async def _security_headers(

--- a/backend/app/services/report_service_persistence.py
+++ b/backend/app/services/report_service_persistence.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import hashlib
+import shutil
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,8 @@ from sqlmodel import Session
 
 from app.core.config import Settings
 from app.models import AnalysisRun, Project, Report
-from app.repositories import ReportRepository
 from app.services.report_models import ReportGenerationError
+from app.services.report_service_records import create_report_record
 from app.services.report_service_retention import prune_run_reports
 
 
@@ -34,35 +35,22 @@ def persist_text_report(
     extra_metadata: dict[str, Any] | None = None,
 ) -> Report:
     content_bytes = content.encode("utf-8")
-    _ensure_report_size_allowed(settings, content_size=len(content_bytes), filename=filename)
-    report_id = uuid.uuid4()
-    path = report_path(
-        settings,
-        project_id=project.id,
-        run_id=run.id,
-        report_id=report_id,
-        filename=filename,
-    )
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-    report = create_report_record(
+    return _persist_report_artifact(
         session,
-        report_id=report_id,
+        settings,
         run=run,
         project=project,
         generated_at=generated_at,
         finding_count=finding_count,
         provider_snapshot_id=provider_snapshot_id,
         content_bytes=content_bytes,
-        report_path=path,
+        write_artifact=lambda path: path.write_text(content, encoding="utf-8"),
         kind=kind,
         report_format=report_format,
         filename=filename,
         content_type=content_type,
         extra_metadata=extra_metadata,
     )
-    prune_run_reports(session, settings, report)
-    return report
 
 
 def persist_binary_report(
@@ -81,7 +69,42 @@ def persist_binary_report(
     content_type: str,
     extra_metadata: dict[str, Any] | None = None,
 ) -> Report:
-    _ensure_report_size_allowed(settings, content_size=len(content), filename=filename)
+    return _persist_report_artifact(
+        session,
+        settings,
+        run=run,
+        project=project,
+        generated_at=generated_at,
+        finding_count=finding_count,
+        provider_snapshot_id=provider_snapshot_id,
+        content_bytes=content,
+        write_artifact=lambda path: path.write_bytes(content),
+        kind=kind,
+        report_format=report_format,
+        filename=filename,
+        content_type=content_type,
+        extra_metadata=extra_metadata,
+    )
+
+
+def _persist_report_artifact(
+    session: Session,
+    settings: Settings,
+    *,
+    run: AnalysisRun,
+    project: Project,
+    generated_at: datetime,
+    finding_count: int,
+    provider_snapshot_id: uuid.UUID | None,
+    content_bytes: bytes,
+    write_artifact: Callable[[Path], object],
+    kind: str,
+    report_format: str,
+    filename: str,
+    content_type: str,
+    extra_metadata: dict[str, Any] | None,
+) -> Report:
+    _ensure_report_size_allowed(settings, content_size=len(content_bytes), filename=filename)
     report_id = uuid.uuid4()
     path = report_path(
         settings,
@@ -91,72 +114,29 @@ def persist_binary_report(
         filename=filename,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(content)
-    report = create_report_record(
-        session,
-        report_id=report_id,
-        run=run,
-        project=project,
-        generated_at=generated_at,
-        finding_count=finding_count,
-        provider_snapshot_id=provider_snapshot_id,
-        content_bytes=content,
-        report_path=path,
-        kind=kind,
-        report_format=report_format,
-        filename=filename,
-        content_type=content_type,
-        extra_metadata=extra_metadata,
-    )
-    prune_run_reports(session, settings, report)
-    return report
-
-
-def create_report_record(
-    session: Session,
-    *,
-    report_id: uuid.UUID,
-    run: AnalysisRun,
-    project: Project,
-    generated_at: datetime,
-    finding_count: int,
-    provider_snapshot_id: uuid.UUID | None,
-    content_bytes: bytes,
-    report_path: Path,
-    kind: str,
-    report_format: str,
-    filename: str,
-    content_type: str,
-    extra_metadata: dict[str, Any] | None = None,
-) -> Report:
-    sha256 = hashlib.sha256(content_bytes).hexdigest()
-    metadata_json = {
-        "generated_at": generated_at.isoformat(),
-        "project_id": str(project.id),
-        "analysis_run_id": str(run.id),
-        "provider_snapshot_id": str(provider_snapshot_id)
-        if provider_snapshot_id is not None
-        else None,
-        "finding_count": finding_count,
-        "format": report_format,
-        "kind": kind,
-        "service": "workbench-report-service",
-    }
-    if extra_metadata:
-        metadata_json.update(extra_metadata)
-    return ReportRepository(session).create_report(
-        report_id=report_id,
-        project_id=project.id,
-        analysis_run_id=run.id,
-        kind=kind,
-        format=report_format,
-        filename=filename,
-        content_type=content_type,
-        path=str(report_path),
-        sha256=sha256,
-        size_bytes=len(content_bytes),
-        metadata_json=metadata_json,
-    )
+    try:
+        write_artifact(path)
+        report = create_report_record(
+            session,
+            report_id=report_id,
+            run=run,
+            project=project,
+            generated_at=generated_at,
+            finding_count=finding_count,
+            provider_snapshot_id=provider_snapshot_id,
+            content_bytes=content_bytes,
+            report_path=path,
+            kind=kind,
+            report_format=report_format,
+            filename=filename,
+            content_type=content_type,
+            extra_metadata=extra_metadata,
+        )
+        prune_run_reports(session, settings, report)
+        return report
+    except Exception:
+        _remove_report_artifact_dir(settings, path)
+        raise
 
 
 def report_path(
@@ -177,6 +157,20 @@ def _ensure_report_size_allowed(settings: Settings, *, content_size: int, filena
         f"Generated report {filename} exceeds configured report size limit "
         f"({settings.MAX_REPORT_MB} MiB)."
     )
+
+
+def _remove_report_artifact_dir(settings: Settings, path: Path) -> None:
+    report_root = settings.report_dir_path.resolve(strict=False)
+    try:
+        report_path = path.resolve(strict=False)
+    except OSError:
+        return
+    if not report_path.is_relative_to(report_root):
+        return
+    report_dir = report_path.parent
+    if report_dir == report_root or not report_dir.is_relative_to(report_root):
+        return
+    shutil.rmtree(report_dir, ignore_errors=True)
 
 
 __all__ = [

--- a/backend/app/services/report_service_records.py
+++ b/backend/app/services/report_service_records.py
@@ -1,0 +1,64 @@
+"""Database record helpers for generated Workbench reports."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlmodel import Session
+
+from app.models import AnalysisRun, Project, Report
+from app.repositories import ReportRepository
+
+
+def create_report_record(
+    session: Session,
+    *,
+    report_id: uuid.UUID,
+    run: AnalysisRun,
+    project: Project,
+    generated_at: datetime,
+    finding_count: int,
+    provider_snapshot_id: uuid.UUID | None,
+    content_bytes: bytes,
+    report_path: Path,
+    kind: str,
+    report_format: str,
+    filename: str,
+    content_type: str,
+    extra_metadata: dict[str, Any] | None = None,
+) -> Report:
+    sha256 = hashlib.sha256(content_bytes).hexdigest()
+    metadata_json = {
+        "generated_at": generated_at.isoformat(),
+        "project_id": str(project.id),
+        "analysis_run_id": str(run.id),
+        "provider_snapshot_id": str(provider_snapshot_id)
+        if provider_snapshot_id is not None
+        else None,
+        "finding_count": finding_count,
+        "format": report_format,
+        "kind": kind,
+        "service": "workbench-report-service",
+    }
+    if extra_metadata:
+        metadata_json.update(extra_metadata)
+    return ReportRepository(session).create_report(
+        report_id=report_id,
+        project_id=project.id,
+        analysis_run_id=run.id,
+        kind=kind,
+        format=report_format,
+        filename=filename,
+        content_type=content_type,
+        path=str(report_path),
+        sha256=sha256,
+        size_bytes=len(content_bytes),
+        metadata_json=metadata_json,
+    )
+
+
+__all__ = ["create_report_record"]

--- a/backend/src/vuln_prioritizer/cache.py
+++ b/backend/src/vuln_prioritizer/cache.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -44,7 +46,29 @@ class FileCache:
         path = self._path_for(namespace, key)
         path.parent.mkdir(parents=True, exist_ok=True)
         document = {"key": key, "cached_at": iso_utc_now(), "payload": payload}
-        path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+        serialized = json.dumps(document, indent=2, sort_keys=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                delete=False,
+                dir=path.parent,
+                encoding="utf-8",
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+            ) as handle:
+                temporary_path = Path(handle.name)
+                handle.write(serialized)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, path)
+        except Exception:
+            if temporary_path is not None:
+                try:
+                    temporary_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            raise
 
     def _path_for(self, namespace: str, key: str) -> Path:
         digest = hashlib.sha256(key.encode("utf-8")).hexdigest()

--- a/backend/src/vuln_prioritizer/cache.py
+++ b/backend/src/vuln_prioritizer/cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -64,10 +65,8 @@ class FileCache:
             os.replace(temporary_path, path)
         except Exception:
             if temporary_path is not None:
-                try:
+                with contextlib.suppress(OSError):
                     temporary_path.unlink(missing_ok=True)
-                except OSError:
-                    pass
             raise
 
     def _path_for(self, namespace: str, key: str) -> Path:

--- a/backend/tests/api/test_workbench_backend_adapter.py
+++ b/backend/tests/api/test_workbench_backend_adapter.py
@@ -579,6 +579,41 @@ def test_workbench_backend_non_local_startup_rejects_stale_schema(tmp_path) -> N
             pass
 
 
+def test_workbench_backend_local_startup_reconciles_stale_import_runs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[Engine, Settings]] = []
+
+    def record_reconciliation(*, engine: Engine, settings: Settings) -> int:
+        calls.append((engine, settings))
+        return 0
+
+    monkeypatch.setattr(
+        "app.main.reconcile_stale_background_import_runs",
+        record_reconciliation,
+    )
+    selected_app = create_app(
+        Settings(SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'local-reconcile.db'}")
+    )
+
+    with TestClient(selected_app) as client:
+        assert client.get("/api/v1/utils/health-check/").status_code == 200
+
+    assert calls == [(selected_app.state.workbench_engine, selected_app.state.workbench_settings)]
+
+
+def test_workbench_backend_local_startup_tolerates_first_run_missing_schema(
+    tmp_path: Path,
+) -> None:
+    selected_app = create_app(
+        Settings(SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'first-run.db'}")
+    )
+
+    with TestClient(selected_app) as client:
+        assert client.get("/api/v1/utils/health-check/").status_code == 200
+
+
 def test_workbench_backend_can_explicitly_expose_openapi_for_client_generation() -> None:
     selected_app = create_app(
         Settings(

--- a/backend/tests/api/test_workbench_provider_status_api.py
+++ b/backend/tests/api/test_workbench_provider_status_api.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 from utils.workbench_env import WorkbenchApiEnv, local_api_headers
 
 from app.services.provider_status import provider_status_payload
+from app.services.provider_updates import PROVIDER_UPDATE_LOCK_FILE
 from vuln_prioritizer.models import (
     KevData,
     ProviderSnapshotItem,
@@ -619,5 +620,38 @@ def test_workbench_provider_update_job_rejects_active_job(
         assert response.status_code == 409
         assert response.json()["code"] == "conflict"
         assert "Provider update already running" in response.json()["detail"]
+    finally:
+        workbench_api_env.client.app.state.workbench_settings = active_settings
+
+
+def test_workbench_provider_update_job_rejects_active_filesystem_lock(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    headers = local_api_headers(workbench_api_env.client)
+    active_settings = workbench_api_env.client.app.state.workbench_settings
+    snapshot_dir = tmp_path / "workbench-provider-snapshots"
+    snapshot_dir.mkdir()
+    (snapshot_dir / PROVIDER_UPDATE_LOCK_FILE).write_text("active", encoding="utf-8")
+    workbench_api_env.client.app.state.workbench_settings = replace(
+        active_settings,
+        PROVIDER_SNAPSHOT_DIR=str(snapshot_dir),
+        PROVIDER_CACHE_DIR=str(tmp_path / "workbench-provider-cache"),
+    )
+    try:
+        response = workbench_api_env.client.post(
+            "/api/v1/providers/update-jobs",
+            headers=headers,
+            json={"sources": ["kev"], "cve_ids": ["CVE-2024-3094"]},
+        )
+
+        assert response.status_code == 409
+        assert response.json()["code"] == "conflict"
+        assert "Provider update already running" in response.json()["detail"]
+        with Session(workbench_api_env.engine) as session:
+            update_runs = workbench_api_env.repositories.RunRepository(
+                session
+            ).list_provider_update_runs()
+        assert update_runs == []
     finally:
         workbench_api_env.client.app.state.workbench_settings = active_settings

--- a/backend/tests/api/test_workbench_reports_api.py
+++ b/backend/tests/api/test_workbench_reports_api.py
@@ -1304,6 +1304,56 @@ def test_report_generation_rejects_artifacts_over_configured_size_limit(
         workbench_api_env.client.app.state.workbench_settings = previous_settings
 
 
+def test_report_persistence_cleans_artifact_directory_when_record_creation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    from app.services import report_service_persistence
+
+    previous_settings = workbench_api_env.client.app.state.workbench_settings
+    try:
+        report_dir = _configure_report_dir(workbench_api_env, tmp_path)
+        headers = local_api_headers(workbench_api_env.client)
+        project = create_project_via_api(workbench_api_env.client, headers)
+        run_id = _seed_reportable_run(workbench_api_env, uuid.UUID(project["id"]))
+
+        def fail_create_report_record(*_args: object, **_kwargs: object) -> app_models.Report:
+            raise RuntimeError("database write failed")
+
+        monkeypatch.setattr(
+            report_service_persistence,
+            "create_report_record",
+            fail_create_report_record,
+        )
+        active_settings = workbench_api_env.client.app.state.workbench_settings
+        with Session(workbench_api_env.engine) as session:
+            run = session.get(app_models.AnalysisRun, run_id)
+            stored_project = session.get(app_models.Project, uuid.UUID(project["id"]))
+            assert run is not None
+            assert stored_project is not None
+
+            with pytest.raises(RuntimeError, match="database write failed"):
+                report_service_persistence.persist_text_report(
+                    session,
+                    active_settings,
+                    run=run,
+                    project=stored_project,
+                    generated_at=datetime.now(UTC),
+                    finding_count=0,
+                    provider_snapshot_id=None,
+                    content="temporary report\n",
+                    kind="technical-markdown",
+                    report_format="markdown",
+                    filename="technical-report.md",
+                    content_type="text/markdown; charset=utf-8",
+                )
+
+        assert not list(report_dir.rglob("technical-report.md"))
+    finally:
+        workbench_api_env.client.app.state.workbench_settings = previous_settings
+
+
 def test_report_generation_prunes_oldest_reports_for_run(
     workbench_api_env: WorkbenchApiEnv,
     tmp_path: Path,

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -5,6 +5,8 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from vuln_prioritizer.cache import FileCache
 
 
@@ -36,6 +38,28 @@ def test_file_cache_returns_none_for_invalid_json(tmp_path: Path) -> None:
     path.write_text("{invalid", encoding="utf-8")
 
     assert cache.get_json("kev", "catalog") is None
+
+
+def test_file_cache_keeps_existing_document_when_atomic_replace_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache = FileCache(tmp_path / "cache", ttl_hours=24)
+    cache.set_json("nvd", "CVE-2026-0001", {"value": "old"})
+    path = cache._path_for("nvd", "CVE-2026-0001")
+    original_content = path.read_text(encoding="utf-8")
+
+    def fail_replace(_source: Path, _target: Path) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr("vuln_prioritizer.cache.os.replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        cache.set_json("nvd", "CVE-2026-0001", {"value": "new"})
+
+    assert path.read_text(encoding="utf-8") == original_content
+    assert cache.get_json("nvd", "CVE-2026-0001") == {"value": "old"}
+    assert list(path.parent.glob(f".{path.name}.*.tmp")) == []
 
 
 def test_file_cache_inspect_namespace_reports_valid_expired_and_invalid_documents(


### PR DESCRIPTION
## Summary
- make provider cache writes atomic with same-directory temp files and replace semantics
- reconcile stale background imports during local startup without breaking first-run local schema setup
- clean generated report artifact directories when record persistence fails
- add request-path coverage for provider update filesystem-lock conflicts

## Validation
- python3 -m pytest -q backend/tests/test_cache.py backend/tests/api/test_workbench_backend_adapter.py::test_workbench_backend_local_startup_reconciles_stale_import_runs backend/tests/api/test_workbench_backend_adapter.py::test_workbench_backend_local_startup_tolerates_first_run_missing_schema backend/tests/api/test_workbench_reports_api.py::test_report_persistence_cleans_artifact_directory_when_record_creation_fails backend/tests/api/test_workbench_provider_status_api.py::test_workbench_provider_update_job_rejects_active_filesystem_lock --no-cov
- python3 -m ruff format --check backend
- python3 -m ruff check backend
- cd backend && python3 -m mypy app src
- python3 -m pytest -q backend/tests --no-cov (854 passed, 4 skipped)

Auth/RBAC remains intentionally out of scope for the local single-user Workbench.