### PR TITLE
[codex] Harden ops reproducibility

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Decide whether Docker smoke is needed
         id: scope
@@ -105,6 +106,8 @@ jobs:
       - name: Check out repository
         if: needs.changes.outputs.run-docker == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Docker quickstart API smoke
         if: needs.changes.outputs.run-docker == 'true'

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/provider-live.yml
+++ b/.github/workflows/provider-live.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -152,6 +154,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Download built distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -208,6 +212,8 @@ jobs:
     steps:
       - name: Check out repository fixtures
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -118,6 +120,8 @@ jobs:
     steps:
       - name: Check out repository fixtures
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,8 +11,7 @@ COPY backend/pyproject.toml backend/requirements.runtime.lock.txt backend/MANIFE
 COPY backend/app ./backend/app
 COPY backend/src ./backend/src
 
-RUN python -m pip install --upgrade pip \
-    && python -m pip install --require-hashes -r backend/requirements.runtime.lock.txt \
+RUN python -m pip install --require-hashes -r backend/requirements.runtime.lock.txt \
     && python -m pip install --no-deps ./backend \
     && adduser --disabled-password --gecos "" --uid 10001 workbench \
     && mkdir -p \

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import os
 import subprocess
 import tarfile
@@ -226,12 +227,35 @@ def test_container_image_digest_policy_covers_compose_service_images() -> None:
     assert "@sha256:" in traefik_compose["services"]["traefik"]["image"]
 
 
+def test_runtime_containers_avoid_unpinned_upgrade_drift() -> None:
+    backend_dockerfile = _read_repo_text("backend/Dockerfile")
+    frontend_dockerfile = _read_repo_text("frontend/Dockerfile")
+
+    assert "python -m pip install --upgrade pip" not in backend_dockerfile
+    assert "python -m pip install --require-hashes" in backend_dockerfile
+    assert "apk upgrade" not in frontend_dockerfile
+    assert "npm ci --workspaces=false" in frontend_dockerfile
+
+
+def test_node_package_manifests_pin_ci_runtime_family() -> None:
+    expected_engines = {"node": ">=22 <23", "npm": ">=10.9 <11"}
+    packages = [
+        json.loads(_read_repo_text("package.json")),
+        json.loads(_read_repo_text("frontend/package.json")),
+    ]
+
+    for package in packages:
+        assert package["packageManager"] == "npm@10.9.4"
+        assert package["engines"] == expected_engines
+
+
 def test_github_workflow_actions_are_sha_pinned() -> None:
     makefile = _read_repo_text("Makefile")
     pin_check = _read_repo_text("scripts/check_github_action_pins.py")
 
     assert "scripts/check_github_action_pins.py" in makefile
     assert "GitHub workflow remote actions must be pinned by commit SHA" in pin_check
