### PR TITLE
[codex] Complete dashboard layout pass

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -71,7 +71,17 @@ Use the installed VPW variables from `frontend/src/styles/tokens.css`.
 - Success: `--vpw-green`
 - Warning: `--vpw-amber`
 - Critical/destructive: `--vpw-red`
-- Support/context: `--vpw-violet`
+- Support/context: `--vpw-violet` mapped to a cool slate support tone, not
+  purple.
+- Chart severity: `--vpw-chart-critical`, `--vpw-chart-high`,
+  `--vpw-chart-medium`, `--vpw-chart-low`
+- Chart rankings and trend: `--vpw-chart-risk`, `--vpw-chart-trend`,
+  `--vpw-chart-grid`
+  Use a clearer cobalt/cyan chart accent set for analytical energy; avoid
+  charcoal-only bars and avoid returning to purple.
+- Ranked entity charts: `--vpw-chart-rank-1` through `--vpw-chart-rank-5`.
+  Use this ordered cool palette for Top Services/Assets so repeated critical
+  services do not collapse into a single solid severity color.
 - Radius: `--vpw-radius-sm`, `--vpw-radius-md`, `--vpw-radius-lg`,
   `--vpw-radius-xl`, `--vpw-radius-pill`
 - Elevation: `--vpw-shadow-0`, `--vpw-shadow-1`, `--vpw-shadow-2`,

