### PR TITLE
[codex] Guard coverage boundary policy

### DIFF
--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import tarfile
+import tomllib
 from collections import deque
 from pathlib import Path
 from typing import Any
@@ -138,6 +139,11 @@ def _as_text(value: Any) -> str:
 
 def _read_repo_text(path: str) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _read_repo_toml(path: str) -> dict[str, Any]:
+    with (REPO_ROOT / path).open("rb") as handle:
+        return tomllib.load(handle)
 
 
 def test_legacy_workbench_runtime_source_is_removed() -> None:
@@ -628,6 +634,23 @@ def test_ci_frontend_gate_runs_coverage_and_full_playwright_suite() -> None:
 
 def test_legacy_cli_entrypoint_is_removed() -> None:
     assert not (REPO_ROOT / "backend/src/vuln_prioritizer/cli.py").exists()
+
+
+def test_backend_package_boundary_matches_pytest_coverage_boundary() -> None:
+    backend_pyproject = _read_repo_toml("backend/pyproject.toml")
+    root_pyproject = _read_repo_toml("pyproject.toml")
+
+    package_include = set(backend_pyproject["tool"]["setuptools"]["packages"]["find"]["include"])
+    assert {"app*", "vuln_prioritizer*"}.issubset(package_include)
+
+    for config, expected_pythonpath in (
+        (backend_pyproject, {".", "src"}),
+        (root_pyproject, {"backend", "backend/src"}),
+    ):
+        pytest_options = config["tool"]["pytest"]["ini_options"]
+        addopts = set(pytest_options["addopts"].split())
+        assert {"--cov=app", "--cov=vuln_prioritizer"}.issubset(addopts)
+        assert set(pytest_options["pythonpath"]) == expected_pythonpath
 
 
 def test_active_status_contract_has_no_migration_or_legacy_fields() -> None:

--- a/docs/dependency-and-package-policy.md
+++ b/docs/dependency-and-package-policy.md
@@ -45,9 +45,9 @@ both `vuln_prioritizer` and the active FastAPI Workbench package under
 `backend/app`. This keeps the domain package and shipped API runtime inside the
 same enforced release threshold.
 
-Recommended follow-up, owned by the coverage-config maintainer: keep the
-coverage command aligned with the package boundary when modules move. Do not
-treat package inclusion of `app*` as coverage proof by itself.
+Coverage configuration must stay aligned with the package boundary when modules
+move. Package inclusion of `app*` is not coverage proof by itself; the pytest
+coverage command must continue to measure both `app` and `vuln_prioritizer`.
 
 ## Python Dependencies
 


### PR DESCRIPTION
## Summary
- Convert the dependency-policy coverage follow-up into a current maintenance rule.
- Add a structured runtime-boundary test that keeps setuptools package inclusion aligned with pytest coverage sources and pythonpath.

## Validation
- python3 -m ruff format --check backend
- python3 -m ruff check backend
- python3 -m pytest -q backend/tests --no-cov
