### PR TITLE
Fix demo workspace container seeding

### DIFF
--- a/backend/app/services/demo_workspace.py
+++ b/backend/app/services/demo_workspace.py
@@ -73,9 +73,9 @@ EXPECTED_WAIVER_STATUS_COUNTS = {
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DATA_DIR = _REPO_ROOT / "data"
-_DEMO_OCCURRENCES = _DATA_DIR / "input_fixtures" / "demo_workspace_occurrences.csv"
-_DEMO_OPENVEX = _DATA_DIR / "input_fixtures" / "demo_workspace_openvex.json"
-_ATTACK_MAPPING = _DATA_DIR / "attack" / "local_curated_demo_mappings.yml"
+_DEMO_OCCURRENCES_FILENAME = "demo_workspace_occurrences.csv"
+_DEMO_OPENVEX_FILENAME = "demo_workspace_openvex.json"
+_ATTACK_MAPPING_FILENAME = "local_curated_demo_mappings.yml"
 
 
 @dataclass(frozen=True, slots=True)
@@ -247,6 +247,7 @@ async def _run_seed_imports(
     settings: Settings,
     local_actor: LocalWorkbenchActor,
 ) -> None:
+    demo_data_dir = _demo_data_dir(settings)
     await execute_project_import_upload(
         project_id=DEMO_PROJECT_ID,
         session=session,
@@ -254,15 +255,37 @@ async def _run_seed_imports(
         settings=settings,
         upload=ProjectImportUploadRequest(
             input_type="generic-occurrence-csv",
-            file=_upload_content(_DEMO_OCCURRENCES, content_type="text/csv"),
-            vex_file=_upload_content(_DEMO_OPENVEX, content_type="application/json"),
+            file=_upload_content(
+                demo_data_dir / "input_fixtures" / _DEMO_OCCURRENCES_FILENAME,
+                content_type="text/csv",
+            ),
+            vex_file=_upload_content(
+                demo_data_dir / "input_fixtures" / _DEMO_OPENVEX_FILENAME,
+                content_type="application/json",
+            ),
             provider_snapshot_file=DEMO_PROVIDER_SNAPSHOT,
             locked_provider_data=True,
             attack_source="local-curated",
-            attack_mapping_file=_ATTACK_MAPPING.name,
+            attack_mapping_file=_ATTACK_MAPPING_FILENAME,
         ),
         execution_mode="request",
     )
+
+
+def _demo_data_dir(settings: Settings) -> Path:
+    attack_artifact_dir = settings.attack_artifact_dir_path
+    candidates = []
+    if attack_artifact_dir.name == "attack":
+        candidates.append(attack_artifact_dir.parent)
+    candidates.append(_DATA_DIR)
+
+    for candidate in candidates:
+        input_fixtures = candidate / "input_fixtures"
+        if (input_fixtures / _DEMO_OCCURRENCES_FILENAME).is_file() and (
+            input_fixtures / _DEMO_OPENVEX_FILENAME
+        ).is_file():
+            return candidate
+    return _DATA_DIR
 
 
 def _create_demo_waivers(session: Session, *, project_id: uuid.UUID) -> None:

--- a/backend/app/services/import_execution_persistence.py
+++ b/backend/app/services/import_execution_persistence.py
@@ -233,6 +233,8 @@ def _persist_workbench_occurrences(
                 flush=False,
             )
             findings_by_dedup_key[dedup_key] = finding
+            if action == "created":
+                session.flush()
             if finding.id not in attack_context_finding_ids and _attack_context_enabled(
                 analysis_result,
                 decision,

--- a/backend/tests/api/test_workbench_demo_workspace.py
+++ b/backend/tests/api/test_workbench_demo_workspace.py
@@ -14,6 +14,7 @@ from sqlmodel import Session, select
 from utils.workbench_env import WorkbenchApiEnv, local_api_headers
 
 from app.models.base import get_datetime_utc
+from app.services.demo_workspace import _demo_data_dir
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 DEMO_PROJECT_NAME = "Online Shop Demo Workspace"
@@ -44,6 +45,25 @@ def test_demo_workspace_status_is_disabled_by_default(
     assert status_response.json()["enabled"] is False
     assert status_response.json()["seeded"] is False
     assert seed_response.status_code == 403
+
+
+def test_demo_workspace_fixture_root_follows_attack_artifact_parent(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    mounted_data = tmp_path / "mounted-data"
+    input_fixtures = mounted_data / "input_fixtures"
+    input_fixtures.mkdir(parents=True)
+    (mounted_data / "attack").mkdir()
+    (input_fixtures / "demo_workspace_occurrences.csv").write_text("cve_id\n", encoding="utf-8")
+    (input_fixtures / "demo_workspace_openvex.json").write_text("{}", encoding="utf-8")
+
+    active_settings = replace(
+        workbench_api_env.client.app.state.workbench_settings,
+        ATTACK_ARTIFACT_DIR=str(mounted_data / "attack"),
+    )
+
+    assert _demo_data_dir(active_settings) == mounted_data
 
 
 def test_demo_workspace_can_be_seeded_reset_and_removed(


### PR DESCRIPTION
## Summary
- resolve demo workspace fixture root from the configured ATT&CK artifact directory so Docker quickstart reads mounted fixtures
- flush newly created findings before persisting dependent ATT&CK/occurrence rows for PostgreSQL
- add regression coverage for container-style demo fixture layout

## Verification
- python3 -m pytest backend/tests/api/test_workbench_demo_workspace.py --no-cov
- make check
- Docker preview: POST /api/v1/workbench/demo reset returned 24 findings, 21 assets, 7 reports, 4 waivers