--- a/frontend/src/components/dashboard/DashboardHero.tsx
+++ b/frontend/src/components/dashboard/DashboardHero.tsx
@@ -66,7 +66,7 @@ export function DashboardHero({
           <div className="flex items-center gap-2 mb-1.5">
             <ShieldCheck
               aria-hidden="true"
-              className="size-3.5 text-[var(--vpw-violet)]"
+              className="size-3.5 text-[var(--vpw-teal)]"
             />
             <span className="text-[10px] font-bold uppercase text-[var(--vpw-text-muted)]">
               Security Operations

--- a/frontend/src/components/dashboard/DashboardHero.tsx
+++ b/frontend/src/components/dashboard/DashboardHero.tsx
@@ -61,7 +61,7 @@ export function DashboardHero({
 
   return (
     <div className="dashboard-analyst-hero">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-2 mb-1.5">
             <ShieldCheck
@@ -72,7 +72,7 @@ export function DashboardHero({
               Security Operations
             </span>
           </div>
-          <p className="truncate text-base font-semibold text-[var(--vpw-text-primary)]">
+          <p className="break-words text-base font-semibold text-[var(--vpw-text-primary)]">
             {effectiveSelectedProject
               ? effectiveSelectedProject.name
               : "No project selected"}
@@ -82,35 +82,53 @@ export function DashboardHero({
           </p>
         </div>
 
-        <div className="flex w-full min-w-0 flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
-          <Select
-            disabled={
-              isDemoMode || projectListLoading || effectiveProjects.length === 0
-            }
-            onValueChange={(value) => {
-              if (value !== "none") onProjectChange(value)
-            }}
-            value={isDemoMode ? DEMO_PROJECT_ID : selectedProjectId || "none"}
+        <Select
+          disabled={
+            isDemoMode || projectListLoading || effectiveProjects.length === 0
+          }
+          onValueChange={(value) => {
+            if (value !== "none") onProjectChange(value)
+          }}
+          value={isDemoMode ? DEMO_PROJECT_ID : selectedProjectId || "none"}
+        >
+          <SelectTrigger
+            aria-label="Dashboard project"
+            className="w-full min-w-0 bg-[var(--vpw-bg-card)] lg:w-72"
           >
-            <SelectTrigger
-              aria-label="Dashboard project"
-              className="w-full min-w-0 bg-[var(--vpw-bg-card)] sm:w-64 xl:w-72"
-            >
-              <SelectValue placeholder="Select project" />
-            </SelectTrigger>
-            <SelectContent>
-              {effectiveProjects.length === 0 ? (
-                <SelectItem value="none">No projects yet</SelectItem>
-              ) : (
-                effectiveProjects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    {project.name}
-                  </SelectItem>
-                ))
-              )}
-            </SelectContent>
-          </Select>
+            <SelectValue placeholder="Select project" />
+          </SelectTrigger>
+          <SelectContent>
+            {effectiveProjects.length === 0 ? (
+              <SelectItem value="none">No projects yet</SelectItem>
+            ) : (
+              effectiveProjects.map((project) => (
+                <SelectItem key={project.id} value={project.id}>
+                  {project.name}
+                </SelectItem>
+              ))
+            )}
+          </SelectContent>
+        </Select>
+      </div>
 
+      <div className="mt-4 flex flex-col gap-3 border-t border-[var(--vpw-border-subtle)] pt-3 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
+          <ProviderStatusBadge
+            status={
+              effectiveProviderStatus?.status ??
+              (providerStatusLoading ? "loading" : "unknown")
+            }
+          />
+          <span className="text-sm text-[var(--vpw-text-secondary)]">
+            {freshness.value}
+          </span>
+          <span className="text-[var(--vpw-text-muted)]">/</span>
+          <span className="text-xs text-[var(--vpw-text-muted)]">
+            {freshness.detail}
+          </span>
+        </div>
+
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center xl:justify-end">
           <Button
             asChild
             className="w-full justify-center font-semibold sm:w-auto"
@@ -152,7 +170,7 @@ export function DashboardHero({
           ) : null}
           <Button
             aria-label="Refresh dashboard"
-            className="self-end text-[var(--vpw-text-muted)] sm:self-auto"
+            className="self-start text-[var(--vpw-text-muted)] sm:self-auto"
             onClick={onRefresh}
             size="icon"
             type="button"
@@ -161,22 +179,6 @@ export function DashboardHero({
             <RefreshCw aria-hidden="true" />
           </Button>
         </div>
-      </div>
-
-      <div className="mt-3 flex flex-wrap items-center gap-3 border-t border-[var(--vpw-border-subtle)] pt-3">
-        <ProviderStatusBadge
-          status={
-            effectiveProviderStatus?.status ??
-            (providerStatusLoading ? "loading" : "unknown")
-          }
-        />
-        <span className="text-sm text-[var(--vpw-text-secondary)]">
-          {freshness.value}
-        </span>
-        <span className="text-[var(--vpw-text-muted)]">/</span>
-        <span className="text-xs text-[var(--vpw-text-muted)]">
-          {freshness.detail}
-        </span>
       </div>
     </div>
   )

--- a/frontend/src/components/dashboard/DashboardMetricGrid.tsx
+++ b/frontend/src/components/dashboard/DashboardMetricGrid.tsx
@@ -13,8 +13,8 @@ export function DashboardMetricGrid({
 }: DashboardMetricGridProps) {
   if (isLoading) {
     return (
-      <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-4">
-        {Array.from({ length: 4 }, (_, i) => i).map((i) => (
+      <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-5">
+        {Array.from({ length: 5 }, (_, i) => i).map((i) => (
           <Skeleton className="h-24 rounded-[var(--vpw-radius-lg)]" key={i} />
         ))}
       </div>
@@ -22,7 +22,7 @@ export function DashboardMetricGrid({
   }
 
   return (
-    <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-4">
+    <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-5">
       {cards.map((card) => (
         <MetricCard
           detail={card.detail}

--- a/frontend/src/components/dashboard/DashboardRemediationSection.tsx
+++ b/frontend/src/components/dashboard/DashboardRemediationSection.tsx
@@ -1,16 +1,7 @@
 import { Link } from "@/lib/router"
-import { Eye, Search } from "lucide-react"
+import { ArrowUpRight, Eye, Search } from "lucide-react"
 import type { FindingPublic } from "@/api-client"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import {
   Sheet,
@@ -48,6 +39,7 @@ type DashboardRemediationSectionProps = {
   onQueueSearchChange: (value: string) => void
   queueFindings: readonly FindingPublic[]
   queueSearch: string
+  selectedProjectId: string
 }
 
 export function DashboardRemediationSection({
@@ -56,7 +48,11 @@ export function DashboardRemediationSection({
   onQueueSearchChange,
   queueFindings,
   queueSearch,
+  selectedProjectId,
 }: DashboardRemediationSectionProps) {
+  const previewFindings = queueFindings.slice(0, 5)
+  const queueProjectId = selectedProjectId || queueFindings[0]?.project_id || ""
+  const fullQueueSearch = selectedProjectRouteSearch(queueProjectId)
   const columns: readonly VpwDataTableColumn<FindingPublic>[] = [
     {
       id: "priority",
@@ -130,32 +126,12 @@ export function DashboardRemediationSection({
       id: "why",
       header: "Why now",
       cell: (finding) => (
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button className="text-xs" size="sm" variant="ghost">
-              Why now
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Why now: {finding.cve_id}</DialogTitle>
-              <DialogDescription>
-                Current priority rationale from scoring and operational context.
-              </DialogDescription>
-            </DialogHeader>
-            <p className="text-sm text-muted-foreground">
-              {findingWhyNow(finding)}
-            </p>
-            <DialogClose asChild>
-              <Button size="sm" type="button" variant="secondary">
-                Close
-              </Button>
-            </DialogClose>
-          </DialogContent>
-        </Dialog>
+        <span className="dashboard-queue-why" title={findingWhyNow(finding)}>
+          {findingWhyNow(finding)}
+        </span>
       ),
-      className: "w-24",
-      headerClassName: "w-24",
+      className: "w-52",
+      headerClassName: "w-52",
     },
     {
       id: "view",
@@ -242,10 +218,10 @@ export function DashboardRemediationSection({
               Prioritized items ranked by risk score for immediate action.
             </VpwSurfaceDescription>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
             <Input
               aria-label="Filter remediation queue"
-              className="w-40"
+              className="w-56 max-w-full"
               onChange={(event) =>
                 onQueueSearchChange(event.currentTarget.value)
               }
@@ -260,6 +236,12 @@ export function DashboardRemediationSection({
             >
               <Search className="size-4" />
             </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link search={fullQueueSearch} to="/findings">
+                View full queue
+                <ArrowUpRight aria-hidden="true" className="size-3.5" />
+              </Link>
+            </Button>
           </div>
         </div>
       </VpwSurfaceHeader>
@@ -272,7 +254,7 @@ export function DashboardRemediationSection({
           <div className="px-6">
             <ErrorState message={findingsError} />
           </div>
-        ) : queueFindings.length === 0 ? (
+        ) : previewFindings.length === 0 ? (
           <div className="px-6">
             <EmptyState
               ariaLabel="No remediation queue items"
@@ -286,16 +268,29 @@ export function DashboardRemediationSection({
             />
           </div>
         ) : (
-          <VpwDataTable
-            ariaLabel="Top remediation queue"
-            caption="Dashboard remediation table"
-            className="rounded-none border-x-0 border-b-0 shadow-none"
-            columns={columns}
-            data={queueFindings}
-            getRowKey={(finding) => finding.id}
-            minWidth="980px"
-            tableClassName="table-fixed"
-          />
+          <>
+            <VpwDataTable
+              ariaLabel="Top remediation queue"
+              caption="Dashboard remediation table"
+              className="rounded-none border-x-0 border-b-0 shadow-none"
+              columns={columns}
+              data={previewFindings}
+              getRowKey={(finding) => finding.id}
+              minWidth="1060px"
+              tableClassName="table-fixed"
+            />
+            <div className="flex flex-col gap-2 px-4 pt-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+              <span>
+                Showing top {previewFindings.length} of {queueFindings.length}
+                {queueSearch ? " matching" : ""} findings
+              </span>
+              <Button asChild size="sm" variant="outline">
+                <Link search={fullQueueSearch} to="/findings">
+                  View all
+                </Link>
+              </Button>
+            </div>
+          </>
         )}
       </VpwSurfaceBody>
     </VpwSurface>

--- a/frontend/src/components/dashboard/DashboardRemediationSection.tsx
+++ b/frontend/src/components/dashboard/DashboardRemediationSection.tsx
@@ -268,29 +268,16 @@ export function DashboardRemediationSection({
             />
           </div>
         ) : (
-          <>
-            <VpwDataTable
-              ariaLabel="Top remediation queue"
-              caption="Dashboard remediation table"
-              className="rounded-none border-x-0 border-b-0 shadow-none"
-              columns={columns}
-              data={previewFindings}
-              getRowKey={(finding) => finding.id}
-              minWidth="1060px"
-              tableClassName="table-fixed"
-            />
-            <div className="flex flex-col gap-2 px-4 pt-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-              <span>
-                Showing top {previewFindings.length} of {queueFindings.length}
-                {queueSearch ? " matching" : ""} findings
-              </span>
-              <Button asChild size="sm" variant="outline">
-                <Link search={fullQueueSearch} to="/findings">
-                  View all
-                </Link>
-              </Button>
-            </div>
-          </>
+          <VpwDataTable
+            ariaLabel="Top remediation queue"
+            caption="Dashboard remediation table"
+            className="rounded-none border-x-0 border-b-0 shadow-none"
+            columns={columns}
+            data={previewFindings}
+            getRowKey={(finding) => finding.id}
+            minWidth="1060px"
+            tableClassName="table-fixed"
+          />
         )}
       </VpwSurfaceBody>
     </VpwSurface>

--- a/frontend/src/components/dashboard/DashboardSidePanel.tsx
+++ b/frontend/src/components/dashboard/DashboardSidePanel.tsx
@@ -105,7 +105,11 @@ export function DashboardSidePanel({
                 Provider recency and run evidence for the selected project.
               </VpwSurfaceDescription>
             </div>
-            <VpwBadge tone={readinessTone}>
+            <VpwBadge
+              className="min-w-fit shrink-0"
+              overflow="wrap"
+              tone={readinessTone}
+            >
               {staleProvider ? "Needs sync" : "Current"}
             </VpwBadge>
           </div>

--- a/frontend/src/components/dashboard/DashboardSidePanel.tsx
+++ b/frontend/src/components/dashboard/DashboardSidePanel.tsx
@@ -1,5 +1,14 @@
 import { Link } from "@/lib/router"
-import { AlertCircle, CheckCircle2 } from "lucide-react"
+import {
+  AlertCircle,
+  CalendarClock,
+  CheckCircle2,
+  ChevronRight,
+  FileArchive,
+  FileCheck2,
+  ListChecks,
+  type LucideIcon,
+} from "lucide-react"
 import type {
   AnalysisRunPublic,
   ProjectDecisionSummaryPublic,
@@ -53,9 +62,40 @@ export function DashboardSidePanel({
     dataQualityWarnings.length + (dataQualityError ? 1 : 0)
   const readinessTone: VpwBadgeTone = staleProvider ? "warning" : "success"
   const projectSearch = selectedProjectRouteSearch(selectedProjectId)
+  const recommendedActions: readonly {
+    icon: LucideIcon
+    label: string
+    to: "/" | "/findings" | "/waivers" | "/reports" | "/imports"
+    tone: VpwBadgeTone
+  }[] = [
+    {
+      icon: ListChecks,
+      label: "Review critical items in Triage",
+      to: "/findings",
+      tone: "critical",
+    },
+    {
+      icon: FileCheck2,
+      label: "Accept or document risk",
+      to: "/waivers",
+      tone: "success",
+    },
+    {
+      icon: FileArchive,
+      label: "Generate evidence bundle",
+      to: "/reports",
+      tone: "support",
+    },
+    {
+      icon: CalendarClock,
+      label: "Schedule next analysis",
+      to: "/imports",
+      tone: "info",
+    },
+  ]
 
   return (
-    <div className="flex flex-col gap-4 lg:sticky lg:top-20">
+    <div className="flex flex-col gap-4">
       <VpwSurface className="gap-4 py-4">
         <VpwSurfaceHeader className="px-4 pb-0">
           <div className="flex items-start justify-between gap-3">
@@ -114,7 +154,14 @@ export function DashboardSidePanel({
 
       <VpwSurface className="gap-3 py-4">
         <VpwSurfaceHeader className="px-4 pb-0">
-          <VpwSurfaceTitle className="text-sm">Recent Runs</VpwSurfaceTitle>
+          <div className="flex items-center justify-between gap-3">
+            <VpwSurfaceTitle className="text-sm">Recent Runs</VpwSurfaceTitle>
+            <Button asChild size="sm" variant="outline">
+              <Link search={projectSearch} to="/imports">
+                View all
+              </Link>
+            </Button>
+          </div>
         </VpwSurfaceHeader>
         <VpwSurfaceBody className="px-4">
           {latestRunFactsRows.length === 0 ? (
@@ -128,10 +175,7 @@ export function DashboardSidePanel({
                   className="flex items-center justify-between gap-2 rounded-md border bg-muted/20 px-2.5 py-2 text-xs"
                   key={run.id}
                 >
-                  <VpwBadge
-                    className="shrink-0"
-                    tone={runBadgeTone(run.tone)}
-                  >
+                  <VpwBadge className="shrink-0" tone={runBadgeTone(run.tone)}>
                     {run.status}
                   </VpwBadge>
                   <span className="truncate text-muted-foreground">
@@ -141,11 +185,6 @@ export function DashboardSidePanel({
               ))}
             </div>
           )}
-          <Button asChild className="mt-3 w-full" size="sm" variant="outline">
-            <Link search={projectSearch} to="/imports">
-              View all imports
-            </Link>
-          </Button>
         </VpwSurfaceBody>
       </VpwSurface>
 
@@ -154,16 +193,29 @@ export function DashboardSidePanel({
           <div className="flex items-center justify-between gap-3">
             <VpwSurfaceTitle className="text-sm">Data Quality</VpwSurfaceTitle>
             <VpwBadge tone={qualityIssueCount > 0 ? "warning" : "success"}>
-              {qualityIssueCount > 0 ? `${qualityIssueCount} issue(s)` : "Clear"}
+              {qualityIssueCount > 0
+                ? `${qualityIssueCount} issue(s)`
+                : "Clear"}
             </VpwBadge>
           </div>
         </VpwSurfaceHeader>
         <VpwSurfaceBody className="px-4">
           {dataQualityWarnings.length === 0 && !dataQualityError ? (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <CheckCircle2 className="size-3.5 shrink-0 text-[var(--vpw-green)]" />
-              <span>No data quality issues detected.</span>
-            </div>
+            <ul className="flex flex-col gap-3">
+              {[
+                "No data quality issues detected.",
+                "All providers reporting normally.",
+                "Evidence context available for bundle generation.",
+              ].map((item) => (
+                <li
+                  className="flex items-center gap-2 text-xs text-muted-foreground"
+                  key={item}
+                >
+                  <CheckCircle2 className="size-3.5 shrink-0 text-[var(--vpw-green)]" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
           ) : (
             <ul className="flex flex-col gap-2">
               {dataQualityWarnings.map((warning) => (
@@ -190,6 +242,47 @@ export function DashboardSidePanel({
               )}
             </ul>
           )}
+        </VpwSurfaceBody>
+      </VpwSurface>
+
+      <VpwSurface className="gap-3 py-4">
+        <VpwSurfaceHeader className="px-4 pb-0">
+          <VpwSurfaceTitle className="text-sm">
+            Recommended Next Actions
+          </VpwSurfaceTitle>
+        </VpwSurfaceHeader>
+        <VpwSurfaceBody className="px-4">
+          <nav aria-label="Recommended dashboard actions">
+            <ul className="flex flex-col gap-1">
+              {recommendedActions.map((action) => {
+                const Icon = action.icon
+                return (
+                  <li key={action.label}>
+                    <Button
+                      asChild
+                      className="dashboard-next-action"
+                      variant="ghost"
+                    >
+                      <Link search={projectSearch} to={action.to}>
+                        <span
+                          className={`dashboard-next-action-icon dashboard-next-action-icon--${action.tone}`}
+                        >
+                          <Icon aria-hidden="true" className="size-3.5" />
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-left">
+                          {action.label}
+                        </span>
+                        <ChevronRight
+                          aria-hidden="true"
+                          className="size-3.5 shrink-0 text-[var(--vpw-text-muted)]"
+                        />
+                      </Link>
+                    </Button>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
         </VpwSurfaceBody>
       </VpwSurface>
     </div>

--- a/frontend/src/components/dashboard/DashboardSignalOverview.tsx
+++ b/frontend/src/components/dashboard/DashboardSignalOverview.tsx
@@ -78,26 +78,53 @@ function ChartDataSummary({
   )
 }
 
-function priorityFill(tone: ChartDatum["tone"]) {
+function riskToneFill(
+  tone: ChartDatum["tone"],
+  fallback = "var(--vpw-chart-risk)",
+) {
   return tone === "critical"
-    ? "var(--vpw-red)"
+    ? "var(--vpw-chart-critical)"
     : tone === "high"
-      ? "var(--vpw-amber)"
+      ? "var(--vpw-chart-high)"
       : tone === "medium"
-        ? "var(--vpw-amber)"
+        ? "var(--vpw-chart-medium)"
         : tone === "low"
-          ? "var(--vpw-green)"
-          : "var(--vpw-text-muted)"
+          ? "var(--vpw-chart-low)"
+          : fallback
+}
+
+function priorityFill(tone: ChartDatum["tone"]) {
+  return riskToneFill(tone, "var(--vpw-text-muted)")
 }
 
 function epssFill(tone: ChartDatum["tone"]) {
-  return tone === "critical"
-    ? "var(--vpw-red)"
-    : tone === "high"
-      ? "var(--vpw-amber)"
-      : tone === "medium"
-        ? "var(--vpw-amber)"
-        : "var(--vpw-green)"
+  return riskToneFill(tone, "var(--vpw-chart-low)")
+}
+
+function rankFill(index: number) {
+  return `var(--vpw-chart-rank-${(index % 5) + 1})`
+}
+
+const chartAxisTick = { fill: "var(--vpw-text-muted)", fontSize: 12 }
+
+const chartTooltipProps = {
+  contentStyle: {
+    background: "var(--vpw-bg-card)",
+    border: "1px solid var(--vpw-border-default)",
+    borderRadius: "var(--vpw-radius-md)",
+    boxShadow: "var(--vpw-shadow-2)",
+    color: "var(--vpw-text-primary)",
+  },
+  cursor: {
+    fill: "color-mix(in srgb, var(--vpw-blue) 7%, transparent)",
+  },
+  itemStyle: {
+    color: "var(--vpw-text-primary)",
+  },
+  labelStyle: {
+    color: "var(--vpw-text-secondary)",
+    fontWeight: 600,
+  },
 }
 
 function DashboardKeyTakeaways({
@@ -213,12 +240,17 @@ export function DashboardSignalOverview({
                       >
                         <CartesianGrid
                           className="opacity-40"
+                          stroke="var(--vpw-chart-grid)"
                           strokeDasharray="3 3"
                         />
-                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                        <YAxis tick={{ fontSize: 12 }} />
-                        <RechartsTooltip />
-                        <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                        <XAxis dataKey="label" tick={chartAxisTick} />
+                        <YAxis tick={chartAxisTick} />
+                        <RechartsTooltip {...chartTooltipProps} />
+                        <Bar
+                          dataKey="value"
+                          maxBarSize={72}
+                          radius={[4, 4, 0, 0]}
+                        >
                           {priorityItems.map((entry) => (
                             <Cell
                               key={entry.label}
@@ -268,12 +300,17 @@ export function DashboardSignalOverview({
                       >
                         <CartesianGrid
                           className="opacity-40"
+                          stroke="var(--vpw-chart-grid)"
                           strokeDasharray="3 3"
                         />
-                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                        <YAxis tick={{ fontSize: 12 }} />
-                        <RechartsTooltip />
-                        <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                        <XAxis dataKey="label" tick={chartAxisTick} />
+                        <YAxis tick={chartAxisTick} />
+                        <RechartsTooltip {...chartTooltipProps} />
+                        <Bar
+                          dataKey="value"
+                          maxBarSize={72}
+                          radius={[4, 4, 0, 0]}
+                        >
                           {epssItems.map((entry) => (
                             <Cell
                               key={entry.label}
@@ -330,16 +367,24 @@ export function DashboardSignalOverview({
                       >
                         <CartesianGrid
                           className="opacity-40"
+                          stroke="var(--vpw-chart-grid)"
                           strokeDasharray="3 3"
                         />
-                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                        <YAxis tick={{ fontSize: 12 }} />
-                        <RechartsTooltip />
+                        <XAxis dataKey="label" tick={chartAxisTick} />
+                        <YAxis tick={chartAxisTick} />
+                        <RechartsTooltip {...chartTooltipProps} />
                         <Bar
                           dataKey="value"
-                          fill="var(--vpw-teal)"
+                          maxBarSize={72}
                           radius={[4, 4, 0, 0]}
-                        />
+                        >
+                          {serviceItems.map((entry, index) => (
+                            <Cell
+                              key={entry.label}
+                              fill={rankFill(index)}
+                            />
+                          ))}
+                        </Bar>
                       </BarChart>
                     </ResponsiveContainer>
                     <ChartDataSummary
@@ -403,15 +448,16 @@ export function DashboardSignalOverview({
                       >
                         <CartesianGrid
                           className="opacity-40"
+                          stroke="var(--vpw-chart-grid)"
                           strokeDasharray="3 3"
                         />
-                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                        <YAxis tick={{ fontSize: 12 }} />
-                        <RechartsTooltip />
+                        <XAxis dataKey="label" tick={chartAxisTick} />
+                        <YAxis tick={chartAxisTick} />
+                        <RechartsTooltip {...chartTooltipProps} />
                         <Line
                           dataKey="value"
                           dot={{ r: 3 }}
-                          stroke="var(--vpw-violet)"
+                          stroke="var(--vpw-chart-trend)"
                           strokeWidth={2}
                           type="monotone"
                         />

--- a/frontend/src/components/dashboard/DashboardSignalOverview.tsx
+++ b/frontend/src/components/dashboard/DashboardSignalOverview.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@/lib/router"
+import { CheckCircle2 } from "lucide-react"
 import {
   Bar,
   BarChart,
@@ -44,6 +45,7 @@ type DashboardSignalOverviewProps = {
   selectedRunRange: DashboardRunRange
   serviceItems: readonly ChartDatum[]
   summaryLoading: boolean
+  keyTakeaways: readonly string[]
   topServiceSource: "assets" | "services"
   trendItems: readonly ChartDatum[]
 }
@@ -98,9 +100,46 @@ function epssFill(tone: ChartDatum["tone"]) {
         : "var(--vpw-green)"
 }
 
+function DashboardKeyTakeaways({
+  items,
+  projectSearch,
+}: {
+  items: readonly string[]
+  projectSearch: ReturnType<typeof selectedProjectRouteSearch>
+}) {
+  return (
+    <aside aria-label="Key takeaways" className="dashboard-key-takeaways">
+      <div>
+        <p className="text-sm font-semibold text-[var(--vpw-text-primary)]">
+          Key takeaways
+        </p>
+        <ul className="mt-4 flex flex-col gap-3">
+          {items.map((item) => (
+            <li className="flex gap-2 text-xs" key={item}>
+              <CheckCircle2
+                aria-hidden="true"
+                className="mt-0.5 size-3.5 shrink-0 text-[var(--vpw-green)]"
+              />
+              <span className="leading-relaxed text-[var(--vpw-text-secondary)]">
+                {item}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <Button asChild className="w-fit" size="sm" variant="outline">
+        <Link search={projectSearch} to="/findings">
+          Go to Triage
+        </Link>
+      </Button>
+    </aside>
+  )
+}
+
 export function DashboardSignalOverview({
   epssItems,
   governanceLoading,
+  keyTakeaways,
   onRunRangeChange,
   priorityItems,
   runsLoading,
@@ -123,263 +162,275 @@ export function DashboardSignalOverview({
         </VpwSurfaceDescription>
       </VpwSurfaceHeader>
       <VpwSurfaceBody>
-        <Tabs className="w-full" defaultValue="priority">
-          <TabsList className="mb-3 grid h-auto w-full grid-cols-2 gap-1 text-xs sm:inline-flex sm:h-8 sm:w-auto sm:grid-cols-none">
-            <TabsTrigger className="min-w-0 px-2" value="priority">
-              <span className="hidden sm:inline">Findings by Priority</span>
-              <span className="sm:hidden">Priority</span>
-            </TabsTrigger>
-            <TabsTrigger className="min-w-0 px-2" value="epss">
-              <span className="hidden sm:inline">EPSS Distribution</span>
-              <span className="sm:hidden">EPSS</span>
-            </TabsTrigger>
-            <TabsTrigger className="min-w-0 px-2" value="services">
-              <span className="hidden sm:inline">Top Services</span>
-              <span className="sm:hidden">Services</span>
-            </TabsTrigger>
-            <TabsTrigger className="min-w-0 px-2" value="trend">
-              <span className="hidden sm:inline">Risk Trend</span>
-              <span className="sm:hidden">Trend</span>
-            </TabsTrigger>
-          </TabsList>
+        <div className="dashboard-signal-layout">
+          <Tabs className="min-w-0 w-full" defaultValue="priority">
+            <TabsList className="mb-3 grid h-auto w-full grid-cols-2 gap-1 text-xs sm:inline-flex sm:h-8 sm:w-auto sm:grid-cols-none">
+              <TabsTrigger className="min-w-0 px-2" value="priority">
+                <span className="hidden sm:inline">Findings by Priority</span>
+                <span className="sm:hidden">Priority</span>
+              </TabsTrigger>
+              <TabsTrigger className="min-w-0 px-2" value="epss">
+                <span className="hidden sm:inline">EPSS Distribution</span>
+                <span className="sm:hidden">EPSS</span>
+              </TabsTrigger>
+              <TabsTrigger className="min-w-0 px-2" value="services">
+                <span className="hidden sm:inline">Top Services</span>
+                <span className="sm:hidden">Services</span>
+              </TabsTrigger>
+              <TabsTrigger className="min-w-0 px-2" value="trend">
+                <span className="hidden sm:inline">Risk Trend</span>
+                <span className="sm:hidden">Trend</span>
+              </TabsTrigger>
+            </TabsList>
 
-          <TabsContent className="mt-4" value="priority">
-            <ChartCard
-              description="Severity distribution across findings in scope"
-              title="Findings by priority"
-            >
-              {summaryLoading ? (
-                <Skeleton className="h-64" />
-              ) : priorityItems.length === 0 ? (
-                <EmptyState
-                  action={
-                    <Button asChild size="sm" variant="outline">
-                      <Link search={projectSearch} to="/imports">
-                        Import findings
-                      </Link>
-                    </Button>
-                  }
-                  ariaLabel="No priority data"
-                  compact
-                  detail="Import findings to populate priority distribution."
-                  title="No findings yet"
-                />
-              ) : (
-                <>
-                  <ResponsiveContainer height={196} width="100%">
-                    <BarChart
+            <TabsContent className="mt-4" value="priority">
+              <ChartCard
+                description="Severity distribution across findings in scope"
+                title="Findings by priority"
+              >
+                {summaryLoading ? (
+                  <Skeleton className="h-64" />
+                ) : priorityItems.length === 0 ? (
+                  <EmptyState
+                    action={
+                      <Button asChild size="sm" variant="outline">
+                        <Link search={projectSearch} to="/imports">
+                          Import findings
+                        </Link>
+                      </Button>
+                    }
+                    ariaLabel="No priority data"
+                    compact
+                    detail="Import findings to populate priority distribution."
+                    title="No findings yet"
+                  />
+                ) : (
+                  <>
+                    <ResponsiveContainer height={196} width="100%">
+                      <BarChart
+                        data={priorityItems}
+                        margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                      >
+                        <CartesianGrid
+                          className="opacity-40"
+                          strokeDasharray="3 3"
+                        />
+                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                        <YAxis tick={{ fontSize: 12 }} />
+                        <RechartsTooltip />
+                        <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                          {priorityItems.map((entry) => (
+                            <Cell
+                              key={entry.label}
+                              fill={priorityFill(entry.tone)}
+                            />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                    <ChartDataSummary
                       data={priorityItems}
-                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                    >
-                      <CartesianGrid
-                        className="opacity-40"
-                        strokeDasharray="3 3"
-                      />
-                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                      <YAxis tick={{ fontSize: 12 }} />
-                      <RechartsTooltip />
-                      <Bar dataKey="value" radius={[4, 4, 0, 0]}>
-                        {priorityItems.map((entry) => (
-                          <Cell
-                            key={entry.label}
-                            fill={priorityFill(entry.tone)}
-                          />
-                        ))}
-                      </Bar>
-                    </BarChart>
-                  </ResponsiveContainer>
-                  <ChartDataSummary
-                    data={priorityItems}
-                    label="Findings by priority chart data"
-                  />
-                </>
-              )}
-            </ChartCard>
-          </TabsContent>
+                      label="Findings by priority chart data"
+                    />
+                  </>
+                )}
+              </ChartCard>
+            </TabsContent>
 
-          <TabsContent className="mt-4" value="epss">
-            <ChartCard
-              description="EPSS bucket distribution for exploit likelihood"
-              title="EPSS exploit probability"
-            >
-              {summaryLoading ? (
-                <Skeleton className="h-64" />
-              ) : epssItems.length === 0 ||
-                epssItems.every((e) => e.value === 0) ? (
-                <EmptyState
-                  action={
-                    <Button asChild size="sm" variant="outline">
-                      <Link search={projectSearch} to="/imports">
-                        Run import
-                      </Link>
-                    </Button>
-                  }
-                  ariaLabel="No EPSS data"
-                  compact
-                  detail="EPSS signals need a provider-enriched import to display buckets."
-                  title="No EPSS data"
-                />
-              ) : (
-                <>
-                  <ResponsiveContainer height={196} width="100%">
-                    <BarChart
+            <TabsContent className="mt-4" value="epss">
+              <ChartCard
+                description="EPSS bucket distribution for exploit likelihood"
+                title="EPSS exploit probability"
+              >
+                {summaryLoading ? (
+                  <Skeleton className="h-64" />
+                ) : epssItems.length === 0 ||
+                  epssItems.every((e) => e.value === 0) ? (
+                  <EmptyState
+                    action={
+                      <Button asChild size="sm" variant="outline">
+                        <Link search={projectSearch} to="/imports">
+                          Run import
+                        </Link>
+                      </Button>
+                    }
+                    ariaLabel="No EPSS data"
+                    compact
+                    detail="EPSS signals need a provider-enriched import to display buckets."
+                    title="No EPSS data"
+                  />
+                ) : (
+                  <>
+                    <ResponsiveContainer height={196} width="100%">
+                      <BarChart
+                        data={epssItems}
+                        margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                      >
+                        <CartesianGrid
+                          className="opacity-40"
+                          strokeDasharray="3 3"
+                        />
+                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                        <YAxis tick={{ fontSize: 12 }} />
+                        <RechartsTooltip />
+                        <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+                          {epssItems.map((entry) => (
+                            <Cell
+                              key={entry.label}
+                              fill={epssFill(entry.tone)}
+                            />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                    <ChartDataSummary
                       data={epssItems}
-                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                    >
-                      <CartesianGrid
-                        className="opacity-40"
-                        strokeDasharray="3 3"
-                      />
-                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                      <YAxis tick={{ fontSize: 12 }} />
-                      <RechartsTooltip />
-                      <Bar dataKey="value" radius={[4, 4, 0, 0]}>
-                        {epssItems.map((entry) => (
-                          <Cell key={entry.label} fill={epssFill(entry.tone)} />
-                        ))}
-                      </Bar>
-                    </BarChart>
-                  </ResponsiveContainer>
-                  <ChartDataSummary
-                    data={epssItems}
-                    label="EPSS distribution chart data"
-                  />
-                </>
-              )}
-            </ChartCard>
-          </TabsContent>
+                      label="EPSS distribution chart data"
+                    />
+                  </>
+                )}
+              </ChartCard>
+            </TabsContent>
 
-          <TabsContent className="mt-4" value="services">
-            <ChartCard
-              description={
-                topServiceSource === "assets"
-                  ? "Assets with highest accumulated risk score"
-                  : "Services with highest accumulated risk score"
-              }
-              title={
-                topServiceSource === "assets"
-                  ? "Top Assets by Risk"
-                  : "Top Services by Risk"
-              }
-            >
-              {governanceLoading ? (
-                <Skeleton className="h-72" />
-              ) : serviceItems.length === 0 ? (
-                <EmptyState
-                  action={
-                    <Button asChild size="sm" variant="outline">
-                      <Link search={projectSearch} to="/findings">
-                        Review findings
-                      </Link>
-                    </Button>
-                  }
-                  ariaLabel="No service risk data"
-                  compact
-                  detail="Add ownership or component labels and rerun analysis to build entity rankings."
-                  title="No rollup data"
-                />
-              ) : (
-                <>
-                  <ResponsiveContainer height={220} width="100%">
-                    <BarChart
+            <TabsContent className="mt-4" value="services">
+              <ChartCard
+                description={
+                  topServiceSource === "assets"
+                    ? "Assets with highest accumulated risk score"
+                    : "Services with highest accumulated risk score"
+                }
+                title={
+                  topServiceSource === "assets"
+                    ? "Top Assets by Risk"
+                    : "Top Services by Risk"
+                }
+              >
+                {governanceLoading ? (
+                  <Skeleton className="h-72" />
+                ) : serviceItems.length === 0 ? (
+                  <EmptyState
+                    action={
+                      <Button asChild size="sm" variant="outline">
+                        <Link search={projectSearch} to="/findings">
+                          Review findings
+                        </Link>
+                      </Button>
+                    }
+                    ariaLabel="No service risk data"
+                    compact
+                    detail="Add ownership or component labels and rerun analysis to build entity rankings."
+                    title="No rollup data"
+                  />
+                ) : (
+                  <>
+                    <ResponsiveContainer height={220} width="100%">
+                      <BarChart
+                        data={serviceItems}
+                        margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                      >
+                        <CartesianGrid
+                          className="opacity-40"
+                          strokeDasharray="3 3"
+                        />
+                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                        <YAxis tick={{ fontSize: 12 }} />
+                        <RechartsTooltip />
+                        <Bar
+                          dataKey="value"
+                          fill="var(--vpw-teal)"
+                          radius={[4, 4, 0, 0]}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                    <ChartDataSummary
                       data={serviceItems}
-                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
-                    >
-                      <CartesianGrid
-                        className="opacity-40"
-                        strokeDasharray="3 3"
-                      />
-                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                      <YAxis tick={{ fontSize: 12 }} />
-                      <RechartsTooltip />
-                      <Bar
-                        dataKey="value"
-                        fill="var(--vpw-teal)"
-                        radius={[4, 4, 0, 0]}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                  <ChartDataSummary
-                    data={serviceItems}
-                    label={`${
-                      topServiceSource === "assets"
-                        ? "Top assets"
-                        : "Top services"
-                    } chart data`}
-                  />
-                </>
-              )}
-            </ChartCard>
-          </TabsContent>
+                      label={`${
+                        topServiceSource === "assets"
+                          ? "Top assets"
+                          : "Top services"
+                      } chart data`}
+                    />
+                  </>
+                )}
+              </ChartCard>
+            </TabsContent>
 
-          <TabsContent className="mt-4" value="trend">
-            <ChartCard
-              action={
-                <Select
-                  onValueChange={onRunRangeChange}
-                  value={selectedRunRange}
-                >
-                  <SelectTrigger aria-label="Risk trend range" className="w-36">
-                    <SelectValue placeholder="Range" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="10">Last 10 runs</SelectItem>
-                    <SelectItem value="30">Last 30 runs</SelectItem>
-                    <SelectItem value="all">All runs</SelectItem>
-                  </SelectContent>
-                </Select>
-              }
-              description="Imported run cadence and trend signal over time"
-              title="Risk trend"
-            >
-              {runsLoading ? (
-                <Skeleton className="h-72" />
-              ) : trendItems.length === 0 ? (
-                <EmptyState
-                  action={
-                    <Button asChild size="sm" variant="outline">
-                      <Link search={projectSearch} to="/imports">
-                        Create first import
-                      </Link>
-                    </Button>
-                  }
-                  ariaLabel="No trend data"
-                  compact
-                  detail="Run at least one import to generate trend history."
-                  title="No trend data"
-                />
-              ) : (
-                <>
-                  <ResponsiveContainer height={220} width="100%">
-                    <LineChart
-                      data={trendItems}
-                      margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+            <TabsContent className="mt-4" value="trend">
+              <ChartCard
+                action={
+                  <Select
+                    onValueChange={onRunRangeChange}
+                    value={selectedRunRange}
+                  >
+                    <SelectTrigger
+                      aria-label="Risk trend range"
+                      className="w-36"
                     >
-                      <CartesianGrid
-                        className="opacity-40"
-                        strokeDasharray="3 3"
-                      />
-                      <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                      <YAxis tick={{ fontSize: 12 }} />
-                      <RechartsTooltip />
-                      <Line
-                        dataKey="value"
-                        dot={{ r: 3 }}
-                        stroke="var(--vpw-violet)"
-                        strokeWidth={2}
-                        type="monotone"
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                  <ChartDataSummary
-                    data={trendItems}
-                    label="Risk trend chart data"
+                      <SelectValue placeholder="Range" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="10">Last 10 runs</SelectItem>
+                      <SelectItem value="30">Last 30 runs</SelectItem>
+                      <SelectItem value="all">All runs</SelectItem>
+                    </SelectContent>
+                  </Select>
+                }
+                description="Imported run cadence and trend signal over time"
+                title="Risk trend"
+              >
+                {runsLoading ? (
+                  <Skeleton className="h-72" />
+                ) : trendItems.length === 0 ? (
+                  <EmptyState
+                    action={
+                      <Button asChild size="sm" variant="outline">
+                        <Link search={projectSearch} to="/imports">
+                          Create first import
+                        </Link>
+                      </Button>
+                    }
+                    ariaLabel="No trend data"
+                    compact
+                    detail="Run at least one import to generate trend history."
+                    title="No trend data"
                   />
-                </>
-              )}
-            </ChartCard>
-          </TabsContent>
-        </Tabs>
+                ) : (
+                  <>
+                    <ResponsiveContainer height={220} width="100%">
+                      <LineChart
+                        data={trendItems}
+                        margin={{ bottom: 0, left: 0, right: 6, top: 6 }}
+                      >
+                        <CartesianGrid
+                          className="opacity-40"
+                          strokeDasharray="3 3"
+                        />
+                        <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                        <YAxis tick={{ fontSize: 12 }} />
+                        <RechartsTooltip />
+                        <Line
+                          dataKey="value"
+                          dot={{ r: 3 }}
+                          stroke="var(--vpw-violet)"
+                          strokeWidth={2}
+                          type="monotone"
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                    <ChartDataSummary
+                      data={trendItems}
+                      label="Risk trend chart data"
+                    />
+                  </>
+                )}
+              </ChartCard>
+            </TabsContent>
+          </Tabs>
+          <DashboardKeyTakeaways
+            items={keyTakeaways}
+            projectSearch={projectSearch}
+          />
+        </div>
       </VpwSurfaceBody>
     </VpwSurface>
   )

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -366,19 +366,6 @@ export function RiskOperationsDashboard({
       ) : (
         <>
           <DashboardMetricGrid cards={summaryCards} isLoading={isLoading} />
-          <DashboardRemediationSection
-            findingsError={findingsError}
-            findingsLoading={findingsLoading}
-            onQueueSearchChange={(queueSearch) =>
-              setFilters((current) => ({
-                ...current,
-                queueSearch,
-              }))
-            }
-            queueFindings={queueFindings}
-            queueSearch={filters.queueSearch}
-            selectedProjectId={isDemoMode ? "" : selectedProjectId}
-          />
           <Suspense fallback={<DashboardSignalOverviewFallback />}>
             <DashboardSignalOverview
               epssItems={epssItems}
@@ -400,6 +387,19 @@ export function RiskOperationsDashboard({
               trendItems={trendItems}
             />
           </Suspense>
+          <DashboardRemediationSection
+            findingsError={findingsError}
+            findingsLoading={findingsLoading}
+            onQueueSearchChange={(queueSearch) =>
+              setFilters((current) => ({
+                ...current,
+                queueSearch,
+              }))
+            }
+            queueFindings={queueFindings}
+            queueSearch={filters.queueSearch}
+            selectedProjectId={isDemoMode ? "" : selectedProjectId}
+          />
         </>
       )}
     </div>

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -3,6 +3,7 @@ import {
   AlertTriangle,
   Globe2,
   ShieldAlert,
+  ShieldCheck,
   TrendingUp,
 } from "lucide-react"
 import { lazy, Suspense, useMemo, useState } from "react"
@@ -198,10 +199,11 @@ export function RiskOperationsDashboard({
   }, [effectiveFindings, filters.queueSearch])
 
   const latestRun = effectiveRuns[0] ?? null
+  const acceptedRiskCount = effectiveSummary?.counts_by_status?.accepted ?? 0
   const summaryCards = useMemo<DashboardMetricSummary[]>(
     () => [
       {
-        detail: "Critical-priority findings in scope",
+        detail: "Critical findings in scope",
         icon: AlertTriangle,
         label: "Critical Priority",
         tone: "critical",
@@ -211,7 +213,7 @@ export function RiskOperationsDashboard({
             : String(priorityCount(effectiveSummary, "Critical")),
       },
       {
-        detail: "Known CISA KEV findings in scope",
+        detail: "Known CISA KEV findings",
         icon: ShieldAlert,
         label: "KEV Exposed",
         tone: "kev",
@@ -221,7 +223,7 @@ export function RiskOperationsDashboard({
             : String(effectiveSummary?.kev_hits ?? 0),
       },
       {
-        detail: "High-confidence EPSS signals (≥70%)",
+        detail: "EPSS ≥70% signals",
         icon: TrendingUp,
         label: "High EPSS",
         tone: "high",
@@ -231,7 +233,7 @@ export function RiskOperationsDashboard({
             : String(effectiveSignalCounts.highEpss),
       },
       {
-        detail: "Critical internet-facing findings",
+        detail: "Internet-facing criticals",
         icon: Globe2,
         label: "Internet Facing",
         tone: "exposure",
@@ -240,9 +242,20 @@ export function RiskOperationsDashboard({
             ? "—"
             : String(effectiveSignalCounts.internetFacingCriticals),
       },
+      {
+        detail: "Accepted-risk findings",
+        icon: ShieldCheck,
+        label: "Accepted Risk Due",
+        tone: "accepted",
+        value:
+          (!isDemoMode && summaryLoading) || effectiveSummary === null
+            ? "—"
+            : String(acceptedRiskCount),
+      },
     ],
     [
       isDemoMode,
+      acceptedRiskCount,
       effectiveSummary,
       effectiveSignalCounts.highEpss,
       effectiveSignalCounts.internetFacingCriticals,
@@ -269,9 +282,6 @@ export function RiskOperationsDashboard({
   const kevCount = effectiveSummary?.kev_hits ?? 0
   const internetFacingCount = effectiveSignalCounts.internetFacingCriticals
   const topServiceLabel = serviceItems[0]?.label ?? null
-  const acceptedRiskCount = effectiveFindings.filter(
-    (finding) => finding.status === "accepted",
-  ).length
   const signalTakeaways = [
     `${criticalCount} critical findings demand immediate action.`,
     kevCount > 0

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -264,6 +264,146 @@ export function RiskOperationsDashboard({
   const latestRunFactsRows = latestRunFacts(effectiveRuns)
   const dataQualityWarnings = effectiveProviderStatus?.warnings ?? []
   const dataQualityError = effectiveProviderStatus?.last_error ?? null
+  const criticalCount =
+    effectiveSummary === null ? 0 : priorityCount(effectiveSummary, "Critical")
+  const kevCount = effectiveSummary?.kev_hits ?? 0
+  const internetFacingCount = effectiveSignalCounts.internetFacingCriticals
+  const topServiceLabel = serviceItems[0]?.label ?? null
+  const acceptedRiskCount = effectiveFindings.filter(
+    (finding) => finding.status === "accepted",
+  ).length
+  const signalTakeaways = [
+    `${criticalCount} critical findings demand immediate action.`,
+    kevCount > 0
+      ? `${kevCount} known-exploited KEV findings are active prioritization signals.`
+      : "No known-exploited KEV findings are currently in scope.",
+    internetFacingCount > 0
+      ? `${internetFacingCount} internet-facing critical findings drive near-term risk.`
+      : "No internet-facing critical findings are currently driving the queue.",
+    acceptedRiskCount > 0
+      ? `${acceptedRiskCount} accepted-risk records should stay on review cadence.`
+      : topServiceLabel
+        ? `${topServiceLabel} is the highest-risk service concentration.`
+        : "Service concentration will appear after ownership data is imported.",
+  ]
+
+  const dashboardContent = (
+    <div className="min-w-0 flex flex-col gap-4">
+      <DashboardHero
+        demoWorkspaceEnabled={demoWorkspaceEnabled}
+        demoWorkspacePending={demoWorkspacePending}
+        effectiveProjects={effectiveProjects}
+        effectiveProviderStatus={effectiveProviderStatus}
+        effectiveSelectedProject={effectiveSelectedProject}
+        freshness={freshness}
+        isManagedDemoWorkspace={isManagedDemoWorkspace}
+        isDemoMode={isDemoMode}
+        onLoadDemoWorkspace={onLoadDemoWorkspace}
+        onProjectChange={onProjectChange}
+        onRefresh={onRefresh}
+        onResetDemoWorkspace={onResetDemoWorkspace}
+        projectListLoading={projectListLoading}
+        providerStatusLoading={providerStatusLoading}
+        selectedProjectId={selectedProjectId}
+      />
+
+      {isDemoMode || isManagedDemoWorkspace ? (
+        <DashboardDemoBanner
+          demoWorkspaceEnabled={demoWorkspaceEnabled}
+          demoWorkspacePending={demoWorkspacePending}
+          isManagedDemoWorkspace={isManagedDemoWorkspace}
+          onLoadDemoWorkspace={onLoadDemoWorkspace}
+          onResetDemoWorkspace={onResetDemoWorkspace}
+        />
+      ) : null}
+
+      {dashboardError ||
+      signalError ||
+      providerStatusError ||
+      findingsError ||
+      demoWorkspaceError ||
+      governanceError ? (
+        <ErrorState
+          message={
+            dashboardError ||
+            signalError ||
+            providerStatusError ||
+            findingsError ||
+            demoWorkspaceError ||
+            governanceError ||
+            "Dashboard is currently unavailable"
+          }
+        />
+      ) : null}
+
+      {staleProvider ? (
+        <VpwSurface className="border-[var(--vpw-amber)] bg-[var(--vpw-bg-warning)]">
+          <VpwSurfaceHeader className="py-3">
+            <div className="flex items-center gap-2">
+              <AlertCircle
+                className="size-4 text-[var(--vpw-amber)]"
+                aria-hidden="true"
+              />
+              <VpwSurfaceTitle className="text-sm text-[var(--vpw-text-primary)]">
+                Provider data needs refresh
+              </VpwSurfaceTitle>
+            </div>
+            <VpwSurfaceDescription className="text-xs text-[var(--vpw-text-secondary)]">
+              Freshness is stale or partially degraded. Remediation priority
+              remains functional, but evidence may not be fully current.
+            </VpwSurfaceDescription>
+          </VpwSurfaceHeader>
+        </VpwSurface>
+      ) : null}
+
+      {showEmptyState ? (
+        <DashboardSetupEmptyState
+          demoWorkspaceEnabled={demoWorkspaceEnabled}
+          demoWorkspacePending={demoWorkspacePending}
+          onLoadDemoWorkspace={onLoadDemoWorkspace}
+          onResetDemoWorkspace={onResetDemoWorkspace}
+        />
+      ) : (
+        <>
+          <DashboardMetricGrid cards={summaryCards} isLoading={isLoading} />
+          <DashboardRemediationSection
+            findingsError={findingsError}
+            findingsLoading={findingsLoading}
+            onQueueSearchChange={(queueSearch) =>
+              setFilters((current) => ({
+                ...current,
+                queueSearch,
+              }))
+            }
+            queueFindings={queueFindings}
+            queueSearch={filters.queueSearch}
+            selectedProjectId={isDemoMode ? "" : selectedProjectId}
+          />
+          <Suspense fallback={<DashboardSignalOverviewFallback />}>
+            <DashboardSignalOverview
+              epssItems={epssItems}
+              governanceLoading={governanceLoading}
+              keyTakeaways={signalTakeaways}
+              onRunRangeChange={(value: DashboardRunRange) =>
+                setFilters((current) => ({
+                  ...current,
+                  selectedRunRange: value,
+                }))
+              }
+              priorityItems={priorityItems}
+              runsLoading={runsLoading}
+              selectedProjectId={isDemoMode ? "" : selectedProjectId}
+              selectedRunRange={filters.selectedRunRange}
+              serviceItems={serviceItems}
+              summaryLoading={summaryLoading}
+              topServiceSource={topServiceSource}
+              trendItems={trendItems}
+            />
+          </Suspense>
+        </>
+      )}
+    </div>
+  )
 
   return (
     <TooltipProvider>
@@ -271,123 +411,15 @@ export function RiskOperationsDashboard({
         aria-label="Risk Operations dashboard"
         className="dashboard-analyst-layout flex flex-col gap-4 pb-4"
       >
-        <DashboardHero
-          demoWorkspaceEnabled={demoWorkspaceEnabled}
-          demoWorkspacePending={demoWorkspacePending}
-          effectiveProjects={effectiveProjects}
-          effectiveProviderStatus={effectiveProviderStatus}
-          effectiveSelectedProject={effectiveSelectedProject}
-          freshness={freshness}
-          isManagedDemoWorkspace={isManagedDemoWorkspace}
-          isDemoMode={isDemoMode}
-          onLoadDemoWorkspace={onLoadDemoWorkspace}
-          onProjectChange={onProjectChange}
-          onRefresh={onRefresh}
-          onResetDemoWorkspace={onResetDemoWorkspace}
-          projectListLoading={projectListLoading}
-          providerStatusLoading={providerStatusLoading}
-          selectedProjectId={selectedProjectId}
-        />
-
-        {isDemoMode || isManagedDemoWorkspace ? (
-          <DashboardDemoBanner
-            demoWorkspaceEnabled={demoWorkspaceEnabled}
-            demoWorkspacePending={demoWorkspacePending}
-            isManagedDemoWorkspace={isManagedDemoWorkspace}
-            onLoadDemoWorkspace={onLoadDemoWorkspace}
-            onResetDemoWorkspace={onResetDemoWorkspace}
-          />
-        ) : null}
-
-        {dashboardError ||
-        signalError ||
-        providerStatusError ||
-        findingsError ||
-        demoWorkspaceError ||
-        governanceError ? (
-          <ErrorState
-            message={
-              dashboardError ||
-              signalError ||
-              providerStatusError ||
-              findingsError ||
-              demoWorkspaceError ||
-              governanceError ||
-              "Dashboard is currently unavailable"
-            }
-          />
-        ) : null}
-
-        {staleProvider ? (
-          <VpwSurface className="border-[var(--vpw-amber)] bg-[var(--vpw-bg-warning)]">
-            <VpwSurfaceHeader className="py-3">
-              <div className="flex items-center gap-2">
-                <AlertCircle
-                  className="size-4 text-[var(--vpw-amber)]"
-                  aria-hidden="true"
-                />
-                <VpwSurfaceTitle className="text-sm text-[var(--vpw-text-primary)]">
-                  Provider data needs refresh
-                </VpwSurfaceTitle>
-              </div>
-              <VpwSurfaceDescription className="text-xs text-[var(--vpw-text-secondary)]">
-                Freshness is stale or partially degraded. Remediation priority
-                remains functional, but evidence may not be fully current.
-              </VpwSurfaceDescription>
-            </VpwSurfaceHeader>
-          </VpwSurface>
-        ) : null}
-
-        {showEmptyState ? (
-          <DashboardSetupEmptyState
-            demoWorkspaceEnabled={demoWorkspaceEnabled}
-            demoWorkspacePending={demoWorkspacePending}
-            onLoadDemoWorkspace={onLoadDemoWorkspace}
-            onResetDemoWorkspace={onResetDemoWorkspace}
-          />
-        ) : null}
-
-        {!showEmptyState ? (
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] 2xl:grid-cols-[minmax(0,1fr)_22rem]">
-            <div className="min-w-0 flex flex-col gap-4">
-              <DashboardMetricGrid
-                cards={summaryCards}
-                isLoading={isLoading}
-              />
-              <DashboardRemediationSection
-                findingsError={findingsError}
-                findingsLoading={findingsLoading}
-                onQueueSearchChange={(queueSearch) =>
-                  setFilters((current) => ({
-                    ...current,
-                    queueSearch,
-                  }))
-                }
-                queueFindings={queueFindings}
-                queueSearch={filters.queueSearch}
-              />
-              <Suspense fallback={<DashboardSignalOverviewFallback />}>
-                <DashboardSignalOverview
-                  epssItems={epssItems}
-                  governanceLoading={governanceLoading}
-                  onRunRangeChange={(value: DashboardRunRange) =>
-                    setFilters((current) => ({
-                      ...current,
-                      selectedRunRange: value,
-                    }))
-                  }
-                  priorityItems={priorityItems}
-                  runsLoading={runsLoading}
-                  selectedProjectId={isDemoMode ? "" : selectedProjectId}
-                  selectedRunRange={filters.selectedRunRange}
-                  serviceItems={serviceItems}
-                  summaryLoading={summaryLoading}
-                  topServiceSource={topServiceSource}
-                  trendItems={trendItems}
-                />
-              </Suspense>
-            </div>
-
+        <div
+          className={
+            showEmptyState
+              ? "grid gap-4"
+              : "dashboard-command-grid grid gap-4 2xl:grid-cols-[minmax(0,1fr)_22rem]"
+          }
+        >
+          {dashboardContent}
+          {!showEmptyState ? (
             <DashboardSidePanel
               dataQualityError={dataQualityError}
               dataQualityWarnings={dataQualityWarnings}
@@ -401,8 +433,8 @@ export function RiskOperationsDashboard({
               selectedProjectId={isDemoMode ? "" : selectedProjectId}
               staleProvider={staleProvider}
             />
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </section>
     </TooltipProvider>
   )

--- a/frontend/src/components/risk/MetricCard.tsx
+++ b/frontend/src/components/risk/MetricCard.tsx
@@ -13,6 +13,7 @@ type MetricCardProps = {
 }
 
 const accentStyles: Record<string, string> = {
+  accepted: "border-l-[var(--vpw-green)]",
   critical: "border-l-[var(--vpw-red)]",
   exposure: "border-l-[var(--vpw-blue)]",
   high: "border-l-[var(--vpw-amber)]",
@@ -24,6 +25,7 @@ const accentStyles: Record<string, string> = {
 }
 
 const iconBgStyles: Record<string, string> = {
+  accepted: "bg-[var(--vpw-bg-success)] text-[var(--vpw-green)]",
   critical: "bg-[var(--vpw-bg-critical)] text-[var(--vpw-red)]",
   exposure: "bg-[var(--vpw-bg-info)] text-[var(--vpw-blue)]",
   high: "bg-[var(--vpw-bg-warning)] text-[var(--vpw-amber)]",

--- a/frontend/src/lib/vpw-tokens.json
+++ b/frontend/src/lib/vpw-tokens.json
@@ -7,7 +7,7 @@
       "success": "#047857",
       "warning": "#B54708",
       "critical": "#C40000",
-      "support": "#7928CA",
+      "support": "#475569",
       "navy": "#171717"
     },
     "neutral": {

--- a/frontend/src/lib/vpw-tokens.ts
+++ b/frontend/src/lib/vpw-tokens.ts
@@ -7,7 +7,7 @@ export const vpwTokens = {
       success: "#047857",
       warning: "#B54708",
       critical: "#C40000",
-      support: "#7928CA",
+      support: "#475569",
       navy: "#171717",
     },
     neutral: {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -56,6 +56,10 @@
   height: 1rem;
 }
 
+.dashboard-command-grid {
+  align-items: start;
+}
+
 .dashboard-metric-grid > .vpw-panel {
   min-height: 104px;
   background: var(--vpw-bg-card);
@@ -470,6 +474,17 @@
   line-height: 1.45;
 }
 
+.dashboard-queue-why {
+  display: block;
+  max-width: 44ch;
+  overflow: hidden;
+  color: var(--vpw-text-secondary);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .finding-view-action {
   display: inline-flex;
   align-items: center;
@@ -572,4 +587,67 @@
   overflow-wrap: anywhere;
   color: var(--vpw-text-muted);
   font-size: 0.78rem;
+}
+
+.dashboard-signal-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.42fr);
+  gap: 14px;
+  align-items: stretch;
+}
+
+.dashboard-key-takeaways {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 16px;
+  min-width: 0;
+  border: 1px solid var(--dashboard-analyst-border);
+  border-radius: 8px;
+  padding: 16px;
+  background: var(--vpw-bg-card);
+}
+
+.dashboard-next-action {
+  width: 100%;
+  justify-content: flex-start;
+  gap: 10px;
+  min-height: 40px;
+  padding-inline: 0;
+  color: var(--vpw-text-secondary);
+}
+
+.dashboard-next-action:hover {
+  color: var(--vpw-text-primary);
+}
+
+.dashboard-next-action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  border-radius: var(--vpw-radius-md);
+  background: var(--vpw-bg-panel);
+}
+
+.dashboard-next-action-icon--critical {
+  background: var(--vpw-bg-critical);
+  color: var(--vpw-red);
+}
+
+.dashboard-next-action-icon--success {
+  background: var(--vpw-bg-success);
+  color: var(--vpw-green);
+}
+
+.dashboard-next-action-icon--support {
+  background: color-mix(in srgb, var(--vpw-violet) 10%, var(--vpw-bg-card));
+  color: var(--vpw-violet);
+}
+
+.dashboard-next-action-icon--info {
+  background: var(--vpw-bg-info);
+  color: var(--vpw-blue);
 }

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -47,7 +47,7 @@
   position: absolute;
   inset: 0 auto 0 0;
   width: 4px;
-  background: var(--vpw-violet);
+  background: var(--vpw-teal);
   content: "";
 }
 
@@ -71,7 +71,7 @@
 .dashboard-metric-grid > .vpw-panel:hover {
   border-color: color-mix(
     in srgb,
-    var(--vpw-violet) 24%,
+    var(--vpw-blue) 22%,
     var(--vpw-border-default)
   );
   box-shadow: none;
@@ -252,19 +252,19 @@
 }
 
 .chart-row.tone-critical .chart-bar-fill {
-  background: var(--vpw-red);
+  background: var(--vpw-chart-critical);
 }
 
 .chart-row.tone-high .chart-bar-fill {
-  background: var(--vpw-amber);
+  background: var(--vpw-chart-high);
 }
 
 .chart-row.tone-medium .chart-bar-fill {
-  background: var(--vpw-amber);
+  background: var(--vpw-chart-medium);
 }
 
 .chart-row.tone-low .chart-bar-fill {
-  background: var(--vpw-blue);
+  background: var(--vpw-chart-low);
 }
 
 .chart-row.tone-accepted .chart-bar-fill {
@@ -305,14 +305,14 @@
 
 .trend-line {
   fill: none;
-  stroke: var(--vpw-teal);
+  stroke: var(--vpw-chart-trend);
   stroke-linecap: round;
   stroke-width: 2.5;
   vector-effect: non-scaling-stroke;
 }
 
 .trend-point {
-  fill: var(--vpw-teal);
+  fill: var(--vpw-chart-trend);
   vector-effect: non-scaling-stroke;
 }
 

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -97,6 +97,7 @@
   .dashboard-chart-grid,
   .dashboard-cockpit-grid,
   .dashboard-readiness-facts,
+  .dashboard-signal-layout,
   .freshness-facts,
   .finding-decision-fact-grid,
   .finding-decision-hero-metrics,

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -133,9 +133,21 @@
   --vpw-green: #047857;
   --vpw-amber: #b54708;
   --vpw-red: #c40000;
-  --vpw-violet: #7928ca;
+  --vpw-violet: #475569;
   --vpw-navy: #171717;
   --vpw-text-info: color-mix(in srgb, var(--vpw-blue) 80%, var(--vpw-text-primary));
+  --vpw-chart-critical: #dc2626;
+  --vpw-chart-high: #f97316;
+  --vpw-chart-medium: #d97706;
+  --vpw-chart-low: #0ea5e9;
+  --vpw-chart-risk: #2563eb;
+  --vpw-chart-trend: #06b6d4;
+  --vpw-chart-grid: #e5e7eb;
+  --vpw-chart-rank-1: #2563eb;
+  --vpw-chart-rank-2: #0284c7;
+  --vpw-chart-rank-3: #0891b2;
+  --vpw-chart-rank-4: #0d9488;
+  --vpw-chart-rank-5: #14b8a6;
 
   --vpw-radius-sm: 4px;
   --vpw-radius-md: 6px;
@@ -207,6 +219,19 @@
     --vpw-green: #34d399;
     --vpw-amber: #fbbf24;
     --vpw-red: #ff7a7a;
+    --vpw-violet: #94a3b8;
+    --vpw-chart-critical: #f87171;
+    --vpw-chart-high: #fb923c;
+    --vpw-chart-medium: #facc15;
+    --vpw-chart-low: #38bdf8;
+    --vpw-chart-risk: #60a5fa;
+    --vpw-chart-trend: #22d3ee;
+    --vpw-chart-grid: #2b2b2b;
+    --vpw-chart-rank-1: #60a5fa;
+    --vpw-chart-rank-2: #38bdf8;
+    --vpw-chart-rank-3: #22d3ee;
+    --vpw-chart-rank-4: #2dd4bf;
+    --vpw-chart-rank-5: #5eead4;
   }
 }
 
@@ -258,6 +283,19 @@
   --vpw-green: #34d399;
   --vpw-amber: #fbbf24;
   --vpw-red: #ff7a7a;
+  --vpw-violet: #94a3b8;
+  --vpw-chart-critical: #f87171;
+  --vpw-chart-high: #fb923c;
+  --vpw-chart-medium: #facc15;
+  --vpw-chart-low: #38bdf8;
+  --vpw-chart-risk: #60a5fa;
+  --vpw-chart-trend: #22d3ee;
+  --vpw-chart-grid: #2b2b2b;
+  --vpw-chart-rank-1: #60a5fa;
+  --vpw-chart-rank-2: #38bdf8;
+  --vpw-chart-rank-3: #22d3ee;
+  --vpw-chart-rank-4: #2dd4bf;
+  --vpw-chart-rank-5: #5eead4;
 }
 
 /* Tailwind v4 uses currentColor for bare `border` - default to the shadcn border token */

--- a/frontend/tests/chart-data.test.ts
+++ b/frontend/tests/chart-data.test.ts
@@ -122,6 +122,7 @@ test("adds highest priority to top service rollup detail", () => {
   ]
   const data = topServicesByRiskChartData(serviceData, 10)
   assert.equal(data[0].detail, "4 findings · highest priority Critical")
+  assert.equal(data[0].tone, "critical")
 })
 
 test("builds run activity trends from the latest limited runs", () => {


### PR DESCRIPTION
## Summary
- restructure the dashboard into a clearer main command column plus right operations rail on wide screens
- refine the hero layout so project selection, status, and actions are grouped consistently
- restore the fifth KPI card: Accepted Risk Due, backed by dashboard summary accepted status counts
- move Signal Overview above the Top Remediation Queue so charts lead the analytical flow
- keep the queue focused by removing the lower table footer and redundant bottom View all button
- keep Operations State badges readable and carry forward the updated cool chart/token palette from the color pass

## Verification
- npm --prefix frontend run lint
- npm --prefix frontend run test:types
- node --test --experimental-strip-types tests/design-system-contracts.test.ts tests/chart-data.test.ts
- npm --prefix frontend run test -- workbench-demo-workspace.spec.ts ui-smoke.spec.ts
- Browser QA on http://127.0.0.1:15191/?projectId=00000000-0000-4000-8000-00000000d001: page identity, no framework overlay, no console warnings/errors, Current badge visible, Signal Overview before queue, table footer removed
- Playwright 1920x1080 visual check: 5 KPI cards in one row, Accepted Risk Due shows 4, no KPI detail ellipsis, Signal Overview above Top Remediation Queue