### PR TITLE
Harden demo workspace self-healing totals

### DIFF
--- a/backend/app/services/demo_workspace.py
+++ b/backend/app/services/demo_workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections import Counter
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -23,11 +24,17 @@ from app.models import (
 )
 from app.models.base import get_datetime_utc
 from app.repositories import RunRepository, WaiverRepository
+from app.repositories.waivers import waiver_lifecycle_status
 from app.services.artifact_cleanup import cleanup_project_artifacts
 from app.services.import_execution import (
     ImportUploadContent,
     ProjectImportUploadRequest,
     execute_project_import_upload,
+)
+from app.services.report_artifacts import (
+    ReportArtifactChecksumError,
+    ReportArtifactNotFoundError,
+    validated_report_path,
 )
 from app.services.reports import ReportService
 
@@ -44,6 +51,25 @@ EXPECTED_REPORT_FORMATS = (
     "sarif",
     "zip",
 )
+EXPECTED_REPORT_FILENAMES = frozenset(
+    {
+        "technical-report.md",
+        "executive-report.html",
+        "analysis-result.v1.json",
+        "findings.csv",
+        "attack-navigator-layer.json",
+        "results.sarif",
+        "evidence-bundle.zip",
+    }
+)
+EXPECTED_FINDING_COUNT = 24
+EXPECTED_ASSET_COUNT = 21
+EXPECTED_WAIVER_COUNT = 4
+EXPECTED_WAIVER_STATUS_COUNTS = {
+    "active": 3,
+    "review_due": 1,
+    "expired": 0,
+}
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DATA_DIR = _REPO_ROOT / "data"
@@ -61,10 +87,30 @@ class DemoWorkspaceSnapshot:
     asset_count: int
     waiver_count: int
     report_count: int
+    waiver_status_counts: dict[str, int]
 
     @property
     def seeded(self) -> bool:
         return self.project is not None and self.latest_run is not None and self.finding_count > 0
+
+    @property
+    def canonical(self) -> bool:
+        if not self.seeded or self.project is None:
+            return False
+        return (
+            self.project.name == DEMO_PROJECT_NAME
+            and DEMO_WORKSPACE_MARKER in (self.project.description or "")
+            and self.finding_count == EXPECTED_FINDING_COUNT
+            and self.asset_count == EXPECTED_ASSET_COUNT
+            and self.waiver_count == EXPECTED_WAIVER_COUNT
+            and self.report_count == len(EXPECTED_REPORT_FORMATS)
+            and {report.filename for report in self.reports} == EXPECTED_REPORT_FILENAMES
+            and {
+                status: self.waiver_status_counts.get(status, 0)
+                for status in EXPECTED_WAIVER_STATUS_COUNTS
+            }
+            == EXPECTED_WAIVER_STATUS_COUNTS
+        )
 
 
 def demo_workspace_enabled(settings: Settings) -> bool:
@@ -84,6 +130,7 @@ def read_demo_workspace_snapshot(session: Session) -> DemoWorkspaceSnapshot:
             asset_count=0,
             waiver_count=0,
             report_count=0,
+            waiver_status_counts={},
         )
 
     latest_run = RunRepository(session).get_latest_analysis_run(project.id)
@@ -96,6 +143,7 @@ def read_demo_workspace_snapshot(session: Session) -> DemoWorkspaceSnapshot:
         asset_count=_count_for_project(session, "asset", project.id),
         waiver_count=_count_for_project(session, "waiver", project.id),
         report_count=_count_for_project(session, "report", project.id),
+        waiver_status_counts=_waiver_status_counts(session, project.id),
     )
 
 
@@ -108,7 +156,7 @@ async def seed_demo_workspace(
 ) -> DemoWorkspaceSnapshot:
     """Create the deterministic local demo workspace using normal import/report services."""
     snapshot = read_demo_workspace_snapshot(session)
-    if snapshot.seeded and not reset and snapshot.report_count >= len(EXPECTED_REPORT_FORMATS):
+    if snapshot.canonical and _report_artifacts_available(snapshot, settings) and not reset:
         return snapshot
 
     if snapshot.project is not None:
@@ -165,6 +213,17 @@ class ReportServiceSnapshot:
             .order_by(col(Report.created_at).desc(), col(Report.id).desc())
         )
         return list(self.session.exec(statement).all())
+
+
+def _report_artifacts_available(snapshot: DemoWorkspaceSnapshot, settings: Settings) -> bool:
+    if not snapshot.reports:
+        return False
+    try:
+        for report in snapshot.reports:
+            validated_report_path(report, settings)
+    except (ReportArtifactChecksumError, ReportArtifactNotFoundError):
+        return False
+    return True
 
 
 def _create_demo_project(session: Session) -> Project:
@@ -302,3 +361,9 @@ def _count_for_project(session: Session, table: str, project_id: uuid.UUID) -> i
     model = model_by_table[table]
     statement = select(func.count()).select_from(model).where(model.project_id == project_id)
     return int(session.exec(statement).one())
+
+
+def _waiver_status_counts(session: Session, project_id: uuid.UUID) -> dict[str, int]:
+    waivers = session.exec(select(Waiver).where(Waiver.project_id == project_id)).all()
+    counts = Counter(waiver_lifecycle_status(waiver)[0] for waiver in waivers)
+    return {status: counts.get(status, 0) for status in EXPECTED_WAIVER_STATUS_COUNTS}

--- a/backend/tests/api/test_workbench_demo_workspace.py
+++ b/backend/tests/api/test_workbench_demo_workspace.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import uuid
+from collections import Counter
 from dataclasses import replace
+from datetime import timedelta
 from pathlib import Path
+from typing import Any
 
+from sqlmodel import Session, select
 from utils.workbench_env import WorkbenchApiEnv, local_api_headers
 
