### PR TITLE
[codex] Harden provider update jobs

### DIFF
--- a/backend/app/api/routes/providers.py
+++ b/backend/app/api/routes/providers.py
@@ -60,6 +60,7 @@ def create_provider_update_job(
 ) -> ProviderUpdateJobPublic:
     """Create a cache-friendly provider snapshot refresh job."""
     active_settings = _request_settings(request)
+    active_engine: Engine | None = None
     try:
         if payload.execution_mode == "background":
             active_bind = session.get_bind()
@@ -104,6 +105,11 @@ def create_provider_update_job(
     session.commit()
     session.refresh(run)
     if payload.execution_mode == "background":
+        if active_engine is None:
+            raise HTTPException(
+                status_code=500,
+                detail="Workbench database engine is not configured.",
+            )
         background_tasks.add_task(
             execute_provider_update_job_background,
             active_engine,

--- a/backend/app/api/routes/providers.py
+++ b/backend/app/api/routes/providers.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, status
+from sqlalchemy.engine import Engine
 
 from app.api.deps import LocalActor, SessionDep
 from app.core.app_state import workbench_settings
@@ -23,6 +24,8 @@ from app.services.provider_status import (
 from app.services.provider_updates import (
     ProviderUpdateConflict,
     ProviderUpdateValidationError,
+    enqueue_provider_update_job,
+    execute_provider_update_job_background,
 )
 from app.services.provider_updates import (
     create_provider_update_job as execute_provider_update_job,
@@ -50,18 +53,33 @@ def list_provider_update_jobs(
 @router.post("/update-jobs", response_model=ProviderUpdateJobPublic)
 def create_provider_update_job(
     request: Request,
+    background_tasks: BackgroundTasks,
     session: SessionDep,
     payload: ProviderUpdateJobCreate,
     local_actor: LocalActor,
 ) -> ProviderUpdateJobPublic:
-    """Synchronously create a cache-friendly provider snapshot refresh job."""
+    """Create a cache-friendly provider snapshot refresh job."""
     active_settings = _request_settings(request)
     try:
-        run = execute_provider_update_job(
-            session,
-            settings=active_settings,
-            payload=payload,
-        )
+        if payload.execution_mode == "background":
+            active_bind = session.get_bind()
+            if not isinstance(active_bind, Engine):
+                raise HTTPException(
+                    status_code=500,
+                    detail="Workbench database engine is not configured.",
+                )
+            active_engine = active_bind
+            run = enqueue_provider_update_job(
+                session,
+                settings=active_settings,
+                payload=payload,
+            )
+        else:
+            run = execute_provider_update_job(
+                session,
+                settings=active_settings,
+                payload=payload,
+            )
     except ProviderUpdateValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -77,10 +95,22 @@ def create_provider_update_job(
         resource_id=run.id,
         status="failure" if run.status == AnalysisRunStatus.FAILED else "success",
         actor=local_actor,
-        detail={"sources": list(payload.sources), "status": str(run.status)},
+        detail={
+            "sources": list(payload.sources),
+            "status": str(run.status),
+            "execution_mode": payload.execution_mode,
+        },
     )
     session.commit()
     session.refresh(run)
+    if payload.execution_mode == "background":
+        background_tasks.add_task(
+            execute_provider_update_job_background,
+            active_engine,
+            active_settings,
+            payload,
+            run.id,
+        )
     job = provider_update_job_public(run, active_settings=active_settings)
     if job is None:  # Defensive; the service always returns a provider_update run.
         raise HTTPException(status_code=500, detail="Provider update job could not be read.")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,6 +65,7 @@ class Settings:
     API_RATE_LIMIT_PER_MINUTE: int = 600
     DECISION_API_MAX_FINDINGS: int = 1000
     BACKGROUND_IMPORT_STALE_MINUTES: int = 120
+    PROVIDER_UPDATE_STALE_MINUTES: int = 120
     TRUSTED_PROXY_CIDRS: tuple[str, ...] = field(default_factory=tuple)
     AUDIT_RETENTION_DAYS: int = 365
     ALLOWED_HOSTS: tuple[str, ...] = field(default_factory=lambda: DEFAULT_ALLOWED_HOSTS)
@@ -218,6 +219,10 @@ def load_settings() -> Settings:
         DECISION_API_MAX_FINDINGS=_positive_int_from_env("DECISION_API_MAX_FINDINGS", 1000),
         BACKGROUND_IMPORT_STALE_MINUTES=_positive_int_from_env(
             "BACKGROUND_IMPORT_STALE_MINUTES",
+            120,
+        ),
+        PROVIDER_UPDATE_STALE_MINUTES=_positive_int_from_env(
+            "PROVIDER_UPDATE_STALE_MINUTES",
             120,
         ),
         TRUSTED_PROXY_CIDRS=parse_trusted_proxy_cidrs(environ.get("TRUSTED_PROXY_CIDRS", "")),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.core.db import create_db_engine
 from app.core.rate_limit import RateLimiter, create_rate_limiter, rate_limit_key
 from app.core.schema_smoke import assert_migrated_schema
 from app.services.import_background import reconcile_stale_background_import_runs
+from app.services.provider_updates import reconcile_stale_provider_update_runs
 
 SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
@@ -105,12 +106,17 @@ def _reconcile_stale_import_runs_on_startup(
     active_engine: Engine,
     selected_settings: Settings,
 ) -> int:
-    """Reconcile background imports without breaking first-run local schema setup."""
+    """Reconcile stale local jobs without breaking first-run local schema setup."""
     try:
-        return reconcile_stale_background_import_runs(
+        reconciled = reconcile_stale_background_import_runs(
             engine=active_engine,
             settings=selected_settings,
         )
+        reconciled += reconcile_stale_provider_update_runs(
+            engine=active_engine,
+            settings=selected_settings,
+        )
+        return reconciled
     except Exception:
         if selected_settings.ENVIRONMENT == "local":
             return 0

--- a/backend/app/models/providers.py
+++ b/backend/app/models/providers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 from sqlmodel import Field, SQLModel
@@ -43,12 +43,13 @@ class ProviderSnapshotStatusPublic(SQLModel):
 
 
 class ProviderUpdateJobCreate(BaseModel):
-    """Request body for a deterministic provider update job."""
+    """Request body for a provider update job."""
 
     sources: list[str] = Field(default_factory=lambda: ["nvd", "epss", "kev"])
     cve_ids: list[str] = Field(default_factory=list)
     max_cves: int | None = Field(default=None, ge=1, le=10000)
     cache_only: bool = True
+    execution_mode: Literal["request", "background"] = "request"
 
 
 class ProviderUpdateJobPublic(BaseModel):

--- a/backend/app/services/provider_updates.py
+++ b/backend/app/services/provider_updates.py
@@ -9,10 +9,12 @@ import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, col, select
 
 from app.core.config import Settings
@@ -61,6 +63,10 @@ class ProviderUpdateValidationError(ValueError):
     """Raised when a provider update request is invalid."""
 
 
+class ProviderUpdateRefreshError(RuntimeError):
+    """Raised when a live provider refresh degrades instead of producing a clean snapshot."""
+
+
 def create_provider_update_job(
     session: Session,
     *,
@@ -74,22 +80,178 @@ def create_provider_update_job(
             "Provider update already running; retry after the active job finishes."
         )
 
-    selected_sources = _normalize_sources(payload.sources)
-    cve_ids = _provider_update_cve_ids(session, payload=payload)
-    project = _provider_update_project(session)
-    run = repository.create_analysis_run(
-        project_id=project.id,
-        input_type=PROVIDER_UPDATE_INPUT_TYPE,
+    selected_sources, cve_ids = _provider_update_request_inputs(session, payload=payload)
+    run = _create_provider_update_run(
+        repository,
+        session=session,
+        selected_sources=selected_sources,
+        cve_ids=cve_ids,
+        cache_only=payload.cache_only,
         status=AnalysisRunStatus.RUNNING,
-        summary_json={
-            "requested_sources": selected_sources,
-            "requested_cves": len(cve_ids),
-            "cache_only": payload.cache_only,
-            "execution_mode": "request",
-            "mode": "workbench-provider-update",
-        },
+        execution_mode="request",
+    )
+    return _execute_provider_update_run(
+        session=session,
+        repository=repository,
+        run=run,
+        settings=settings,
+        selected_sources=selected_sources,
+        cve_ids=cve_ids,
+        cache_only=payload.cache_only,
+        execution_mode="request",
+        fail_conflicts=False,
     )
 
+
+def enqueue_provider_update_job(
+    session: Session,
+    *,
+    settings: Settings,
+    payload: ProviderUpdateJobCreate,
+) -> AnalysisRun:
+    """Create a provider update job that can be resumed outside the request path."""
+    repository = RunRepository(session)
+    if repository.get_running_provider_update_run() is not None:
+        raise ProviderUpdateConflict(
+            "Provider update already running; retry after the active job finishes."
+        )
+    _reject_active_provider_update_lock(settings.provider_snapshot_dir_path)
+    selected_sources, cve_ids = _provider_update_request_inputs(session, payload=payload)
+    return _create_provider_update_run(
+        repository,
+        session=session,
+        selected_sources=selected_sources,
+        cve_ids=cve_ids,
+        cache_only=payload.cache_only,
+        status=AnalysisRunStatus.PENDING,
+        execution_mode="background",
+    )
+
+
+def execute_provider_update_job_background(
+    engine: Engine,
+    settings: Settings,
+    payload: ProviderUpdateJobCreate,
+    run_id: uuid.UUID,
+) -> None:
+    """Resume a queued provider update job outside the request/response path."""
+    with Session(engine) as session:
+        try:
+            resume_provider_update_job(
+                session,
+                settings=settings,
+                payload=payload,
+                run_id=run_id,
+            )
+            session.commit()
+        except Exception:
+            session.rollback()
+            mark_provider_update_job_background_failed(session=session, run_id=run_id)
+
+
+def resume_provider_update_job(
+    session: Session,
+    *,
+    settings: Settings,
+    payload: ProviderUpdateJobCreate,
+    run_id: uuid.UUID,
+) -> AnalysisRun | None:
+    """Execute a pending provider update job in the current session."""
+    repository = RunRepository(session)
+    run = repository.get_analysis_run(run_id)
+    if run is None or run.input_type != PROVIDER_UPDATE_INPUT_TYPE:
+        return None
+    if run.status not in {AnalysisRunStatus.PENDING, AnalysisRunStatus.RUNNING}:
+        return run
+
+    selected_sources, cve_ids = _provider_update_request_inputs(session, payload=payload)
+    run.status = AnalysisRunStatus.RUNNING
+    run.summary_json = {
+        **_dict_payload(run.summary_json),
+        "requested_sources": selected_sources,
+        "requested_cves": len(cve_ids),
+        "cache_only": payload.cache_only,
+        "execution_mode": "background",
+        "mode": "workbench-provider-update",
+    }
+    session.add(run)
+    session.flush()
+    return _execute_provider_update_run(
+        session=session,
+        repository=repository,
+        run=run,
+        settings=settings,
+        selected_sources=selected_sources,
+        cve_ids=cve_ids,
+        cache_only=payload.cache_only,
+        execution_mode="background",
+        fail_conflicts=True,
+    )
+
+
+def reconcile_stale_provider_update_runs(
+    *,
+    engine: Engine,
+    settings: Settings,
+) -> int:
+    """Fail stale provider update rows that could otherwise block future updates."""
+    stale_before = get_datetime_utc() - timedelta(minutes=settings.PROVIDER_UPDATE_STALE_MINUTES)
+    reconciled = 0
+    with Session(engine) as session:
+        repository = RunRepository(session)
+        for run in repository.list_active_analysis_runs_started_before(stale_before):
+            if run.input_type != PROVIDER_UPDATE_INPUT_TYPE:
+                continue
+            failed = mark_provider_update_job_background_failed(
+                session=session,
+                run_id=run.id,
+                error_message=(
+                    "Provider update did not finish before the Workbench process restarted."
+                ),
+            )
+            if failed is not None and failed.status == AnalysisRunStatus.FAILED:
+                reconciled += 1
+    return reconciled
+
+
+def mark_provider_update_job_background_failed(
+    *,
+    session: Session,
+    run_id: uuid.UUID,
+    error_message: str = "Provider update execution failed.",
+) -> AnalysisRun | None:
+    """Mark an unfinished provider update failed when background execution exits."""
+    repository = RunRepository(session)
+    run = repository.get_analysis_run(run_id)
+    if run is None or run.status not in {AnalysisRunStatus.PENDING, AnalysisRunStatus.RUNNING}:
+        return run
+    metadata = _dict_payload(run.summary_json)
+    failed = _mark_provider_update_run_failed(
+        session=session,
+        run=run,
+        selected_sources=_string_list(metadata.get("requested_sources")),
+        requested_cves=_int_value(metadata.get("requested_cves")),
+        cache_only=bool(metadata.get("cache_only", True)),
+        execution_mode=str(metadata.get("execution_mode") or "background"),
+        error_message=error_message,
+        detail="Provider refresh failed before replacing or mutating existing snapshots.",
+    )
+    session.commit()
+    return failed
+
+
+def _execute_provider_update_run(
+    *,
+    session: Session,
+    repository: RunRepository,
+    run: AnalysisRun,
+    settings: Settings,
+    selected_sources: list[str],
+    cve_ids: list[str],
+    cache_only: bool,
+    execution_mode: str,
+    fail_conflicts: bool,
+) -> AnalysisRun:
     try:
         with _provider_update_lock(settings.provider_snapshot_dir_path):
             if _other_running_update(repository, run.id) is not None:
@@ -101,40 +263,107 @@ def create_provider_update_job(
                 settings=settings,
                 selected_sources=selected_sources,
                 cve_ids=cve_ids,
-                cache_only=payload.cache_only,
+                cache_only=cache_only,
             )
-    except ProviderUpdateConflict:
+    except ProviderUpdateConflict as exc:
+        if fail_conflicts:
+            return _mark_provider_update_run_failed(
+                session=session,
+                run=run,
+                selected_sources=selected_sources,
+                requested_cves=len(cve_ids),
+                cache_only=cache_only,
+                execution_mode=execution_mode,
+                error_message=str(exc),
+                detail="Provider refresh did not start because another job was active.",
+            )
         raise
     except Exception as exc:
-        failed_metadata = {
-            "requested_sources": selected_sources,
-            "requested_cves": len(cve_ids),
-            "cache_only": payload.cache_only,
-            "execution_mode": "request",
-            "snapshot_created": False,
-            "detail": "Provider refresh failed before replacing or mutating existing snapshots.",
-        }
-        run.status = AnalysisRunStatus.FAILED
-        run.finished_at = get_datetime_utc()
-        run.error_message = str(exc)
-        run.error_json = _redacted_payload({"detail": str(exc)})
-        run.summary_json = _redacted_payload(failed_metadata)
-        session.add(run)
-        session.flush()
-        return run
+        return _mark_provider_update_run_failed(
+            session=session,
+            run=run,
+            selected_sources=selected_sources,
+            requested_cves=len(cve_ids),
+            cache_only=cache_only,
+            execution_mode=execution_mode,
+            error_message=str(exc),
+            detail="Provider refresh failed before replacing or mutating existing snapshots.",
+        )
 
     metadata = {
         **metadata,
         "requested_sources": selected_sources,
         "requested_cves": len(cve_ids),
-        "cache_only": payload.cache_only,
-        "execution_mode": "request",
+        "cache_only": cache_only,
+        "execution_mode": execution_mode,
         "provider_snapshot_id": str(snapshot.id),
     }
     run.provider_snapshot_id = snapshot.id
     run.status = AnalysisRunStatus.COMPLETED
     run.finished_at = get_datetime_utc()
     run.summary_json = _redacted_payload(metadata)
+    session.add(run)
+    session.flush()
+    return run
+
+
+def _provider_update_request_inputs(
+    session: Session,
+    *,
+    payload: ProviderUpdateJobCreate,
+) -> tuple[list[str], list[str]]:
+    return _normalize_sources(payload.sources), _provider_update_cve_ids(session, payload=payload)
+
+
+def _create_provider_update_run(
+    repository: RunRepository,
+    *,
+    session: Session,
+    selected_sources: list[str],
+    cve_ids: list[str],
+    cache_only: bool,
+    status: AnalysisRunStatus,
+    execution_mode: str,
+) -> AnalysisRun:
+    project = _provider_update_project(session)
+    return repository.create_analysis_run(
+        project_id=project.id,
+        input_type=PROVIDER_UPDATE_INPUT_TYPE,
+        status=status,
+        summary_json={
+            "requested_sources": selected_sources,
+            "requested_cves": len(cve_ids),
+            "cache_only": cache_only,
+            "execution_mode": execution_mode,
+            "mode": "workbench-provider-update",
+        },
+    )
+
+
+def _mark_provider_update_run_failed(
+    *,
+    session: Session,
+    run: AnalysisRun,
+    selected_sources: list[str],
+    requested_cves: int,
+    cache_only: bool,
+    execution_mode: str,
+    error_message: str,
+    detail: str,
+) -> AnalysisRun:
+    failed_metadata = {
+        "requested_sources": selected_sources,
+        "requested_cves": requested_cves,
+        "cache_only": cache_only,
+        "execution_mode": execution_mode,
+        "snapshot_created": False,
+        "detail": detail,
+    }
+    run.status = AnalysisRunStatus.FAILED
+    run.finished_at = get_datetime_utc()
+    run.error_message = error_message
+    run.error_json = _redacted_payload({"detail": error_message})
+    run.summary_json = _redacted_payload(failed_metadata)
     session.add(run)
     session.flush()
     return run
@@ -226,6 +455,7 @@ def _write_provider_snapshot(
         settings=settings,
     )
     warnings = list(baseline_warnings)
+    refresh_warnings: list[str] = []
     source_counts: dict[str, dict[str, int]] = {}
     nvd_results: dict[str, NvdData] = {}
     epss_results: dict[str, EpssData] = {}
@@ -240,6 +470,7 @@ def _write_provider_snapshot(
             nvd_api_key_env=settings.NVD_API_KEY_ENV,
         )
         warnings.extend(source_warnings)
+        refresh_warnings.extend(source_warnings if not cache_only else [])
     if "epss" in selected_sources:
         epss_results, source_warnings, source_counts["epss"] = _provider_records_for_snapshot(
             source="epss",
@@ -249,6 +480,7 @@ def _write_provider_snapshot(
             baseline_items=baseline_items,
         )
         warnings.extend(source_warnings)
+        refresh_warnings.extend(source_warnings if not cache_only else [])
     if "kev" in selected_sources:
         kev_results, source_warnings, source_counts["kev"] = _provider_records_for_snapshot(
             source="kev",
@@ -258,6 +490,7 @@ def _write_provider_snapshot(
             baseline_items=baseline_items,
         )
         warnings.extend(source_warnings)
+        refresh_warnings.extend(source_warnings if not cache_only else [])
 
     source_hashes = _provider_cache_source_hashes(cache, selected_sources)
     report = ProviderSnapshotReport(
@@ -295,6 +528,13 @@ def _write_provider_snapshot(
             *(["No CVEs were available for provider snapshot refresh."] if not cve_ids else []),
         ],
     )
+    refresh_failure = _provider_refresh_failure(
+        selected_sources=selected_sources,
+        cache_only=cache_only,
+        refresh_warnings=refresh_warnings,
+    )
+    if refresh_failure is not None:
+        raise ProviderUpdateRefreshError(refresh_failure)
     document = generate_provider_snapshot_json(report)
     output_path.write_text(document, encoding="utf-8")
     content_hash = hashlib.sha256(document.encode("utf-8")).hexdigest()
@@ -310,14 +550,18 @@ def _write_provider_snapshot(
             "snapshot_mode": "cache-only" if cache_only else "snapshot",
         }
     )
-    snapshot = repository.get_or_create_provider_snapshot(
-        content_hash=content_hash,
-        nvd_last_sync=_latest_nvd_sync(nvd_results.values()),
-        epss_date=_latest_epss_date(epss_results.values()),
-        kev_catalog_version=_latest_kev_date(kev_results.values()),
-        source_hashes_json={"provider_snapshot": content_hash},
-        source_metadata_json=metadata_json,
-    )
+    try:
+        snapshot = repository.get_or_create_provider_snapshot(
+            content_hash=content_hash,
+            nvd_last_sync=_latest_nvd_sync(nvd_results.values()),
+            epss_date=_latest_epss_date(epss_results.values()),
+            kev_catalog_version=_latest_kev_date(kev_results.values()),
+            source_hashes_json={"provider_snapshot": content_hash},
+            source_metadata_json=metadata_json,
+        )
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
     return snapshot, {
         "mode": "workbench-provider-update",
         "snapshot_created": True,
@@ -328,6 +572,23 @@ def _write_provider_snapshot(
         "source_counts": source_counts,
         "warnings": report.warnings,
     }
+
+
+def _provider_refresh_failure(
+    *,
+    selected_sources: list[str],
+    cache_only: bool,
+    refresh_warnings: list[str],
+) -> str | None:
+    if cache_only or not refresh_warnings:
+        return None
+    warning_text = "; ".join(refresh_warnings[:3])
+    suffix = " ..." if len(refresh_warnings) > 3 else ""
+    return (
+        "Provider refresh returned degraded live data for source(s) "
+        + ", ".join(selected_sources)
+        + f": {warning_text}{suffix}"
+    )
 
 
 def _load_latest_snapshot_items(
@@ -547,6 +808,19 @@ def _provider_update_lock(snapshot_root: Path) -> Iterator[Path]:
             lock_path.unlink(missing_ok=True)
 
 
+def _reject_active_provider_update_lock(snapshot_root: Path) -> None:
+    snapshot_root.mkdir(parents=True, exist_ok=True)
+    lock_path = snapshot_root / PROVIDER_UPDATE_LOCK_FILE
+    if not lock_path.exists():
+        return
+    if _provider_update_lock_is_stale(lock_path):
+        lock_path.unlink(missing_ok=True)
+        return
+    raise ProviderUpdateConflict(
+        "Provider update already running; retry after the active job finishes."
+    )
+
+
 def _open_provider_update_lock(lock_path: Path) -> int:
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     try:
@@ -568,6 +842,22 @@ def _provider_update_lock_is_stale(lock_path: Path) -> bool:
         return time.time() - lock_path.stat().st_mtime > PROVIDER_UPDATE_LOCK_STALE_SECONDS
     except OSError:
         return False
+
+
+def _dict_payload(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _int_value(value: Any) -> int:
+    if isinstance(value, int):
+        return value
+    return 0
 
 
 def _redacted_payload(payload: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/api/test_workbench_provider_status_api.py
+++ b/backend/tests/api/test_workbench_provider_status_api.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from sqlmodel import Session
 from utils.workbench_env import WorkbenchApiEnv, local_api_headers
 
+from app.models.base import get_datetime_utc
+from app.services import provider_updates as provider_updates_module
 from app.services.provider_status import provider_status_payload
-from app.services.provider_updates import PROVIDER_UPDATE_LOCK_FILE
+from app.services.provider_updates import (
+    PROVIDER_UPDATE_LOCK_FILE,
+    reconcile_stale_provider_update_runs,
+)
 from vuln_prioritizer.models import (
     KevData,
     ProviderSnapshotItem,
@@ -453,6 +458,153 @@ def test_workbench_provider_update_job_create_list_and_status(
         workbench_api_env.client.app.state.workbench_settings = active_settings
 
 
+def test_workbench_provider_update_job_can_run_in_background(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    headers = local_api_headers(workbench_api_env.client)
+    active_settings = workbench_api_env.client.app.state.workbench_settings
+    workbench_api_env.client.app.state.workbench_settings = replace(
+        active_settings,
+        PROVIDER_SNAPSHOT_DIR=str(tmp_path / "workbench-provider-snapshots"),
+        PROVIDER_CACHE_DIR=str(tmp_path / "workbench-provider-cache"),
+    )
+    try:
+        response = workbench_api_env.client.post(
+            "/api/v1/providers/update-jobs",
+            headers=headers,
+            json={
+                "sources": ["kev"],
+                "cve_ids": ["CVE-2024-3094"],
+                "cache_only": True,
+                "execution_mode": "background",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        queued_job = response.json()
+        assert queued_job["execution_mode"] == "background"
+        assert queued_job["status"] == "pending"
+
+        with Session(workbench_api_env.engine) as session:
+            run = session.get(
+                workbench_api_env.app_models.AnalysisRun,
+                uuid.UUID(queued_job["id"]),
+            )
+
+        assert run is not None
+        assert run.status == workbench_api_env.app_models.AnalysisRunStatus.COMPLETED
+        assert run.summary_json["execution_mode"] == "background"
+        assert run.summary_json["snapshot_created"] is True
+    finally:
+        workbench_api_env.client.app.state.workbench_settings = active_settings
+
+
+def test_workbench_provider_update_live_failure_preserves_previous_snapshot(
+    monkeypatch,
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    class FailingKevProvider:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def fetch_many(
+            self,
+            cve_ids: list[str],
+            *,
+            refresh: bool = False,
+        ) -> tuple[dict[str, KevData], list[str]]:
+            assert refresh is True
+            return (
+                {cve_id: KevData(cve_id=cve_id, in_kev=False) for cve_id in cve_ids},
+                ["KEV catalog load failed: upstream unavailable"],
+            )
+
+    headers = local_api_headers(workbench_api_env.client)
+    active_settings = workbench_api_env.client.app.state.workbench_settings
+    snapshot_dir = tmp_path / "workbench-provider-snapshots"
+    cache_dir = tmp_path / "workbench-provider-cache"
+    workbench_api_env.client.app.state.workbench_settings = replace(
+        active_settings,
+        PROVIDER_SNAPSHOT_DIR=str(snapshot_dir),
+        PROVIDER_CACHE_DIR=str(cache_dir),
+    )
+    monkeypatch.setattr(provider_updates_module, "KevProvider", FailingKevProvider)
+    try:
+        snapshot_dir.mkdir()
+        baseline_path = snapshot_dir / "baseline-provider-snapshot.json"
+        baseline_path.write_text(
+            generate_provider_snapshot_json(
+                ProviderSnapshotReport(
+                    metadata=ProviderSnapshotMetadata(
+                        snapshot_id="baseline-workbench-provider-data",
+                        generated_at="2026-04-30T10:00:00Z",
+                        input_paths=[],
+                        input_format="workbench-test",
+                        selected_sources=["kev"],
+                        requested_cves=1,
+                        output_path=baseline_path.name,
+                        cache_enabled=True,
+                        cache_only=True,
+                        cache_dir=None,
+                        source_hashes={"kev": "sha256:baseline-kev"},
+                        source_metadata={"kev": {"source": "CISA KEV catalog"}},
+                        nvd_api_key_env=None,
+                    ),
+                    items=[ProviderSnapshotItem(cve_id="CVE-2024-3094")],
+                )
+            ),
+            encoding="utf-8",
+        )
+        with Session(workbench_api_env.engine) as session:
+            previous_snapshot = workbench_api_env.repositories.RunRepository(
+                session
+            ).create_provider_snapshot(
+                kev_catalog_version="2026-04-01",
+                content_hash="sha256:baseline-workbench-provider-data",
+                source_hashes_json={"provider_snapshot": "sha256:baseline-workbench-provider-data"},
+                source_metadata_json={
+                    "snapshot_file": baseline_path.name,
+                    "selected_sources": ["kev"],
+                    "requested_cves": 1,
+                    "generated_at": "2026-04-30T10:00:00Z",
+                },
+            )
+            previous_snapshot_id = previous_snapshot.id
+            session.commit()
+
+        response = workbench_api_env.client.post(
+            "/api/v1/providers/update-jobs",
+            headers=headers,
+            json={
+                "sources": ["kev"],
+                "cve_ids": ["CVE-2024-3094"],
+                "cache_only": False,
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        job = response.json()
+        assert job["status"] == "failed"
+        assert job["metadata"]["snapshot_created"] is False
+        assert "upstream unavailable" in job["error_message"]
+        assert sorted(path.name for path in snapshot_dir.glob("*.json")) == [
+            "baseline-provider-snapshot.json"
+        ]
+
+        status_payload = workbench_api_env.client.get(
+            "/api/v1/providers/status",
+            headers=headers,
+        ).json()
+        assert status_payload["status"] == "degraded"
+        assert status_payload["snapshot"]["id"] == str(previous_snapshot_id)
+        assert status_payload["latest_update_job"]["id"] == job["id"]
+        assert any("Latest provider update failed" in item for item in status_payload["warnings"])
+    finally:
+        workbench_api_env.client.app.state.workbench_settings = active_settings
+
+
 def test_workbench_provider_update_job_reuses_previous_provider_records(
     workbench_api_env: WorkbenchApiEnv,
     tmp_path: Path,
@@ -622,6 +774,51 @@ def test_workbench_provider_update_job_rejects_active_job(
         assert "Provider update already running" in response.json()["detail"]
     finally:
         workbench_api_env.client.app.state.workbench_settings = active_settings
+
+
+def test_workbench_provider_update_reconciliation_fails_stale_active_job(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    active_settings = replace(
+        workbench_api_env.client.app.state.workbench_settings,
+        PROVIDER_SNAPSHOT_DIR=str(tmp_path / "workbench-provider-snapshots"),
+        PROVIDER_CACHE_DIR=str(tmp_path / "workbench-provider-cache"),
+        PROVIDER_UPDATE_STALE_MINUTES=1,
+    )
+    with Session(workbench_api_env.engine) as session:
+        project = workbench_api_env.repositories.ProjectRepository(session).create_project(
+            workbench_api_env.app_models.ProjectCreate(name="Stale Provider Job")
+        )
+        run = workbench_api_env.repositories.RunRepository(session).create_analysis_run(
+            project_id=project.id,
+            input_type="provider_update",
+            status=workbench_api_env.app_models.AnalysisRunStatus.RUNNING,
+            summary_json={
+                "requested_sources": ["kev"],
+                "requested_cves": 1,
+                "cache_only": True,
+                "execution_mode": "request",
+            },
+        )
+        run.started_at = get_datetime_utc() - timedelta(minutes=5)
+        session.add(run)
+        session.commit()
+        run_id = run.id
+
+    reconciled = reconcile_stale_provider_update_runs(
+        engine=workbench_api_env.engine,
+        settings=active_settings,
+    )
+
+    assert reconciled == 1
+    with Session(workbench_api_env.engine) as session:
+        reconciled_run = session.get(workbench_api_env.app_models.AnalysisRun, run_id)
+
+    assert reconciled_run is not None
+    assert reconciled_run.status == workbench_api_env.app_models.AnalysisRunStatus.FAILED
+    assert reconciled_run.finished_at is not None
+    assert "did not finish" in reconciled_run.error_message
 
 
 def test_workbench_provider_update_job_rejects_active_filesystem_lock(

--- a/backend/tests/test_docs_hygiene.py
+++ b/backend/tests/test_docs_hygiene.py
@@ -251,6 +251,13 @@ def test_dependency_audit_docs_cover_frontend_build_chain_dependencies() -> None
     assert violations == {name: [] for name in active_docs}
 
 
+def test_dependency_policy_does_not_carry_closed_dependency_prs() -> None:
+    policy = (REPO_ROOT / "docs" / "dependency-and-package-policy.md").read_text(encoding="utf-8")
+
+    assert "pull/287" not in policy
+    assert "remains the linked GitHub Actions dependency-update follow-up" not in policy
+
+
 def test_testpypi_release_docs_do_not_mix_package_indexes() -> None:
     runbook = RELEASE_OPERATIONS_FILE.read_text(encoding="utf-8")
     testpypi_section = runbook.split("## TestPyPI Validation Path", maxsplit=1)[1].split(

--- a/docs/dependency-and-package-policy.md
+++ b/docs/dependency-and-package-policy.md
@@ -159,12 +159,10 @@ The current automation label policy is:
 | GitHub Actions | `maintenance`, `dependencies`, `github-actions` |
 | Frontend npm | `maintenance`, `dependencies`, `type:frontend`, `area:ui` |
 
-Dependabot PR
-[#287](https://github.com/Noetheon/vuln-prioritizer-workbench/pull/287)
-remains the linked GitHub Actions dependency-update follow-up for this policy.
-It should be merged, closed, or explicitly carried forward by a maintainer after
-the release gate confirms the `actions/upload-artifact` upgrade is compatible
-with the current artifact upload usage.
+Closed dependency-update PRs are not carried forward as active policy tasks in
+this document. When an ecosystem still needs a dependency refresh, track it in a
+current issue or PR and remove the reference when the release gate accepts or
+rejects the update.
 
 ## Release Evidence Commands
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4177,7 +4177,7 @@ export const ProviderStatusPublicSchema = {
 } as const;
 
 export const ProviderUpdateJobCreateSchema = {
-    description: 'Request body for a deterministic provider update job.',
+    description: 'Request body for a provider update job.',
     properties: {
         cache_only: {
             default: true,
@@ -4190,6 +4190,15 @@ export const ProviderUpdateJobCreateSchema = {
             },
             title: 'Cve Ids',
             type: 'array'
+        },
+        execution_mode: {
+            default: 'request',
+            enum: [
+                'request',
+                'background'
+            ],
+            title: 'Execution Mode',
+            type: 'string'
         },
         max_cves: {
             anyOf: [

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -668,7 +668,7 @@ export class ProvidersService {
     /**
      * Create Provider Update Job
      *
-     * Synchronously create a cache-friendly provider snapshot refresh job.
+     * Create a cache-friendly provider snapshot refresh job.
      */
     public static createProviderUpdateJob<ThrowOnError extends boolean = true>(parameters: {
         providerUpdateJobCreate: ProviderUpdateJobCreate;

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2345,7 +2345,7 @@ export type ProviderStatusPublic = {
 /**
  * ProviderUpdateJobCreate
  *
- * Request body for a deterministic provider update job.
+ * Request body for a provider update job.
  */
 export type ProviderUpdateJobCreate = {
     /**
@@ -2356,6 +2356,10 @@ export type ProviderUpdateJobCreate = {
      * Cve Ids
      */
     cve_ids?: Array<string>;
+    /**
+     * Execution Mode
+     */
+    execution_mode?: 'request' | 'background';
     /**
      * Max Cves
      */


### PR DESCRIPTION
## Summary
- Add opt-in background execution for provider update jobs while keeping request-mode as the default.
- Reconcile stale provider-update rows on startup so old RUNNING/PENDING rows do not block local updates indefinitely.
- Fail live provider refreshes that return provider warnings before replacing the latest valid snapshot, and keep stale closed-PR dependency guidance out of active docs.

## Validation
- python3 -m ruff format --check backend
- python3 -m ruff check backend
- cd backend && python3 -m mypy app src
- python3 -m pytest -q backend/tests --no-cov
- cd frontend && npm run lint
- cd frontend && npm run test:types
- cd frontend && npm run test:unit:coverage
- cd frontend && npm run build
- cd frontend && npm run test -- --reporter=line
