### PR TITLE
[codex] Harden Workbench UI audit contracts

### DIFF
--- a/backend/tests/test_refactor_hygiene.py
+++ b/backend/tests/test_refactor_hygiene.py
@@ -9,6 +9,12 @@ REPO_ROOT = ROOT.parent
 SRC_ROOT = ROOT / "src" / "vuln_prioritizer"
 
 
+def _assert_metric_strip_adapter(source: str, label: str) -> None:
+    assert "MetricStrip" in source, label
+    assert "VpwMetricStrip" not in source, label
+    assert "VpwCompactMetric" not in source, label
+
+
 def _imported_modules(path: str) -> set[str]:
     tree = ast.parse((ROOT / path).read_text(encoding="utf-8"))
     modules: set[str] = set()
@@ -892,8 +898,7 @@ def test_findings_queue_uses_vpw_product_surfaces() -> None:
     )
 
     assert "@/components/vpw" in source
-    assert "VpwMetricStrip" in source
-    assert "VpwCompactMetric" in source
+    _assert_metric_strip_adapter(source, "findings queue metric strip")
     assert "VpwEmptyState" in source
     assert "VpwStatusBanner" in source
     assert "@/components/ui/card" not in source
@@ -1033,8 +1038,10 @@ def test_dashboard_and_finding_detail_use_vpw_surfaces() -> None:
     assert "DashboardPriorityChart" in dashboard_signal_tabs_source
     assert "DashboardKeyTakeaways" in dashboard_key_takeaways_source
     assert "CheckCircle2" in dashboard_key_takeaways_source
-    assert "VpwMetricStrip" in dashboard_metric_strip_source
-    assert "VpwCompactMetric" in dashboard_metric_strip_source
+    _assert_metric_strip_adapter(
+        dashboard_metric_strip_source,
+        "dashboard metric strip",
+    )
     assert len(dashboard_source.splitlines()) <= 340
     assert len(dashboard_context_source.splitlines()) <= 90
     assert len(dashboard_context_actions_source.splitlines()) <= 130
@@ -1055,7 +1062,10 @@ def test_dashboard_and_finding_detail_use_vpw_surfaces() -> None:
     assert "VpwSurface" in dashboard_paths[5].read_text(encoding="utf-8")
     assert "VpwDataTable" in dashboard_paths[5].read_text(encoding="utf-8")
     assert "VpwSurface" in dashboard_paths[6].read_text(encoding="utf-8")
-    assert "VpwMetricStrip" in dashboard_paths[8].read_text(encoding="utf-8")
+    _assert_metric_strip_adapter(
+        dashboard_paths[8].read_text(encoding="utf-8"),
+        "dashboard route metric strip",
+    )
     assert "VpwSurface" in dashboard_operations_source
     assert "VpwSurface" in dashboard_recent_runs_source
     assert "VpwSurface" in dashboard_data_quality_source
@@ -1063,8 +1073,7 @@ def test_dashboard_and_finding_detail_use_vpw_surfaces() -> None:
     assert "VpwSurface" in dashboard_signal_overview_source
     assert "VpwStatusBanner" in finding_detail_paths[0].read_text(encoding="utf-8")
     assert "VpwCommandPanel" in finding_context_source
-    assert "VpwMetricStrip" in finding_context_source
-    assert "VpwCompactMetric" in finding_context_source
+    _assert_metric_strip_adapter(finding_context_source, "finding detail metric strip")
     assert "finding-decision-brief__facts" in finding_detail_paths[2].read_text(encoding="utf-8")
     assert "FindingEvidenceSummaryGrid" in finding_detail_paths[3].read_text(encoding="utf-8")
     assert "FindingOccurrencesPanel" in finding_detail_paths[3].read_text(encoding="utf-8")
@@ -1728,8 +1737,7 @@ def test_workbench_frontend_feature_containers_delegate_to_sections() -> None:
     assert "VpwToolbar" in projects_context_source
     assert "VpwCommandPanel" in projects_context_source
     assert "ProjectMetrics" in projects_metrics_source
-    assert "VpwMetricStrip" in projects_metrics_source
-    assert "VpwCompactMetric" in projects_metrics_source
+    _assert_metric_strip_adapter(projects_metrics_source, "projects metric strip")
     assert "VpwMetricCard" not in projects_overview_source
     assert "ProjectsWorkbenchSetup" in projects_sections_source
     assert "ProjectsWorkbenchDirectory" in projects_sections_source
@@ -1741,7 +1749,7 @@ def test_workbench_frontend_feature_containers_delegate_to_sections() -> None:
     assert "selectedProjectRouteSearch" not in projects_active_source
     assert "WaiversContext" in waivers_sections_source
     assert "VpwCommandPanel" in waivers_context_source
-    assert "VpwMetricStrip" in waivers_context_source
+    _assert_metric_strip_adapter(waivers_context_source, "waivers metric strip")
     assert "WaiversWorkbenchCreate" in waivers_sections_source
     assert "WaiversWorkbenchRegister" in waivers_sections_source
     assert "WaiversWorkbenchReview" in waivers_sections_source

--- a/docs/workbench-ui-migration-plan.md
+++ b/docs/workbench-ui-migration-plan.md
@@ -1,7 +1,8 @@
 # Workbench UI Migration Plan
 
 Status: completed UI-normalization plan plus retained guardrails for future
-route work. This document does not migrate route code.
+route work. This document does not migrate route code, and it does not track
+active open route-migration tasks.
 
 The migration must preserve the current frontend architecture: React, Vite, TypeScript, TanStack Query, local route adapter, `WorkbenchShell`, route containers, shared components, and shared CSS. Do not reintroduce old file-route scaffolding or generated route-tree assumptions. Do not edit generated client files manually.
 
@@ -41,6 +42,17 @@ Rationale:
 
 This plan recorded the remaining drift after the first VPW pattern pass. It is
 retained as a guardrail for future route work rather than as an open work queue.
+
+## Current Open Risks
+
+No active UI-normalization backlog is tracked in this document. New UI risks
+should be opened as concrete issues or added to a current audit page with owner,
+route, acceptance criteria, and evidence requirements.
+
+The current baseline is protected by the named design-audit gate, responsive
+shell checks, accessibility checks, and the component contract tests. Historical
+checklists below are retained only to explain the migration sequence and to help
+reviewers recognize regressions.
 
 ### Done or enforced in the current baseline
 
@@ -229,12 +241,12 @@ Files:
 
 Tasks:
 
-- [ ] Replace route-local summary/header with `ContextBar` plus `MetricStrip`.
-- [ ] Replace custom filters with `FilterBar`.
-- [ ] Wrap the queue in `DataTableFrame`.
-- [ ] Replace mobile cards with shared responsive row mode.
-- [ ] Replace quick-view card sections with `DetailDrawer`, `DecisionSummary`, `DefinitionList`, `SignalBadge`, and `EvidenceRow`.
-- [ ] Remove findings-specific typography, shadow, card, and tab styles that become redundant.
+- Historical target: Replace route-local summary/header with `ContextBar` plus `MetricStrip`.
+- Historical target: Replace custom filters with `FilterBar`.
+- Historical target: Wrap the queue in `DataTableFrame`.
+- Historical target: Replace mobile cards with shared responsive row mode.
+- Historical target: Replace quick-view card sections with `DetailDrawer`, `DecisionSummary`, `DefinitionList`, `SignalBadge`, and `EvidenceRow`.
+- Historical target: Remove findings-specific typography, shadow, card, and tab styles that become redundant.
 
 ### 2. Finding Detail
 
@@ -252,13 +264,13 @@ Files:
 
 Tasks:
 
-- [ ] Replace hero with `ContextBar` and `DecisionSummary`.
-- [ ] Replace `FindingDetailActionRail` with `DetailRail`.
-- [ ] Normalize detail tabs through shared tab styling.
-- [ ] Convert object/provider/assignment facts to `DefinitionList`.
-- [ ] Convert source/proof sections to `EvidenceRow`.
-- [ ] Convert TTP context narrative/action cards to evidence rows, compact lists, and caveat callouts.
-- [ ] Remove detail-specific page typography and heavy card styles.
+- Historical target: Replace hero with `ContextBar` and `DecisionSummary`.
+- Historical target: Replace `FindingDetailActionRail` with `DetailRail`.
+- Historical target: Normalize detail tabs through shared tab styling.
+- Historical target: Convert object/provider/assignment facts to `DefinitionList`.
+- Historical target: Convert source/proof sections to `EvidenceRow`.
+- Historical target: Convert TTP context narrative/action cards to evidence rows, compact lists, and caveat callouts.
+- Historical target: Remove detail-specific page typography and heavy card styles.
 
 ### 3. Imports
 
@@ -274,12 +286,12 @@ Files:
 
 Tasks:
 
