### PR TITLE
[codex] Harden frontend field a11y and downloads

### DIFF
--- a/frontend/src/components/vpw/VpwField.tsx
+++ b/frontend/src/components/vpw/VpwField.tsx
@@ -1,4 +1,12 @@
-import { useId, type ComponentPropsWithoutRef, type ReactNode } from "react"
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useId,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -26,6 +34,114 @@ export type FieldProps = ComponentPropsWithoutRef<"div"> & {
 
 export type FieldErrorProps = ComponentPropsWithoutRef<"div"> & {
   errors?: Array<{ message?: string } | undefined>
+}
+
+type FieldControlProps = {
+  children?: ReactNode
+  id?: string
+  "aria-describedby"?: string
+  "aria-errormessage"?: string
+  "aria-invalid"?: boolean | "true" | "false"
+  "aria-required"?: boolean | "true" | "false"
+}
+
+type FieldControlA11y = {
+  controlId: string
+  describedBy: string | undefined
+  errorId: string | undefined
+  invalid: boolean
+  required: boolean
+}
+
+type FieldControlElementType = ReactElement<FieldControlProps>["type"]
+
+const nativeFieldControlNames = new Set(["button", "input", "select", "textarea"])
+const componentFieldControlNames = new Set([
+  "Input",
+  "SelectTrigger",
+  "Textarea",
+  "VpwFileInput",
+])
+
+function elementTypeName(type: FieldControlElementType): string | undefined {
+  if (typeof type === "string") return type
+  if (typeof type === "function") {
+    const namedType = type as { displayName?: string; name?: string }
+    return namedType.displayName ?? namedType.name
+  }
+  if (typeof type === "object" && type !== null) {
+    const namedType = type as {
+      displayName?: string
+      name?: string
+      render?: { displayName?: string; name?: string }
+    }
+    return (
+      namedType.displayName ??
+      namedType.name ??
+      namedType.render?.displayName ??
+      namedType.render?.name
+    )
+  }
+  return undefined
+}
+
+function mergeIdRefs(...values: Array<string | undefined>) {
+  const ids = values
+    .flatMap((value) => value?.split(/\s+/) ?? [])
+    .filter(Boolean)
+  return ids.length > 0 ? [...new Set(ids)].join(" ") : undefined
+}
+
+function isFieldControlElement(
+  element: ReactElement<FieldControlProps>,
+  controlId: string,
+) {
+  if (element.props.id === controlId) return true
+
+  const name = elementTypeName(element.type)
+  if (!name) return false
+  return nativeFieldControlNames.has(name) || componentFieldControlNames.has(name)
+}
+
+function controlPropsFor(
+  props: FieldControlProps,
+  { controlId, describedBy, errorId, invalid, required }: FieldControlA11y,
+): FieldControlProps {
+  const nextProps: FieldControlProps = {
+    "aria-describedby": mergeIdRefs(props["aria-describedby"], describedBy),
+    id: controlId,
+  }
+
+  if (required) nextProps["aria-required"] = true
+  if (invalid) {
+    nextProps["aria-invalid"] = true
+    if (errorId) nextProps["aria-errormessage"] = errorId
+  }
+
+  return nextProps
+}
+
+function withFieldControlA11y(children: ReactNode, a11y: FieldControlA11y) {
+  let controlEnhanced = false
+
+  function visit(child: ReactNode): ReactNode {
+    if (controlEnhanced || !isValidElement<FieldControlProps>(child)) {
+      return child
+    }
+
+    if (isFieldControlElement(child, a11y.controlId)) {
+      controlEnhanced = true
+      return cloneElement(child, controlPropsFor(child.props, a11y))
+    }
+
+    if (!child.props.children) return child
+
+    return cloneElement(child, {
+      children: Children.map(child.props.children, visit),
+    } satisfies Partial<FieldControlProps>)
+  }
+
+  return Children.map(children, visit)
 }
 
 export function Field({
@@ -132,13 +248,22 @@ export function VpwField({
   const labelId = `${generatedId}-label`
   const descriptionId = description ? `${generatedId}-description` : undefined
   const errorId = error ? `${generatedId}-error` : undefined
+  const controlId = htmlFor ?? `${generatedId}-control`
+  const describedBy = mergeIdRefs(descriptionId, errorId)
+  const fieldChildren = withFieldControlA11y(children, {
+    controlId,
+    describedBy,
+    errorId,
+    invalid: Boolean(error),
+    required,
+  })
 
   return (
     <Field
       className={className}
       data-invalid={error ? true : undefined}
     >
-      <FieldLabel htmlFor={htmlFor} id={labelId}>
+      <FieldLabel htmlFor={controlId} id={labelId}>
         {label}
         {required ? (
           <span className="ml-1 text-[var(--vpw-red)]" aria-hidden="true">
@@ -146,7 +271,7 @@ export function VpwField({
           </span>
         ) : null}
       </FieldLabel>
-      {children}
+      {fieldChildren}
       {description ? (
         <FieldDescription id={descriptionId}>{description}</FieldDescription>
       ) : null}

--- a/frontend/src/components/vpw/VpwFileInput.tsx
+++ b/frontend/src/components/vpw/VpwFileInput.tsx
@@ -7,6 +7,10 @@ export type VpwFileInputProps = {
   id: string
   label: string
   accept?: string
+  "aria-describedby"?: string
+  "aria-errormessage"?: string
+  "aria-invalid"?: boolean | "true" | "false"
+  "aria-required"?: boolean | "true" | "false"
   className?: string
   disabled?: boolean
   file?: File | null
@@ -16,6 +20,10 @@ export type VpwFileInputProps = {
 
 export function VpwFileInput({
   accept,
+  "aria-describedby": ariaDescribedBy,
+  "aria-errormessage": ariaErrorMessage,
+  "aria-invalid": ariaInvalid,
+  "aria-required": ariaRequired,
   className,
   disabled = false,
   file,
@@ -32,12 +40,16 @@ export function VpwFileInput({
     <div className={cn("grid gap-2", className)}>
       <input
         accept={accept}
+        aria-describedby={ariaDescribedBy}
+        aria-errormessage={ariaErrorMessage}
         aria-label={label}
+        aria-invalid={ariaInvalid}
         className="sr-only"
         disabled={disabled}
         id={id}
         name={name}
         onChange={handleChange}
+        required={ariaRequired === true || ariaRequired === "true"}
         type="file"
       />
       <label

--- a/frontend/src/workbench/report-download.ts
+++ b/frontend/src/workbench/report-download.ts
@@ -5,6 +5,22 @@ export type ReportDownloadArtifact = {
   filename: string
 }
 
+type ReportDownloadDocument = Pick<Document, "createElement"> & {
+  body: Pick<HTMLElement, "append">
+}
+type ReportDownloadTimer = (handler: () => void, delayMs: number) => unknown
+type ReportDownloadUrlApi = Pick<
+  typeof URL,
+  "createObjectURL" | "revokeObjectURL"
+>
+
+export type StartReportDownloadOptions = {
+  document?: ReportDownloadDocument
+  revokeDelayMs?: number
+  setTimeout?: ReportDownloadTimer
+  urlApi?: ReportDownloadUrlApi
+}
+
 type ReportDownloadResult = {
   data: Blob | File
   request: Request
@@ -16,6 +32,8 @@ type DownloadReportClient = (
 ) => Promise<ReportDownloadResult>
 
 let reportDownloadClient: DownloadReportClient | null = null
+
+export const REPORT_OBJECT_URL_REVOKE_DELAY_MS = 1_000
 
 export function configureReportDownloadClient(
   client: DownloadReportClient | null,
@@ -37,6 +55,29 @@ export async function fetchReportDownload(
       filenameFromContentDisposition(
         result.response.headers.get("content-disposition"),
       ) || report.filename,
+  }
+}
+
+export function startReportDownload(
+  { blob, filename }: ReportDownloadArtifact,
+  options: StartReportDownloadOptions = {},
+): void {
+  const ownerDocument = options.document ?? document
+  const setTimer = options.setTimeout ?? globalThis.setTimeout
+  const urlApi = options.urlApi ?? URL
+  const objectUrl = urlApi.createObjectURL(blob)
+  const anchor = ownerDocument.createElement("a")
+
+  anchor.href = objectUrl
+  anchor.download = filename
+  ownerDocument.body.append(anchor)
+  try {
+    anchor.click()
+  } finally {
+    anchor.remove()
+    setTimer(() => {
+      urlApi.revokeObjectURL(objectUrl)
+    }, options.revokeDelayMs ?? REPORT_OBJECT_URL_REVOKE_DELAY_MS)
   }
 }
 

--- a/frontend/src/workbench/useReportsRouteState.ts
+++ b/frontend/src/workbench/useReportsRouteState.ts
@@ -11,7 +11,7 @@ import type { WorkbenchReportFormat } from "../lib/app-defaults"
 import { apiErrorMessage, objectRecord } from "../lib/app-errors"
 import { reportFormatLabel } from "../lib/report-format"
 import type { WorkbenchPath } from "../lib/workbench-navigation"
-import { fetchReportDownload } from "./report-download"
+import { fetchReportDownload, startReportDownload } from "./report-download"
 import { reportActionsAvailable } from "./report-action-state.ts"
 import { workbenchQueryKeys } from "./workbench-query-keys"
 
@@ -22,15 +22,7 @@ type UseReportsRouteStateOptions = {
 }
 
 async function downloadReportArtifact(report: ReportPublic) {
-  const { blob, filename } = await fetchReportDownload(report)
-  const objectUrl = URL.createObjectURL(blob)
-  const anchor = document.createElement("a")
-  anchor.href = objectUrl
-  anchor.download = filename
-  document.body.append(anchor)
-  anchor.click()
-  anchor.remove()
-  URL.revokeObjectURL(objectUrl)
+  startReportDownload(await fetchReportDownload(report))
 }
 
 export function useReportsRouteState({

--- a/frontend/tests/design-system-contracts.test.ts
+++ b/frontend/tests/design-system-contracts.test.ts
@@ -310,3 +310,23 @@ test("typography does not use viewport-scaled text or tracking drift", () => {
 
   assert.deepEqual(offenders, [])
 })
+
+test("VpwField associates descriptions and errors with field controls", () => {
+  const field = readProjectFile("src/components/vpw/VpwField.tsx")
+  const fileInput = readProjectFile("src/components/vpw/VpwFileInput.tsx")
+
+  assert.match(field, /withFieldControlA11y\(children/)
+  assert.match(field, /"aria-describedby": mergeIdRefs/)
+  assert.match(field, /nextProps\["aria-required"\] = true/)
+  assert.match(field, /nextProps\["aria-invalid"\] = true/)
+  assert.match(field, /nextProps\["aria-errormessage"\] = errorId/)
+  assert.match(field, /<FieldLabel htmlFor=\{controlId\}/)
+  assert.match(field, /aria-hidden="true"/)
+  assert.match(field, /<FieldDescription id=\{descriptionId\}/)
+  assert.match(field, /<FieldError id=\{errorId\}/)
+
+  assert.match(fileInput, /aria-describedby=\{ariaDescribedBy\}/)
+  assert.match(fileInput, /aria-errormessage=\{ariaErrorMessage\}/)
+  assert.match(fileInput, /aria-invalid=\{ariaInvalid\}/)
+  assert.match(fileInput, /required=\{ariaRequired === true/)
+})

--- a/frontend/tests/report-download.test.ts
+++ b/frontend/tests/report-download.test.ts
@@ -4,6 +4,8 @@ import test from "node:test"
 import {
   configureReportDownloadClient,
   fetchReportDownload,
+  startReportDownload,
+  type StartReportDownloadOptions,
 } from "../src/workbench/report-download.ts"
 
 type DownloadReportClient = Parameters<typeof configureReportDownloadClient>[0]
@@ -74,4 +76,77 @@ test("does not derive report download targets from absolute metadata URLs", asyn
       id: "visible-report",
     } as Parameters<typeof fetchReportDownload>[0],
   )
+})
+
+test("delays report object URL revocation until after download click returns", () => {
+  const events: string[] = []
+  const timers: Array<() => void> = []
+  const anchor = {
+    download: "",
+    href: "",
+    click() {
+      events.push(`click:${anchor.href}:${anchor.download}`)
+    },
+    remove() {
+      events.push("remove")
+    },
+  }
+  const documentStub: StartReportDownloadOptions["document"] = {
+    body: {
+      append(node: HTMLElement) {
+        assert.equal(node, anchor)
+        events.push("append")
+      },
+    },
+    createElement(tagName: string) {
+      assert.equal(tagName, "a")
+      return anchor as HTMLAnchorElement
+    },
+  }
+  const urlApi: StartReportDownloadOptions["urlApi"] = {
+    createObjectURL(blob: Blob) {
+      assert.equal(blob.type, "text/markdown")
+      events.push("create")
+      return "blob:visible"
+    },
+    revokeObjectURL(objectUrl: string) {
+      events.push(`revoke:${objectUrl}`)
+    },
+  }
+
+  startReportDownload(
+    {
+      blob: new Blob(["report-body"], { type: "text/markdown" }),
+      filename: "visible.md",
+    },
+    {
+      document: documentStub,
+      revokeDelayMs: 25,
+      setTimeout(handler, delayMs) {
+        events.push(`timer:${delayMs}`)
+        timers.push(handler)
+      },
+      urlApi,
+    },
+  )
+
+  assert.deepEqual(events, [
+    "create",
+    "append",
+    "click:blob:visible:visible.md",
+    "remove",
+    "timer:25",
+  ])
+  assert.equal(timers.length, 1)
+
+  timers[0]()
+
+  assert.deepEqual(events, [
+    "create",
+    "append",
+    "click:blob:visible:visible.md",
+    "remove",
+    "timer:25",
+    "revoke:blob:visible",
+  ])
 })


### PR DESCRIPTION
## Summary
- propagate VpwField description, error, invalid, and required state onto the owning control without changing existing field composition
- forward VpwField ARIA state through VpwFileInput to its hidden file input
- move report download DOM handling into a tested helper and delay object URL revocation to avoid browser download races

## Validation
- cd frontend && npm run lint
- cd frontend && npm run test:types
- cd frontend && npm run test:unit:coverage
- cd frontend && npm run build
- cd frontend && npm run test -- accessibility.spec.ts --reporter=line

Auth/RBAC remains explicitly out of scope for this local single-user Workbench hardening PR.