### PR TITLE
[codex] Polish dashboard layout

### DIFF
--- a/frontend/src/components/app/AppShell.tsx
+++ b/frontend/src/components/app/AppShell.tsx
@@ -298,7 +298,7 @@ export function AppShell({
         {/* Main area */}
         <main className="flex h-dvh min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {/* Topbar */}
-          <header className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-[var(--vpw-border-default)] bg-[var(--vpw-bg-page)] px-4 py-3 lg:h-14 lg:px-6 lg:py-0">
+          <header className="flex h-16 shrink-0 items-center justify-between gap-3 border-b border-[var(--vpw-border-default)] bg-[var(--vpw-bg-page)] px-4 lg:px-6">
             <div className="flex min-w-0 items-center gap-3">
               <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
                 <SheetTrigger asChild>
@@ -394,13 +394,13 @@ export function AppShell({
                 </SheetContent>
               </Sheet>
               <div className="min-w-0">
-                <p className="text-[10px] font-bold uppercase text-[var(--vpw-text-muted)]">
+                <p className="text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--vpw-text-muted)]">
                   {eyebrow}
                 </p>
-                <h1 className="truncate text-base font-bold leading-tight text-[var(--vpw-text-primary)]">
+                <h1 className="truncate text-base font-bold leading-tight text-[var(--vpw-text-primary)] sm:text-lg">
                   {title}
                 </h1>
-                <p className="hidden truncate text-xs text-[var(--vpw-text-muted)] md:block">
+                <p className="sr-only">
                   {description}
                 </p>
               </div>

--- a/frontend/src/components/dashboard/DashboardMetricGrid.tsx
+++ b/frontend/src/components/dashboard/DashboardMetricGrid.tsx
@@ -13,8 +13,8 @@ export function DashboardMetricGrid({
 }: DashboardMetricGridProps) {
   if (isLoading) {
     return (
-      <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }, (_, i) => i).map((i) => (
+      <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => i).map((i) => (
           <Skeleton className="h-24 rounded-[var(--vpw-radius-lg)]" key={i} />
         ))}
       </div>
@@ -22,7 +22,7 @@ export function DashboardMetricGrid({
   }
 
   return (
-    <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+    <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-4">
       {cards.map((card) => (
         <MetricCard
           detail={card.detail}

--- a/frontend/src/components/dashboard/DashboardSidePanel.tsx
+++ b/frontend/src/components/dashboard/DashboardSidePanel.tsx
@@ -114,6 +114,43 @@ export function DashboardSidePanel({
 
       <VpwSurface className="gap-3 py-4">
         <VpwSurfaceHeader className="px-4 pb-0">
+          <VpwSurfaceTitle className="text-sm">Recent Runs</VpwSurfaceTitle>
+        </VpwSurfaceHeader>
+        <VpwSurfaceBody className="px-4">
+          {latestRunFactsRows.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No analysis runs yet.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {latestRunFactsRows.map((run) => (
+                <div
+                  className="flex items-center justify-between gap-2 rounded-md border bg-muted/20 px-2.5 py-2 text-xs"
+                  key={run.id}
+                >
+                  <VpwBadge
+                    className="shrink-0"
+                    tone={runBadgeTone(run.tone)}
+                  >
+                    {run.status}
+                  </VpwBadge>
+                  <span className="truncate text-muted-foreground">
+                    {run.startedAt}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+          <Button asChild className="mt-3 w-full" size="sm" variant="outline">
+            <Link search={projectSearch} to="/imports">
+              View all imports
+            </Link>
+          </Button>
+        </VpwSurfaceBody>
+      </VpwSurface>
+
+      <VpwSurface className="gap-3 py-4">
+        <VpwSurfaceHeader className="px-4 pb-0">
           <div className="flex items-center justify-between gap-3">
             <VpwSurfaceTitle className="text-sm">Data Quality</VpwSurfaceTitle>
             <VpwBadge tone={qualityIssueCount > 0 ? "warning" : "success"}>
@@ -153,43 +190,6 @@ export function DashboardSidePanel({
               )}
             </ul>
           )}
-        </VpwSurfaceBody>
-      </VpwSurface>
-
-      <VpwSurface className="gap-3 py-4">
-        <VpwSurfaceHeader className="px-4 pb-0">
-          <VpwSurfaceTitle className="text-sm">Recent Runs</VpwSurfaceTitle>
-        </VpwSurfaceHeader>
-        <VpwSurfaceBody className="px-4">
-          {latestRunFactsRows.length === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              No analysis runs yet.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-2">
-              {latestRunFactsRows.map((run) => (
-                <div
-                  className="flex items-center justify-between gap-2 rounded-md border bg-muted/20 px-2.5 py-2 text-xs"
-                  key={run.id}
-                >
-                  <VpwBadge
-                    className="shrink-0"
-                    tone={runBadgeTone(run.tone)}
-                  >
-                    {run.status}
-                  </VpwBadge>
-                  <span className="truncate text-muted-foreground">
-                    {run.startedAt}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-          <Button asChild className="mt-3 w-full" size="sm" variant="outline">
-            <Link search={projectSearch} to="/imports">
-              View all imports
-            </Link>
-          </Button>
         </VpwSurfaceBody>
       </VpwSurface>
     </div>

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -1,9 +1,7 @@
 import {
   AlertCircle,
   AlertTriangle,
-  BellRing,
-  CheckCircle2,
-  Database,
+  Globe2,
   ShieldAlert,
   TrendingUp,
 } from "lucide-react"
@@ -33,10 +31,7 @@ import {
   DEMO_SUMMARY,
   DEMO_TOP_SERVICES,
 } from "@/lib/demo-data"
-import {
-  evidenceReadiness,
-  formatProviderFreshness,
-} from "@/lib/provider-format"
+import { formatProviderFreshness } from "@/lib/provider-format"
 import { DEMO_MODE_ENABLED } from "@/lib/runtime-config"
 import { ErrorState } from "../states"
 import {
@@ -49,7 +44,6 @@ import { DashboardRemediationSection } from "./DashboardRemediationSection"
 import { DashboardSidePanel } from "./DashboardSidePanel"
 import {
   latestRunFacts,
-  latestRunLabel,
   type DashboardMetricSummary,
   type DashboardRunRange,
   type QueueFilterState,
@@ -204,7 +198,7 @@ export function RiskOperationsDashboard({
   }, [effectiveFindings, filters.queueSearch])
 
   const latestRun = effectiveRuns[0] ?? null
-  const freshnessCard = useMemo<DashboardMetricSummary[]>(
+  const summaryCards = useMemo<DashboardMetricSummary[]>(
     () => [
       {
         detail: "Critical-priority findings in scope",
@@ -232,63 +226,28 @@ export function RiskOperationsDashboard({
         label: "High EPSS",
         tone: "high",
         value:
-          (!isDemoMode && summaryLoading) || effectiveSummary === null
+          !isDemoMode && signalLoading
             ? "—"
             : String(effectiveSignalCounts.highEpss),
       },
       {
-        detail: "High-priority findings in scope",
-        icon: AlertCircle,
-        label: "High Priority",
-        tone: "high",
+        detail: "Critical internet-facing findings",
+        icon: Globe2,
+        label: "Internet Facing",
+        tone: "exposure",
         value:
-          (!isDemoMode && summaryLoading) || effectiveSummary === null
+          !isDemoMode && signalLoading
             ? "—"
-            : String(priorityCount(effectiveSummary, "High")),
-      },
-      {
-        detail: freshness.detail,
-        icon: Database,
-        label: "Provider Freshness",
-        tone: freshness.tone,
-        value: <span className="text-sm font-semibold">{freshness.value}</span>,
-      },
-      {
-        detail: "Provider data status for report and audit evidence.",
-        icon: CheckCircle2,
-        label: "Evidence Readiness",
-        tone: staleProvider ? "medium" : "run",
-        value: (
-          <span className="text-sm font-semibold">
-            {evidenceReadiness(effectiveProviderStatus)}
-          </span>
-        ),
-      },
-      {
-        detail: latestRun ? latestRunLabel(latestRun) : "No runs available",
-        icon: BellRing,
-        label: "Latest Analysis",
-        tone: "run",
-        value: (
-          <span className="text-sm font-semibold">
-            {effectiveSummary?.latest_run_id
-              ? `Run ${effectiveSummary.latest_run_id.slice(0, 8)}`
-              : latestRun
-                ? latestRunLabel(latestRun)
-                : "No runs"}
-          </span>
-        ),
+            : String(effectiveSignalCounts.internetFacingCriticals),
       },
     ],
     [
       isDemoMode,
       effectiveSummary,
       effectiveSignalCounts.highEpss,
-      effectiveProviderStatus,
-      latestRun,
+      effectiveSignalCounts.internetFacingCriticals,
+      signalLoading,
       summaryLoading,
-      freshness,
-      staleProvider,
     ],
   )
 
@@ -392,8 +351,20 @@ export function RiskOperationsDashboard({
           <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] 2xl:grid-cols-[minmax(0,1fr)_22rem]">
             <div className="min-w-0 flex flex-col gap-4">
               <DashboardMetricGrid
-                cards={freshnessCard}
+                cards={summaryCards}
                 isLoading={isLoading}
+              />
+              <DashboardRemediationSection
+                findingsError={findingsError}
+                findingsLoading={findingsLoading}
+                onQueueSearchChange={(queueSearch) =>
+                  setFilters((current) => ({
+                    ...current,
+                    queueSearch,
+                  }))
+                }
+                queueFindings={queueFindings}
+                queueSearch={filters.queueSearch}
               />
               <Suspense fallback={<DashboardSignalOverviewFallback />}>
                 <DashboardSignalOverview
@@ -415,18 +386,6 @@ export function RiskOperationsDashboard({
                   trendItems={trendItems}
                 />
               </Suspense>
-              <DashboardRemediationSection
-                findingsError={findingsError}
-                findingsLoading={findingsLoading}
-                onQueueSearchChange={(queueSearch) =>
-                  setFilters((current) => ({
-                    ...current,
-                    queueSearch,
-                  }))
-                }
-                queueFindings={queueFindings}
-                queueSearch={filters.queueSearch}
-              />
             </div>
 
             <DashboardSidePanel

--- a/frontend/src/components/risk/MetricCard.tsx
+++ b/frontend/src/components/risk/MetricCard.tsx
@@ -14,6 +14,7 @@ type MetricCardProps = {
 
 const accentStyles: Record<string, string> = {
   critical: "border-l-[var(--vpw-red)]",
+  exposure: "border-l-[var(--vpw-blue)]",
   high: "border-l-[var(--vpw-amber)]",
   kev: "border-l-[var(--vpw-violet)]",
   low: "border-l-[var(--vpw-green)]",
@@ -24,6 +25,7 @@ const accentStyles: Record<string, string> = {
 
 const iconBgStyles: Record<string, string> = {
   critical: "bg-[var(--vpw-bg-critical)] text-[var(--vpw-red)]",
+  exposure: "bg-[var(--vpw-bg-info)] text-[var(--vpw-blue)]",
   high: "bg-[var(--vpw-bg-warning)] text-[var(--vpw-amber)]",
   kev: "bg-[var(--vpw-bg-panel)] text-[var(--vpw-violet)]",
   low: "bg-[var(--vpw-bg-success)] text-[var(--vpw-green)]",

--- a/frontend/src/styles/vpw-components.css
+++ b/frontend/src/styles/vpw-components.css
@@ -142,8 +142,9 @@
     max-width: 100%;
     min-width: 0;
     overflow-x: auto;
+    overflow-y: hidden;
     overscroll-behavior-inline: contain;
-    scrollbar-gutter: stable;
+    scrollbar-gutter: auto;
     border: 1px solid var(--vpw-border-default);
     border-radius: var(--vpw-radius-xl);
     background: var(--vpw-bg-card);
@@ -157,14 +158,14 @@
   }
 
   .vpw-table-container {
-    width: max(100%, var(--vpw-table-min-width, 100%));
-    min-width: 100%;
+    width: 100%;
+    min-width: var(--vpw-table-min-width, 100%);
     overflow: visible;
   }
 
   .vpw-table {
-    width: max(100%, var(--vpw-table-min-width, 100%));
-    min-width: var(--vpw-table-min-width, 100%);
+    width: 100%;
+    min-width: 100%;
     border-collapse: separate;
     border-spacing: 0;
     color: var(--vpw-text-primary);

--- a/frontend/tests/workbench-entry-status.spec.ts
+++ b/frontend/tests/workbench-entry-status.spec.ts
@@ -85,9 +85,7 @@ test("workbench frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(page.getByLabel("Critical Priority summary card")).toContainText(
     "0",
   )
-  await expect(page.getByLabel("Latest Analysis summary card")).toContainText(
-    "No runs",
-  )
+  await expect(page.getByText("No runs yet").first()).toBeVisible()
 
   const importResponse = await page.request.post(
     `${backendBaseUrl}/api/v1/projects/${project.id}/imports`,
@@ -110,9 +108,7 @@ test("workbench frontend covers core Workbench E2E smoke", async ({ page }) => {
   await expect(page.getByLabel("KEV Exposed summary card")).toContainText(
     /[1-9]/,
   )
-  await expect(page.getByLabel("Latest Analysis summary card")).toContainText(
-    "succeeded",
-  )
+  await expect(page.getByText("succeeded").first()).toBeVisible()
   await expect(page.getByText("Top Remediation Queue")).toBeVisible()
   await expect(
     page.getByRole("link", { name: "CVE-2024-3094" }).first(),


### PR DESCRIPTION
## Summary

- Align the global workbench header with the sidebar divider and keep the route title focused on `Overview`.
- Remove redundant dashboard metric cards so the overview shows four high-signal cards: Critical Priority, KEV Exposed, High EPSS, and Internet Facing.
- Move the dashboard flow to metrics, remediation queue, then signal overview, with the side rail ordered as Operations State, Recent Runs, and Data Quality.
- Remove the right-hand table gutter by tightening the shared VPW table container sizing.

## Why

The dashboard and shared table surfaces were visually noisy and made the main user actions harder to identify. This PR keeps the existing design language but reduces duplicate status surfaces, improves hierarchy, and fixes table edge alignment.

## Validation

- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:types`
- `VPW_PLAYWRIGHT_REUSE_EXISTING_SERVER=1 VPW_E2E_BACKEND_URL=http://127.0.0.1:18141 VPW_E2E_FRONTEND_URL=http://127.0.0.1:15191 npm --prefix frontend test -- workbench-demo-workspace.spec.ts --project=chromium`
- Browser layout check on the local demo dashboard