-- [ ] Normalize imports home with `ContextBar`, `MetricStrip`, compact lists, and `DataTableFrame`.
-- [ ] Convert new import wizard panels to form `PageSection`s plus `DetailRail` for validation/context.
-- [ ] Convert run detail metrics to `MetricStrip`.
-- [ ] Convert diagnostics to `DetailDrawer`, `Callout`, `DefinitionList`, and `EvidenceRow`.
-- [ ] Convert supported formats to registry rows and definition/status rows.
-- [ ] Keep copy scoped to supplied evidence and local import results.
+- Historical target: Normalize imports home with `ContextBar`, `MetricStrip`, compact lists, and `DataTableFrame`.
+- Historical target: Convert new import wizard panels to form `PageSection`s plus `DetailRail` for validation/context.
+- Historical target: Convert run detail metrics to `MetricStrip`.
+- Historical target: Convert diagnostics to `DetailDrawer`, `Callout`, `DefinitionList`, and `EvidenceRow`.
+- Historical target: Convert supported formats to registry rows and definition/status rows.
+- Historical target: Keep copy scoped to supplied evidence and local import results.
 
 ### 4. Providers/Data Sources
 
@@ -294,11 +306,11 @@ Files:
 
 Tasks:
 
-- [ ] Replace provider-specific context wrappers with `ContextBar` and `MetricStrip`.
-- [ ] Preserve sources as `DataTableFrame`.
-- [ ] Convert snapshots, diagnostics, and quality facts to `DefinitionList` and status rows.
-- [ ] Align provider states with `StatusBadge` and source signals with `SignalBadge`.
-- [ ] Remove provider-specific tabs/panel styles where shared styles apply.
+- Historical target: Replace provider-specific context wrappers with `ContextBar` and `MetricStrip`.
+- Historical target: Preserve sources as `DataTableFrame`.
+- Historical target: Convert snapshots, diagnostics, and quality facts to `DefinitionList` and status rows.
+- Historical target: Align provider states with `StatusBadge` and source signals with `SignalBadge`.
+- Historical target: Remove provider-specific tabs/panel styles where shared styles apply.
 
 ### 5. Assets
 
@@ -315,12 +327,12 @@ Files:
 
 Tasks:
 
-- [ ] Preserve table-first inventory through `FilterBar` and `DataTableFrame`.
-- [ ] Convert summary cards to `MetricStrip`.
-- [ ] Convert asset drawer to `DetailDrawer`.
-- [ ] Convert asset metadata and scoring panels to `DefinitionList`, status rows, and `SignalBadge`.
-- [ ] Convert service rollup cards to compact list or table rows.
-- [ ] Remove asset-specific card and typography styles.
+- Historical target: Preserve table-first inventory through `FilterBar` and `DataTableFrame`.
+- Historical target: Convert summary cards to `MetricStrip`.
+- Historical target: Convert asset drawer to `DetailDrawer`.
+- Historical target: Convert asset metadata and scoring panels to `DefinitionList`, status rows, and `SignalBadge`.
+- Historical target: Convert service rollup cards to compact list or table rows.
+- Historical target: Remove asset-specific card and typography styles.
 
 ### 6. Risk Acceptance/Waivers
 
@@ -336,12 +348,12 @@ Files:
 
 Tasks:
 
-- [ ] Preserve register as `DataTableFrame`.
-- [ ] Replace waiver KPI wrappers with `MetricStrip`.
-- [ ] Convert review cards to `DecisionSummary` and status rows.
-- [ ] Convert drawer/form panel stacks to `DetailDrawer`, form `PageSection`s, `DefinitionList`, and `EvidenceRow`.
-- [ ] Align waiver lifecycle and expiry states with `StatusBadge`.
-- [ ] Remove waiver-specific card and badge styles.
+- Historical target: Preserve register as `DataTableFrame`.
+- Historical target: Replace waiver KPI wrappers with `MetricStrip`.
+- Historical target: Convert review cards to `DecisionSummary` and status rows.
+- Historical target: Convert drawer/form panel stacks to `DetailDrawer`, form `PageSection`s, `DefinitionList`, and `EvidenceRow`.
+- Historical target: Align waiver lifecycle and expiry states with `StatusBadge`.
+- Historical target: Remove waiver-specific card and badge styles.
 
 ### 7. Overview/Dashboard
 
@@ -356,12 +368,12 @@ Files:
 
 Tasks:
 
-- [ ] Replace dashboard hero with `ContextBar`.
-- [ ] Replace large metric cards with `MetricStrip`.
-- [ ] Convert side panel cards to `DetailRail`.
-- [ ] Normalize chart frames with `PageSection`.
-- [ ] Keep the dashboard focused on current next action and evidence freshness.
-- [ ] Remove hover shadows and page-specific hero typography.
+- Historical target: Replace dashboard hero with `ContextBar`.
+- Historical target: Replace large metric cards with `MetricStrip`.
+- Historical target: Convert side panel cards to `DetailRail`.
+- Historical target: Normalize chart frames with `PageSection`.
+- Historical target: Keep the dashboard focused on current next action and evidence freshness.
+- Historical target: Remove hover shadows and page-specific hero typography.
 
 ### 8. Reports/Evidence Center
 
@@ -378,12 +390,12 @@ Files:
 
 Tasks:
 
-- [ ] Replace run context panel with `ContextBar` or `DetailRail`.
-- [ ] Preserve history as `DataTableFrame`.
-- [ ] Convert decision and quality panels to `DecisionSummary`, `DefinitionList`, `EvidenceRow`, and `Callout`.
-- [ ] Convert generate drawer to `DetailDrawer`.
-- [ ] Keep artifact cards only when representing bounded generated artifacts; use rows for provenance comparison.
-- [ ] Normalize evidence center tabs.
+- Historical target: Replace run context panel with `ContextBar` or `DetailRail`.
+- Historical target: Preserve history as `DataTableFrame`.
+- Historical target: Convert decision and quality panels to `DecisionSummary`, `DefinitionList`, `EvidenceRow`, and `Callout`.
+- Historical target: Convert generate drawer to `DetailDrawer`.
+- Historical target: Keep artifact cards only when representing bounded generated artifacts; use rows for provenance comparison.
+- Historical target: Normalize evidence center tabs.
 
 ### 9. Projects, TTP Context, Settings
 
@@ -402,11 +414,11 @@ Files:
 
 Tasks:
 
-- [ ] Convert project hero/metrics/selection strip to `ContextBar`, `MetricStrip`, and registry rows.
-- [ ] Preserve project directory as `DataTableFrame`.
-- [ ] Convert TTP context cards to `EvidenceRow`, compact lists, and caveat `Callout`s.
-- [ ] Convert settings hero/cards/tabs to settings `PageSection`s, `DefinitionList`, `Callout`, and status rows.
-- [ ] Remove remaining route-local typography and shadow styles.
+- Historical target: Convert project hero/metrics/selection strip to `ContextBar`, `MetricStrip`, and registry rows.
+- Historical target: Preserve project directory as `DataTableFrame`.
+- Historical target: Convert TTP context cards to `EvidenceRow`, compact lists, and caveat `Callout`s.
+- Historical target: Convert settings hero/cards/tabs to settings `PageSection`s, `DefinitionList`, `Callout`, and status rows.
+- Historical target: Remove remaining route-local typography and shadow styles.
 
 ## Test Commands After Each Migration
 
@@ -439,21 +451,21 @@ If a command fails because dependencies are missing, install dependencies using 
 
 For each migrated route, capture or verify the following before considering the migration complete:
 
-- [ ] Desktop screenshot of the route first viewport.
-- [ ] Mobile screenshot of the route first viewport.
-- [ ] Screenshot of the primary table/list with realistic data.
-- [ ] Screenshot of the empty state.
-- [ ] Screenshot of loading or skeleton state when the route supports it.
-- [ ] Screenshot of the main drawer or right rail if present.
-- [ ] Screenshot of the primary form state if the route has a form.
-- [ ] Evidence that page header appears once and is shell-owned.
-- [ ] Evidence that repeated data uses table/list/row semantics, not decorative cards.
-- [ ] Evidence that object metadata uses definition lists.
-- [ ] Evidence that remediation or acceptance rationale uses decision summaries.
-- [ ] Evidence that source proof/provenance uses evidence rows.
-- [ ] Evidence that badges use shared status/signal semantics.
-- [ ] Evidence that color remains low, density remains compact, borders are thin, and shadows are limited to legitimate overlays/popovers.
-- [ ] Evidence that no new product scope or speculative inference was introduced in route copy.
+- Historical target: Desktop screenshot of the route first viewport.
+- Historical target: Mobile screenshot of the route first viewport.
+- Historical target: Screenshot of the primary table/list with realistic data.
+- Historical target: Screenshot of the empty state.
+- Historical target: Screenshot of loading or skeleton state when the route supports it.
+- Historical target: Screenshot of the main drawer or right rail if present.
+- Historical target: Screenshot of the primary form state if the route has a form.
+- Historical target: Evidence that page header appears once and is shell-owned.
+- Historical target: Evidence that repeated data uses table/list/row semantics, not decorative cards.
+- Historical target: Evidence that object metadata uses definition lists.
+- Historical target: Evidence that remediation or acceptance rationale uses decision summaries.
+- Historical target: Evidence that source proof/provenance uses evidence rows.
+- Historical target: Evidence that badges use shared status/signal semantics.
+- Historical target: Evidence that color remains low, density remains compact, borders are thin, and shadows are limited to legitimate overlays/popovers.
+- Historical target: Evidence that no new product scope or speculative inference was introduced in route copy.
 
 ## Completion Criteria for Each Migration
 

