### PR TITLE
[codex] Refine responsive dashboard layout

### DIFF
--- a/frontend/src/components/app/AppShell.tsx
+++ b/frontend/src/components/app/AppShell.tsx
@@ -1,11 +1,11 @@
 import { Link } from "@/lib/router"
-import {
-  Menu,
-  Sidebar,
-} from "lucide-react"
+import { Menu, Sidebar } from "lucide-react"
 import { type ReactNode, useEffect, useRef, useState } from "react"
 import { cn } from "../../lib/utils"
-import type { NavigationGroup, WorkbenchPath } from "../../lib/workbench-navigation"
+import type {
+  NavigationGroup,
+  WorkbenchPath,
+} from "../../lib/workbench-navigation"
 import { Button } from "../ui/button"
 import {
   Sheet,
@@ -297,131 +297,133 @@ export function AppShell({
 
         {/* Main area */}
         <main className="flex h-dvh min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-          {/* Topbar */}
-          <header className="flex h-16 shrink-0 items-center justify-between gap-3 border-b border-[var(--vpw-border-default)] bg-[var(--vpw-bg-page)] px-4 lg:px-6">
-            <div className="flex min-w-0 items-center gap-3">
-              <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
-                <SheetTrigger asChild>
-                  <Button
-                    aria-label="Open navigation"
-                    className="size-9 border-[var(--vpw-border-default)] text-[var(--vpw-text-secondary)] lg:hidden"
-                    ref={mobileNavButtonRef}
-                    size="icon"
-                    type="button"
-                    variant="outline"
+          {/* Page header */}
+          <header className="shrink-0 bg-[var(--vpw-bg-app)] pt-5 pb-3 sm:pt-6 sm:pb-4">
+            <div className="vpw-page-container flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 items-start gap-3 sm:flex-1">
+                <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+                  <SheetTrigger asChild>
+                    <Button
+                      aria-label="Open navigation"
+                      className="mt-0.5 size-9 shrink-0 border-[var(--vpw-border-default)] bg-[var(--vpw-bg-card)] text-[var(--vpw-text-secondary)] lg:hidden"
+                      ref={mobileNavButtonRef}
+                      size="icon"
+                      type="button"
+                      variant="outline"
+                    >
+                      <Menu aria-hidden="true" size={18} />
+                    </Button>
+                  </SheetTrigger>
+                  <SheetContent
+                    className="flex w-[min(22rem,calc(100vw-2rem))] flex-col overflow-y-auto bg-[var(--vpw-bg-page)] p-0 text-[var(--vpw-text-primary)]"
+                    onCloseAutoFocus={(event) => {
+                      event.preventDefault()
+                      mobileNavButtonRef.current?.focus({
+                        preventScroll: true,
+                      })
+                    }}
+                    side="left"
                   >
-                    <Menu aria-hidden="true" size={18} />
-                  </Button>
-                </SheetTrigger>
-                <SheetContent
-                  className="flex w-[min(22rem,calc(100vw-2rem))] flex-col overflow-y-auto bg-[var(--vpw-bg-page)] p-0 text-[var(--vpw-text-primary)]"
-                  onCloseAutoFocus={(event) => {
-                    event.preventDefault()
-                    mobileNavButtonRef.current?.focus({
-                      preventScroll: true,
-                    })
-                  }}
-                  side="left"
-                >
-                  <SheetHeader className="border-b border-[var(--vpw-border-default)] px-4 py-4 text-left">
-                    <div className="flex items-center gap-3">
-                      <div className="flex size-9 shrink-0 items-center justify-center rounded-[var(--vpw-radius-lg)] bg-[var(--vpw-text-primary)] text-xs font-extrabold text-[var(--vpw-bg-card)]">
-                        VP
+                    <SheetHeader className="border-b border-[var(--vpw-border-default)] px-4 py-4 text-left">
+                      <div className="flex items-center gap-3">
+                        <div className="flex size-9 shrink-0 items-center justify-center rounded-[var(--vpw-radius-lg)] bg-[var(--vpw-text-primary)] text-xs font-extrabold text-[var(--vpw-bg-card)]">
+                          VP
+                        </div>
+                        <div className="min-w-0">
+                          <SheetTitle className="truncate text-sm font-semibold text-[var(--vpw-text-primary)]">
+                            Vuln Prioritizer
+                          </SheetTitle>
+                          <SheetDescription className="truncate text-xs text-[var(--vpw-text-muted)]">
+                            Workbench
+                          </SheetDescription>
+                        </div>
                       </div>
-                      <div className="min-w-0">
-                        <SheetTitle className="truncate text-sm font-semibold text-[var(--vpw-text-primary)]">
-                          Vuln Prioritizer
-                        </SheetTitle>
-                        <SheetDescription className="truncate text-xs text-[var(--vpw-text-muted)]">
-                          Workbench
-                        </SheetDescription>
-                      </div>
+                    </SheetHeader>
+                    <nav
+                      aria-label="Workbench mobile navigation"
+                      className="flex-1 p-2"
+                    >
+                      <ul className="flex flex-col gap-3">
+                        {navigationGroups.map((group) => (
+                          <li key={group.label}>
+                            <p className="px-3 pb-1 text-[10px] font-bold uppercase text-[var(--vpw-text-muted)]">
+                              {group.label}
+                            </p>
+                            <ul className="flex flex-col gap-1">
+                              {group.items.map((entry) => {
+                                const isActive = activePath === entry.to
+                                return (
+                                  <li key={entry.label}>
+                                    <Link
+                                      aria-current={
+                                        isActive ? "page" : undefined
+                                      }
+                                      className={cn(
+                                        "flex min-h-11 items-center gap-3 rounded-[var(--vpw-radius-md)] px-3 text-sm font-medium transition-colors",
+                                        isActive
+                                          ? "bg-[var(--vpw-text-primary)] text-[var(--vpw-bg-card)]"
+                                          : "text-[var(--vpw-text-secondary)] hover:bg-[var(--vpw-bg-panel)] hover:text-[var(--vpw-text-primary)]",
+                                      )}
+                                      onClick={() => setMobileNavOpen(false)}
+                                      to={entry.to}
+                                    >
+                                      <entry.icon
+                                        aria-hidden="true"
+                                        className="shrink-0"
+                                        size={17}
+                                      />
+                                      <span className="truncate">
+                                        {entry.label}
+                                      </span>
+                                    </Link>
+                                  </li>
+                                )
+                              })}
+                            </ul>
+                          </li>
+                        ))}
+                      </ul>
+                    </nav>
+                    <div className="flex shrink-0 items-center gap-2 border-t border-[var(--vpw-border-default)] p-3">
+                      <span className="flex size-8 shrink-0 items-center justify-center rounded-full border border-[var(--vpw-border-default)] bg-[var(--vpw-bg-panel)] text-xs font-semibold text-[var(--vpw-text-secondary)]">
+                        {workspaceInitial}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-left text-xs text-[var(--vpw-text-secondary)]">
+                        {workspaceLabel}
+                      </span>
                     </div>
-                  </SheetHeader>
-                  <nav
-                    aria-label="Workbench mobile navigation"
-                    className="flex-1 p-2"
-                  >
-                    <ul className="flex flex-col gap-3">
-                      {navigationGroups.map((group) => (
-                        <li key={group.label}>
-                          <p className="px-3 pb-1 text-[10px] font-bold uppercase text-[var(--vpw-text-muted)]">
-                            {group.label}
-                          </p>
-                          <ul className="flex flex-col gap-1">
-                            {group.items.map((entry) => {
-                              const isActive = activePath === entry.to
-                              return (
-                                <li key={entry.label}>
-                                  <Link
-                                    aria-current={
-                                      isActive ? "page" : undefined
-                                    }
-                                    className={cn(
-                                      "flex min-h-11 items-center gap-3 rounded-[var(--vpw-radius-md)] px-3 text-sm font-medium transition-colors",
-                                      isActive
-                                        ? "bg-[var(--vpw-text-primary)] text-[var(--vpw-bg-card)]"
-                                        : "text-[var(--vpw-text-secondary)] hover:bg-[var(--vpw-bg-panel)] hover:text-[var(--vpw-text-primary)]",
-                                    )}
-                                    onClick={() => setMobileNavOpen(false)}
-                                    to={entry.to}
-                                  >
-                                    <entry.icon
-                                      aria-hidden="true"
-                                      className="shrink-0"
-                                      size={17}
-                                    />
-                                    <span className="truncate">
-                                      {entry.label}
-                                    </span>
-                                  </Link>
-                                </li>
-                              )
-                            })}
-                          </ul>
-                        </li>
-                      ))}
-                    </ul>
-                  </nav>
-                  <div className="flex shrink-0 items-center gap-2 border-t border-[var(--vpw-border-default)] p-3">
-                    <span className="flex size-8 shrink-0 items-center justify-center rounded-full border border-[var(--vpw-border-default)] bg-[var(--vpw-bg-panel)] text-xs font-semibold text-[var(--vpw-text-secondary)]">
-                      {workspaceInitial}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-left text-xs text-[var(--vpw-text-secondary)]">
-                      {workspaceLabel}
-                    </span>
-                  </div>
-                </SheetContent>
-              </Sheet>
-              <div className="min-w-0">
-                <p className="text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--vpw-text-muted)]">
-                  {eyebrow}
-                </p>
-                <h1 className="truncate text-base font-bold leading-tight text-[var(--vpw-text-primary)] sm:text-lg">
-                  {title}
-                </h1>
-                <p className="sr-only">
-                  {description}
-                </p>
+                  </SheetContent>
+                </Sheet>
+                <div className="min-w-0">
+                  <p className="sr-only">{eyebrow}</p>
+                  <h1 className="text-2xl font-semibold leading-tight text-[var(--vpw-text-primary)] sm:text-[1.625rem]">
+                    {title}
+                  </h1>
+                  <p className="mt-1 max-w-[52rem] text-sm leading-5 text-[var(--vpw-text-muted)] sm:leading-6">
+                    {description}
+                  </p>
+                </div>
               </div>
-            </div>
-            <div
-              aria-label={`Workspace health: ${healthLabel}`}
-              className="flex min-w-0 shrink-0 items-center gap-1.5"
-              role="status"
-            >
               <div
-                className={cn(
-                  "size-2 rounded-full",
-                  isHealthy ? "bg-[var(--vpw-green)]" : "bg-[var(--vpw-amber)]",
-                )}
-              />
-              <span className="text-sm text-[var(--vpw-text-muted)] sm:hidden">
-                {mobileHealthLabel}
-              </span>
-              <span className="hidden text-sm text-[var(--vpw-text-muted)] sm:inline">
-                {healthLabel}
-              </span>
+                aria-label={`Workspace health: ${healthLabel}`}
+                className="flex min-w-0 shrink-0 items-center gap-1.5 sm:mt-1"
+                role="status"
+              >
+                <div
+                  className={cn(
+                    "size-2 rounded-full",
+                    isHealthy
+                      ? "bg-[var(--vpw-green)]"
+                      : "bg-[var(--vpw-amber)]",
+                  )}
+                />
+                <span className="text-sm text-[var(--vpw-text-muted)] sm:hidden">
+                  {mobileHealthLabel}
+                </span>
+                <span className="hidden text-sm text-[var(--vpw-text-muted)] sm:inline">
+                  {healthLabel}
+                </span>
+              </div>
             </div>
           </header>
 
@@ -465,7 +467,7 @@ export function AppShell({
             // biome-ignore lint/a11y/noNoninteractiveTabindex: This is the app's keyboard-scroll owner.
             tabIndex={0}
           >
-            <div className="vpw-page-container py-6">{children}</div>
+            <div className="vpw-page-container pt-2 pb-6">{children}</div>
           </section>
         </main>
       </div>

--- a/frontend/src/components/dashboard/DashboardMetricGrid.tsx
+++ b/frontend/src/components/dashboard/DashboardMetricGrid.tsx
@@ -13,7 +13,7 @@ export function DashboardMetricGrid({
 }: DashboardMetricGridProps) {
   if (isLoading) {
     return (
-      <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-5">
+      <div className="dashboard-metric-grid grid gap-2">
         {Array.from({ length: 5 }, (_, i) => i).map((i) => (
           <Skeleton className="h-24 rounded-[var(--vpw-radius-lg)]" key={i} />
         ))}
@@ -22,7 +22,7 @@ export function DashboardMetricGrid({
   }
 
   return (
-    <div className="dashboard-metric-grid grid gap-2 sm:grid-cols-2 2xl:grid-cols-5">
+    <div className="dashboard-metric-grid grid gap-2">
       {cards.map((card) => (
         <MetricCard
           detail={card.detail}

--- a/frontend/src/components/dashboard/DashboardSignalOverview.tsx
+++ b/frontend/src/components/dashboard/DashboardSignalOverview.tsx
@@ -116,7 +116,7 @@ export function DashboardSignalOverview({
             onValueChange={(value) => setActiveSignalTab(value as SignalTab)}
             value={activeSignalTab}
           >
-            <TabsList className="mb-3 grid h-auto w-full grid-cols-2 gap-1 text-xs sm:inline-flex sm:h-8 sm:w-auto sm:grid-cols-none">
+            <TabsList className="mb-3 grid h-auto w-full grid-cols-2 gap-1 text-xs sm:h-8 sm:grid-cols-4 2xl:inline-flex 2xl:w-auto 2xl:grid-cols-none">
               <TabsTrigger className="min-w-0 px-2" value="priority">
                 <span className="hidden sm:inline">Findings by Priority</span>
                 <span className="sm:hidden">Priority</span>

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -423,9 +423,7 @@ export function RiskOperationsDashboard({
       >
         <div
           className={
-            showEmptyState
-              ? "grid gap-4"
-              : "dashboard-command-grid grid gap-4 2xl:grid-cols-[minmax(0,1fr)_22rem]"
+            showEmptyState ? "grid gap-4" : "dashboard-command-grid grid gap-4"
           }
         >
           {dashboardContent}

--- a/frontend/src/components/risk/MetricCard.tsx
+++ b/frontend/src/components/risk/MetricCard.tsx
@@ -54,14 +54,11 @@ export function MetricCard({
       )}
     >
       <VpwSurfaceBody className="p-3">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             <p className="vpw-label truncate text-[11px]">{label}</p>
             <p className="mt-1 text-2xl font-bold leading-none text-[var(--vpw-text-primary)]">
               {value}
-            </p>
-            <p className="mt-0.5 truncate text-xs text-[var(--vpw-text-muted)]">
-              {detail}
             </p>
           </div>
           <div
@@ -73,6 +70,9 @@ export function MetricCard({
             <Icon size={18} />
           </div>
         </div>
+        <p className="mt-0.5 truncate text-xs text-[var(--vpw-text-muted)]">
+          {detail}
+        </p>
       </VpwSurfaceBody>
     </VpwSurface>
   )

--- a/frontend/src/components/vpw/VpwDesignSystemShowcase.tsx
+++ b/frontend/src/components/vpw/VpwDesignSystemShowcase.tsx
@@ -510,7 +510,7 @@ export function VpwDesignSystemShowcase() {
           <VpwKeyValueList
             columns={2}
             items={[
-              { label: "Container", value: "1920px max", tone: "info" },
+              { label: "Container", value: "2400px max", tone: "info" },
               { label: "Density", value: "40px standard rows" },
               { label: "Radius", value: "4 / 6 / 8 / 8" },
               { label: "Overlay", value: "Shadow 3", tone: "support" },

--- a/frontend/src/lib/app-route-config.ts
+++ b/frontend/src/lib/app-route-config.ts
@@ -8,12 +8,10 @@ type RouteDetail = {
   panelDetail: string
 }
 
-export const routeDetails: Record<
-  WorkbenchPath,
-  RouteDetail
-> = {
+export const routeDetails: Record<WorkbenchPath, RouteDetail> = {
   "/": {
-    description: "Current risk posture, provider freshness, and next remediation priorities.",
+    description:
+      "Current risk posture, data trust, and next remediation priorities.",
     eyebrow: "Operate",
     title: "Overview",
     panelTitle: "Overview",
@@ -27,7 +25,8 @@ export const routeDetails: Record<
     panelDetail: "Manage local Workbench projects.",
   },
   "/imports": {
-    description: "Import supplied vulnerability evidence and review parser/provider results.",
+    description:
+      "Import supplied vulnerability evidence and review parser/provider results.",
     eyebrow: "Prepare",
     title: "Imports",
     panelTitle: "Imports",
@@ -42,35 +41,40 @@ export const routeDetails: Record<
     panelDetail: "Decide what to remediate or accept next.",
   },
   "/waivers": {
-    description: "Track accepted risk, review deadlines, expiry, and matched findings.",
+    description:
+      "Track accepted risk, review deadlines, expiry, and matched findings.",
     eyebrow: "Govern",
     title: "Risk Acceptance",
     panelTitle: "Risk Acceptance",
     panelDetail: "Track accepted risk, reviews, and expiry.",
   },
   "/assets": {
-    description: "Maintain ownership, service, exposure, and criticality context for findings.",
+    description:
+      "Maintain ownership, service, exposure, and criticality context for findings.",
     eyebrow: "Prepare",
     title: "Assets",
     panelTitle: "Assets",
     panelDetail: "Maintain asset context and ownership.",
   },
   "/providers": {
-    description: "Check provider freshness, local snapshots, warnings, and diagnostics.",
+    description:
+      "Check provider freshness, local snapshots, warnings, and diagnostics.",
     eyebrow: "Prepare",
     title: "Data Sources",
     panelTitle: "Data Sources",
     panelDetail: "Check provider freshness and trust state.",
   },
   "/reports": {
-    description: "Generate, verify, and download reports and deterministic evidence bundles.",
+    description:
+      "Generate, verify, and download reports and deterministic evidence bundles.",
     eyebrow: "Govern",
     title: "Evidence Center",
     panelTitle: "Evidence Center",
     panelDetail: "Generate, verify, and download evidence.",
   },
   "/settings": {
-    description: "Inspect local Workbench runtime, provider, and diagnostic state.",
+    description:
+      "Inspect local Workbench runtime, provider, and diagnostic state.",
     eyebrow: "System",
     title: "Workspace Settings",
     panelTitle: "Workspace Settings",

--- a/frontend/src/lib/vpw-tokens.json
+++ b/frontend/src/lib/vpw-tokens.json
@@ -55,13 +55,13 @@
     "3": "0 2px 2px rgba(0, 0, 0, 0.04), 0 8px 16px -4px rgba(0, 0, 0, 0.08)"
   },
   "layout": {
-    "maxWidth": "1920px",
+    "maxWidth": "2400px",
     "pagePadding": {
       "base": "1rem",
       "sm": "1.5rem",
       "lg": "2rem",
       "xl": "2.5rem",
-      "xxl": "3rem"
+      "xxl": "2.5rem"
     }
   }
 }

--- a/frontend/src/lib/vpw-tokens.ts
+++ b/frontend/src/lib/vpw-tokens.ts
@@ -55,13 +55,13 @@ export const vpwTokens = {
     3: "0 2px 2px rgba(0, 0, 0, 0.04), 0 8px 16px -4px rgba(0, 0, 0, 0.08)",
   },
   layout: {
-    maxWidth: "1920px",
+    maxWidth: "2400px",
     pagePadding: {
       base: "1rem",
       sm: "1.5rem",
       lg: "2rem",
       xl: "2.5rem",
-      xxl: "3rem",
+      xxl: "2.5rem",
     },
   },
 } as const

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -531,9 +531,15 @@
 
 .dashboard-signal-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.42fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 14px;
   align-items: stretch;
+}
+
+@media (min-width: 1536px) {
+  .dashboard-signal-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 0.42fr);
+  }
 }
 
 .dashboard-key-takeaways {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -60,6 +60,28 @@
   align-items: start;
 }
 
+.dashboard-metric-grid {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .dashboard-metric-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 10.75rem), 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .dashboard-command-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 20rem);
+  }
+}
+
+@media (min-width: 1536px) {
+  .dashboard-command-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(20rem, 22rem);
+  }
+}
+
 .dashboard-metric-grid > .vpw-panel {
   min-height: 104px;
   background: var(--vpw-bg-card);

--- a/frontend/src/styles/layout-tokens.css
+++ b/frontend/src/styles/layout-tokens.css
@@ -18,6 +18,6 @@
 
 @media (min-width: 1536px) {
   :root {
-    --vpw-container-padding: 3rem;
+    --vpw-container-padding: 2.5rem;
   }
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -135,7 +135,11 @@
   --vpw-red: #c40000;
   --vpw-violet: #475569;
   --vpw-navy: #171717;
-  --vpw-text-info: color-mix(in srgb, var(--vpw-blue) 80%, var(--vpw-text-primary));
+  --vpw-text-info: color-mix(
+    in srgb,
+    var(--vpw-blue) 80%,
+    var(--vpw-text-primary)
+  );
   --vpw-chart-critical: #dc2626;
   --vpw-chart-high: #f97316;
   --vpw-chart-medium: #d97706;
@@ -156,15 +160,17 @@
   --vpw-radius-pill: 9999px;
   --vpw-shadow-0: none;
   --vpw-shadow-1: 0 1px 1px rgba(0, 0, 0, 0.03), 0 2px 2px rgba(0, 0, 0, 0.04);
-  --vpw-shadow-2: 0 2px 2px rgba(0, 0, 0, 0.04), 0 8px 8px -8px rgba(0, 0, 0, 0.08);
-  --vpw-shadow-3: 0 2px 2px rgba(0, 0, 0, 0.04), 0 8px 16px -4px rgba(0, 0, 0, 0.08);
+  --vpw-shadow-2:
+    0 2px 2px rgba(0, 0, 0, 0.04), 0 8px 8px -8px rgba(0, 0, 0, 0.08);
+  --vpw-shadow-3:
+    0 2px 2px rgba(0, 0, 0, 0.04), 0 8px 16px -4px rgba(0, 0, 0, 0.08);
   --vpw-panel-padding: 1.25rem;
   --vpw-surface-padding-inline: 1.5rem;
   --vpw-surface-padding-block: 1rem;
   --vpw-surface-gap: 0.875rem;
   --vpw-control-height: 2.25rem;
   --vpw-control-height-lg: 2.5rem;
-  --vpw-container-max: 1920px;
+  --vpw-container-max: 2400px;
   --vpw-container-padding: 1rem;
 
   color: var(--vpw-text-primary);

--- a/frontend/tests/design-system-contracts.test.ts
+++ b/frontend/tests/design-system-contracts.test.ts
@@ -693,11 +693,11 @@ test("runtime CSS, TypeScript tokens, JSON tokens, and showcase copy stay synchr
     pill: "9999px",
   }
 
-  assert.equal(tokenJson.layout.maxWidth, "1920px")
+  assert.equal(tokenJson.layout.maxWidth, "2400px")
   assert.deepEqual(tokenJson.radius, expectedRadius)
-  assert.match(tokenTs, /maxWidth:\s*"1920px"/)
-  assert.match(tokenCss, /--vpw-container-max:\s*1920px;/)
-  assert.match(showcase, /1920px max/)
+  assert.match(tokenTs, /maxWidth:\s*"2400px"/)
+  assert.match(tokenCss, /--vpw-container-max:\s*2400px;/)
+  assert.match(showcase, /2400px max/)
 
   for (const [name, value] of Object.entries(expectedRadius)) {
     assert.match(tokenTs, new RegExp(`${name}:\\s*"${value}"`))

--- a/frontend/tests/responsive-shell.spec.ts
+++ b/frontend/tests/responsive-shell.spec.ts
@@ -1,7 +1,11 @@
 import { expect, type Page, test } from "@playwright/test"
 import { openWorkbench } from "./workbench-runtime-helpers"
 import { evidenceScreenshotPath } from "./evidence-paths"
-import { mockFinding, mockProject, routeWorkbenchShell } from "./workbench-route-mocks"
+import {
+  mockFinding,
+  mockProject,
+  routeWorkbenchShell,
+} from "./workbench-route-mocks"
 
 async function expectNoPageOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({
@@ -23,7 +27,9 @@ async function expectWqhdContainerBehavior(
   viewport: { width: number; height: number },
 ) {
   const metrics = await page
-    .locator('section[aria-label="Workbench page content"] > .vpw-page-container')
+    .locator(
+      'section[aria-label="Workbench page content"] > .vpw-page-container',
+    )
     .first()
     .evaluate((container) => {
       const rect = container.getBoundingClientRect()
@@ -33,10 +39,10 @@ async function expectWqhdContainerBehavior(
       }
     })
 
-  expect(metrics.cssMaxWidth).toBe("1920px")
-  expect(metrics.width).toBeLessThanOrEqual(1922)
+  expect(metrics.cssMaxWidth).toBe("2400px")
+  expect(metrics.width).toBeLessThanOrEqual(2402)
   if (viewport.width >= 2560) {
-    expect(metrics.width).toBeGreaterThanOrEqual(1918)
+    expect(metrics.width).toBeGreaterThanOrEqual(2300)
   }
 }
 
@@ -72,9 +78,7 @@ async function expectFindingsTableScrollContainment(
     }
   })
 
-  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(
-    metrics.viewportWidth + 1,
-  )
+  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 1)
   expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
     metrics.viewportWidth + 1,
   )
@@ -83,15 +87,18 @@ async function expectFindingsTableScrollContainment(
     metrics.viewportWidth + 1,
   )
   if (viewport.width >= 1200) {
-    expect(metrics.tableScrollWidth, JSON.stringify(metrics)).toBeLessThanOrEqual(
-      metrics.regionClientWidth + 2,
-    )
-    expect(metrics.regionScrollWidth, JSON.stringify(metrics)).toBeLessThanOrEqual(
-      metrics.regionClientWidth + 2,
-    )
-    expect(metrics.regionScrollLeft, JSON.stringify(metrics)).toBeLessThanOrEqual(
-      1,
-    )
+    expect(
+      metrics.tableScrollWidth,
+      JSON.stringify(metrics),
+    ).toBeLessThanOrEqual(metrics.regionClientWidth + 2)
+    expect(
+      metrics.regionScrollWidth,
+      JSON.stringify(metrics),
+    ).toBeLessThanOrEqual(metrics.regionClientWidth + 2)
+    expect(
+      metrics.regionScrollLeft,
+      JSON.stringify(metrics),
+    ).toBeLessThanOrEqual(1)
   } else {
     expect(metrics.tableScrollWidth, JSON.stringify(metrics)).toBeGreaterThan(
       metrics.regionClientWidth,
@@ -150,9 +157,7 @@ async function expectFindingsMobileCards(page: Page) {
 
   expect(metrics.cardCount).toBeGreaterThan(0)
   expect(metrics.cardsFit).toBe(true)
-  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(
-    metrics.viewportWidth + 1,
-  )
+  expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 1)
   expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
     metrics.viewportWidth + 1,
   )
@@ -208,8 +213,9 @@ async function expectFindingsMobileCards(page: Page) {
   ).toBeInViewport()
   await expect(drawer).toContainText("Decision summary")
   await expect(drawer).toContainText("Open full detail")
-  await expect(drawer.getByRole("link", { name: "Open full detail" }))
-    .toHaveAttribute("href", /\/findings\/finding-1/)
+  await expect(
+    drawer.getByRole("link", { name: "Open full detail" }),
+  ).toHaveAttribute("href", /\/findings\/finding-1/)
   await drawer.getByRole("button", { name: "Close" }).first().click()
   await expect(drawer).toHaveCount(0)
 
@@ -267,8 +273,7 @@ test("mobile shell exposes drawer navigation without page-width overflow", async
   await expect(
     navDialog.getByRole("navigation", { name: "Workbench mobile navigation" }),
   ).toBeVisible()
-  await expect(navDialog.getByRole("button", { name: "Close" }))
-    .toBeVisible()
+  await expect(navDialog.getByRole("button", { name: "Close" })).toBeVisible()
   await expect
     .poll(async () =>
       navDialog.evaluate((element) => {
@@ -346,7 +351,9 @@ test("mobile shell keeps compact health status without duplicate summary strip",
   await page.goto("/settings")
 
   const statusSummary = page.getByLabel("Workbench status summary")
-  const headerHealth = page.getByLabel("Workspace health: Data services healthy")
+  const headerHealth = page.getByLabel(
+    "Workspace health: Data services healthy",
+  )
   await expect(statusSummary).toHaveCount(0)
   const visibleHeaderHealthText = await headerHealth.evaluate((element) =>
     Array.from(element.querySelectorAll("span"))
@@ -365,8 +372,9 @@ test("desktop shell keeps sidebar pinned while long content scrolls internally",
   await openWorkbench(page)
   await page.setViewportSize({ height: 900, width: 1440 })
   await page.goto("/imports")
-  await expect(page.getByRole("complementary", { name: "Workbench sidebar" }))
-    .toBeVisible()
+  await expect(
+    page.getByRole("complementary", { name: "Workbench sidebar" }),
+  ).toBeVisible()
   await expect(
     page.getByRole("region", { name: "Workbench page content" }),
   ).toBeVisible()


### PR DESCRIPTION
## Summary
- replace the separated shell header with the shared open page headline/subtitle pattern
- widen the global content container for WQHD while keeping controlled gutters
- make dashboard cards and side panels denser across laptop and large desktop widths

## Verification
- npm run lint
- npm run build
- npm run test:unit
- npx playwright test tests/responsive-shell.spec.ts --project mobile-chromium -g "Workbench routes keep content within desktop, tablet, and mobile viewports|mobile shell keeps compact health status"