+from app.models.base import get_datetime_utc
+
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEMO_PROJECT_NAME = "Online Shop Demo Workspace"
+EXPECTED_REPORT_FILENAMES = {
+    "technical-report.md",
+    "executive-report.html",
+    "analysis-result.v1.json",
+    "findings.csv",
+    "attack-navigator-layer.json",
+    "results.sarif",
+    "evidence-bundle.zip",
+}
 
 
 def test_demo_workspace_status_is_disabled_by_default(
@@ -80,8 +97,12 @@ def test_demo_workspace_can_be_seeded_reset_and_removed(
         f"/api/v1/runs/{first_run_id}/reports",
         headers=headers,
     )
+    dashboard_response = workbench_api_env.client.get(
+        f"/api/v1/projects/{project_id}/dashboard",
+        headers=headers,
+    )
     governance_response = workbench_api_env.client.get(
-        f"/api/v1/projects/{project_id}/governance/rollups/",
+        f"/api/v1/projects/{project_id}/governance/rollups/?limit=20",
         headers=headers,
     )
     attack_response = workbench_api_env.client.get(
@@ -116,7 +137,17 @@ def test_demo_workspace_can_be_seeded_reset_and_removed(
     assert waiver_debt["accepted_finding_count"] == 4
     assert reports_response.status_code == 200
     assert reports_response.json()["count"] == 7
+    assert dashboard_response.status_code == 200
     assert attack_response.status_code == 200
+    _assert_demo_totals_are_coherent(
+        dashboard=dashboard_response.json(),
+        findings=findings,
+        assets=assets_response.json()["data"],
+        waivers=waivers_response.json()["data"],
+        reports=reports_response.json()["data"],
+        governance=governance_response.json(),
+        attack=attack_response.json(),
+    )
     assert attack_response.json()["mapped_finding_count"] == 21
     assert attack_response.json()["mapped_coverage_percent"] == 87.5
     assert (tmp_path / "uploads" / project_id).exists()
@@ -153,6 +184,109 @@ def test_demo_workspace_can_be_seeded_reset_and_removed(
     assert status_response.json()["seeded"] is False
     assert not (tmp_path / "uploads" / project_id).exists()
     assert not (tmp_path / "reports" / project_id).exists()
+
+    recreated_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": False},
+    )
+    assert recreated_response.status_code == 200
+    assert recreated_response.json()["project"]["id"] == project_id
+    assert recreated_response.json()["finding_count"] == 24
+    assert recreated_response.json()["asset_count"] == 21
+    assert recreated_response.json()["waiver_count"] == 4
+    assert recreated_response.json()["report_count"] == 7
+
+
+def test_demo_workspace_load_self_heals_mutated_state(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    _enable_demo_workspace(workbench_api_env, tmp_path)
+    headers = local_api_headers(workbench_api_env.client)
+
+    first_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": True},
+    )
+    assert first_response.status_code == 200
+    first_payload = first_response.json()
+    project_id = first_payload["project"]["id"]
+    first_run_id = first_payload["latest_run"]["id"]
+
+    _corrupt_demo_workspace_without_changing_counts(workbench_api_env, project_id)
+
+    repaired_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": False},
+    )
+
+    assert repaired_response.status_code == 200
+    repaired_payload = repaired_response.json()
+    assert repaired_payload["project"]["id"] == project_id
+    assert repaired_payload["project"]["name"] == DEMO_PROJECT_NAME
+    assert repaired_payload["latest_run"]["id"] != first_run_id
+    assert repaired_payload["finding_count"] == 24
+    assert repaired_payload["asset_count"] == 21
+    assert repaired_payload["waiver_count"] == 4
+    assert repaired_payload["report_count"] == 7
+
+    governance_response = workbench_api_env.client.get(
+        f"/api/v1/projects/{project_id}/governance/rollups/?limit=20",
+        headers=headers,
+    )
+    assert governance_response.status_code == 200
+    waiver_debt = governance_response.json()["waiver_debt"]
+    assert waiver_debt["active_count"] == 3
+    assert waiver_debt["review_due_count"] == 1
+    assert waiver_debt["expired_count"] == 0
+
+
+def test_demo_workspace_load_repairs_missing_report_artifact(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    _enable_demo_workspace(workbench_api_env, tmp_path)
+    headers = local_api_headers(workbench_api_env.client)
+
+    first_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": True},
+    )
+    assert first_response.status_code == 200
+    first_payload = first_response.json()
+    project_id = first_payload["project"]["id"]
+    first_run_id = first_payload["latest_run"]["id"]
+
+    deleted_artifact = _delete_one_demo_report_artifact(
+        workbench_api_env,
+        project_id=project_id,
+        run_id=first_run_id,
+    )
+    assert not deleted_artifact.exists()
+
+    repaired_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": False},
+    )
+
+    assert repaired_response.status_code == 200
+    repaired_payload = repaired_response.json()
+    assert repaired_payload["project"]["id"] == project_id
+    assert repaired_payload["latest_run"]["id"] != first_run_id
+    assert repaired_payload["finding_count"] == 24
+    assert repaired_payload["asset_count"] == 21
+    assert repaired_payload["waiver_count"] == 4
+    assert repaired_payload["report_count"] == 7
+    assert _all_demo_report_artifacts_exist(
+        workbench_api_env,
+        project_id=project_id,
+        run_id=repaired_payload["latest_run"]["id"],
+    )
 
 
 def test_demo_workspace_seed_stays_disabled_outside_local(
@@ -195,3 +329,167 @@ def _enable_demo_workspace(
         SECRET_KEY="workbench-demo-test-secret-0123456789",
     )
     workbench_api_env.client.app.state.workbench_settings = active_settings
+
+
+def _corrupt_demo_workspace_without_changing_counts(
+    workbench_api_env: WorkbenchApiEnv,
+    project_id: str,
+) -> None:
+    project_uuid = uuid.UUID(project_id)
+    models = workbench_api_env.app_models
+    with Session(workbench_api_env.engine) as session:
+        project = session.get(models.Project, project_uuid)
+        assert project is not None
+        project.name = "Mutated Demo Project"
+        project.description = "corrupted by local demo exploration"
+
+        waiver = session.exec(
+            select(models.Waiver).where(models.Waiver.project_id == project_uuid)
+        ).first()
+        assert waiver is not None
+        expired_at = get_datetime_utc().date() - timedelta(days=1)
+        waiver.expires_at = expired_at
+        waiver.review_at = expired_at
+
+        session.add(project)
+        session.add(waiver)
+        session.commit()
+
+
+def _delete_one_demo_report_artifact(
+    workbench_api_env: WorkbenchApiEnv,
+    *,
+    project_id: str,
+    run_id: str,
+) -> Path:
+    project_uuid = uuid.UUID(project_id)
+    run_uuid = uuid.UUID(run_id)
+    models = workbench_api_env.app_models
+    with Session(workbench_api_env.engine) as session:
+        report = session.exec(
+            select(models.Report)
+            .where(models.Report.project_id == project_uuid)
+            .where(models.Report.analysis_run_id == run_uuid)
+        ).first()
+        assert report is not None
+        artifact_path = Path(report.path)
+    assert artifact_path.is_file()
+    artifact_path.unlink()
+    return artifact_path
+
+
+def _all_demo_report_artifacts_exist(
+    workbench_api_env: WorkbenchApiEnv,
+    *,
+    project_id: str,
+    run_id: str,
+) -> bool:
+    project_uuid = uuid.UUID(project_id)
+    run_uuid = uuid.UUID(run_id)
+    models = workbench_api_env.app_models
+    with Session(workbench_api_env.engine) as session:
+        reports = session.exec(
+            select(models.Report)
+            .where(models.Report.project_id == project_uuid)
+            .where(models.Report.analysis_run_id == run_uuid)
+        ).all()
+    return len(reports) == 7 and all(Path(report.path).is_file() for report in reports)
+
+
+def _assert_demo_totals_are_coherent(
+    *,
+    dashboard: dict[str, Any],
+    findings: list[dict[str, Any]],
+    assets: list[dict[str, Any]],
+    waivers: list[dict[str, Any]],
+    reports: list[dict[str, Any]],
+    governance: dict[str, Any],
+    attack: dict[str, Any],
+) -> None:
+    summary = dashboard["summary"]
+    signal_counts = dashboard["findings"]["signal_counts"]
+
+    assert summary["finding_count"] == len(findings) == 24
+    assert summary["open_finding_count"] == sum(
+        1 for finding in findings if finding["status"] in {"open", "in_review", "remediating"}
+    )
+    assert summary["counts_by_status"] == _expected_count_map(
+        Counter(finding["status"] for finding in findings),
+        summary["counts_by_status"],
+    )
+    assert summary["counts_by_priority"] == _expected_count_map(
+        Counter(str(finding["priority"]).title() for finding in findings),
+        summary["counts_by_priority"],
+    )
+    assert sum(summary["counts_by_status"].values()) == summary["finding_count"]
+    assert sum(summary["counts_by_priority"].values()) == summary["finding_count"]
+
+    assert len({asset["asset_key"] for asset in assets}) == 21
+    assert sum(asset["finding_count"] for asset in assets) == summary["finding_count"]
+    assert len(waivers) == 4
+    assert {report["filename"] for report in reports} == EXPECTED_REPORT_FILENAMES
+
+    epss_bucket_counts = {
+        "low": sum(1 for finding in findings if _epss_in_range(finding, 0, 0.25)),
+        "medium": sum(1 for finding in findings if _epss_in_range(finding, 0.25, 0.5)),
+        "high": sum(1 for finding in findings if _epss_in_range(finding, 0.5, 0.7)),
+        "critical": sum(1 for finding in findings if _epss_in_range(finding, 0.7, None)),
+    }
+    assert signal_counts["epss_buckets"] == epss_bucket_counts
+    assert signal_counts["high_epss"] == epss_bucket_counts["critical"]
+    assert sum(signal_counts["epss_buckets"].values()) == summary["epss_hits"]
+    assert signal_counts["internet_facing_criticals"] == sum(
+        1
+        for finding in findings
+        if finding["priority"] == "critical" and finding["exposure"] == "internet-facing"
+    )
+
+    waiver_debt = governance["waiver_debt"]
+    assert waiver_debt["waiver_count"] == (
+        waiver_debt["active_count"] + waiver_debt["review_due_count"] + waiver_debt["expired_count"]
+    )
+    assert waiver_debt["accepted_finding_count"] == sum(
+        1 for finding in findings if finding["status"] == "accepted" or finding["waived"]
+    )
+    assert attack["mapped_finding_count"] + attack["unmapped_finding_count"] == len(findings)
+
+    assert sum(service["finding_count"] for service in governance["services"]) == len(findings)
+    for rollup_group in (
+        governance["owners"],
+        governance["services"],
+        governance["environments"],
+        governance["assets"],
+        governance["top_services_by_risk"],
+        governance["top_assets_by_risk"],
+    ):
+        for rollup in rollup_group:
+            _assert_rollup_counts_are_coherent(rollup)
+
+
+def _assert_rollup_counts_are_coherent(rollup: dict[str, Any]) -> None:
+    assert sum(rollup["priority_counts"].values()) == rollup["finding_count"]
+    assert sum(rollup["status_counts"].values()) == rollup["finding_count"]
+    assert rollup["open_count"] == sum(
+        rollup["status_counts"].get(status, 0) for status in ("open", "in_review", "remediating")
+    )
+    assert rollup["accepted_count"] >= rollup["status_counts"].get("accepted", 0)
+    assert rollup["fixed_count"] == rollup["status_counts"].get("fixed", 0)
+    assert rollup["suppressed_count"] == rollup["status_counts"].get("suppressed", 0)
+
+
+def _expected_count_map(
+    actual_counts: Counter[str],
+    expected_shape: dict[str, int],
+) -> dict[str, int]:
+    return {key: actual_counts.get(key, 0) for key in expected_shape}
+
+
+def _epss_in_range(
+    finding: dict[str, Any],
+    minimum: float,
+    maximum: float | None,
+) -> bool:
+    value = finding.get("epss")
+    if not isinstance(value, (int, float)) or value < minimum:
+        return False
+    return maximum is None or value < maximum

--- a/frontend/src/components/dashboard/DashboardSignalOverview.tsx
+++ b/frontend/src/components/dashboard/DashboardSignalOverview.tsx
@@ -145,7 +145,7 @@ export function DashboardSignalOverview({
 
           <TabsContent className="mt-4" value="priority">
             <ChartCard
-              description="Severity distribution across open findings"
+              description="Severity distribution across findings in scope"
               title="Findings by priority"
             >
               {summaryLoading ? (
@@ -180,7 +180,10 @@ export function DashboardSignalOverview({
                       <RechartsTooltip />
                       <Bar dataKey="value" radius={[4, 4, 0, 0]}>
                         {priorityItems.map((entry) => (
-                          <Cell key={entry.label} fill={priorityFill(entry.tone)} />
+                          <Cell
+                            key={entry.label}
+                            fill={priorityFill(entry.tone)}
+                          />
                         ))}
                       </Bar>
                     </BarChart>
@@ -299,7 +302,9 @@ export function DashboardSignalOverview({
                   <ChartDataSummary
                     data={serviceItems}
                     label={`${
-                      topServiceSource === "assets" ? "Top assets" : "Top services"
+                      topServiceSource === "assets"
+                        ? "Top assets"
+                        : "Top services"
                     } chart data`}
                   />
                 </>
@@ -310,7 +315,10 @@ export function DashboardSignalOverview({
           <TabsContent className="mt-4" value="trend">
             <ChartCard
               action={
-                <Select onValueChange={onRunRangeChange} value={selectedRunRange}>
+                <Select
+                  onValueChange={onRunRangeChange}
+                  value={selectedRunRange}
+                >
                   <SelectTrigger aria-label="Risk trend range" className="w-36">
                     <SelectValue placeholder="Range" />
                   </SelectTrigger>

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -39,7 +39,10 @@ import {
 } from "@/lib/provider-format"
 import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { ErrorState } from "../states"
-import { DashboardDemoBanner, DashboardSetupEmptyState } from "./DashboardEmptyState"
+import {
+  DashboardDemoBanner,
+  DashboardSetupEmptyState,
+} from "./DashboardEmptyState"
 import { DashboardHero } from "./DashboardHero"
 import { DashboardMetricGrid } from "./DashboardMetricGrid"
 import { DashboardRemediationSection } from "./DashboardRemediationSection"
@@ -204,9 +207,9 @@ export function RiskOperationsDashboard({
   const freshnessCard = useMemo<DashboardMetricSummary[]>(
     () => [
       {
-        detail: "Critical-priority active findings",
+        detail: "Critical-priority findings in scope",
         icon: AlertTriangle,
-        label: "Critical Open",
+        label: "Critical Priority",
         tone: "critical",
         value:
           (!isDemoMode && summaryLoading) || effectiveSummary === null
@@ -234,9 +237,9 @@ export function RiskOperationsDashboard({
             : String(effectiveSignalCounts.highEpss),
       },
       {
-        detail: "High-priority active findings",
+        detail: "High-priority findings in scope",
         icon: AlertCircle,
-        label: "High Open",
+        label: "High Priority",
         tone: "high",
         value:
           (!isDemoMode && summaryLoading) || effectiveSummary === null
@@ -388,7 +391,10 @@ export function RiskOperationsDashboard({
         {!showEmptyState ? (
           <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] 2xl:grid-cols-[minmax(0,1fr)_22rem]">
             <div className="min-w-0 flex flex-col gap-4">
-              <DashboardMetricGrid cards={freshnessCard} isLoading={isLoading} />
+              <DashboardMetricGrid
+                cards={freshnessCard}
+                isLoading={isLoading}
+              />
               <Suspense fallback={<DashboardSignalOverviewFallback />}>
                 <DashboardSignalOverview
                   epssItems={epssItems}

--- a/frontend/src/lib/chart-data.ts
+++ b/frontend/src/lib/chart-data.ts
@@ -38,32 +38,14 @@ const priorityKeyAliases: Record<PriorityBucket, string[]> = {
   Low: ["Low", "low"],
 }
 
-const lifecyclePriorityOrder: Array<{
-  key: string
-  label: string
-  tone: string
-}> = [
-  { key: "accepted", label: "Accepted", tone: "accepted" },
-  { key: "suppressed", label: "Suppressed", tone: "suppressed" },
-]
-
 export function findingsByPriorityChartData(
   summary: ProjectDecisionSummaryPublic | null,
 ): ChartDatum[] {
-  const priorityItems = priorityOrder.map((priority) => ({
+  return priorityOrder.map((priority) => ({
     label: priority.label,
     tone: priority.tone,
     value: priorityCount(summary, priority.key),
   }))
-  const lifecycleItems = lifecyclePriorityOrder
-    .map((status) => ({
-      detail: "lifecycle state",
-      label: status.label,
-      tone: status.tone,
-      value: summary?.counts_by_status?.[status.key] ?? 0,
-    }))
-    .filter((item) => item.value > 0)
-  return [...priorityItems, ...lifecycleItems]
 }
 
 export function priorityCount(
@@ -101,17 +83,20 @@ export function runActivityTrendData(
   runs: readonly AnalysisRunPublic[],
   limit = 6,
 ): ChartDatum[] {
-  return runs.slice(0, limit).reverse().map((run, index) => ({
-    detail: run.status ?? "pending",
-    label: run.started_at
-      ? new Intl.DateTimeFormat(undefined, {
-          month: "short",
-          day: "numeric",
-        }).format(new Date(run.started_at))
-      : `Run ${index + 1}`,
-    tone: run.status ?? "pending",
-    value: index + 1,
-  }))
+  return runs
+    .slice(0, limit)
+    .reverse()
+    .map((run, index) => ({
+      detail: run.status ?? "pending",
+      label: run.started_at
+        ? new Intl.DateTimeFormat(undefined, {
+            month: "short",
+            day: "numeric",
+          }).format(new Date(run.started_at))
+        : `Run ${index + 1}`,
+      tone: run.status ?? "pending",
+      value: index + 1,
+    }))
 }
 
 export function epssBucketChartData(

--- a/frontend/tests/chart-data.test.ts
+++ b/frontend/tests/chart-data.test.ts
@@ -23,19 +23,21 @@ function runFixture(value: Partial<AnalysisRunPublic>): AnalysisRunPublic {
   return value as unknown as AnalysisRunPublic
 }
 
-test("includes lifecycle states when present", () => {
-  const data = findingsByPriorityChartData(summaryFixture({
-    counts_by_priority: {
-      Critical: 2,
-      High: 1,
-      Medium: 0,
-      Low: 3,
-    },
-    counts_by_status: {
-      accepted: 4,
-      suppressed: 1,
-    },
-  }))
+test("keeps priority chart additive when lifecycle states are present", () => {
+  const data = findingsByPriorityChartData(
+    summaryFixture({
+      counts_by_priority: {
+        Critical: 2,
+        High: 1,
+        Medium: 0,
+        Low: 3,
+      },
+      counts_by_status: {
+        accepted: 4,
+        suppressed: 1,
+      },
+    }),
+  )
 
   assert.deepEqual(
     data.map((item) => [item.label, item.value]),
@@ -44,21 +46,25 @@ test("includes lifecycle states when present", () => {
       ["High", 1],
       ["Medium", 0],
       ["Low", 3],
-      ["Accepted", 4],
-      ["Suppressed", 1],
     ],
+  )
+  assert.equal(
+    data.reduce((total, item) => total + item.value, 0),
+    6,
   )
 })
 
 test("keeps base priority buckets when lifecycle states are zero", () => {
-  const data = findingsByPriorityChartData(summaryFixture({
-    counts_by_priority: {
-      Critical: 1,
-    },
-    counts_by_status: {
-      accepted: 0,
-    },
-  }))
+  const data = findingsByPriorityChartData(
+    summaryFixture({
+      counts_by_priority: {
+        Critical: 1,
+      },
+      counts_by_status: {
+        accepted: 0,
+      },
+    }),
+  )
 
   assert.deepEqual(
     data.map((item) => item.label),

--- a/frontend/tests/workbench-demo-workspace.spec.ts
+++ b/frontend/tests/workbench-demo-workspace.spec.ts
@@ -31,8 +31,26 @@ test("workbench demo workspace seeds persisted dashboard and reports", async ({
     page.getByText("Online Shop Demo Workspace").first(),
   ).toBeVisible({ timeout: 60_000 })
   await expect(page.getByText("Demo workspace").first()).toBeVisible()
-  await expect(page.getByLabel("Critical Open summary card")).toContainText("24")
+  await expect(page.getByLabel("Critical Priority summary card")).toContainText(
+    "24",
+  )
   await expect(page.getByLabel("High EPSS summary card")).toContainText("24")
+  await expect(
+    page.getByRole("table", { name: "Findings by priority chart data" }),
+  ).toContainText("Critical")
+  await expect(
+    page.getByRole("table", { name: "Findings by priority chart data" }),
+  ).toContainText("24")
+  await expect(
+    page.getByRole("table", { name: "Findings by priority chart data" }),
+  ).not.toContainText("Accepted")
+  await page.getByRole("tab", { name: "EPSS Distribution" }).click()
+  await expect(
+    page.getByRole("table", { name: "EPSS distribution chart data" }),
+  ).toContainText("Critical Exposure")
+  await expect(
+    page.getByRole("table", { name: "EPSS distribution chart data" }),
+  ).toContainText("24")
   await expect(
     page.getByRole("link", { name: "CVE-2021-44228" }).first(),
   ).toBeVisible()

--- a/frontend/tests/workbench-entry-status.spec.ts
+++ b/frontend/tests/workbench-entry-status.spec.ts
@@ -81,7 +81,9 @@ test("workbench frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(page.getByLabel("No remediation queue items")).toContainText(
     "No findings",
   )
-  await expect(page.getByLabel("Critical Open summary card")).toContainText("0")
+  await expect(page.getByLabel("Critical Priority summary card")).toContainText(
+    "0",
+  )
   await expect(page.getByLabel("Latest Analysis summary card")).toContainText(
     "No runs",
   )


### PR DESCRIPTION
## Summary
- make the local demo workspace canonical check strict enough to reseed mutated demo data and missing/corrupt report artifacts
- add backend coherence tests for demo dashboard, governance, ATT&CK, assets, waivers, and report totals
- keep priority dashboard/chart totals additive by removing lifecycle rows from the priority chart and clarifying metric labels

## Test evidence
- python3 -m ruff format --check backend && python3 -m ruff check backend
- cd backend && python3 -m mypy app src
- python3 -m pytest -q backend/tests --no-cov
- cd frontend && npm run lint
- cd frontend && npm run test:types
- cd frontend && npm run test:unit:coverage
- cd frontend && npm run build
- cd frontend && npm run test -- --reporter=line
- local runtime: DELETE /api/v1/workbench/demo followed by POST /api/v1/workbench/demo {"reset":false} recreated 24 findings, 21 assets, 4 waivers, 7 reports