--- a/docs/workbench-ui-system.md
+++ b/docs/workbench-ui-system.md
@@ -195,6 +195,9 @@ Components to narrow or retire from Workbench route use:
 - Generic `Card` route wrappers from `frontend/src/components/ui/card.tsx`.
 - Card-based state wrappers in `frontend/src/components/states/EmptyState.tsx`, `LoadingSkeleton.tsx`, and `ErrorState.tsx`.
 - Former route-local metric-card implementations.
+- Direct route composition with `VpwMetricStrip` and `VpwCompactMetric`; route
+  code should use the canonical `MetricStrip` adapter, while VPW primitives and
+  showcase evidence may continue to use the lower-level components.
 - Route-local hero, tab, drawer, panel, and badge variants listed as baseline
   findings in `docs/workbench-ui-audit.md`.
 

--- a/frontend/src/components/assets/AssetSummaryCards.tsx
+++ b/frontend/src/components/assets/AssetSummaryCards.tsx
@@ -1,7 +1,7 @@
 import { Globe2, Link2, RefreshCw, Server, ShieldCheck } from "lucide-react"
 import type { ReactNode } from "react"
 
-import { VpwCompactMetric, VpwMetricStrip } from "../vpw"
+import { MetricStrip, type MetricStripMetric } from "../vpw"
 import type { AssetSummary } from "./asset-model"
 
 export function AssetSummaryCards({
@@ -9,51 +9,54 @@ export function AssetSummaryCards({
 }: {
   assetSummary: AssetSummary
 }) {
+  const metrics: MetricStripMetric[] = [
+    assetKpi({
+      description: "Assets and target references in scope",
+      icon: <Server aria-hidden="true" />,
+      label: "Total assets",
+      value: assetSummary.total,
+    }),
+    assetKpi({
+      description: "External exposure",
+      icon: <Globe2 aria-hidden="true" />,
+      label: "Internet-facing",
+      tone: "warning",
+      value: assetSummary.internetFacing,
+    }),
+    assetKpi({
+      description: "Critical or high context",
+      icon: <ShieldCheck aria-hidden="true" />,
+      label: "Critical services",
+      tone: "critical",
+      value: assetSummary.criticalServices,
+    }),
+    assetKpi({
+      description: "Associated findings",
+      icon: <Link2 aria-hidden="true" />,
+      label: "Linked findings",
+      tone: "info",
+      value: assetSummary.linkedFindings,
+    }),
+    assetKpi({
+      description: `${assetSummary.ownerCoverage}% owner coverage; ${assetSummary.production} production assets`,
+      icon: <RefreshCw aria-hidden="true" />,
+      label: "Rescore needed",
+      tone: assetSummary.rescoreNeeded > 0 ? "warning" : "success",
+      value: assetSummary.rescoreNeeded,
+    }),
+  ]
+
   return (
-    <VpwMetricStrip
+    <MetricStrip
       aria-label="Asset summary"
       className="assets-summary-strip"
+      metrics={metrics}
       minCardWidth="11.75rem"
-    >
-      <AssetKpi
-        description="Assets and target references in scope"
-        icon={<Server aria-hidden="true" />}
-        label="Total assets"
-        value={assetSummary.total}
-      />
-      <AssetKpi
-        description="External exposure"
-        icon={<Globe2 aria-hidden="true" />}
-        label="Internet-facing"
-        tone="warning"
-        value={assetSummary.internetFacing}
-      />
-      <AssetKpi
-        description="Critical or high context"
-        icon={<ShieldCheck aria-hidden="true" />}
-        label="Critical services"
-        tone="critical"
-        value={assetSummary.criticalServices}
-      />
-      <AssetKpi
-        description="Associated findings"
-        icon={<Link2 aria-hidden="true" />}
-        label="Linked findings"
-        tone="info"
-        value={assetSummary.linkedFindings}
-      />
-      <AssetKpi
-        description={`${assetSummary.ownerCoverage}% owner coverage; ${assetSummary.production} production assets`}
-        icon={<RefreshCw aria-hidden="true" />}
-        label="Rescore needed"
-        tone={assetSummary.rescoreNeeded > 0 ? "warning" : "success"}
-        value={assetSummary.rescoreNeeded}
-      />
-    </VpwMetricStrip>
+    />
   )
 }
 
-function AssetKpi({
+function assetKpi({
   description,
   icon,
   label,
@@ -65,14 +68,6 @@ function AssetKpi({
   label: string
   tone?: "success" | "warning" | "critical" | "info"
   value: ReactNode
-}) {
-  return (
-    <VpwCompactMetric
-      description={description}
-      icon={icon}
-      label={label}
-      tone={tone}
-      value={value}
-    />
-  )
+}): MetricStripMetric {
+  return { description, icon, label, tone, value }
 }

--- a/frontend/src/components/dashboard/DashboardDetailRail.tsx
+++ b/frontend/src/components/dashboard/DashboardDetailRail.tsx
@@ -51,6 +51,7 @@ export function DashboardDetailRail({
         providerStatusLoading={providerStatusLoading}
         staleProvider={staleProvider}
       />
+      <DashboardRecommendedActionsPanel selectedProjectId={selectedProjectId} />
       <DashboardRecentRunsPanel
         latestRunFactsRows={latestRunFactsRows}
         selectedProjectId={selectedProjectId}
@@ -59,7 +60,6 @@ export function DashboardDetailRail({
         dataQualityError={dataQualityError}
         dataQualityWarnings={dataQualityWarnings}
       />
-      <DashboardRecommendedActionsPanel selectedProjectId={selectedProjectId} />
     </aside>
   )
 }

--- a/frontend/src/components/dashboard/DashboardMetricStrip.tsx
+++ b/frontend/src/components/dashboard/DashboardMetricStrip.tsx
@@ -1,8 +1,7 @@
-import { Skeleton } from "@/components/ui/skeleton"
 import {
-  VpwCompactMetric,
   type VpwCompactTone,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
 } from "@/components/vpw"
 import type { DashboardMetricSummary } from "./dashboard-model"
 
@@ -15,39 +14,26 @@ export function DashboardMetricStrip({
   isLoading,
   metrics,
 }: DashboardMetricStripProps) {
-  if (isLoading) {
-    return (
-      <VpwMetricStrip
-        aria-label="Dashboard metrics loading"
-        minCardWidth="8.25rem"
-      >
-        {Array.from({ length: 5 }, (_, i) => i).map((i) => (
-          <Skeleton className="h-[4.5rem]" key={i} />
-        ))}
-      </VpwMetricStrip>
-    )
-  }
+  const dashboardMetrics: MetricStripMetric[] = metrics.map((metric) => {
+    const Icon = metric.icon
+    return {
+      ariaLabel: `${metric.label} summary card`,
+      description: metric.detail,
+      icon: <Icon aria-hidden="true" />,
+      label: metric.label,
+      tone: dashboardMetricTone(metric.tone),
+      value: metric.value,
+    }
+  })
 
   return (
-    <VpwMetricStrip
-      aria-label="Dashboard metrics"
+    <MetricStrip
+      aria-label={isLoading ? "Dashboard metrics loading" : "Dashboard metrics"}
+      loading={isLoading}
+      loadingCount={5}
+      metrics={dashboardMetrics}
       minCardWidth="8.25rem"
-    >
-      {metrics.map((metric) => {
-        const Icon = metric.icon
-        return (
-          <VpwCompactMetric
-            aria-label={`${metric.label} summary card`}
-            description={metric.detail}
-            icon={<Icon aria-hidden="true" />}
-            key={metric.label}
-            label={metric.label}
-            tone={dashboardMetricTone(metric.tone)}
-            value={metric.value}
-          />
-        )
-      })}
-    </VpwMetricStrip>
+    />
   )
 }
 

--- a/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
+++ b/frontend/src/components/dashboard/RiskOperationsDashboard.tsx
@@ -250,6 +250,19 @@ export function RiskOperationsDashboard({
             isLoading={isLoading}
             metrics={summaryMetrics}
           />
+          <DashboardRemediationSection
+            findingsError={findingsError}
+            findingsLoading={findingsLoading}
+            onQueueSearchChange={(queueSearch) =>
+              setFilters((current) => ({
+                ...current,
+                queueSearch,
+              }))
+            }
+            queueFindings={queueFindings}
+            queueSearch={filters.queueSearch}
+            selectedProjectId={isDemoMode ? "" : selectedProjectId}
+          />
           <Suspense fallback={<DashboardSignalOverviewFallback />}>
             <DashboardSignalOverview
               epssItems={epssItems}
@@ -271,19 +284,6 @@ export function RiskOperationsDashboard({
               trendItems={trendItems}
             />
           </Suspense>
-          <DashboardRemediationSection
-            findingsError={findingsError}
-            findingsLoading={findingsLoading}
-            onQueueSearchChange={(queueSearch) =>
-              setFilters((current) => ({
-                ...current,
-                queueSearch,
-              }))
-            }
-            queueFindings={queueFindings}
-            queueSearch={filters.queueSearch}
-            selectedProjectId={isDemoMode ? "" : selectedProjectId}
-          />
         </>
       )}
     </div>

--- a/frontend/src/components/finding-detail/FindingDetailContext.tsx
+++ b/frontend/src/components/finding-detail/FindingDetailContext.tsx
@@ -5,8 +5,8 @@ import type {
 import { formatEpss, formatNullableNumber } from "@/lib/risk-format"
 import {
   VpwCommandPanel,
-  VpwCompactMetric,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   RiskBadge,
   SignalChip,
   StatusLozenge,
@@ -41,6 +41,32 @@ export function FindingDetailContext({
     `${action.title}. Validate affected assets, then record the fix path in Triage.`,
     150,
   )
+  const riskMetrics: MetricStripMetric[] = [
+    {
+      description: "Operational priority",
+      label: "Risk score",
+      tone: "critical",
+      value: formatNullableNumber(finding.risk_score),
+    },
+    {
+      description: "Probability signal",
+      label: "EPSS",
+      tone: "warning",
+      value: formatEpss(finding.epss),
+    },
+    {
+      description: "Impact signal",
+      label: "CVSS",
+      tone: "info",
+      value: formatNullableNumber(finding.cvss_base_score),
+    },
+    {
+      description: "Response target",
+      label: "SLA",
+      tone: "success",
+      value: findingSlaLabel(finding.priority),
+    },
+  ]
 
   return (
     <>
@@ -90,32 +116,11 @@ export function FindingDetailContext({
         role="region"
         title={<span className="font-mono">{finding.cve_id}</span>}
       >
-        <VpwMetricStrip aria-label="Risk indicators" minCardWidth="10.75rem">
-          <VpwCompactMetric
-            description="Operational priority"
-            label="Risk score"
-            tone="critical"
-            value={formatNullableNumber(finding.risk_score)}
-          />
-          <VpwCompactMetric
-            description="Probability signal"
-            label="EPSS"
-            tone="warning"
-            value={formatEpss(finding.epss)}
-          />
-          <VpwCompactMetric
-            description="Impact signal"
-            label="CVSS"
-            tone="info"
-            value={formatNullableNumber(finding.cvss_base_score)}
-          />
-          <VpwCompactMetric
-            description="Response target"
-            label="SLA"
-            tone="success"
-            value={findingSlaLabel(finding.priority)}
-          />
-        </VpwMetricStrip>
+        <MetricStrip
+          aria-label="Risk indicators"
+          metrics={riskMetrics}
+          minCardWidth="10.75rem"
+        />
       </VpwCommandPanel>
     </>
   )

--- a/frontend/src/components/findings/RemediationQueueSummary.tsx
+++ b/frontend/src/components/findings/RemediationQueueSummary.tsx
@@ -1,14 +1,12 @@
 import { Link } from "@/lib/router"
 import { AlertTriangle, ArrowUp, Eye, FileDown, Upload } from "lucide-react"
-import type { ReactNode } from "react"
 import type { ProjectPublic } from "@/api-client"
 import { Button } from "@/components/ui/button"
 import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwCommandPanel,
-  VpwCompactMetric,
-  type VpwCompactTone,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   VpwSection,
   VpwDemoBanner,
 } from "@/components/vpw"
@@ -20,14 +18,6 @@ export function DemoBanner() {
       findings. Connect a real project to see live data.
     </VpwDemoBanner>
   )
-}
-
-type SummaryMetric = {
-  description: string
-  icon: ReactNode
-  label: string
-  tone: VpwCompactTone
-  value: number
 }
 
 type RemediationQueueSummaryProps = {
@@ -47,7 +37,7 @@ export function RemediationQueueSummary({
 }: RemediationQueueSummaryProps) {
   const projectSearch = selectedProjectRouteSearch(displayProject?.id ?? "")
   const projectName = displayProject?.name ?? "the selected project"
-  const metrics: SummaryMetric[] = [
+  const metrics: MetricStripMetric[] = [
     {
       description: "Immediate owner attention",
       icon: <AlertTriangle aria-hidden="true" className="h-4 w-4" />,
@@ -102,21 +92,11 @@ export function RemediationQueueSummary({
         eyebrow="Remediation workspace"
         title="Findings queue"
       >
-        <VpwMetricStrip
+        <MetricStrip
           aria-label="Queue signal summary"
+          metrics={metrics}
           minCardWidth="10.75rem"
-        >
-          {metrics.map((metric) => (
-            <VpwCompactMetric
-              description={metric.description}
-              icon={metric.icon}
-              key={metric.label}
-              label={metric.label}
-              tone={metric.tone}
-              value={metric.value}
-            />
-          ))}
-        </VpwMetricStrip>
+        />
       </VpwCommandPanel>
     </VpwSection>
   )

--- a/frontend/src/components/imports/ImportRunDetailRoute.tsx
+++ b/frontend/src/components/imports/ImportRunDetailRoute.tsx
@@ -5,8 +5,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   VpwCommandPanel,
   VpwEmptyState,
-  VpwCompactMetric,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   VpwPanel,
   VpwSection,
   VpwSkeletonStack,
@@ -80,6 +80,31 @@ export function ImportRunDetailRoute({
     (selectedRunSummary.finding_count ?? 0) > 0 ||
     (selectedRunSummary.created_findings ?? 0) > 0 ||
     (selectedRunSummary.updated_findings ?? 0) > 0
+  const metrics: MetricStripMetric[] = [
+    {
+      label: "Status",
+      tone: runTone(selectedRunSummary.status),
+      value: runStatusLabel(selectedRunSummary.status),
+    },
+    {
+      label: "Created findings",
+      tone:
+        (selectedRunSummary.created_findings ?? 0) > 0 ? "success" : "info",
+      value: selectedRunSummary.created_findings ?? 0,
+    },
+    {
+      label: "Updated findings",
+      tone:
+        (selectedRunSummary.updated_findings ?? 0) > 0 ? "info" : "support",
+      value: selectedRunSummary.updated_findings ?? 0,
+    },
+    {
+      label: "Ignored lines",
+      tone:
+        (selectedRunSummary.ignored_lines ?? 0) > 0 ? "warning" : "success",
+      value: selectedRunSummary.ignored_lines ?? 0,
+    },
+  ]
 
   return (
     <div className="imports-page-shell vpw-page-stack w-full min-w-0">
@@ -110,40 +135,7 @@ export function ImportRunDetailRoute({
           eyebrow="Import run"
           title="Run evidence context"
         >
-          <VpwMetricStrip minCardWidth="10rem">
-            <VpwCompactMetric
-              label="Status"
-              tone={runTone(selectedRunSummary.status)}
-              value={runStatusLabel(selectedRunSummary.status)}
-            />
-            <VpwCompactMetric
-              label="Created findings"
-              tone={
-                (selectedRunSummary.created_findings ?? 0) > 0
-                  ? "success"
-                  : "info"
-              }
-              value={selectedRunSummary.created_findings ?? 0}
-            />
-            <VpwCompactMetric
-              label="Updated findings"
-              tone={
-                (selectedRunSummary.updated_findings ?? 0) > 0
-                  ? "info"
-                  : "support"
-              }
-              value={selectedRunSummary.updated_findings ?? 0}
-            />
-            <VpwCompactMetric
-              label="Ignored lines"
-              tone={
-                (selectedRunSummary.ignored_lines ?? 0) > 0
-                  ? "warning"
-                  : "success"
-              }
-              value={selectedRunSummary.ignored_lines ?? 0}
-            />
-          </VpwMetricStrip>
+          <MetricStrip metrics={metrics} minCardWidth="10rem" />
         </VpwCommandPanel>
       </VpwSection>
 

--- a/frontend/src/components/imports/ImportsHomeRoute.tsx
+++ b/frontend/src/components/imports/ImportsHomeRoute.tsx
@@ -14,8 +14,8 @@ import {
 import { Button } from "@/components/ui/button"
 import {
   VpwCommandPanel,
-  VpwCompactMetric,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   VpwPanel,
   VpwSection,
   VpwSectionHeader,
@@ -43,6 +43,33 @@ export function ImportsHomeRoute(props: ImportsHomeRouteProps) {
   const providerSummary = formatProviderFreshness(props.providerStatus)
   const lastRun = props.projectRuns[0] ?? null
   const projectSearch = selectedProjectRouteSearch(props.selectedProjectId)
+  const metrics: MetricStripMetric[] = [
+    {
+      description: props.selectedProject
+        ? "Active project"
+        : "No project selected",
+      icon: <ListChecks aria-hidden="true" className="h-4 w-4" />,
+      label: "Current project",
+      tone: props.selectedProject ? "info" : "warning",
+      value: props.selectedProject?.name ?? "Required",
+    },
+    {
+      description: providerSummary.detail,
+      icon: <Database aria-hidden="true" className="h-4 w-4" />,
+      label: "Provider data",
+      tone: props.providerStatus?.status === "ok" ? "success" : "warning",
+      value: providerSummary.value,
+    },
+    {
+      description: lastRun
+        ? `${runFileLabel(lastRun)} - ${formatDateTime(lastRun.started_at)}`
+        : "No import run recorded yet",
+      icon: <History aria-hidden="true" className="h-4 w-4" />,
+      label: "Last import",
+      tone: lastRun?.status ? runTone(lastRun.status) : "info",
+      value: lastRun ? runStatusLabel(lastRun.status) : "None yet",
+    },
+  ]
 
   return (
     <div className="imports-page-shell vpw-page-stack w-full min-w-0">
@@ -71,37 +98,7 @@ export function ImportsHomeRoute(props: ImportsHomeRouteProps) {
           eyebrow="Evidence intake"
           title="Import workspace"
         >
-          <VpwMetricStrip minCardWidth="13rem">
-            <VpwCompactMetric
-              description={
-                props.selectedProject ? "Active project" : "No project selected"
-              }
-              icon={<ListChecks aria-hidden="true" className="h-4 w-4" />}
-              label="Current project"
-              tone={props.selectedProject ? "info" : "warning"}
-              value={props.selectedProject?.name ?? "Required"}
-            />
-            <VpwCompactMetric
-              description={providerSummary.detail}
-              icon={<Database aria-hidden="true" className="h-4 w-4" />}
-              label="Provider data"
-              tone={
-                props.providerStatus?.status === "ok" ? "success" : "warning"
-              }
-              value={providerSummary.value}
-            />
-            <VpwCompactMetric
-              description={
-                lastRun
-                  ? `${runFileLabel(lastRun)} - ${formatDateTime(lastRun.started_at)}`
-                  : "No import run recorded yet"
-              }
-              icon={<History aria-hidden="true" className="h-4 w-4" />}
-              label="Last import"
-              tone={lastRun?.status ? runTone(lastRun.status) : "info"}
-              value={lastRun ? runStatusLabel(lastRun.status) : "None yet"}
-            />
-          </VpwMetricStrip>
+          <MetricStrip metrics={metrics} minCardWidth="13rem" />
         </VpwCommandPanel>
       </VpwSection>
 

--- a/frontend/src/components/projects/ProjectMetrics.tsx
+++ b/frontend/src/components/projects/ProjectMetrics.tsx
@@ -5,7 +5,7 @@ import {
   Gauge,
   ShieldCheck,
 } from "lucide-react"
-import { VpwCompactMetric, VpwMetricStrip, VpwSection } from "@/components/vpw"
+import { MetricStrip, type MetricStripMetric, VpwSection } from "@/components/vpw"
 import {
   evidenceState,
   latestRunLabel,
@@ -26,52 +26,52 @@ export function ProjectMetrics({
 >) {
   const evidence = evidenceState(projectSummary)
   const totalOpen = totalOpenFindings(projects, projectSummaryById)
+  const metrics: MetricStripMetric[] = [
+    {
+      description: "Workbench projects",
+      icon: <FolderKanban aria-hidden="true" className="h-5 w-5" />,
+      label: "Total projects",
+      tone: "info",
+      value: projects.length,
+    },
+    {
+      description: selectedProject?.name ?? "Create or select a project",
+      icon: <CheckCircle2 aria-hidden="true" className="h-5 w-5" />,
+      label: "Active project",
+      tone: selectedProject ? "success" : "warning",
+      value: selectedProject ? "Selected" : "Required",
+    },
+    {
+      description: latestRunLabel(projectSummary),
+      icon: <Clock3 aria-hidden="true" className="h-5 w-5" />,
+      label: "Latest import run",
+      tone: runTone(projectSummary?.latest_run_status),
+      value: latestRunStatus(projectSummary),
+    },
+    {
+      description: "Open or total findings",
+      icon: <Gauge aria-hidden="true" className="h-5 w-5" />,
+      label: "Open findings",
+      tone:
+        typeof totalOpen === "number"
+          ? totalOpen > 0
+            ? "warning"
+            : "success"
+          : "info",
+      value: totalOpen ?? "No data",
+    },
+    {
+      description: evidence.detail,
+      icon: <ShieldCheck aria-hidden="true" className="h-5 w-5" />,
+      label: "Evidence readiness",
+      tone: evidence.tone === "neutral" ? "info" : evidence.tone,
+      value: evidence.label,
+    },
+  ]
 
   return (
     <VpwSection>
-      <VpwMetricStrip minCardWidth="12rem">
-        <VpwCompactMetric
-          description="Workbench projects"
-          icon={<FolderKanban aria-hidden="true" className="h-5 w-5" />}
-          label="Total projects"
-          tone="info"
-          value={projects.length}
-        />
-        <VpwCompactMetric
-          description={selectedProject?.name ?? "Create or select a project"}
-          icon={<CheckCircle2 aria-hidden="true" className="h-5 w-5" />}
-          label="Active project"
-          tone={selectedProject ? "success" : "warning"}
-          value={selectedProject ? "Selected" : "Required"}
-        />
-        <VpwCompactMetric
-          description={latestRunLabel(projectSummary)}
-          icon={<Clock3 aria-hidden="true" className="h-5 w-5" />}
-          label="Latest import run"
-          tone={runTone(projectSummary?.latest_run_status)}
-          value={latestRunStatus(projectSummary)}
-        />
-        <VpwCompactMetric
-          description="Open or total findings"
-          icon={<Gauge aria-hidden="true" className="h-5 w-5" />}
-          label="Open findings"
-          tone={
-            typeof totalOpen === "number"
-              ? totalOpen > 0
-                ? "warning"
-                : "success"
-              : "info"
-          }
-          value={totalOpen ?? "No data"}
-        />
-        <VpwCompactMetric
-          description={evidence.detail}
-          icon={<ShieldCheck aria-hidden="true" className="h-5 w-5" />}
-          label="Evidence readiness"
-          tone={evidence.tone === "neutral" ? "info" : evidence.tone}
-          value={evidence.label}
-        />
-      </VpwMetricStrip>
+      <MetricStrip metrics={metrics} minCardWidth="12rem" />
     </VpwSection>
   )
 }

--- a/frontend/src/components/providers/ProvidersWorkbenchContext.tsx
+++ b/frontend/src/components/providers/ProvidersWorkbenchContext.tsx
@@ -13,8 +13,8 @@ import type { ProviderStatusPublic } from "@/api-client"
 import { Button } from "@/components/ui/button"
 import {
   VpwCommandPanel,
-  VpwCompactMetric,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   type VpwCompactTone,
   VpwPanel,
   VpwSection,
@@ -55,16 +55,14 @@ function ProviderContextItem({
   label: string
   tone: VpwCompactTone
   value: string
-}) {
-  return (
-    <VpwCompactMetric
-      description={detail}
-      icon={icon}
-      label={label}
-      tone={tone}
-      value={value}
-    />
-  )
+}): MetricStripMetric {
+  return {
+    description: detail,
+    icon,
+    label,
+    tone,
+    value,
+  }
 }
 
 export function ProvidersContext({
@@ -80,6 +78,47 @@ export function ProvidersContext({
     .locked_provider_data
     ? "support"
     : "info"
+  const metrics: MetricStripMetric[] = [
+    ProviderContextItem({
+      detail: "Provider signals for prioritization",
+      icon: <Signal aria-hidden="true" />,
+      label: "Provider health",
+      tone: providerHealthTone(providerStatus),
+      value: providerHealthLabel(providerStatus),
+    }),
+    ProviderContextItem({
+      detail: "Stored cache age and sync state",
+      icon: <Database aria-hidden="true" />,
+      label: "Freshness",
+      tone: providerFreshnessTone(providerStatus),
+      value: providerFreshnessLabel(providerStatus),
+    }),
+    ProviderContextItem({
+      detail: "Replay behavior for reports",
+      icon: <LockKeyhole aria-hidden="true" />,
+      label: "Snapshot",
+      tone: snapshotTone,
+      value: snapshotModeLabel(providerStatus),
+    }),
+    ProviderContextItem({
+      detail: "Report artifact metadata",
+      icon: <FileCheck2 aria-hidden="true" />,
+      label: "Evidence readiness",
+      tone: evidenceReadinessCardTone(providerStatus),
+      value: evidenceReadiness,
+    }),
+    ProviderContextItem({
+      detail: "Source warnings and update errors",
+      icon: <AlertTriangle aria-hidden="true" />,
+      label: "Warnings",
+      tone: providerStatus?.last_error
+        ? "critical"
+        : warningCount > 0
+          ? "warning"
+          : "success",
+      value: warningSummary(providerStatus),
+    }),
+  ]
 
   return (
     <VpwSection>
@@ -110,49 +149,11 @@ export function ProvidersContext({
         eyebrow="Data source trust"
         title="Provider status"
       >
-        <VpwMetricStrip className="providers-context-strip" minCardWidth="13rem">
-          <ProviderContextItem
-            detail="Provider signals for prioritization"
-            icon={<Signal aria-hidden="true" />}
-            label="Provider health"
-            tone={providerHealthTone(providerStatus)}
-            value={providerHealthLabel(providerStatus)}
-          />
-          <ProviderContextItem
-            detail="Stored cache age and sync state"
-            icon={<Database aria-hidden="true" />}
-            label="Freshness"
-            tone={providerFreshnessTone(providerStatus)}
-            value={providerFreshnessLabel(providerStatus)}
-          />
-          <ProviderContextItem
-            detail="Replay behavior for reports"
-            icon={<LockKeyhole aria-hidden="true" />}
-            label="Snapshot"
-            tone={snapshotTone}
-            value={snapshotModeLabel(providerStatus)}
-          />
-          <ProviderContextItem
-            detail="Report artifact metadata"
-            icon={<FileCheck2 aria-hidden="true" />}
-            label="Evidence readiness"
-            tone={evidenceReadinessCardTone(providerStatus)}
-            value={evidenceReadiness}
-          />
-          <ProviderContextItem
-            detail="Source warnings and update errors"
-            icon={<AlertTriangle aria-hidden="true" />}
-            label="Warnings"
-            tone={
-              providerStatus?.last_error
-                ? "critical"
-                : warningCount > 0
-                  ? "warning"
-                  : "success"
-            }
-            value={warningSummary(providerStatus)}
-          />
-        </VpwMetricStrip>
+        <MetricStrip
+          className="providers-context-strip"
+          metrics={metrics}
+          minCardWidth="13rem"
+        />
       </VpwCommandPanel>
     </VpwSection>
   )

--- a/frontend/src/components/providers/ProvidersWorkbenchMetrics.tsx
+++ b/frontend/src/components/providers/ProvidersWorkbenchMetrics.tsx
@@ -9,8 +9,8 @@ import type { ReactNode } from "react"
 
 import type { ProviderStatusPublic } from "@/api-client"
 import {
-  VpwCompactMetric,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   type VpwCompactTone,
 } from "@/components/vpw"
 import {
@@ -42,63 +42,61 @@ function ProviderKpiCard({
   label: string
   tone: VpwCompactTone
   value: string
-}) {
-  return (
-    <VpwCompactMetric
-      description={<span title={description}>{description}</span>}
-      icon={icon}
-      label={label}
-      tone={tone}
-      value={value}
-    />
-  )
+}): MetricStripMetric {
+  return {
+    description: <span title={description}>{description}</span>,
+    icon,
+    label,
+    tone,
+    value,
+  }
 }
 
 export function ProviderMetricsGrid({
   providerStatus,
 }: ProviderMetricsGridProps) {
+  const metrics: MetricStripMetric[] = [
+    ProviderKpiCard({
+      description: providerHealthDescription(providerStatus),
+      icon: <Signal aria-hidden="true" />,
+      label: "Provider health",
+      tone: providerHealthTone(providerStatus),
+      value: providerHealthLabel(providerStatus),
+    }),
+    ProviderKpiCard({
+      description: providerFreshnessDetail(providerStatus),
+      icon: <Database aria-hidden="true" />,
+      label: "Freshness",
+      tone: providerFreshnessTone(providerStatus),
+      value: providerFreshnessLabel(providerStatus),
+    }),
+    ProviderKpiCard({
+      description: snapshotModeDescription(providerStatus),
+      icon: <LockKeyhole aria-hidden="true" />,
+      label: "Snapshot mode",
+      tone: providerStatus?.snapshot.locked_provider_data ? "support" : "info",
+      value: snapshotModeLabel(providerStatus),
+    }),
+    ProviderKpiCard({
+      description:
+        "Provider metadata can be attached to evidence bundles where available.",
+      icon: providerStatus?.last_error ? (
+        <FileArchive aria-hidden="true" />
+      ) : (
+        <FileCheck2 aria-hidden="true" />
+      ),
+      label: "Evidence readiness",
+      tone: evidenceReadinessCardTone(providerStatus),
+      value: evidenceReadinessLabel(providerStatus),
+    }),
+  ]
+
   return (
-    <VpwMetricStrip
+    <MetricStrip
       aria-label="Provider summary"
       className="providers-kpi-strip"
+      metrics={metrics}
       minCardWidth="13rem"
-    >
-      <ProviderKpiCard
-        description={providerHealthDescription(providerStatus)}
-        icon={<Signal aria-hidden="true" />}
-        label="Provider health"
-        tone={providerHealthTone(providerStatus)}
-        value={providerHealthLabel(providerStatus)}
-      />
-      <ProviderKpiCard
-        description={providerFreshnessDetail(providerStatus)}
-        icon={<Database aria-hidden="true" />}
-        label="Freshness"
-        tone={providerFreshnessTone(providerStatus)}
-        value={providerFreshnessLabel(providerStatus)}
-      />
-      <ProviderKpiCard
-        description={snapshotModeDescription(providerStatus)}
-        icon={<LockKeyhole aria-hidden="true" />}
-        label="Snapshot mode"
-        tone={
-          providerStatus?.snapshot.locked_provider_data ? "support" : "info"
-        }
-        value={snapshotModeLabel(providerStatus)}
-      />
-      <ProviderKpiCard
-        description="Provider metadata can be attached to evidence bundles where available."
-        icon={
-          providerStatus?.last_error ? (
-            <FileArchive aria-hidden="true" />
-          ) : (
-            <FileCheck2 aria-hidden="true" />
-          )
-        }
-        label="Evidence readiness"
-        tone={evidenceReadinessCardTone(providerStatus)}
-        value={evidenceReadinessLabel(providerStatus)}
-      />
-    </VpwMetricStrip>
+    />
   )
 }

--- a/frontend/src/components/reports/EvidenceCenterRunContext.tsx
+++ b/frontend/src/components/reports/EvidenceCenterRunContext.tsx
@@ -14,9 +14,9 @@ import type {
 import { Button } from "@/components/ui/button"
 import {
   VpwCommandPanel,
-  VpwCompactMetric,
   VpwDemoBanner,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   VpwSection,
   VpwToolbar,
   VpwToolbarGroup,
@@ -83,6 +83,36 @@ export function RunContext({
     : providerSnapshotLabel(selectedReportRun, providerStatus)
   const readinessTone = evidenceReadinessTone(readiness)
   const runTone = runsLoading ? "neutral" : runMetricTone(run, isDemo)
+  const metrics: MetricStripMetric[] = [
+    {
+      description: "Artifact ownership scope",
+      icon: <BriefcaseBusiness aria-hidden="true" />,
+      label: "Project",
+      tone: "neutral",
+      value: projectName,
+    },
+    {
+      description: runDetail,
+      icon: <GitBranch aria-hidden="true" />,
+      label: "Analysis run",
+      tone: runTone,
+      value: run ? runShortId(run) : runStatus,
+    },
+    {
+      description: "Provider replay basis",
+      icon: <Database aria-hidden="true" />,
+      label: "Provider snapshot",
+      tone: "support",
+      value: snapshotLabel,
+    },
+    {
+      description: "Generation readiness",
+      icon: <ShieldCheck aria-hidden="true" />,
+      label: "Evidence state",
+      tone: readinessTone,
+      value: readiness,
+    },
+  ]
 
   return (
     <VpwSection>
@@ -113,39 +143,11 @@ export function RunContext({
         eyebrow="Govern"
         title="Evidence run context"
       >
-        <VpwMetricStrip
+        <MetricStrip
           className="evidence-run-context-facts"
+          metrics={metrics}
           minCardWidth="13rem"
-        >
-          <VpwCompactMetric
-            description="Artifact ownership scope"
-            icon={<BriefcaseBusiness aria-hidden="true" />}
-            label="Project"
-            tone="neutral"
-            value={projectName}
-          />
-          <VpwCompactMetric
-            description={runDetail}
-            icon={<GitBranch aria-hidden="true" />}
-            label="Analysis run"
-            tone={runTone}
-            value={run ? runShortId(run) : runStatus}
-          />
-          <VpwCompactMetric
-            description="Provider replay basis"
-            icon={<Database aria-hidden="true" />}
-            label="Provider snapshot"
-            tone="support"
-            value={snapshotLabel}
-          />
-          <VpwCompactMetric
-            description="Generation readiness"
-            icon={<ShieldCheck aria-hidden="true" />}
-            label="Evidence state"
-            tone={readinessTone}
-            value={readiness}
-          />
-        </VpwMetricStrip>
+        />
       </VpwCommandPanel>
     </VpwSection>
   )

--- a/frontend/src/components/vpw/README.md
+++ b/frontend/src/components/vpw/README.md
@@ -42,6 +42,10 @@ Precision Light Analyst usage rules:
 - Use fields, segmented controls, selection cards, status banners, and explicit
   action buttons for write surfaces such as decision capture, waiver review,
   report generation, and provider verification.
+- Route-level KPI/status summaries should use the canonical `MetricStrip`
+  adapter from `WorkbenchComponents.tsx`. Direct `VpwMetricStrip` and
+  `VpwCompactMetric` composition is reserved for VPW primitives and showcase
+  evidence, so route wrappers cannot silently drift into a second KPI system.
 - Keep severity and provider state visible through component tone props and
   state copy. Color alone is not enough.
 - Preserve demo/sample labeling whenever showcase or seeded evidence could be

--- a/frontend/src/components/vpw/WorkbenchComponents.tsx
+++ b/frontend/src/components/vpw/WorkbenchComponents.tsx
@@ -13,6 +13,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 
 import { VpwBadge, type BadgeDensity, type VpwBadgeTone } from "./VpwBadge"
@@ -190,6 +191,7 @@ export function ContextBar({
 }
 
 export type MetricStripMetric = {
+  ariaLabel?: string
   label: string
   value: ReactNode
   description?: ReactNode
@@ -201,32 +203,57 @@ export type MetricStripProps = Omit<
   ComponentPropsWithoutRef<"section">,
   "children"
 > & {
+  loading?: boolean
+  loadingCardClassName?: string
+  loadingCount?: number
+  maxCardWidth?: string
   maxVisible?: 3 | 4 | 5
   metrics: readonly MetricStripMetric[]
+  minCardWidth?: string
 }
 
 export function MetricStrip({
   className,
+  loading = false,
+  loadingCardClassName,
+  loadingCount,
+  maxCardWidth,
   maxVisible = 5,
   metrics,
+  minCardWidth = "10rem",
   ...props
 }: MetricStripProps) {
+  const visibleMetrics = metrics.slice(0, maxVisible)
+  const loadingSlotKeys = Array.from(
+    { length: loadingCount ?? Math.max(visibleMetrics.length, 3) },
+    (_, index) => `metric-loading-slot-${index + 1}`,
+  )
+
   return (
     <VpwMetricStrip
       className={cn("workbench-metric-strip", className)}
-      minCardWidth="10rem"
+      maxCardWidth={maxCardWidth}
+      minCardWidth={minCardWidth}
       {...props}
     >
-      {metrics.slice(0, maxVisible).map((metric) => (
-        <VpwCompactMetric
-          description={metric.description}
-          icon={metric.icon}
-          key={metric.label}
-          label={metric.label}
-          tone={metric.tone}
-          value={metric.value}
-        />
-      ))}
+      {loading
+        ? loadingSlotKeys.map((slotKey) => (
+            <Skeleton
+              className={cn("h-[4.5rem]", loadingCardClassName)}
+              key={slotKey}
+            />
+          ))
+        : visibleMetrics.map((metric) => (
+            <VpwCompactMetric
+              aria-label={metric.ariaLabel}
+              description={metric.description}
+              icon={metric.icon}
+              key={metric.label}
+              label={metric.label}
+              tone={metric.tone}
+              value={metric.value}
+            />
+          ))}
     </VpwMetricStrip>
   )
 }

--- a/frontend/src/components/waivers/WaiversWorkbenchContext.tsx
+++ b/frontend/src/components/waivers/WaiversWorkbenchContext.tsx
@@ -13,8 +13,8 @@ import { Button } from "@/components/ui/button"
 import { selectedProjectRouteSearch } from "@/workbench/selected-project-search"
 import {
   VpwCommandPanel,
-  VpwCompactMetric,
-  VpwMetricStrip,
+  MetricStrip,
+  type MetricStripMetric,
   VpwSection,
   VpwToolbar,
   VpwToolbarGroup,
@@ -106,48 +106,51 @@ export function WaiverMetrics({
   reviewDue,
   waiversLoading,
 }: WaiverMetricValues) {
+  const metrics: MetricStripMetric[] = [
+    WaiverKpiCard({
+      description: "accepted risk currently active",
+      icon: <ShieldCheck aria-hidden="true" className="h-4 w-4" />,
+      label: "Active decisions",
+      tone: "success",
+      value: waiversLoading ? "Loading" : activeWaivers,
+    }),
+    WaiverKpiCard({
+      description: "requires owner review",
+      icon: <ClipboardCheck aria-hidden="true" className="h-4 w-4" />,
+      label: "Review due",
+      tone: Number(reviewDue) > 0 ? "warning" : "success",
+      value: reviewDue,
+    }),
+    WaiverKpiCard({
+      description: "within the review window",
+      icon: <CalendarClock aria-hidden="true" className="h-4 w-4" />,
+      label: "Expiring soon",
+      tone: Number(expiringSoon) > 0 ? "warning" : "success",
+      value: expiringSoon,
+    }),
+    WaiverKpiCard({
+      description: "findings currently accepted",
+      icon: <FileCheck2 aria-hidden="true" className="h-4 w-4" />,
+      label: "Accepted findings",
+      tone: "info",
+      value: acceptedFindings,
+    }),
+    WaiverKpiCard({
+      description: "missing approval reference or ticket",
+      icon: <AlertTriangle aria-hidden="true" className="h-4 w-4" />,
+      label: "Evidence incomplete",
+      tone: missingApprovals > 0 ? "warning" : "success",
+      value: waiversLoading ? "Loading" : missingApprovals,
+    }),
+  ]
+
   return (
-    <VpwMetricStrip
+    <MetricStrip
       aria-label="Risk acceptance summary"
       className="waivers-kpi-strip"
+      metrics={metrics}
       minCardWidth="11.5rem"
-    >
-      <WaiverKpiCard
-        description="accepted risk currently active"
-        icon={<ShieldCheck aria-hidden="true" className="h-4 w-4" />}
-        label="Active decisions"
-        tone="success"
-        value={waiversLoading ? "Loading" : activeWaivers}
-      />
-      <WaiverKpiCard
-        description="requires owner review"
-        icon={<ClipboardCheck aria-hidden="true" className="h-4 w-4" />}
-        label="Review due"
-        tone={Number(reviewDue) > 0 ? "warning" : "success"}
-        value={reviewDue}
-      />
-      <WaiverKpiCard
-        description="within the review window"
-        icon={<CalendarClock aria-hidden="true" className="h-4 w-4" />}
-        label="Expiring soon"
-        tone={Number(expiringSoon) > 0 ? "warning" : "success"}
-        value={expiringSoon}
-      />
-      <WaiverKpiCard
-        description="findings currently accepted"
-        icon={<FileCheck2 aria-hidden="true" className="h-4 w-4" />}
-        label="Accepted findings"
-        tone="info"
-        value={acceptedFindings}
-      />
-      <WaiverKpiCard
-        description="missing approval reference or ticket"
-        icon={<AlertTriangle aria-hidden="true" className="h-4 w-4" />}
-        label="Evidence incomplete"
-        tone={missingApprovals > 0 ? "warning" : "success"}
-        value={waiversLoading ? "Loading" : missingApprovals}
-      />
-    </VpwMetricStrip>
+    />
   )
 }
 
@@ -163,14 +166,6 @@ function WaiverKpiCard({
   label: string
   tone?: VpwCompactTone
   value: ReactNode
-}) {
-  return (
-    <VpwCompactMetric
-      description={description}
-      icon={icon}
-      label={label}
-      tone={tone}
-      value={value}
-    />
-  )
+}): MetricStripMetric {
+  return { description, icon, label, tone, value }
 }

--- a/frontend/src/styles/findings.css
+++ b/frontend/src/styles/findings.css
@@ -625,14 +625,14 @@
 
 .findings-mobile-cards {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 .findings-mobile-card {
   min-width: 0;
   border: 1px solid var(--findings-analyst-border);
   border-radius: var(--vpw-radius-xl);
-  padding: 14px;
+  padding: 11px;
   background: var(--vpw-bg-card);
   box-shadow: none;
 }
@@ -656,19 +656,19 @@
 
 .findings-mobile-cve {
   overflow-wrap: anywhere;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .findings-mobile-component {
   display: grid;
   min-width: 0;
   gap: 3px;
-  margin-top: 12px;
+  margin-top: 9px;
 }
 
 .findings-mobile-component-name {
   color: var(--vpw-text-primary);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   overflow-wrap: anywhere;
 }
 
@@ -682,42 +682,50 @@
 
 .findings-mobile-meta-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 10px;
-  margin-top: 12px;
+  gap: 7px;
+  margin-top: 9px;
+  border-block: 1px solid var(--findings-analyst-soft-border);
+  padding-block: 8px;
 }
 
 .findings-mobile-meta-grid > div {
   display: grid;
+  grid-template-columns: 4.25rem minmax(0, 1fr);
   min-width: 0;
   align-content: start;
-  gap: 4px;
-  border: 1px solid var(--findings-analyst-border);
-  border-radius: var(--vpw-radius-lg);
-  padding: 9px;
-  background: var(--findings-analyst-muted-fill);
+  align-items: start;
+  gap: 3px 8px;
 }
 
 .findings-mobile-meta-value {
   color: var(--vpw-text-primary);
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   overflow-wrap: anywhere;
+}
+
+.findings-mobile-meta-grid .finding-meta-tags,
+.findings-mobile-meta-grid .findings-mobile-meta-detail {
+  grid-column: 2;
 }
 
 .findings-mobile-label {
   color: var(--vpw-text-muted);
   font-size: 0.7rem;
   font-weight: 800;
-  line-height: 1;
+  line-height: 1.25;
   text-transform: uppercase;
 }
 
 .findings-mobile-signals {
-  margin-top: 12px;
+  margin-top: 9px;
 }
 
 .findings-mobile-why {
-  margin-top: 12px;
+  display: -webkit-box;
+  margin-top: 9px;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   color: var(--vpw-text-secondary);
   font-size: 0.83rem;
   line-height: 1.45;
@@ -726,7 +734,9 @@
 
 .findings-mobile-card-actions {
   align-items: center;
-  margin-top: 8px;
+  margin-top: 9px;
+  border-top: 1px solid var(--findings-analyst-soft-border);
+  padding-top: 9px;
 }
 
 @media (min-width: 760px) {

--- a/frontend/tests/design-system-contracts.test.ts
+++ b/frontend/tests/design-system-contracts.test.ts
@@ -855,8 +855,12 @@ test("workspace context and summary surfaces use shared VPW shell primitives", (
 
   for (const path of compactMetricContractFiles) {
     const source = readProjectFile(path)
-    assert.match(source, /VpwMetricStrip/, `${path}: metric strip`)
-    assert.match(source, /VpwCompactMetric/, `${path}: compact metric`)
+    assert.match(source, /MetricStrip/, `${path}: canonical metric strip`)
+    assert.doesNotMatch(
+      source,
+      /VpwMetricStrip|VpwCompactMetric/,
+      `${path}: route metrics should use the canonical MetricStrip adapter`,
+    )
   }
 
   const settingsOverview = readProjectFile(

--- a/frontend/tests/workbench-design-audit.spec.ts
+++ b/frontend/tests/workbench-design-audit.spec.ts
@@ -21,6 +21,7 @@ type AuditRoute = {
   readyText: RegExp | string
   segments: number
   slug: string
+  stableText?: RegExp | string
 }
 
 type ScreenshotManifestEntry = {
@@ -43,6 +44,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Critical Priority|Priority distribution/i,
     segments: 3,
     slug: "overview",
+    stableText: "Top Remediation Queue",
   },
   {
     name: "Triage",
@@ -50,6 +52,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Prioritized findings|Findings queue/i,
     segments: 3,
     slug: "triage",
+    stableText: /Showing|CVE-/,
   },
   {
     name: "Finding Detail",
@@ -58,6 +61,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Why this priority\?|Decision core/i,
     segments: 3,
     slug: "finding-detail",
+    stableText: "Recommended action:",
   },
   {
     name: "Imports",
@@ -65,6 +69,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Recent Imports|Quick start/i,
     segments: 2,
     slug: "imports",
+    stableText: /Recent Imports|Import history/i,
   },
   {
     name: "New Import",
@@ -72,6 +77,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: "Choose source",
     segments: 3,
     slug: "imports-new",
+    stableText: "CVE list",
   },
   {
     name: "Supported Formats",
@@ -79,6 +85,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: "CVE list",
     segments: 2,
     slug: "imports-formats",
+    stableText: "Trivy JSON",
   },
   {
     name: "Import Run",
@@ -87,6 +94,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: "Source details",
     segments: 2,
     slug: "imports-run",
+    stableText: /Review findings|Diagnostics/,
   },
   {
     name: "Assets",
@@ -94,6 +102,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Asset inventory|Asset register/i,
     segments: 4,
     slug: "assets",
+    stableText: /Asset register|analytics-etl-01/,
   },
   {
     name: "Data Sources",
@@ -101,6 +110,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Provider status|Source inventory/i,
     segments: 2,
     slug: "providers",
+    stableText: /Source inventory|Provider diagnostics/,
   },
   {
     name: "Risk Acceptance",
@@ -108,6 +118,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Decision register|Accepted risk control center/i,
     segments: 4,
     slug: "waivers",
+    stableText: /DEMO-RISK|No accepted-risk lifecycle debt/,
   },
   {
     name: "Evidence Center",
@@ -115,6 +126,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Evidence summary|Generated artifacts/i,
     segments: 3,
     slug: "reports",
+    stableText: /Generated artifacts|evidence-bundle\.zip/,
   },
   {
     name: "Workspace Settings",
@@ -122,6 +134,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: "Workspace state",
     segments: 1,
     slug: "settings",
+    stableText: "Credentials are never displayed",
   },
   {
     name: "Projects",
@@ -129,6 +142,7 @@ const auditRoutes: AuditRoute[] = [
     readyText: /Workspace projects|Projects directory/i,
     segments: 4,
     slug: "projects",
+    stableText: /Projects directory|Online Shop Demo Workspace/,
   },
 ]
 
@@ -146,6 +160,7 @@ test("design audit captures the 36 VPW route section screenshots", async ({
     await page.goto(route.path(workspace, findingId))
     await expect(page.getByRole("main")).toBeVisible()
     await waitForVisibleText(page, route.readyText)
+    await waitForStableRouteContent(page, route)
     await page.evaluate(() => document.fonts.ready.then(() => undefined))
 
     const content = page
@@ -236,6 +251,54 @@ async function waitForVisibleText(page: Page, text: RegExp | string) {
       )
     },
     matcher,
+    { timeout: 60_000 },
+  )
+}
+
+async function waitForStableRouteContent(page: Page, route: AuditRoute) {
+  if (route.stableText) {
+    await waitForVisibleText(page, route.stableText)
+  }
+
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {
+    // Some runs keep dev-server bookkeeping requests alive; DOM stability below
+    // is the authoritative screenshot gate.
+  })
+
+  await page.waitForFunction(
+    () => {
+      const content = document.querySelector(
+        'section[aria-label="Workbench page content"]',
+      )
+      if (!content) return false
+
+      const visible = (element: Element) => {
+        const rect = element.getBoundingClientRect()
+        const style = getComputedStyle(element)
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          style.display !== "none" &&
+          style.visibility !== "hidden"
+        )
+      }
+
+      const visiblePendingSurfaces = [
+        ...content.querySelectorAll('[data-slot="skeleton"], .animate-pulse'),
+      ].filter(visible)
+      if (visiblePendingSurfaces.length > 0) return false
+
+      const visibleLoadingText = [...content.querySelectorAll("*")]
+        .filter(visible)
+        .some((element) =>
+          /^(?:Loading|Loading\.\.\.)$/i.test(
+            (element.textContent ?? "").trim(),
+          ),
+        )
+
+      return !visibleLoadingText
+    },
+    {},
     { timeout: 60_000 },
   )
 }


### PR DESCRIPTION
## Summary

- add route-specific stability waits to the Workbench design-audit screenshots
- route KPI/status summaries now use the canonical MetricStrip adapter, with guardrails updated to prevent primitive drift
- clarify the UI migration plan as completed baseline plus historical targets, not an active open checklist
- reduce Overview first-viewport competition and compact mobile Findings cards

## Validation

- make local-workbench-check
- make frontend-check
- make frontend-design-audit
- npm --prefix frontend run test -- tests/workbench-demo-workspace.spec.ts tests/workbench-entry-status.spec.ts --project=chromium
- make playwright-check
- make dependency-audit

Note: local npm emitted the expected engine warning because this machine is on Node 25 while the project declares Node >=22 <23; all commands completed successfully.