+    assert "GitHub checkout steps must disable persisted credentials" in pin_check
 
     result = subprocess.run(
         ["python3", "scripts/check_github_action_pins.py"],
@@ -242,6 +266,36 @@ def test_github_workflow_actions_are_sha_pinned() -> None:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_github_workflow_checkouts_do_not_persist_credentials() -> None:
+    offenders: list[str] = []
+
+    for workflow in sorted((REPO_ROOT / ".github" / "workflows").glob("*.y*ml")):
+        document = yaml.safe_load(workflow.read_text(encoding="utf-8")) or {}
+        jobs = document.get("jobs", {})
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in sorted(jobs.items()):
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps", [])
+            if not isinstance(steps, list):
+                continue
+            for index, step in enumerate(steps, 1):
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses")
+                if not isinstance(uses, str) or not uses.startswith("actions/checkout@"):
+                    continue
+                with_config = step.get("with")
+                if (
+                    not isinstance(with_config, dict)
+                    or with_config.get("persist-credentials") is not False
+                ):
+                    offenders.append(f"{workflow.relative_to(REPO_ROOT)}:{job_name}:step-{index}")
+
+    assert offenders == []
 
 
 def test_import_service_modules_do_not_import_http_or_route_boundaries() -> None:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,11 +15,7 @@ ENV NODE_ENV=$NODE_ENV
 
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
-
-USER root
-RUN apk upgrade --no-cache
-USER 101
+FROM nginxinc/nginx-unprivileged:1.29-alpine@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6
 
 COPY --from=build-stage /app/frontend/dist/ /usr/share/nginx/html
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,11 @@
   "private": true,
   "version": "1.1.0",
   "type": "module",
+  "packageManager": "npm@10.9.4",
+  "engines": {
+    "node": ">=22 <23",
+    "npm": ">=10.9 <11"
+  },
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc -p tsconfig.build.json && vite build",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "vuln-prioritizer-workbench",
   "description": "Local-first Workbench for prioritizing known CVEs from existing evidence.",
   "private": true,
+  "packageManager": "npm@10.9.4",
+  "engines": {
+    "node": ">=22 <23",
+    "npm": ">=10.9 <11"
+  },
   "workspaces": [
     "frontend"
   ],

--- a/scripts/check_github_action_pins.py
+++ b/scripts/check_github_action_pins.py
@@ -4,6 +4,8 @@ import re
 import sys
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
 USES_RE = re.compile(r"^\s*uses:\s*(?P<value>[^#\n]+)")
@@ -13,7 +15,8 @@ REMOTE_ACTION_SHA_RE = re.compile(
 
 
 def main() -> int:
-    failures: list[str] = []
+    pin_failures: list[str] = []
+    checkout_failures: list[str] = []
     for workflow in sorted(WORKFLOW_DIR.glob("*.y*ml")):
         for line_number, line in enumerate(workflow.read_text(encoding="utf-8").splitlines(), 1):
             match = USES_RE.match(line)
@@ -24,15 +27,23 @@ def main() -> int:
                 continue
             if value.startswith("docker://"):
                 if "@sha256:" not in value:
-                    failures.append(f"{workflow.relative_to(ROOT)}:{line_number}: {value}")
+                    pin_failures.append(f"{workflow.relative_to(ROOT)}:{line_number}: {value}")
                 continue
             if not REMOTE_ACTION_SHA_RE.fullmatch(value):
-                failures.append(f"{workflow.relative_to(ROOT)}:{line_number}: {value}")
+                pin_failures.append(f"{workflow.relative_to(ROOT)}:{line_number}: {value}")
 
-    if failures:
+        checkout_failures.extend(_checkout_credential_failures(workflow))
+
+    if pin_failures:
         print("GitHub workflow remote actions must be pinned by commit SHA:", file=sys.stderr)
-        for failure in failures:
+        for failure in pin_failures:
             print(f"- {failure}", file=sys.stderr)
+    if checkout_failures:
+        print("GitHub checkout steps must disable persisted credentials:", file=sys.stderr)
+        for failure in checkout_failures:
+            print(f"- {failure}", file=sys.stderr)
+
+    if pin_failures or checkout_failures:
         return 1
     return 0
 
@@ -45,6 +56,34 @@ def _unquote(value: str) -> str:
 
 def _is_local_action(value: str) -> bool:
     return value.startswith(("./", "../"))
+
+
+def _checkout_credential_failures(workflow: Path) -> list[str]:
+    document = yaml.safe_load(workflow.read_text(encoding="utf-8")) or {}
+    jobs = document.get("jobs", {})
+    if not isinstance(jobs, dict):
+        return []
+
+    failures: list[str] = []
+    for job_name, job in sorted(jobs.items()):
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps", [])
+        if not isinstance(steps, list):
+            continue
+        for index, step in enumerate(steps, 1):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not uses.startswith("actions/checkout@"):
+                continue
+            with_config = step.get("with")
+            if (
+                not isinstance(with_config, dict)
+                or with_config.get("persist-credentials") is not False
+            ):
+                failures.append(f"{workflow.relative_to(ROOT)}:jobs.{job_name}.steps[{index}]")
+    return failures
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove runtime package-manager upgrade drift from Dockerfiles while keeping digest-pinned bases
- refresh the frontend nginx-unprivileged Alpine base digest so the image stays clean without `apk upgrade`
- declare CI-aligned Node 22/npm 10 runtime expectations in root and frontend package manifests
- disable persisted checkout credentials where workflows do not need git write credentials
- extend the GitHub Actions pin check and runtime boundary tests to cover checkout credential persistence, Docker upgrade drift, and package manifest runtime pins

## Validation
- python3 scripts/check_github_action_pins.py
- python3 scripts/check_dockerfile_base_digests.py
- python3 scripts/check_release_evidence_hygiene.py
- python3 -m ruff format --check backend scripts/check_github_action_pins.py
- python3 -m ruff check backend scripts/check_github_action_pins.py
- python3 -m pytest -q backend/tests/test_backend_runtime_boundary.py backend/tests/test_workbench_integration_contracts.py --no-cov
- cd frontend && npm run lint
- cd frontend && npm run test:types
- cd frontend && npm run build
- python3 -m pip_audit --requirement backend/requirements.lock.txt
- cd frontend && npm --workspaces=false audit --audit-level=high
- docker build -f frontend/Dockerfile -t vuln-prioritizer-workbench-frontend:local .
- docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker.io/anchore/grype:v0.106.0@sha256:f6fa9ac31f97591957edb13b7c7c24fd172cf11b6e2a2df5dd3464ebb8eefefc vuln-prioritizer-workbench-frontend:local --only-fixed --fail-on high

Auth/RBAC remains explicitly out of scope for this local single-user Workbench hardening PR.