### PR TITLE
[codex] Centralize badge sizing

### DIFF
--- a/frontend/src/components/assets/AssetsRoute.tsx
+++ b/frontend/src/components/assets/AssetsRoute.tsx
@@ -159,7 +159,8 @@ export function AssetsWorkbench(state: AssetsWorkbenchProps) {
             >
               <VpwToolbarGroup className="min-w-0">
                 <VpwBadge
-                  className="max-w-full whitespace-normal text-left [overflow-wrap:anywhere]"
+                  className="max-w-full"
+                  overflow="wrap"
                   tone="info"
                 >
                   Active project: {state.activeProjectLabel}

--- a/frontend/src/components/findings/RemediationQueueFilters.tsx
+++ b/frontend/src/components/findings/RemediationQueueFilters.tsx
@@ -139,7 +139,7 @@ export function RemediationQueueFilters({
               <ListFilter aria-hidden="true" size={14} />
               Signals
               {signalFilterCount > 0 ? (
-                <VpwBadge className="ml-1 h-4 min-w-4 px-1 py-0 text-[10px]">
+                <VpwBadge className="ml-1" density="compact">
                   {signalFilterCount}
                 </VpwBadge>
               ) : null}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import type * as React from "react"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border border-transparent px-2 py-0.5 text-xs font-medium transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  "inline-flex w-fit max-w-full min-w-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border border-transparent px-2 py-0.5 text-xs font-medium transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
   {
     variants: {
       variant: {

--- a/frontend/src/components/vpw/VpwBadge.tsx
+++ b/frontend/src/components/vpw/VpwBadge.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react"
 import { Badge, type BadgeProps } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 
+export type BadgeDensity = "default" | "compact"
+
 export type VpwBadgeTone =
   | "neutral"
   | "info"
@@ -13,6 +15,8 @@ export type VpwBadgeTone =
 
 export type VpwBadgeProps = Omit<BadgeProps, "children" | "variant"> & {
   children: ReactNode
+  density?: BadgeDensity
+  overflow?: "truncate" | "wrap"
   tone?: VpwBadgeTone
 }
 
@@ -28,16 +32,43 @@ const toneClass: Record<VpwBadgeTone, string> = {
 export function VpwBadge({
   children,
   className,
+  density = "default",
+  overflow = "truncate",
+  title,
   tone = "neutral",
   ...props
 }: VpwBadgeProps) {
   return (
     <Badge
-      className={cn("vpw-badge", toneClass[tone], className)}
+      className={cn(
+        "vpw-badge",
+        `vpw-badge--${density}`,
+        `vpw-badge--${overflow}`,
+        toneClass[tone],
+        className,
+      )}
+      title={title ?? textTitle(children)}
       variant="outline"
       {...props}
     >
-      {children}
+      <span className="vpw-badge__label">{children}</span>
     </Badge>
   )
+}
+
+function textTitle(children: ReactNode): string | undefined {
+  if (typeof children === "string" || typeof children === "number") {
+    return String(children)
+  }
+  if (!Array.isArray(children)) return undefined
+
+  const text = children
+    .map((child) =>
+      typeof child === "string" || typeof child === "number"
+        ? String(child)
+        : "",
+    )
+    .join("")
+    .trim()
+  return text || undefined
 }

--- a/frontend/src/components/vpw/VpwSemanticBadges.tsx
+++ b/frontend/src/components/vpw/VpwSemanticBadges.tsx
@@ -1,8 +1,7 @@
 import { cn } from "@/lib/utils"
 
-import { VpwBadge, type VpwBadgeTone } from "./VpwBadge"
+import { VpwBadge, type BadgeDensity, type VpwBadgeTone } from "./VpwBadge"
 import {
-  type BadgeDensity,
   type RiskLevel,
   type SignalKind,
   type StatusKind,
@@ -20,13 +19,11 @@ import {
 
 function semanticBadgeClass(
   kind: string,
-  density: BadgeDensity,
   className?: string,
 ) {
   return cn(
     "vpw-semantic-badge",
     `vpw-semantic-badge--${kind}`,
-    density === "compact" && "vpw-semantic-badge--compact",
     className,
   )
 }
@@ -45,7 +42,8 @@ export function RiskBadge({
   const normalized = normalizeRiskLevel(level)
   return (
     <VpwBadge
-      className={semanticBadgeClass("risk", density, className)}
+      className={semanticBadgeClass("risk", className)}
+      density={density}
       tone={riskTone(normalized)}
     >
       {label ?? riskLabel(normalized)}
@@ -64,7 +62,8 @@ export function RiskScoreBadge({
 }) {
   return (
     <VpwBadge
-      className={semanticBadgeClass("score", density, className)}
+      className={semanticBadgeClass("score", className)}
+      density={density}
       tone={riskScoreTone(value)}
     >
       {formatRiskScore(value)}
@@ -86,7 +85,8 @@ export function StatusLozenge({
   const normalized = normalizeStatus(status)
   return (
     <VpwBadge
-      className={semanticBadgeClass("status", density, className)}
+      className={semanticBadgeClass("status", className)}
+      density={density}
       tone={statusTone(normalized)}
     >
       {label ?? statusLabel(normalized)}
@@ -109,7 +109,8 @@ export function SignalChip({
 }) {
   return (
     <VpwBadge
-      className={semanticBadgeClass("signal", density, className)}
+      className={semanticBadgeClass("signal", className)}
+      density={density}
       tone={signalTone(kind)}
     >
       {label ?? signalLabel({ kind, value })}
@@ -132,7 +133,8 @@ export function CountBadge({
 }) {
   return (
     <VpwBadge
-      className={semanticBadgeClass("count", density, className)}
+      className={semanticBadgeClass("count", className)}
+      density={density}
       tone={tone}
     >
       {label ?? value}
@@ -151,7 +153,8 @@ export function MetaTag({
 }) {
   return (
     <VpwBadge
-      className={semanticBadgeClass("meta", density, className)}
+      className={semanticBadgeClass("meta", className)}
+      density={density}
       tone="neutral"
     >
       {label}
@@ -172,7 +175,8 @@ export function SourceMark({
 }) {
   return (
     <VpwBadge
-      className={semanticBadgeClass("source", density, className)}
+      className={semanticBadgeClass("source", className)}
+      density={density}
       tone="info"
     >
       {label ?? source.toUpperCase()}

--- a/frontend/src/components/vpw/semantic-badge-model.ts
+++ b/frontend/src/components/vpw/semantic-badge-model.ts
@@ -1,7 +1,5 @@
 import type { VpwBadgeTone } from "./VpwBadge"
 
-export type BadgeDensity = "default" | "compact"
-
 export type RiskLevel =
   | "critical"
   | "high"

--- a/frontend/src/styles/vpw-components.css
+++ b/frontend/src/styles/vpw-components.css
@@ -55,11 +55,16 @@
   }
 
   .vpw-badge {
+    --vpw-badge-max-inline-size: 16rem;
+    --vpw-badge-min-inline-size: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    max-width: 100%;
+    width: fit-content;
+    max-width: min(100%, var(--vpw-badge-max-inline-size));
+    min-width: var(--vpw-badge-min-inline-size);
     min-height: 1.5rem;
+    flex: 0 1 auto;
     gap: 0.25rem;
     border-radius: var(--vpw-radius-pill);
     border-width: 1px;
@@ -74,11 +79,66 @@
     white-space: nowrap;
   }
 
-  .vpw-semantic-badge--compact,
   .vpw-badge--compact {
     min-height: 1.375rem;
     padding-inline: 0.375rem;
     font-size: 0.72rem;
+  }
+
+  .vpw-badge__label {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .vpw-badge--truncate .vpw-badge__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .vpw-badge--wrap {
+    max-width: 100%;
+    align-items: flex-start;
+    white-space: normal;
+  }
+
+  .vpw-badge--wrap .vpw-badge__label {
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+  }
+
+  .vpw-badge svg {
+    flex: 0 0 auto;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  .vpw-badge--compact svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  .vpw-semantic-badge {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .vpw-semantic-badge--count {
+    --vpw-badge-max-inline-size: 4.5rem;
+    --vpw-badge-min-inline-size: 1.375rem;
+  }
+
+  .vpw-semantic-badge--meta,
+  .vpw-semantic-badge--source,
+  .vpw-semantic-badge--signal {
+    --vpw-badge-max-inline-size: 12rem;
+  }
+
+  .vpw-semantic-badge--risk,
+  .vpw-semantic-badge--score,
+  .vpw-semantic-badge--status {
+    --vpw-badge-max-inline-size: 9rem;
   }
 
   .vpw-signal-cluster,

--- a/frontend/tests/design-system-contracts.test.ts
+++ b/frontend/tests/design-system-contracts.test.ts
@@ -268,6 +268,33 @@ test("legacy risk and KEV wrappers emit semantic badges without absent placehold
   assert.doesNotMatch(kevBadge, />\s*—\s*</)
 })
 
+test("badges use centralized density and overflow contracts", () => {
+  const badge = readProjectFile("src/components/vpw/VpwBadge.tsx")
+  const semanticBadges = readProjectFile(
+    "src/components/vpw/VpwSemanticBadges.tsx",
+  )
+  const badgeStyles = readProjectFile("src/styles/vpw-components.css")
+  const rawBadge = readProjectFile("src/components/ui/badge.tsx")
+  const remediationFilters = readProjectFile(
+    "src/components/findings/RemediationQueueFilters.tsx",
+  )
+
+  assert.match(badge, /export type BadgeDensity = "default" \| "compact"/)
+  assert.match(badge, /overflow\?: "truncate" \| "wrap"/)
+  assert.match(badge, /vpw-badge__label/)
+  assert.match(badgeStyles, /--vpw-badge-max-inline-size/)
+  assert.match(badgeStyles, /\.vpw-badge--compact/)
+  assert.match(badgeStyles, /\.vpw-badge--wrap/)
+  assert.match(rawBadge, /max-w-full min-w-0/)
+
+  assert.match(semanticBadges, /density=\{density\}/)
+  assert.doesNotMatch(semanticBadges, /vpw-semantic-badge--compact/)
+  assert.doesNotMatch(
+    remediationFilters,
+    /h-4 min-w-4 px-1 py-0 text-\[10px\]/,
+  )
+})
+
 test("design-system colors are tokenized outside token and showcase files", () => {
   const offenders: string[] = []
 


### PR DESCRIPTION
## Summary

- Add a centralized `VpwBadge` density and overflow contract for default and compact pills.
- Route semantic badges through the shared density API instead of compact class-name side effects.
- Add global badge CSS for max width, truncation, wrapping, icon sizing, tabular numbers, and semantic max-width limits.
- Replace local one-off badge sizing in findings filters and asset toolbar context with the shared API.
- Add a design-system contract test so badge density and overflow behavior stay centralized.

## Why

Badge and pill sizing had started drifting across views, which made status chips feel inconsistent and harder to scan. This keeps the existing visual language but makes sizing, text overflow, and compact behavior reusable and enforced centrally.

## Validation

- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:types`
- `npm --prefix frontend run test:unit -- design-system-contracts.test.ts`
- `VPW_PLAYWRIGHT_REUSE_EXISTING_SERVER=1 VPW_E2E_BACKEND_URL=http://127.0.0.1:18141 VPW_E2E_FRONTEND_URL=http://127.0.0.1:15191 npm --prefix frontend test -- ui-smoke.spec.ts --project=chromium`
- Browser badge overflow checks on dashboard, assets, and findings routes