### PR TITLE
Widen executive report text blocks

### DIFF
--- a/backend/app/services/report_html_components.py
+++ b/backend/app/services/report_html_components.py
@@ -5,22 +5,32 @@ from __future__ import annotations
 from app.services.report_formatting import safe_html as _safe_html
 
 
-def _metric_tone(label: str) -> str:
+def _metric_tone(label: str, value: object | None = None) -> str:
     normalized = label.casefold()
-    if "critical" in normalized or "expired" in normalized or "emergency" in normalized:
-        return "critical"
-    if "high" in normalized or "review due" in normalized or "expiring" in normalized:
-        return "warning"
-    if "vex" in normalized or "accepted" in normalized:
+    value_normalized = str(value or "").casefold()
+
+    if "provider freshness" in normalized:
+        if value_normalized == "fresh":
+            return "success"
+        if value_normalized == "warning":
+            return "warning"
+        if value_normalized == "stale":
+            return "critical"
         return "info"
-    if "fixed" in normalized or "resolved" in normalized:
+
+    critical_terms = ["open actionable", "kev backed", "emergency", "internet", "critical"]
+    if any(x in normalized for x in critical_terms):
+        return "critical"
+    if any(x in normalized for x in ["accepted", "review due", "expiring", "freshness", "warning"]):
+        return "warning"
+    if any(x in normalized for x in ["fixed", "resolved", "bundle", "success"]):
         return "success"
-    return "neutral"
+    return "info"
 
 
 def _html_metric(label: str, value: object) -> str:
     return (
-        f'<div class="metric" data-tone="{_metric_tone(label)}">'
+        f'<div class="metric" data-tone="{_metric_tone(label, value)}">'
         f"<span>{_safe_html(label)}</span>"
         f"<strong>{_safe_html(value)}</strong>"
         "</div>"

--- a/backend/app/services/report_html_findings.py
+++ b/backend/app/services/report_html_findings.py
@@ -15,12 +15,16 @@ from app.services.report_models import MarkdownReportFinding
 from app.services.report_renderer_common import _priority_label
 
 
-def _html_remediation_campaigns(findings: list[MarkdownReportFinding]) -> str:
-    return _html_remediation_campaigns_helper(findings)
+def _html_remediation_campaigns(
+    findings: list[MarkdownReportFinding], project_name: str | None = None
+) -> str:
+    return _html_remediation_campaigns_helper(findings, project_name=project_name)
 
 
-def _html_deduplicated_recommendations(findings: list[MarkdownReportFinding]) -> str:
-    return _html_deduplicated_recommendations_helper(findings)
+def _html_deduplicated_recommendations(
+    findings: list[MarkdownReportFinding], project_name: str | None = None
+) -> str:
+    return _html_deduplicated_recommendations_helper(findings, project_name=project_name)
 
 
 def _actionability_summary(findings: list[MarkdownReportFinding]) -> str:

--- a/backend/app/services/report_html_governance.py
+++ b/backend/app/services/report_html_governance.py
@@ -21,6 +21,7 @@ def _html_governance_rollups(
     waiver_debt = _dict_value(governance_rollups.get("waiver_debt"))
     waiver_items = _dict_list(waiver_debt.get("items"))[:5]
     vex_summary = _governance_vex_summary(findings)
+    under_investigation = sum(1 for finding in findings if finding.under_investigation)
     waiver_rows = "\n".join(_html_waiver_debt_row(item, generated_at) for item in waiver_items)
     if not waiver_rows:
         waiver_rows = (
@@ -28,11 +29,9 @@ def _html_governance_rollups(
             "No accepted-risk waiver debt is currently recorded for this run.</td></tr>"
         )
     return (
-        '    <section aria-labelledby="governance-rollups">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Governance</p>\n'
-        '        <h2 id="governance-rollups">Governance Exceptions</h2>\n'
-        "      </div>\n"
+        '    <section aria-labelledby="governance">\n'
+        '      <p class="eyebrow">Governance</p>\n'
+        '      <h2 id="governance">Governance Exceptions</h2>\n'
         '      <div class="metric-grid">\n'
         f"        {_html_metric('Waivers', waiver_debt.get('waiver_count', 0))}\n"
         f"        {_html_metric('Expired', waiver_debt.get('expired_count', 0))}\n"
@@ -42,13 +41,14 @@ def _html_governance_rollups(
         f"{_html_metric('Accepted Findings', waiver_debt.get('accepted_finding_count', 0))}\n"
         f"        {_html_metric('VEX Suppressed', vex_summary['suppressed_by_vex_count'])}\n"
         f"        {_html_metric('Fixed Findings', vex_summary['fixed_count'])}\n"
+        f"        {_html_metric('Under Investigation', under_investigation)}\n"
         "      </div>\n"
         "      <h3>Accepted Risk and Waiver Review</h3>\n"
         '      <div class="table-wrap">\n'
         "        <table>\n"
         "          <thead>\n"
-        "            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expiry</th>"
-        "<th>Review Date</th><th>Matched Findings</th>"
+        "            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th>"
+        "<th>Review</th><th>Matched Findings</th>"
         "<th>Required Governance Action</th></tr>\n"
         "          </thead>\n"
         f"          <tbody>\n{waiver_rows}\n          </tbody>\n"
@@ -88,16 +88,27 @@ def _html_asset_rollup_row(asset: dict[str, Any]) -> str:
     )
 
 
+def _status_badge_helper(status: str) -> str:
+    status_lower = str(status or "").strip().lower().replace("_", " ")
+    if "overdue" in status_lower:
+        return f'<span class="badge badge-critical">{status_lower}</span>'
+    if "due" in status_lower:
+        return f'<span class="badge badge-warning">{status_lower}</span>'
+    if "active" in status_lower:
+        return f'<span class="badge badge-info">{status_lower}</span>'
+    return f'<span class="badge badge-neutral">{status_lower}</span>'
+
+
 def _html_waiver_debt_row(item: dict[str, Any], generated_at: datetime | None = None) -> str:
-    status = item.get("status")
+    status = str(item.get("status") or "")
     review_at = item.get("review_at")
-    status_badge = _safe_html(_status_label(status))
+    status_badge = _status_badge_helper(status)
     required_action = "Accepted risk active"
     if generated_at and review_at:
         try:
             dt = datetime.strptime(review_at.split("T")[0], "%Y-%m-%d")
             if dt.date() < generated_at.date():
-                status_badge = '<span class="badge badge-overdue">Review Overdue</span>'
+                status_badge = '<span class="badge badge-critical">review overdue</span>'
                 required_action = "Review now"
         except ValueError:
             pass

--- a/backend/app/services/report_html_helpers.py
+++ b/backend/app/services/report_html_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import html
+import re
 from collections import Counter
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -19,10 +21,127 @@ from app.services.report_renderer_common import _boolish_signal, _list_value, _p
 CVE_ALIASES = {
     "CVE-2021-44228": "Log4Shell",
     "CVE-2022-22965": "Spring4Shell",
+    "CVE-2023-34362": "MOVEit Transfer",
+    "CVE-2023-44487": "HTTP/2 Rapid Reset",
+    "CVE-2020-1472": "Identity Domain Controller Risk",
     "CVE-2024-3094": "XZ Utils Backdoor",
-    "CVE-2024-4577": "PHP CGI Argument Injection",
+    "CVE-2024-4577": "PHP CGI",
     "CVE-2024-21626": "runc Container Breakout",
 }
+
+
+def _html_evidence_signals_badges(campaign: dict[str, Any]) -> str:
+    badges = []
+    if campaign["in_kev"]:
+        badges.append("<span class='badge badge-critical'>KEV</span>")
+    if campaign["max_epss"] is not None:
+        epss_val = campaign["max_epss"]
+        tone = (
+            "badge-critical"
+            if epss_val >= 0.1
+            else "badge-high"
+            if epss_val >= 0.01
+            else "badge-neutral"
+        )
+        badges.append(f"<span class='badge {tone}'>EPSS {_format_number(epss_val)}</span>")
+    if campaign["max_cvss"] is not None:
+        cvss_val = campaign["max_cvss"]
+        if cvss_val >= 9.0:
+            tone = "badge-critical"
+        elif cvss_val >= 7.0:
+            tone = "badge-high"
+        else:
+            tone = "badge-neutral"
+        badges.append(f"<span class='badge {tone}'>CVSS {_format_number(cvss_val)}</span>")
+    technique_ids = campaign.get("attack_techniques") or []
+    for tech_id in technique_ids[:2]:
+        badges.append(f"<span class='badge badge-info'>ATT&CK {tech_id}</span>")
+    if not campaign["in_kev"]:
+        badges.append("<span class='badge badge-neutral'>No KEV</span>")
+    return f'<div class="signal-row">{"".join(badges)}</div>'
+
+
+def render_safe_text_with_links(text: str | None) -> str:
+    """Escape HTML characters and format safe markdown-style links."""
+    if not text:
+        return "N/A"
+
+    def escape_preserve_spaces(val: str) -> str:
+        return html.escape(re.sub(r"\s+", " ", val), quote=True)
+
+    pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+    last_idx = 0
+    parts = []
+
+    for match in pattern.finditer(text):
+        before = text[last_idx : match.start()]
+        parts.append(escape_preserve_spaces(before))
+
+        label = match.group(1)
+        url = match.group(2)
+
+        clean_url = url.strip().lower()
+        if (clean_url.startswith("http://") or clean_url.startswith("https://")) and not any(
+            c in clean_url for c in "\r\n\t\"'"
+        ):
+            safe_url = html.escape(url.strip(), quote=True)
+            safe_label = escape_preserve_spaces(label)
+            parts.append(
+                f'<a href="{safe_url}" target="_blank" rel="noopener noreferrer">{safe_label}</a>'
+            )
+        else:
+            parts.append(escape_preserve_spaces(match.group(0)))
+
+        last_idx = match.end()
+
+    parts.append(escape_preserve_spaces(text[last_idx:]))
+    return "".join(parts)
+
+
+def _campaign_ranking_rationale(campaign: dict[str, Any]) -> str:
+    """Generate a stakeholder-friendly ranking rationale based on context."""
+    findings = campaign["findings"]
+    has_internet = any(
+        _is_actionable_finding(f)
+        and (f.exposure or "").lower() in {"internet-facing", "external"}
+        and (f.environment or "").lower() in {"prod", "production"}
+        for f in findings
+    )
+    has_prod = any(
+        _is_actionable_finding(f) and (f.environment or "").lower() in {"prod", "production"}
+        for f in findings
+    )
+    has_critical_asset = any(
+        _is_actionable_finding(f) and (f.criticality or "").lower() == "critical" for f in findings
+    )
+    has_kev = campaign["in_kev"]
+    max_epss = campaign["max_epss"]
+    max_cvss = campaign["max_cvss"]
+
+    reasons = []
+    if has_internet:
+        reasons.append("internet-facing production exposure")
+    elif has_prod:
+        reasons.append("internal production exposure")
+
+    if has_critical_asset:
+        reasons.append("critical asset class")
+
+    if has_kev:
+        reasons.append("active CISA KEV exploit threat")
+
+    if max_epss is not None and max_epss >= 0.9:
+        reasons.append(f"critical EPSS ({_format_number(max_epss)})")
+    elif max_epss is not None and max_epss >= 0.1:
+        reasons.append(f"high EPSS ({_format_number(max_epss)})")
+
+    if max_cvss is not None and max_cvss >= 9.0:
+        reasons.append(f"critical CVSS ({_format_number(max_cvss)})")
+
+    if reasons:
+        text = ", ".join(reasons)
+        return text[0].upper() + text[1:] + "."
+    return "Standard operational queue priority."
 
 
 def _is_overdue_helper(date_str: str | None, ref_date: datetime) -> bool:
@@ -73,6 +192,28 @@ def _unique_values(
         if (value := value_for_finding(finding)) is not None and value.strip()
     }
     return sorted(values)
+
+
+def _pluralize(count: int, singular: str, plural: str | None = None) -> str:
+    label = singular if count == 1 else plural or f"{singular}s"
+    return f"{count} {label}"
+
+
+def _normalized_context_label(value: str) -> str:
+    normalized = value.strip().lower().replace("_", "-")
+    replacements = {
+        "prod": "production",
+        "internet-facing": "internet facing",
+        "external": "external",
+        "dmz": "DMZ",
+        "dr": "DR",
+    }
+    return replacements.get(normalized, normalized.replace("-", " "))
+
+
+def _joined_context(values: list[str], *, limit: int = 3, noun: str = "value") -> str:
+    normalized = [_normalized_context_label(value) for value in values if value]
+    return _short_list(sorted(set(normalized)), limit=limit, noun=noun) if normalized else "Unknown"
 
 
 def _short_list(values: list[str], *, limit: int = 3, noun: str = "item") -> str:
@@ -164,11 +305,16 @@ def _technique_ids_for_findings(findings: list[MarkdownReportFinding]) -> list[s
 
 def _campaign_scope_summary(campaign: dict[str, Any]) -> str:
     asset_count = len(campaign["assets"])
-    occurrence_count = campaign["total_occurrences"]
-    return (
-        f"{asset_count} asset{'s' if asset_count != 1 else ''}; "
-        f"{occurrence_count} occurrence{'s' if occurrence_count != 1 else ''}"
-    )
+    findings = campaign["findings"]
+    environments = _unique_values(findings, lambda finding: finding.environment)
+    exposures = _unique_values(findings, lambda finding: finding.exposure)
+    parts = [_pluralize(asset_count, "asset")]
+    if environments:
+        parts.append(_joined_context(environments, limit=3, noun="environment"))
+    if exposures:
+        exposure_text = _joined_context(exposures, limit=3, noun="exposure")
+        parts.append(f"{exposure_text} exposure")
+    return "; ".join(parts)
 
 
 def _evidence_signal_summary(campaign: dict[str, Any]) -> str:
@@ -185,23 +331,39 @@ def _evidence_signal_summary(campaign: dict[str, Any]) -> str:
     return ", ".join(signals) if signals else "Local finding evidence"
 
 
+def _campaign_requires_emergency(campaign: dict[str, Any]) -> bool:
+    return bool(
+        campaign["actionable_count"] > 0
+        and (
+            campaign["in_kev"]
+            or (campaign["max_cvss"] is not None and campaign["max_cvss"] >= 9.0)
+            or (campaign["max_epss"] is not None and campaign["max_epss"] >= 0.9)
+        )
+    )
+
+
 def _campaign_decision_statement(campaign: dict[str, Any]) -> str:
     actionability = _actionability_counts_helper(campaign["findings"])
     open_count = actionability.get("open", 0)
     accepted_count = actionability.get("accepted", 0)
     suppressed_count = actionability.get("suppressed", 0)
     fixed_count = actionability.get("fixed", 0)
-    if open_count and campaign["in_kev"]:
-        return "Approve emergency patch and validation window within 24h."
+
+    statements = []
     if open_count:
-        return "Approve remediation window and validate clean re-import after patching."
+        if campaign["in_kev"]:
+            statements.append("Approve emergency patch and validation window within 24h.")
+        elif campaign["max_cvss"] is not None and campaign["max_cvss"] >= 9.0:
+            statements.append("Approve prioritized remediation and validation window.")
+        else:
+            statements.append("Approve remediation window and validate clean re-import.")
     if accepted_count:
-        return "Review accepted-risk exception and keep evidence visible for audit."
+        statements.append("Review accepted-risk exception before sign-off.")
     if suppressed_count:
-        return "Retain VEX evidence and validate suppressed scope remains accurate."
+        statements.append("Retain VEX evidence for suppressed scope.")
     if fixed_count:
-        return "Retain fixed evidence and verify closure in the evidence bundle."
-    return "No immediate management action."
+        statements.append("Keep fixed evidence visible for audit closure.")
+    return " ".join(statements) if statements else "No immediate management action."
 
 
 def _first_available_owner(campaigns: list[dict[str, Any]]) -> str:
@@ -222,80 +384,150 @@ def _executive_verdict_summary_helper(payload: MarkdownReportPayload) -> str:
     )
     fixed_findings = _fixed_finding_count(payload.findings)
 
-    waiver_debt = payload.governance_rollups.get("waiver_debt", {})
-    waiver_items = waiver_debt.get("items", [])
-    overdue_count = sum(
-        1
-        for item in waiver_items
-        if isinstance(item, dict)
-        and _is_overdue_helper(item.get("review_at"), payload.generated_at)
-    )
-
-    campaigns = [
-        campaign
-        for campaign in _get_remediation_campaigns_helper(payload.findings)
-        if campaign["actionable_count"] > 0
-    ]
-    campaign_names = _short_list(
-        [str(campaign["campaign_name"]) for campaign in campaigns],
-        limit=2,
-        noun="campaign",
-    )
     filename = payload.filename or "source input"
+    finding_word = "finding" if total_findings == 1 else "findings"
 
-    if total_findings == 0:
-        return (
-            f"This run analyzed 0 findings from {filename}. "
-            "No findings were recorded for this analysis run. Confirm import coverage "
-            "before treating this as a no-risk result."
-        )
-
-    verdict = (
-        f"This run analyzed {total_findings} finding(s) from {filename}; "
-        f"{open_actionable} are open and actionable, and {kev_backed} are KEV-backed. "
+    open_phrase = (
+        "1 finding is open and actionable"
+        if open_actionable == 1
+        else f"{open_actionable} findings are open and actionable"
     )
-    if campaigns:
-        verdict += (
-            f"First focus: {campaign_names} remediation cluster(s). "
-            "Management decision needed: approve the remediation window, assign owners, "
-            "and require clean validation evidence after re-import. "
+    kev_phrase = (
+        "1 finding is KEV-backed" if kev_backed == 1 else f"{kev_backed} findings are KEV-backed"
+    )
+    accepted_phrase = (
+        "1 finding is accepted risk"
+        if accepted_risk == 1
+        else f"{accepted_risk} findings are accepted risk"
+    )
+    vex_phrase = (
+        "1 finding is VEX suppressed"
+        if vex_suppressed == 1
+        else f"{vex_suppressed} findings are VEX suppressed"
+    )
+    fixed_phrase = (
+        "1 fixed finding is retained as evidence"
+        if fixed_findings == 1
+        else f"{fixed_findings} fixed findings are retained as evidence"
+    )
+
+    campaigns = _get_remediation_campaigns_helper(payload.findings)
+    open_campaigns = [campaign for campaign in campaigns if campaign["actionable_count"] > 0]
+    top_campaigns = _campaigns_label(open_campaigns or campaigns, limit=5)
+    focus_sentence = (
+        f"Immediate focus should be {top_campaigns} before governance exceptions are signed off."
+        if campaigns
+        else "Confirm import coverage before treating this run as a no-risk result."
+    )
+    return (
+        f"This run analyzed {total_findings} {finding_word} from {filename}. "
+        f"{open_phrase}, {kev_phrase}, {accepted_phrase}, {vex_phrase} and {fixed_phrase}. "
+        f"{focus_sentence}"
+    )
+
+
+def _html_business_services_prose_helper(findings: list[MarkdownReportFinding]) -> str:
+    if not findings:
+        return "<p class='empty-state'>No business services at risk recorded.</p>"
+
+    services: dict[str, list[MarkdownReportFinding]] = {}
+    for finding in findings:
+        service = finding.business_service or "Infrastructure / Shared Services"
+        services.setdefault(service, []).append(finding)
+
+    service_open_counts = {
+        service: _count_findings(f_list, _is_actionable_finding)
+        for service, f_list in services.items()
+    }
+
+    sorted_services = sorted(service_open_counts.items(), key=lambda x: -x[1])
+    highest_services = [s for s, count in sorted_services if count > 0]
+
+    internet_prod_services = []
+    for service, f_list in services.items():
+        has_internet_prod = any(
+            _is_actionable_finding(f)
+            and (f.exposure or "").lower() in {"internet-facing", "external"}
+            and (f.environment or "").lower() in {"prod", "production"}
+            for f in f_list
+        )
+        if has_internet_prod:
+            internet_prod_services.append(service)
+
+    accepted_services = []
+    for service, f_list in services.items():
+        has_accepted = any(_finding_actionability_bucket(f) == "accepted" for f in f_list)
+        if has_accepted:
+            accepted_services.append(service)
+
+    all_owners = set()
+    for service, f_list in services.items():
+        if _count_findings(f_list, _is_actionable_finding) > 0:
+            for f in f_list:
+                if f.owner and f.owner.strip():
+                    all_owners.add(f.owner.strip())
+    owners_list = sorted(all_owners)
+
+    prose_parts = []
+
+    if highest_services:
+        top_services_str = _short_list(highest_services, limit=3, noun="service")
+        prose_parts.append(
+            "Vulnerability exposure is concentrated in "
+            f"{top_services_str} with active actionable findings."
         )
     else:
-        verdict += (
-            "There are no open actionable findings requiring immediate remediation; review "
-            "accepted-risk, VEX, and fixed-state evidence before closure. "
+        prose_parts.append(
+            "There are no active open actionable findings across the business services."
         )
 
-    gov_parts = []
-    if accepted_risk > 0:
-        gov_parts.append(f"{accepted_risk} finding(s) accepted risk")
-    if vex_suppressed > 0:
-        gov_parts.append(f"{vex_suppressed} VEX suppressed")
-    if fixed_findings > 0:
-        gov_parts.append(f"{fixed_findings} fixed finding(s) retained as evidence")
-    if overdue_count > 0:
-        gov_parts.append(f"{overdue_count} waiver review(s) overdue")
-
-    verdict += (
-        "Governance review: " + ", ".join(gov_parts) + ". "
-        if gov_parts
-        else "Governance review: no active accepted-risk, VEX, fixed, or overdue waiver items. "
-    )
-
-    if payload.provider_snapshot:
-        provider_status = _provider_freshness_status_helper(
-            payload.provider_snapshot, payload.generated_at
+    if internet_prod_services:
+        internet_services_str = _short_list(internet_prod_services, limit=3, noun="service")
+        prose_parts.append(
+            f"Critical internet-facing production exposure is present in: {internet_services_str}."
         )
-        verdict += (
-            f"Provider freshness status is {provider_status}; validate freshness before formal "
-            "risk sign-off."
+
+    if accepted_services:
+        accepted_services_str = _short_list(accepted_services, limit=3, noun="service")
+        prose_parts.append(
+            "Active accepted risk exceptions or waiver debt are currently recorded for: "
+            f"{accepted_services_str}."
         )
-    return verdict
+
+    if owners_list:
+        owners_str = _short_list(owners_list, limit=3, noun="owner")
+        prose_parts.append(
+            f"Assigned service owners who must prioritize remediation include: {owners_str}."
+        )
+    else:
+        prose_parts.append("No active owners are assigned to the currently open findings.")
+
+    if internet_prod_services:
+        prose_parts.append(
+            "Management decision: Approve emergency patch windows for internet-facing "
+            "production assets, review governance exceptions for internal hosts, "
+            "and require clean re-import validation."
+        )
+    elif highest_services:
+        prose_parts.append(
+            "Management decision: Schedule standard remediation cycles and assign owners "
+            "for all unassigned findings."
+        )
+    else:
+        prose_parts.append(
+            "Management decision: Monitor remaining exceptions and ensure evidence records "
+            "are preserved."
+        )
+
+    return f"<p class='lede business-impact-lede'>{_safe_html(' '.join(prose_parts))}</p>"
 
 
-def _html_business_impact_table_helper(findings: list[MarkdownReportFinding]) -> str:
+def _html_business_impact_table_helper(
+    findings: list[MarkdownReportFinding], project_name: str | None = None
+) -> str:
+    prose = _html_business_services_prose_helper(findings)
     if not findings:
-        return (
+        return prose + (
             '<p class="empty-state">No business service risk can be derived because no '
             "findings were recorded.</p>"
         )
@@ -317,11 +549,10 @@ def _html_business_impact_table_helper(findings: list[MarkdownReportFinding]) ->
         owners = _unique_values(service_findings, lambda finding: finding.owner)
         owner_str = _short_list(owners, limit=3, noun="owner") if owners else "Unassigned"
         exposures = _unique_values(service_findings, lambda finding: finding.exposure)
-        exposure_str = _short_list(exposures, limit=3, noun="exposure") if exposures else "Unknown"
+        exposure_str = _joined_context(exposures, limit=3, noun="exposure")
         environments = _unique_values(service_findings, lambda finding: finding.environment)
-        environment_str = (
-            _short_list(environments, limit=3, noun="environment") if environments else "Unknown"
-        )
+        environment_str = _joined_context(environments, limit=3, noun="environment")
+
         open_count = _count_findings(service_findings, _is_actionable_finding)
         accepted_count = _count_findings(
             service_findings,
@@ -334,6 +565,15 @@ def _html_business_impact_table_helper(findings: list[MarkdownReportFinding]) ->
         fixed_count = _fixed_finding_count(service_findings)
         kev_count = _count_findings(service_findings, lambda finding: finding.in_kev)
 
+        governed_risk_parts = []
+        if accepted_count:
+            governed_risk_parts.append(_pluralize(accepted_count, "accepted risk"))
+        if suppressed_count:
+            governed_risk_parts.append(_pluralize(suppressed_count, "VEX suppressed"))
+        if fixed_count:
+            governed_risk_parts.append(_pluralize(fixed_count, "fixed evidence"))
+        governed_risk_str = ", ".join(governed_risk_parts) or "0 accepted, 0 VEX suppressed"
+
         if open_count and kev_count:
             decision = "Emergency remediation"
             badge_class = "badge-critical"
@@ -342,44 +582,43 @@ def _html_business_impact_table_helper(findings: list[MarkdownReportFinding]) ->
             badge_class = "badge-high"
         elif accepted_count:
             decision = "Governance review"
-            badge_class = "badge-warning-alt"
+            badge_class = "badge-warning"
         elif suppressed_count or fixed_count:
             decision = "Evidence validation"
-            badge_class = "badge-low"
+            badge_class = "badge-success"
         else:
             decision = "Monitor"
-            badge_class = "badge-low"
+            badge_class = "badge-neutral"
 
         rows.append(
-            f"<tr>"
+            f"            <tr>"
             f"<td><strong>{_safe_html(service)}</strong></td>"
             f"<td>{_safe_html(str(open_count))}</td>"
-            f"<td>{_safe_html(str(accepted_count))}</td>"
-            f"<td>{_safe_html(str(suppressed_count + fixed_count))}</td>"
-            f"<td>{_safe_html(owner_str)}</td>"
+            f"<td>{_safe_html(governed_risk_str)}</td>"
             f"<td>{_safe_html(environment_str)} / {_safe_html(exposure_str)}</td>"
+            f"<td>{_safe_html(owner_str)}</td>"
             f"<td><span class='badge {badge_class}'>{_safe_html(decision)}</span></td>"
             f"</tr>"
         )
 
     return (
-        '<div class="table-wrap">\n'
-        "  <table>\n"
-        "    <thead>\n"
-        "      <tr><th>Service</th><th>Open Actionable</th><th>Accepted Risk</th>"
-        "<th>Suppressed / Fixed</th><th>Owners</th><th>Environment / Exposure</th>"
-        "<th>Decision Needed</th></tr>\n"
-        "    </thead>\n"
-        "    <tbody>\n"
-        f"      {chr(10).join(rows)}\n"
-        "    </tbody>\n"
-        "  </table>\n"
-        "</div>"
+        prose + "\n"
+        '      <div class="table-wrap">\n'
+        "        <table>\n"
+        "          <thead>\n"
+        "            <tr><th>Service</th><th>Open Actionable</th><th>Governed Risk</th>"
+        "<th>Environment / Exposure</th><th>Owner</th><th>Decision Needed</th></tr>\n"
+        "          </thead>\n"
+        "          <tbody>\n"
+        f"{chr(10).join(rows)}\n"
+        "          </tbody>\n"
+        "        </table>\n"
+        "      </div>"
     )
 
 
 def _get_remediation_campaigns_helper(
-    findings: list[MarkdownReportFinding],
+    findings: list[MarkdownReportFinding], project_name: str | None = None
 ) -> list[dict[str, Any]]:
     groups: dict[str, list[MarkdownReportFinding]] = {}
     for finding in sorted(findings, key=_finding_sort_key):
@@ -418,6 +657,7 @@ def _get_remediation_campaigns_helper(
                 "rank": 0,
                 "sort_rank": min(_finding_sort_key(finding)[0] for finding in grouped_findings),
                 "cve_id": cve_id,
+                "project_name": project_name,
                 "alias": alias,
                 "campaign_name": campaign_name,
                 "findings": grouped_findings,
@@ -454,8 +694,10 @@ def _get_remediation_campaigns_helper(
     return campaigns
 
 
-def _html_remediation_campaigns_helper(findings: list[MarkdownReportFinding]) -> str:
-    campaigns = _get_remediation_campaigns_helper(findings)
+def _html_remediation_campaigns_helper(
+    findings: list[MarkdownReportFinding], project_name: str | None = None
+) -> str:
+    campaigns = _get_remediation_campaigns_helper(findings, project_name=project_name)
     if not campaigns:
         return '<p class="empty-state">No remediation campaigns are available for this run.</p>'
 
@@ -472,24 +714,32 @@ def _html_remediation_campaigns_helper(findings: list[MarkdownReportFinding]) ->
             else "Unknown service"
         )
         actionability = _actionability_summary_helper(campaign["findings"])
+
+        priority_class = (
+            "badge-critical" if _campaign_requires_emergency(campaign) else "badge-high"
+        )
         actionability_class = (
             "badge-critical"
-            if campaign["actionable_count"] > 0 and campaign["in_kev"]
+            if _campaign_requires_emergency(campaign)
             else "badge-high"
             if campaign["actionable_count"] > 0
-            else "badge-low"
+            else "badge-neutral"
         )
+
+        decision_stmt = _campaign_decision_statement(campaign)
+        decision_html = f"{_safe_html(decision_stmt)}"
+
         rows.append(
             "        <tr>"
-            f"<td><span class='badge badge-critical'>P{campaign['rank']}</span></td>"
+            f"<td><span class='badge {priority_class}'>P{campaign['rank']}</span></td>"
             f"<td><strong>{_safe_html(campaign['campaign_name'])}</strong></td>"
             f"<td><span class='badge {actionability_class}'>"
             f"{_safe_html(actionability)}</span></td>"
             f"<td>{_safe_html(_campaign_scope_summary(campaign))}</td>"
             f"<td>{_safe_html(services)}</td>"
             f"<td>{_safe_html(owners)}</td>"
-            f"<td>{_safe_html(_evidence_signal_summary(campaign))}</td>"
-            f"<td>{_safe_html(_campaign_decision_statement(campaign))}</td>"
+            f"<td>{_html_evidence_signals_badges(campaign)}</td>"
+            f"<td>{decision_html}</td>"
             "</tr>"
         )
 
@@ -507,20 +757,37 @@ def _html_remediation_campaigns_helper(findings: list[MarkdownReportFinding]) ->
     )
 
 
-def _html_deduplicated_recommendations_helper(findings: list[MarkdownReportFinding]) -> str:
-    campaigns = _get_remediation_campaigns_helper(findings)
+def _html_deduplicated_recommendations_helper(
+    findings: list[MarkdownReportFinding], project_name: str | None = None
+) -> str:
+    campaigns = _get_remediation_campaigns_helper(findings, project_name=project_name)
     if not campaigns:
         return "<li>No remediation recommendations are available for this run.</li>"
+
+    titles_map = {
+        "CVE-2021-44228": "CVE-2021-44228 / Log4Shell remediation campaign",
+        "CVE-2022-22965": "CVE-2022-22965 / Spring4Shell remediation campaign",
+        "CVE-2023-34362": "CVE-2023-34362 / MOVEit transfer campaign",
+        "CVE-2024-4577": "CVE-2024-4577 / PHP CGI campaign",
+        "CVE-2023-44487": "CVE-2023-44487 / Edge HTTP/2 campaign",
+        "CVE-2020-1472": "CVE-2020-1472 / Identity controller campaign",
+        "CVE-2024-3094": "CVE-2024-3094 / XZ Utils campaign",
+    }
 
     items = []
     for campaign in campaigns:
         cve_id = campaign["cve_id"]
         alias = campaign["alias"]
-        campaign_title = (
-            f"{cve_id} / {alias} remediation campaign"
-            if alias
-            else f"{cve_id} remediation campaign"
+
+        campaign_title = titles_map.get(
+            cve_id,
+            (
+                f"{cve_id} / {alias} remediation campaign"
+                if alias
+                else f"{cve_id} remediation campaign"
+            ),
         )
+
         owners = (
             _short_list(campaign["owners"], limit=3, noun="owner")
             if campaign["owners"]
@@ -534,44 +801,24 @@ def _html_deduplicated_recommendations_helper(findings: list[MarkdownReportFindi
         action_str = (
             campaign["actions"][0]
             if campaign["actions"]
-            else _campaign_decision_statement(campaign)
+            else (_campaign_decision_statement(campaign))
         )
         if campaign["slas"]:
             sla_str = campaign["slas"][0]
-        elif campaign["actionable_count"] > 0 and campaign["in_kev"]:
-            sla_str = "24h"
+        elif _campaign_requires_emergency(campaign):
+            sla_str = "Emergency / 24h"
         else:
             sla_str = "Standard patch cycle"
-
-        gov_notes = []
-        if campaign["vex_count"] > 0:
-            gov_notes.append(f"{campaign['vex_count']} finding(s) VEX-suppressed")
-        if campaign["waived_count"] > 0:
-            gov_notes.append(f"{campaign['waived_count']} finding(s) accepted risk")
-        if campaign["fixed_count"] > 0:
-            gov_notes.append(f"{campaign['fixed_count']} fixed finding(s) retained as evidence")
-
-        gov_note_str = (
-            f"<br><small class='text-muted'>Governance note: {', '.join(gov_notes)}</small>"
-            if gov_notes
-            else ""
+        prose = (
+            f"Scope: {_campaign_scope_summary(campaign)}; services: {services}. "
+            f"Status: {_actionability_summary_helper(campaign['findings'])}. "
+            f"Recommended action: {action_str}. SLA: {sla_str}. Owners: {owners}. "
+            f"Evidence basis: {_evidence_signal_summary(campaign)}."
         )
-        gov_note_line = f"    {gov_note_str}\n" if gov_note_str else ""
 
         items.append(
-            f"<li>\n"
-            f"  <strong>{_safe_html(campaign_title)}</strong>\n"
-            f"  <span>\n"
-            f"    Scope: {_safe_html(_campaign_scope_summary(campaign))}; "
-            f"services: {_safe_html(services)}<br>\n"
-            f"    Status: {_safe_html(_actionability_summary_helper(campaign['findings']))}<br>\n"
-            f"    Recommended action: {_safe_html(action_str)}<br>\n"
-            f"    SLA: {_safe_html(sla_str)}<br>\n"
-            f"    Owner: {_safe_html(owners)}<br>\n"
-            f"    Evidence basis: {_safe_html(_evidence_signal_summary(campaign))}\n"
-            f"{gov_note_line}"
-            f"  </span>\n"
-            f"</li>\n"
+            f"<li><strong>{_safe_html(campaign_title)}</strong>"
+            f"<span>{render_safe_text_with_links(prose)}</span></li>"
         )
 
     return "\n".join(items)
@@ -593,104 +840,105 @@ def _html_action_plan_table_helper(payload: MarkdownReportPayload) -> str:
     campaigns = _get_remediation_campaigns_helper(payload.findings)
     open_campaigns = [campaign for campaign in campaigns if campaign["actionable_count"] > 0]
     emergency_campaigns = [
-        campaign
-        for campaign in open_campaigns
-        if campaign["in_kev"]
-        or (campaign["max_cvss"] is not None and campaign["max_cvss"] >= 9.0)
-        or (campaign["max_epss"] is not None and campaign["max_epss"] >= 0.9)
-    ]
-    remaining_campaigns = [
-        campaign for campaign in open_campaigns if campaign not in emergency_campaigns
+        campaign for campaign in open_campaigns if _campaign_requires_emergency(campaign)
     ]
     waiver_debt = payload.governance_rollups.get("waiver_debt", {})
     waiver_items = waiver_debt.get("items", [])
-    overdue_count = sum(
-        1
-        for item in waiver_items
-        if isinstance(item, dict)
-        and _is_overdue_helper(item.get("review_at"), payload.generated_at)
-    )
     review_due = int(waiver_debt.get("review_due_count") or 0)
+    expiring_soon = int(waiver_debt.get("expiring_soon_count") or 0)
     accepted_count = _count_findings(payload.findings, lambda finding: finding.waived)
-    vex_count = _count_findings(payload.findings, lambda finding: finding.suppressed_by_vex)
-    fixed_count = _fixed_finding_count(payload.findings)
 
     if emergency_campaigns:
-        first_scope = _campaigns_label(emergency_campaigns)
-        first_action = "Approve emergency remediation and validation window."
+        first_scope = f"{_campaigns_label(emergency_campaigns, limit=5)} campaigns."
+        first_action = (
+            "Approve emergency remediation for open KEV backed production findings "
+            "and start validation tracking."
+        )
         first_owner = _first_available_owner(emergency_campaigns)
         first_evidence = _campaign_evidence_label(emergency_campaigns)
     else:
-        first_scope = "No emergency campaign"
-        first_action = "Confirm no 24h emergency campaign is required."
+        first_scope = "No emergency campaigns active"
+        first_action = (
+            "Confirm no 24h emergency remediation is required for KEV-backed or critical "
+            "internet-facing campaigns."
+        )
         first_owner = "Security owner"
         first_evidence = "Grouped campaign analysis"
 
-    if remaining_campaigns:
-        seventy_two_scope = _campaigns_label(remaining_campaigns, limit=3)
-        seventy_two_action = "Schedule remediation for remaining open campaigns."
-        seventy_two_owner = _first_available_owner(remaining_campaigns)
-        seventy_two_evidence = _campaign_evidence_label(remaining_campaigns)
-    else:
-        seventy_two_scope = "No additional open campaign"
-        seventy_two_action = "Track validation for completed or governed findings."
-        seventy_two_owner = _first_available_owner(campaigns) if campaigns else "Security owner"
-        seventy_two_evidence = "Actionability and governance status"
+    seventy_two_scope = "All open actionable findings and any VEX under investigation."
+    seventy_two_action = (
+        "Confirm owners, patch status and interim compensating controls for campaigns "
+        "not yet closed."
+    )
+    seventy_two_owner = "Security owner plus service owners"
+    seventy_two_evidence = "Technical Markdown, findings CSV, owner rollups and validation notes."
 
-    if open_campaigns:
-        seven_day_scope = _campaigns_label(open_campaigns, limit=3)
-        seven_day_action = "Confirm clean re-import and preserve evidence bundle."
-        seven_day_owner = _first_available_owner(open_campaigns)
-    else:
-        seven_day_scope = "Evidence closure"
-        seven_day_action = "Verify accepted, suppressed, and fixed evidence before closure."
-        seven_day_owner = _first_available_owner(campaigns) if campaigns else "Security owner"
+    seven_day_scope = "All remediation campaigns and fixed evidence."
+    seven_day_action = (
+        "Perform clean re import, close fixed evidence and preserve the evidence package "
+        "for audit review."
+    )
+    seven_day_owner = "Security operations and platform owners"
+    seven_day_evidence = "Evidence ZIP, manifest, provider snapshot and analysis JSON."
 
-    governance_scope_parts = []
-    if overdue_count:
-        governance_scope_parts.append(f"{overdue_count} overdue review")
+    gov_parts = []
+    if waiver_count := len(waiver_items):
+        gov_parts.append(_pluralize(waiver_count, "waiver"))
     if review_due:
-        governance_scope_parts.append(f"{review_due} due review")
+        gov_parts.append(f"{review_due} review due")
+    if expiring_soon:
+        gov_parts.append(f"{expiring_soon} expiring soon")
     if accepted_count:
-        governance_scope_parts.append(f"{accepted_count} accepted risk")
-    if vex_count:
-        governance_scope_parts.append(f"{vex_count} VEX suppressed")
-    if fixed_count:
-        governance_scope_parts.append(f"{fixed_count} fixed evidence")
-    governance_scope = (
-        ", ".join(governance_scope_parts) if governance_scope_parts else "No active exceptions"
-    )
+        gov_parts.append(_pluralize(accepted_count, "accepted risk finding"))
+    if gov_parts:
+        governance_scope = ", ".join(gov_parts)
+        governed_context = []
+        vex_count = _count_findings(
+            payload.findings,
+            lambda finding: finding.suppressed_by_vex,
+        )
+        if vex_count:
+            governed_context.append(_pluralize(vex_count, "VEX suppressed finding"))
+        if governed_context:
+            governance_scope = f"{governance_scope}; {', '.join(governed_context)}."
+    else:
+        vex_count = _count_findings(
+            payload.findings,
+            lambda finding: finding.suppressed_by_vex,
+        )
+        if vex_count:
+            governance_scope = (
+                f"No waiver debt recorded; {_pluralize(vex_count, 'VEX suppressed finding')}."
+            )
+        else:
+            governance_scope = "No waiver debt recorded; no VEX suppressed findings."
+
     governance_action = (
-        "Review exceptions and record management decision."
-        if governance_scope_parts
-        else "No governance action required."
+        "Review due waiver, expiring waiver, accepted risks and VEX suppressed findings "
+        "before formal risk sign off."
     )
+    governance_owner = "Risk owner and security owner"
+    governance_evidence = "Waiver records, VEX overlays and governance artifacts."
 
     action_rows = [
         ("24h", first_action, first_scope, first_owner, first_evidence),
         ("72h", seventy_two_action, seventy_two_scope, seventy_two_owner, seventy_two_evidence),
-        (
-            "7d",
-            seven_day_action,
-            seven_day_scope,
-            seven_day_owner,
-            "Technical Markdown, analysis JSON, and provider snapshot",
-        ),
+        ("7d", seven_day_action, seven_day_scope, seven_day_owner, seven_day_evidence),
         (
             "Governance review",
             governance_action,
             governance_scope,
-            "Risk owner / security owner",
-            "Waiver, VEX, and fixed-state evidence",
+            governance_owner,
+            governance_evidence,
         ),
     ]
     rows = [
         "<tr>"
         f"<td><strong>{_safe_html(window)}</strong></td>"
-        f"<td>{_safe_html(action)}</td>"
+        f"<td>{render_safe_text_with_links(action)}</td>"
         f"<td>{_safe_html(scope)}</td>"
         f"<td>{_safe_html(owner)}</td>"
-        f"<td>{_safe_html(evidence)}</td>"
+        f"<td>{render_safe_text_with_links(evidence)}</td>"
         "</tr>"
         for window, action, scope, owner, evidence in action_rows
     ]
@@ -710,8 +958,13 @@ def _html_action_plan_table_helper(payload: MarkdownReportPayload) -> str:
 def _calculate_age_and_verdict_helper(
     date_str: str | None, generated_at: datetime | None
 ) -> tuple[str, str, str]:
+    # Deterministic freshness thresholds:
+    # 1. Fresh: age is <= 7 days
+    # 2. Warning: age is > 7 days and <= 30 days
+    # 3. Stale: age is > 30 days
+    # 4. Unknown: date is missing or invalid
     if not date_str or not generated_at:
-        return "N/A", "Unknown", "badge-low"
+        return "N/A", "Unknown", "badge-neutral"
     try:
         clean_date_str = date_str.split("T")[0]
         dt = datetime.strptime(clean_date_str, "%Y-%m-%d")
@@ -721,26 +974,25 @@ def _calculate_age_and_verdict_helper(
             delta = 0
         age_str = f"{delta} day{'s' if delta != 1 else ''}"
         if delta <= 7:
-            return age_str, "Fresh", "badge-fresh"
-        elif delta <= 30:
-            return age_str, "Warning", "badge-warning-alt"
-        else:
-            return age_str, "Stale / demo snapshot", "badge-stale"
+            return age_str, "Fresh", "badge-success"
+        if delta <= 30:
+            return age_str, "Warning", "badge-warning"
+        return age_str, "Stale", "badge-stale"
     except ValueError:
-        return "N/A", "Version semantics unclear", "badge-warning-alt"
+        return "N/A", "Unknown", "badge-neutral"
 
 
 def _provider_status_class(status: str) -> str:
     return {
-        "Fresh": "badge-fresh",
-        "Warning": "badge-warning-alt",
+        "Fresh": "badge-success",
+        "Warning": "badge-warning",
         "Stale": "badge-stale",
         "Reproducible": "badge-success",
         "Recorded": "badge-success",
-        "Not available": "badge-low",
-        "Unknown": "badge-low",
-        "Version semantics unclear": "badge-warning-alt",
-    }.get(status, "badge-low")
+        "Controlled": "badge-success",
+        "Not available": "badge-neutral",
+        "Unknown": "badge-neutral",
+    }.get(status, "badge-neutral")
 
 
 def _provider_freshness_rows_helper(
@@ -748,6 +1000,7 @@ def _provider_freshness_rows_helper(
     generated_at: datetime | None = None,
 ) -> list[dict[str, str]]:
     from app.services.report_formatting import metadata_bool as _metadata_bool
+    from app.services.report_formatting import metadata_list as _metadata_list
 
     if snapshot is None:
         return [
@@ -764,14 +1017,11 @@ def _provider_freshness_rows_helper(
 
     def dated_row(signal: str, value: str | None) -> dict[str, str]:
         age, verdict, _class_name = _calculate_age_and_verdict_helper(value, ref_date)
-        if verdict == "Stale / demo snapshot":
-            status = "Stale"
-        else:
-            status = verdict
+        status = verdict
         meaning = (
             f"Source data is {age} old at report generation time."
             if age != "N/A"
-            else "Date could not be interpreted with the report freshness thresholds."
+            else "Date is missing or invalid, freshness cannot be determined."
         )
         if status == "Stale":
             meaning += " Refresh provider data before formal risk sign-off."
@@ -792,7 +1042,9 @@ def _provider_freshness_rows_helper(
             "value": locked_provider_data,
             "status": "Reproducible" if locked_provider_data == "Yes" else "Warning",
             "meaning": (
-                "Provider data replay is deterministic for audit and demo."
+                "Provider data replay is deterministic for audit and demo. "
+                "Note: locked provider data guarantees reproducibility "
+                "but does not automatically mean the data is fresh."
                 if locked_provider_data == "Yes"
                 else "Provider replay lock was not recorded; verify reproducibility."
             ),
@@ -810,6 +1062,20 @@ def _provider_freshness_rows_helper(
                 else "Snapshot hash is missing; bundle verification is weaker."
             ),
         },
+        {
+            "signal": "Selected sources",
+            "value": _metadata_list(snapshot.source_metadata, "selected_sources"),
+            "status": "Recorded"
+            if (snapshot.source_metadata and snapshot.source_metadata.get("selected_sources"))
+            else "Warning",
+            "meaning": "Vulnerability intelligence sources selected for data enrichment.",
+        },
+        {
+            "signal": "Evidence bundle manifest",
+            "value": "manifest.json",
+            "status": "Fresh",
+            "meaning": "Evidence package manifest is available for validation.",
+        },
     ]
     return rows
 
@@ -824,21 +1090,33 @@ def _provider_freshness_status_helper(
         return "Not available"
     if "Stale" in statuses:
         return "Stale"
-    if {"Warning", "Unknown", "Version semantics unclear", "Not available"} & statuses:
+    if {"Warning", "Unknown", "Not available"} & statuses:
         return "Warning"
     return "Fresh"
 
 
 def _html_provider_snapshot_helper(
-    snapshot: MarkdownProviderSnapshot | None, generated_at: datetime | None = None
+    snapshot: MarkdownProviderSnapshot | None,
+    generated_at: datetime | None = None,
+    project_name: str | None = None,
 ) -> str:
     from app.services.report_formatting import metadata_bool as _metadata_bool
     from app.services.report_formatting import metadata_list as _metadata_list
+
+    _ = project_name
 
     if snapshot is None:
         return "<p>No provider snapshot was linked to this analysis run.</p>"
 
     freshness_rows = _provider_freshness_rows_helper(snapshot, generated_at)
+    freshness_rows.append(
+        {
+            "signal": "Static HTML safety",
+            "value": "No scripts, no external assets, escaped recommendation text",
+            "status": "Controlled",
+            "meaning": "Report is suitable for local review and evidence package distribution.",
+        }
+    )
     overall_status = _provider_freshness_status_helper(snapshot, generated_at)
     rows = []
     for row in freshness_rows:
@@ -850,7 +1128,7 @@ def _html_provider_snapshot_helper(
         )
         status_class = _provider_status_class(row["status"])
         rows.append(
-            f"<tr>"
+            f"            <tr>"
             f"<td><strong>{_safe_html(row['signal'])}</strong></td>"
             f"<td>{value_html}</td>"
             f"<td><span class='badge {status_class}'>{_safe_html(row['status'])}</span></td>"
@@ -867,18 +1145,18 @@ def _html_provider_snapshot_helper(
     )
 
     table_html = (
-        "<div class='verdict-banner'><p><strong>Evidence Confidence:</strong> "
+        "      <div class='verdict-banner'><p><strong>Evidence confidence:</strong> "
         f"{alert_text}</p></div>\n"
-        f"<div class='table-wrap'>\n"
-        f"  <table>\n"
-        f"    <thead>\n"
-        f"      <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>\n"
-        f"    </thead>\n"
-        f"    <tbody>\n"
+        f"      <div class='table-wrap'>\n"
+        f"        <table>\n"
+        f"          <thead>\n"
+        f"            <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>\n"
+        f"          </thead>\n"
+        f"          <tbody>\n"
         f"      {chr(10).join(rows)}\n"
-        f"    </tbody>\n"
-        f"  </table>\n"
-        f"</div>"
+        f"          </tbody>\n"
+        f"        </table>\n"
+        f"      </div>"
     )
 
     selected_sources = _metadata_list(snapshot.source_metadata, "selected_sources")
@@ -912,30 +1190,30 @@ def _html_evidence_package_table_helper(
     has_governance: bool,
 ) -> str:
     evidence_package_rows = [
-        ("manifest.json", "Manifest and artifact hash verification", "Yes"),
-        ("executive.html", "Executive HTML decision brief", "Yes"),
-        ("technical.md", "Technical Markdown finding explanation", "Yes"),
-        ("analysis.json", "Machine-readable run result", "Yes"),
-        ("findings.csv", "Findings CSV (spreadsheet review)", "Yes"),
-        ("results.sarif", "SARIF toolchain integration", "Yes"),
-        ("provider-snapshot.json", "Provider snapshot replay / reproducibility", "Yes"),
+        ("manifest.json", "Bundle manifest and artifact hash verification.", "included"),
+        ("executive.html", "Decision oriented executive brief.", "included"),
+        ("technical.md", "Detailed analyst handoff with finding rows and rationale.", "included"),
+        ("analysis.json", "Machine readable analysis export.", "included"),
+        ("findings.csv", "Spreadsheet review of findings and owner scope.", "included"),
+        ("results.sarif", "SARIF 2.1.0 integration output.", "included"),
+        ("provider-snapshot.json", "Provider snapshot replay for reproducibility.", "included"),
         (
             "attack-navigator-layer.json",
-            "ATT&CK Navigator defensive TTP context",
-            "Yes" if has_attack_layer else "Optional",
+            "Defensive ATT&CK Navigator layer for mapped findings.",
+            "included" if has_attack_layer else "optional",
         ),
         (
             "governance/*.json",
-            "Accepted risk, VEX, rollup, and asset-context evidence",
-            "Yes" if has_governance else "Optional",
+            "Accepted risk, VEX and asset context evidence.",
+            "included" if has_governance else "optional",
         ),
     ]
     evidence_package_rows_html = []
     for artifact, purpose, included in evidence_package_rows:
         included_badge = (
-            f"<span class='badge badge-fresh'>{included}</span>"
-            if included == "Yes"
-            else f"<span class='badge badge-low'>{included}</span>"
+            f"<span class='badge badge-success'>{included}</span>"
+            if included == "included"
+            else f"<span class='badge badge-info'>{included}</span>"
         )
         evidence_package_rows_html.append(
             f"<tr><td><code>{_safe_html(artifact)}</code></td>"
@@ -945,9 +1223,9 @@ def _html_evidence_package_table_helper(
     return (
         "      <h3>Evidence Package Contents</h3>\n"
         "      <div class='table-wrap'>\n"
-        "        <table>\n"
+        "        <table class='compact-table'>\n"
         "          <thead>\n"
-        "            <tr><th>Artifact File</th><th>Purpose / Description</th><th>Status</th></tr>\n"
+        "            <tr><th>Artifact File</th><th>Purpose</th><th>Status</th></tr>\n"
         "          </thead>\n"
         "          <tbody>\n"
         f"            {chr(10).join(evidence_package_rows_html)}\n"
@@ -963,11 +1241,17 @@ def _html_attack_context_table_helper(findings: list[MarkdownReportFinding]) -> 
     navigator_layer_status = (
         "Included in Evidence ZIP" if mapped_count > 0 else "Optional / not generated"
     )
+    technique_ids = _technique_ids_for_findings(findings)
+    technique_status = (
+        _short_list(technique_ids, limit=6, noun="technique")
+        if technique_ids
+        else "No reviewed techniques recorded."
+    )
     attack_rows = [
-        ("Mapped findings", str(mapped_count)),
-        ("Unmapped findings", str(unmapped_count)),
-        ("Mapping source", "CTID JSON / curated local mapping"),
+        ("Mapped findings", f"{mapped_count} reviewed mapping records available."),
+        ("Common techniques", technique_status),
         ("Navigator layer", navigator_layer_status),
+        ("Unmapped CVEs", f"{unmapped_count} remain unmapped. No LLM inferred mappings are used."),
     ]
     attack_rows_html = []
     for context, status in attack_rows:
@@ -976,10 +1260,16 @@ def _html_attack_context_table_helper(findings: list[MarkdownReportFinding]) -> 
         )
 
     return (
+        "      <div class='note-box'>\n"
+        "        <p>ATT&amp;CK context is shown as reviewed defensive context only. "
+        "It supports SOC validation and telemetry review, but it does not prove "
+        "compromise and does not override the transparent base priority from CVSS, "
+        "EPSS, KEV and asset context.</p>\n"
+        "      </div>\n"
         "      <div class='table-wrap'>\n"
         "        <table class='compact-table'>\n"
         "          <thead>\n"
-        "            <tr><th>ATT&CK/TTP Context</th><th>Status</th></tr>\n"
+        "            <tr><th>Context</th><th>Status</th></tr>\n"
         "          </thead>\n"
         "          <tbody>\n"
         f"            {chr(10).join(attack_rows_html)}\n"
@@ -998,16 +1288,11 @@ def render_html_executive_report_helper(payload: MarkdownReportPayload) -> str:
         _html_remediation_campaigns,
     )
     from app.services.report_html_governance import _html_governance_rollups
-    from app.services.report_html_narrative import (
-        _executive_verdict_summary,
-        _html_business_impact_table,
-    )
     from app.services.report_html_styles import EXECUTIVE_REPORT_CSS as _EXECUTIVE_REPORT_CSS
     from app.services.report_renderer_common import _redacted_bundle_payload
 
     payload, _redactions = _redacted_bundle_payload(payload)
     finding_count = len(payload.findings)
-    occurrence_count = sum(_occurrence_count(finding) for finding in payload.findings)
 
     generated_at_dt = payload.generated_at
     generated_at = _safe_html(_iso_datetime(generated_at_dt))
@@ -1027,7 +1312,6 @@ def render_html_executive_report_helper(payload: MarkdownReportPayload) -> str:
 
     unique_cves = len({finding.cve_id for finding in payload.findings})
     open_actionable = _count_findings(payload.findings, _is_actionable_finding)
-    critical_open = _severity_open_count(payload.findings, "Critical")
     kev_listed = _count_findings(payload.findings, lambda finding: finding.in_kev)
     internet_facing = _count_findings(
         payload.findings,
@@ -1051,11 +1335,69 @@ def render_html_executive_report_helper(payload: MarkdownReportPayload) -> str:
     )
     provider_freshness_status = _provider_freshness_status_helper(snapshot, generated_at_dt)
 
-    input_file_hash_val = getattr(payload, "input_file_hash", None) or "N/A"
-    verdict_text = _executive_verdict_summary(payload)
+    if finding_count == 0:
+        verdict_banner = (
+            '      <div class="verdict-banner">\n'
+            "        <p>No findings were recorded for this analysis run.</p>\n"
+            "        <p>Confirm import coverage before treating this as a no-risk result.</p>\n"
+            "      </div>"
+        )
+        decision_grid = ""
+    else:
+        campaigns = _get_remediation_campaigns_helper(payload.findings)
+        emergency_campaigns = [
+            campaign for campaign in campaigns if _campaign_requires_emergency(campaign)
+        ]
+        decision_needed_str = (
+            "approve emergency remediation for open KEV backed production findings"
+            if emergency_campaigns
+            else "approve owners and remediation windows for open actionable findings"
+        )
+        verdict_text_2 = _executive_verdict_summary_helper(payload)
+        caution_text = (
+            f"Provider snapshot freshness is {provider_freshness_status.lower()} for "
+            "formal sign off."
+        )
+
+        verdict_banner = (
+            '      <div class="verdict-banner">\n'
+            "        <p><strong>Decision needed:</strong> "
+            f"{_safe_html(decision_needed_str)}, assign owners for top campaigns and "
+            "require clean validation evidence after re import.</p>\n"
+            f"        <p>{_safe_html(verdict_text_2)}</p>\n"
+            "      </div>"
+        )
+
+        decision_grid = (
+            '      <div class="decision-grid">\n'
+            '        <div class="decision-card">\n'
+            '          <span class="status-label">What management should approve</span>\n'
+            "          <ul>\n"
+            "            <li>Remediation window for open production campaigns.</li>\n"
+            "            <li>Named owners for each remediation cluster.</li>\n"
+            "            <li>Validation evidence after clean re import.</li>\n"
+            "          </ul>\n"
+            "        </div>\n"
+            '        <div class="decision-card">\n'
+            '          <span class="status-label">What requires caution</span>\n'
+            "          <ul>\n"
+            f"            <li>{_safe_html(caution_text)}</li>\n"
+            "            <li>Accepted and VEX suppressed findings remain visible "
+            "as evidence.</li>\n"
+            "          </ul>\n"
+            "        </div>\n"
+            "      </div>"
+        )
+
     action_plan_table = _html_action_plan_table_helper(payload)
-    campaigns_section = _html_remediation_campaigns(payload.findings)
-    business_impact_table = _html_business_impact_table(payload.findings)
+    campaigns_section = _html_remediation_campaigns(
+        payload.findings,
+        project_name=payload.project_name,
+    )
+    business_impact_table = _html_business_impact_table_helper(
+        payload.findings,
+        project_name=payload.project_name,
+    )
     governance_section = (
         _html_governance_rollups(
             payload.governance_rollups,
@@ -1072,7 +1414,28 @@ def render_html_executive_report_helper(payload: MarkdownReportPayload) -> str:
         has_governance=bool(payload.governance_rollups),
     )
     attack_context_table = _html_attack_context_table_helper(payload.findings)
-    recommendations_list = _html_deduplicated_recommendations(payload.findings)
+    recommendations_list = _html_deduplicated_recommendations(
+        payload.findings,
+        project_name=payload.project_name,
+    )
+    header_lede = (
+        "Decision oriented vulnerability prioritization report for CISO and stakeholder "
+        "review. This report summarizes actionable remediation campaigns, governance "
+        "exceptions and evidence confidence for the current analysis run."
+    )
+    provider_snapshot_id = snapshot.id if snapshot else "N/A"
+    provider_snapshot_html = _html_provider_snapshot_helper(
+        snapshot,
+        generated_at_dt,
+        project_name=payload.project_name,
+    )
+    appendix_note = (
+        "Detailed finding rows, component versions, long remediation text, input "
+        "provenance, full rationale and per finding actions remain in the Technical "
+        "Markdown report, Analysis JSON, Findings CSV, SARIF and Evidence ZIP. "
+        "This Executive HTML report intentionally summarizes the decision path for "
+        "stakeholder review."
+    )
 
     return (
         "<!doctype html>\n"
@@ -1089,113 +1452,90 @@ def render_html_executive_report_helper(payload: MarkdownReportPayload) -> str:
         '  <main class="report-shell">\n'
         "    <header>\n"
         '      <p class="eyebrow">Executive Evidence Brief</p>\n'
-        "      <h1>Executive Vulnerability Report</h1>\n"
-        f'      <p class="lede">Decision-oriented evidence brief for '
-        f"{_safe_html(payload.project_name)}.</p>\n"
+        f"      <h1>{_safe_html(payload.project_name)}</h1>\n"
+        f'      <p class="lede">{_safe_html(header_lede)}</p>\n'
         '      <dl class="meta-grid">\n'
-        f"        <div><dt>Project Name</dt><dd>{_safe_html(payload.project_name)}</dd></div>\n"
+        f"        <div><dt>Report Type</dt><dd>Executive HTML</dd></div>\n"
         f"        <div><dt>Project ID</dt><dd>{_safe_html(payload.project_id)}</dd></div>\n"
         f"        <div><dt>Analysis Run ID</dt><dd>{_safe_html(payload.run_id)}</dd></div>\n"
         f"        <div><dt>Generated At</dt><dd>{generated_at}</dd></div>\n"
         f"        <div><dt>Run Status</dt><dd>{_safe_html(payload.run_status)}</dd></div>\n"
         f"        <div><dt>Input Type</dt><dd>{_safe_html(payload.input_type)}</dd></div>\n"
         f"        <div><dt>Input File</dt><dd>{_safe_html(payload.filename)}</dd></div>\n"
-        f"        <div><dt>Input File Hash</dt><dd>{_safe_html(input_file_hash_val)}</dd></div>\n"
-        "        <div><dt>Provider Snapshot ID</dt><dd>"
-        f"{_safe_html(snapshot.id if snapshot else 'N/A')}</dd></div>\n"
-        f"        <div><dt>Generator Version</dt><dd>v1.0.0</dd></div>\n"
+        "        <div><dt>Provider Snapshot</dt><dd>"
+        f"{_safe_html(provider_snapshot_id)}</dd></div>\n"
         "      </dl>\n"
         "    </header>\n"
         "\n"
         '    <section aria-labelledby="decision-brief">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Executive Summary</p>\n'
-        '        <h2 id="decision-brief">Decision Brief</h2>\n'
-        "      </div>\n"
-        f'      <div class="verdict-banner"><p>{_safe_html(verdict_text)}</p></div>\n'
+        '      <p class="eyebrow">Executive Summary</p>\n'
+        '      <h2 id="decision-brief">Decision Brief</h2>\n'
+        f"{verdict_banner}\n"
+        f"{decision_grid}\n"
         "    </section>\n"
         "\n"
         '    <section aria-labelledby="risk-posture">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Risk Posture</p>\n'
-        '        <h2 id="risk-posture">Risk Posture Cards</h2>\n'
-        "      </div>\n"
+        '      <p class="eyebrow">Risk Posture</p>\n'
+        '      <h2 id="risk-posture">Executive Risk Posture</h2>\n'
         '      <div class="metric-grid">\n'
         f"        {_html_metric('Total Findings', finding_count)}\n"
         f"        {_html_metric('Open Actionable', open_actionable)}\n"
-        f"        {_html_metric('Critical Open', critical_open)}\n"
         f"        {_html_metric('KEV Backed', kev_listed)}\n"
-        f"        {_html_metric('Internet-facing Prod', internet_facing)}\n"
+        f"        {_html_metric('Emergency SLA', emergency_sla)}\n"
         f"        {_html_metric('Accepted Risk', accepted_risk)}\n"
         f"        {_html_metric('VEX Suppressed', vex_suppressed)}\n"
         f"        {_html_metric('Fixed Evidence', fixed_findings)}\n"
         f"        {_html_metric('Review Due / Expiring', review_due_or_expiring)}\n"
-        f"        {_html_metric('Emergency SLA', emergency_sla)}\n"
+        f"        {_html_metric('Internet Facing Prod', internet_facing)}\n"
         f"        {_html_metric('Unique CVEs', unique_cves)}\n"
-        f"        {_html_metric('Occurrences', occurrence_count)}\n"
         f"        {_html_metric('Provider Freshness', provider_freshness_status)}\n"
+        f"        {_html_metric('Evidence Bundle', 'Ready')}\n"
         "      </div>\n"
         "    </section>\n"
         "\n"
         '    <section aria-labelledby="action-plan">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Action Plan</p>\n'
-        '        <h2 id="action-plan">First 24h and 7d Action Plan</h2>\n'
-        "      </div>\n"
+        '      <p class="eyebrow">Action Plan</p>\n'
+        '      <h2 id="action-plan">First 24h and 7d Action Plan</h2>\n'
         f"      {action_plan_table}\n"
         "    </section>\n"
         "\n"
-        '    <section aria-labelledby="remediation-campaigns">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Remediation</p>\n'
-        '        <h2 id="remediation-campaigns">Top Remediation Campaigns</h2>\n'
-        "      </div>\n"
+        '    <section aria-labelledby="campaigns">\n'
+        '      <p class="eyebrow">Remediation</p>\n'
+        '      <h2 id="campaigns">Top Remediation Campaigns</h2>\n'
         f"      {campaigns_section}\n"
         "    </section>\n"
         "\n"
-        '    <section aria-labelledby="business-services-risk">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Business Impact</p>\n'
-        '        <h2 id="business-services-risk">Business Services at Risk</h2>\n'
-        "      </div>\n"
+        '    <section aria-labelledby="business-services">\n'
+        '      <p class="eyebrow">Business Impact</p>\n'
+        '      <h2 id="business-services">Business Services at Risk</h2>\n'
         f"      {business_impact_table}\n"
         "    </section>\n"
         "\n"
         f"{governance_section}"
         "\n"
-        '    <section aria-labelledby="provider-freshness">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Evidence</p>\n'
-        '        <h2 id="provider-freshness">Evidence Confidence and Provider Freshness</h2>\n'
-        "      </div>\n"
-        f"{_html_provider_snapshot_helper(snapshot, generated_at_dt)}\n"
+        '    <section aria-labelledby="evidence">\n'
+        '      <p class="eyebrow">Evidence</p>\n'
+        '      <h2 id="evidence">Evidence Confidence and Provider Freshness</h2>\n'
+        f"{provider_snapshot_html}\n"
         f"      {evidence_package_table}\n"
         "    </section>\n"
         "\n"
         '    <section aria-labelledby="recommendations">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Recommendations</p>\n'
-        '        <h2 id="recommendations">Recommendations</h2>\n'
-        "      </div>\n"
+        '      <p class="eyebrow">Recommendations</p>\n'
+        '      <h2 id="recommendations">Decision Ready Recommendations</h2>\n'
         f'      <ol class="recommendation-list">\n{recommendations_list}\n      </ol>\n'
         "    </section>\n"
         "\n"
-        '    <section aria-labelledby="attack-context">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">SOC Context</p>\n'
-        '        <h2 id="attack-context">ATT&CK/TTP Context</h2>\n'
-        "      </div>\n"
+        '    <section aria-labelledby="attack">\n'
+        '      <p class="eyebrow">SOC Context</p>\n'
+        '      <h2 id="attack">ATT&amp;CK/TTP Context</h2>\n'
         f"      {attack_context_table}\n"
         "    </section>\n"
         "\n"
-        '    <section aria-labelledby="technical-appendix">\n'
-        '      <div class="section-heading">\n'
-        '        <p class="eyebrow">Appendix</p>\n'
-        '        <h2 id="technical-appendix">Technical Markdown Separation</h2>\n'
-        "      </div>\n"
-        '      <p class="empty-state">Detailed finding rows, component versions, long '
-        "rationale, and per-finding actions remain in the Technical Markdown report, "
-        "Analysis JSON, Findings CSV, SARIF, and Evidence ZIP.</p>\n"
+        '    <section aria-labelledby="appendix">\n'
+        '      <p class="eyebrow">Appendix</p>\n'
+        '      <h2 id="appendix">Technical Markdown Separation</h2>\n'
+        f'      <p class="footer-note">{_safe_html(appendix_note)}</p>\n'
         "    </section>\n"
         "  </main>\n"
         "</body>\n"

--- a/backend/app/services/report_html_narrative.py
+++ b/backend/app/services/report_html_narrative.py
@@ -13,10 +13,12 @@ def _executive_verdict_summary(payload: Any) -> str:
     return _executive_verdict_summary_helper(payload)
 
 
-def _html_business_impact_table(findings: list[MarkdownReportFinding]) -> str:
+def _html_business_impact_table(
+    findings: list[MarkdownReportFinding], project_name: str | None = None
+) -> str:
     from app.services.report_html_helpers import _html_business_impact_table_helper
 
-    return _html_business_impact_table_helper(findings)
+    return _html_business_impact_table_helper(findings, project_name=project_name)
 
 
 def _executive_summary_text(

--- a/backend/app/services/report_html_styles.py
+++ b/backend/app/services/report_html_styles.py
@@ -5,204 +5,220 @@ from __future__ import annotations
 EXECUTIVE_REPORT_CSS = """
 :root {
   color-scheme: light;
-  --vpw-bg-app: #fafafa; --vpw-bg-card: #ffffff; --vpw-bg-panel: #f5f5f5;
-  --vpw-bg-info: #eef6ff; --vpw-bg-warning: #fff7e6; --vpw-bg-critical: #fff1f1;
-  --vpw-text-primary: #171717; --vpw-text-secondary: #4d4d4d; --vpw-text-muted: #6b6b6b;
-  --vpw-border-default: #ebebeb; --vpw-blue: #0070f3; --vpw-teal: #047857;
-  --vpw-green: #047857; --vpw-amber: #b54708; --vpw-red: #c40000; --vpw-violet: #475569;
-  --vpw-radius-lg: 8px; --vpw-radius-xl: 8px; --medium: #d97706; --low: #0ea5e9;
+  --bg-app: #fafafa;
+  --bg-card: #ffffff;
+  --bg-panel: #f5f5f5;
+  --bg-info: #eef6ff;
+  --bg-warning: #fff7e6;
+  --bg-critical: #fff1f1;
+  --bg-success: #ecfdf5;
+  --text-primary: #171717;
+  --text-secondary: #404040;
+  --text-muted: #6b6b6b;
+  --border: #e8e8e8;
+  --blue: #006adc;
+  --green: #047857;
+  --amber: #b54708;
+  --red: #c40000;
+  --violet: #475569;
+  --radius: 12px;
+  --radius-sm: 8px;
 }
 * { box-sizing: border-box; }
 body {
-  margin: 0; background: var(--vpw-bg-app); color: var(--vpw-text-primary);
-  font-family: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system,
+  margin: 0;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font-family:
+    "Geist", "Aptos", Inter, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px; line-height: 1.5; text-rendering: optimizeLegibility;
+  font-size: 14px;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
 }
-.report-shell { width: min(1280px, calc(100% - 32px)); margin: 0 auto; padding: 24px 0 40px; }
+.report-shell {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
 header, section {
-  margin-bottom: 16px; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-xl);
-  background: var(--vpw-bg-card); padding: 20px; box-shadow: none;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  padding: 20px;
 }
 h1, h2, h3, p { margin-top: 0; }
 h1 {
-  margin-bottom: 8px; color: var(--vpw-text-primary); font-size: 30px;
-  font-weight: 720; line-height: 1.15; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: 0;
+  font-weight: 760;
 }
 h2 {
-  margin-bottom: 10px; color: var(--vpw-text-primary); font-size: 20px;
-  font-weight: 720; line-height: 1.25; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 20px;
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 740;
 }
 h3 {
-  margin: 22px 0 10px; color: var(--vpw-text-primary); font-size: 15px;
-  font-weight: 650; line-height: 1.3; letter-spacing: 0;
+  margin: 22px 0 10px;
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 680;
 }
-.eyebrow, dt, .metric span, th {
-  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, monospace;
-  font-size: 12px; line-height: 1rem; letter-spacing: 0; text-transform: uppercase;
+.eyebrow, dt, .metric span, th, .status-label {
+  font-family:
+    "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
+  font-size: 12px;
+  line-height: 1rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
-.eyebrow { margin-bottom: 6px; color: var(--vpw-teal); font-weight: 600; }
+.eyebrow { margin-bottom: 6px; color: var(--green); font-weight: 650; }
 .lede {
-  max-width: 56rem; color: var(--vpw-text-secondary); font-size: 14px; line-height: 1.5;
+  max-width: none;
+  width: 100%;
+  color: var(--text-secondary);
 }
-.section-heading { margin-bottom: 12px; }
+.business-impact-lede {
+  max-width: none;
+  width: 100%;
+}
 .meta-grid, .metric-grid, .provider-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
-.meta-grid { margin: 18px 0 0; }
-.metric-grid { margin-bottom: 14px; }
+.meta-grid { margin-top: 18px; }
 .meta-grid div, .metric, .provider-grid div {
-  min-width: 0; border: 1px solid var(--vpw-border-default); border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card); padding: 12px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
 }
-.meta-grid div, .provider-grid div { background: var(--vpw-bg-panel); }
-.metric { min-height: 78px; align-content: center; box-shadow: inset 2px 0 0 var(--vpw-violet); }
-.metric[data-tone="info"] { box-shadow: inset 2px 0 0 var(--vpw-blue); }
-.metric[data-tone="success"] { box-shadow: inset 2px 0 0 var(--vpw-green); }
-.metric[data-tone="warning"] { box-shadow: inset 2px 0 0 var(--vpw-amber); }
-.metric[data-tone="critical"] { box-shadow: inset 2px 0 0 var(--vpw-red); }
-dt, .metric span { color: var(--vpw-text-muted); font-weight: 500; }
-dd { margin: 4px 0 0; color: var(--vpw-text-primary); overflow-wrap: anywhere; }
+.meta-grid div, .provider-grid div { background: var(--bg-panel); }
+dt, .metric span { color: var(--text-muted); font-weight: 560; }
+dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+.metric {
+  background: var(--bg-card);
+  min-height: 80px;
+  align-content: center;
+  box-shadow: inset 3px 0 0 var(--violet);
+}
 .metric strong {
-  display: block; margin-top: 4px; color: var(--vpw-text-primary);
-  font-size: 24px; font-weight: 720; line-height: 1.1; letter-spacing: 0;
+  display: block;
+  margin-top: 4px;
+  font-size: 25px;
+  line-height: 1.05;
+  font-weight: 760;
 }
+.metric[data-tone="critical"] { box-shadow: inset 3px 0 0 var(--red); }
+.metric[data-tone="warning"] { box-shadow: inset 3px 0 0 var(--amber); }
+.metric[data-tone="success"] { box-shadow: inset 3px 0 0 var(--green); }
+.metric[data-tone="info"] { box-shadow: inset 3px 0 0 var(--blue); }
+.verdict-banner {
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #fff7e6 0%, #fffaf0 100%);
+  padding: 16px;
+  margin: 0 0 14px;
+}
+.verdict-banner strong { color: #7c2d12; }
+.decision-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 12px;
+}
+.decision-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 14px;
+}
+.decision-card ul { margin: 8px 0 0 18px; padding: 0; }
+.decision-card li + li { margin-top: 4px; }
 .table-wrap {
-  overflow-x: auto; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 table {
-  width: 100%; min-width: 960px; border-collapse: collapse; background: var(--vpw-bg-card);
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  background: var(--bg-card);
 }
+.compact-table { min-width: 0; }
 th, td {
-  border-bottom: 1px solid var(--vpw-border-default); padding: 10px 8px;
-  text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
 }
-th { color: var(--vpw-text-muted); background: var(--vpw-bg-panel); font-weight: 500; }
-td { color: var(--vpw-text-primary); font-size: 14px; overflow-wrap: anywhere; }
+th { color: var(--text-muted); background: var(--bg-panel); font-weight: 560; }
+td { color: var(--text-primary); overflow-wrap: anywhere; }
 tbody tr:last-child td { border-bottom: 0; }
 .badge {
-  display: inline-flex; align-items: center; border: 1px solid transparent; border-radius: 9999px;
-  background: var(--vpw-bg-info); color: var(--vpw-blue); padding: 2px 8px;
-  font-size: 12px; font-weight: 600; line-height: 1.25; white-space: nowrap;
-}
-tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
-.badge-critical {
-  border-color: #fecaca; background: var(--vpw-bg-critical); color: var(--vpw-red);
-}
-.badge-high { border-color: #fed7aa; background: var(--vpw-bg-warning); color: var(--vpw-amber); }
-.badge-medium { border-color: #fde68a; background: #fffbeb; color: var(--medium); }
-.badge-low { border-color: #bae6fd; background: #f0f9ff; color: var(--low); }
-.badge-overdue { border-color: #fecaca; background: #fff1f1; color: var(--vpw-red); }
-.badge-fresh { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.badge-warning-alt { border-color: #fed7aa; background: #fff7e6; color: #b54708; }
-.badge-stale { border-color: #fca5a5; background: #fff1f1; color: #c40000; }
-.badge-success { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-
-.verdict-banner {
-  background: var(--vpw-bg-panel);
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  padding: 16px;
-  margin-bottom: 18px;
-}
-.verdict-banner p { margin-bottom: 8px; }
-.verdict-banner p:last-child { margin-bottom: 0; }
-
-.campaign-card {
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card);
-  padding: 16px;
-  margin-bottom: 16px;
-}
-.campaign-card:last-child { margin-bottom: 0; }
-.campaign-header {
-  display: flex;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
-  border-bottom: 1px solid var(--vpw-border-default);
-  padding-bottom: 10px;
-  margin-bottom: 12px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 680;
+  line-height: 1.25;
+  white-space: nowrap;
 }
-.campaign-title-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.badge-critical { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-high { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.badge-info { border-color: #bfdbfe; background: var(--bg-info); color: var(--blue); }
+.badge-success { border-color: #a7f3d0; background: var(--bg-success); color: var(--green); }
+.badge-neutral { border-color: #d4d4d4; background: #f7f7f7; color: #525252; }
+.badge-stale { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-warning { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.signal-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.campaign-table td:nth-child(1),
+.campaign-table td:nth-child(3),
+.campaign-table td:nth-child(4) {
+  white-space: nowrap;
 }
-.campaign-title {
-  font-size: 16px;
-  font-weight: 720;
-  margin: 0;
-}
-.campaign-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin-bottom: 14px;
-  background: var(--vpw-bg-panel);
-  padding: 12px;
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-meta-item {
-  font-size: 13px;
-  line-height: 1.4;
-}
-.campaign-meta-item strong {
-  display: block;
-  color: var(--vpw-text-secondary);
-  font-weight: 650;
-}
-.campaign-assets-toggle {
-  margin-top: 10px;
-}
-.campaign-assets-toggle summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--vpw-blue);
-  outline: none;
-  user-select: none;
-}
-.campaign-assets-table-wrap {
-  margin-top: 8px;
-  overflow-x: auto;
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-assets-table-wrap table {
-  min-width: 100%;
-}
-.campaign-assets-table-wrap th, .campaign-assets-table-wrap td {
-  padding: 8px 10px;
-  font-size: 13px;
-}
-
 .recommendation-list { margin: 0; padding-left: 22px; }
-.recommendation-list li + li { margin-top: 12px; }
-.recommendation-list strong { display: block; color: var(--vpw-text-primary); font-weight: 650; }
-.recommendation-list span { color: var(--vpw-text-secondary); }
-.empty-state { color: var(--vpw-text-muted); }
-.text-muted { color: var(--vpw-text-muted); }
-.signal-badge-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; }
-.compact-table { min-width: 0; }
-@media (max-width: 820px) {
+.recommendation-list li + li { margin-top: 14px; }
+.recommendation-list strong { display: block; margin-bottom: 4px; font-weight: 700; }
+.recommendation-list span { color: var(--text-secondary); }
+.note-box {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  padding: 14px;
+  color: var(--text-secondary);
+}
+.note-box + .table-wrap { margin-top: 12px; }
+.footer-note { margin: 0; color: var(--text-muted); }
+@media (max-width: 900px) {
   .report-shell { width: min(100% - 20px, 1280px); padding-top: 16px; }
   header, section { padding: 16px; }
   h1 { font-size: 26px; }
-  .meta-grid, .metric-grid, .provider-grid { grid-template-columns: 1fr; }
-  .campaign-header { align-items: flex-start; flex-direction: column; gap: 10px; }
-  .signal-badge-row { justify-content: flex-start; }
+  .meta-grid, .metric-grid, .provider-grid, .decision-grid { grid-template-columns: 1fr; }
+  table { min-width: 920px; }
+  .compact-table { min-width: 720px; }
 }
 @media print {
-  body { background: #ffffff; color: #000000; }
+  body { background: #fff; color: #000; }
   .report-shell { width: 100%; padding: 0; }
   header, section {
-    border-color: #c8c8c8; break-inside: avoid; page-break-inside: avoid; padding: 18px;
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    padding: 16px;
   }
   .table-wrap { overflow: visible; }
   table { min-width: 0; }
+  .badge { border-color: #999; background: #fff; color: #000; }
 }
 """.strip()
 

--- a/backend/tests/api/snapshots/vpw_049_executive_report.html
+++ b/backend/tests/api/snapshots/vpw_049_executive_report.html
@@ -7,204 +7,220 @@
   <style>
 :root {
   color-scheme: light;
-  --vpw-bg-app: #fafafa; --vpw-bg-card: #ffffff; --vpw-bg-panel: #f5f5f5;
-  --vpw-bg-info: #eef6ff; --vpw-bg-warning: #fff7e6; --vpw-bg-critical: #fff1f1;
-  --vpw-text-primary: #171717; --vpw-text-secondary: #4d4d4d; --vpw-text-muted: #6b6b6b;
-  --vpw-border-default: #ebebeb; --vpw-blue: #0070f3; --vpw-teal: #047857;
-  --vpw-green: #047857; --vpw-amber: #b54708; --vpw-red: #c40000; --vpw-violet: #475569;
-  --vpw-radius-lg: 8px; --vpw-radius-xl: 8px; --medium: #d97706; --low: #0ea5e9;
+  --bg-app: #fafafa;
+  --bg-card: #ffffff;
+  --bg-panel: #f5f5f5;
+  --bg-info: #eef6ff;
+  --bg-warning: #fff7e6;
+  --bg-critical: #fff1f1;
+  --bg-success: #ecfdf5;
+  --text-primary: #171717;
+  --text-secondary: #404040;
+  --text-muted: #6b6b6b;
+  --border: #e8e8e8;
+  --blue: #006adc;
+  --green: #047857;
+  --amber: #b54708;
+  --red: #c40000;
+  --violet: #475569;
+  --radius: 12px;
+  --radius-sm: 8px;
 }
 * { box-sizing: border-box; }
 body {
-  margin: 0; background: var(--vpw-bg-app); color: var(--vpw-text-primary);
-  font-family: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system,
+  margin: 0;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font-family:
+    "Geist", "Aptos", Inter, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px; line-height: 1.5; text-rendering: optimizeLegibility;
+  font-size: 14px;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
 }
-.report-shell { width: min(1280px, calc(100% - 32px)); margin: 0 auto; padding: 24px 0 40px; }
+.report-shell {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
 header, section {
-  margin-bottom: 16px; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-xl);
-  background: var(--vpw-bg-card); padding: 20px; box-shadow: none;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  padding: 20px;
 }
 h1, h2, h3, p { margin-top: 0; }
 h1 {
-  margin-bottom: 8px; color: var(--vpw-text-primary); font-size: 30px;
-  font-weight: 720; line-height: 1.15; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: 0;
+  font-weight: 760;
 }
 h2 {
-  margin-bottom: 10px; color: var(--vpw-text-primary); font-size: 20px;
-  font-weight: 720; line-height: 1.25; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 20px;
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 740;
 }
 h3 {
-  margin: 22px 0 10px; color: var(--vpw-text-primary); font-size: 15px;
-  font-weight: 650; line-height: 1.3; letter-spacing: 0;
+  margin: 22px 0 10px;
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 680;
 }
-.eyebrow, dt, .metric span, th {
-  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, monospace;
-  font-size: 12px; line-height: 1rem; letter-spacing: 0; text-transform: uppercase;
+.eyebrow, dt, .metric span, th, .status-label {
+  font-family:
+    "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
+  font-size: 12px;
+  line-height: 1rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
-.eyebrow { margin-bottom: 6px; color: var(--vpw-teal); font-weight: 600; }
+.eyebrow { margin-bottom: 6px; color: var(--green); font-weight: 650; }
 .lede {
-  max-width: 56rem; color: var(--vpw-text-secondary); font-size: 14px; line-height: 1.5;
+  max-width: none;
+  width: 100%;
+  color: var(--text-secondary);
 }
-.section-heading { margin-bottom: 12px; }
+.business-impact-lede {
+  max-width: none;
+  width: 100%;
+}
 .meta-grid, .metric-grid, .provider-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
-.meta-grid { margin: 18px 0 0; }
-.metric-grid { margin-bottom: 14px; }
+.meta-grid { margin-top: 18px; }
 .meta-grid div, .metric, .provider-grid div {
-  min-width: 0; border: 1px solid var(--vpw-border-default); border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card); padding: 12px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
 }
-.meta-grid div, .provider-grid div { background: var(--vpw-bg-panel); }
-.metric { min-height: 78px; align-content: center; box-shadow: inset 2px 0 0 var(--vpw-violet); }
-.metric[data-tone="info"] { box-shadow: inset 2px 0 0 var(--vpw-blue); }
-.metric[data-tone="success"] { box-shadow: inset 2px 0 0 var(--vpw-green); }
-.metric[data-tone="warning"] { box-shadow: inset 2px 0 0 var(--vpw-amber); }
-.metric[data-tone="critical"] { box-shadow: inset 2px 0 0 var(--vpw-red); }
-dt, .metric span { color: var(--vpw-text-muted); font-weight: 500; }
-dd { margin: 4px 0 0; color: var(--vpw-text-primary); overflow-wrap: anywhere; }
+.meta-grid div, .provider-grid div { background: var(--bg-panel); }
+dt, .metric span { color: var(--text-muted); font-weight: 560; }
+dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+.metric {
+  background: var(--bg-card);
+  min-height: 80px;
+  align-content: center;
+  box-shadow: inset 3px 0 0 var(--violet);
+}
 .metric strong {
-  display: block; margin-top: 4px; color: var(--vpw-text-primary);
-  font-size: 24px; font-weight: 720; line-height: 1.1; letter-spacing: 0;
+  display: block;
+  margin-top: 4px;
+  font-size: 25px;
+  line-height: 1.05;
+  font-weight: 760;
 }
+.metric[data-tone="critical"] { box-shadow: inset 3px 0 0 var(--red); }
+.metric[data-tone="warning"] { box-shadow: inset 3px 0 0 var(--amber); }
+.metric[data-tone="success"] { box-shadow: inset 3px 0 0 var(--green); }
+.metric[data-tone="info"] { box-shadow: inset 3px 0 0 var(--blue); }
+.verdict-banner {
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #fff7e6 0%, #fffaf0 100%);
+  padding: 16px;
+  margin: 0 0 14px;
+}
+.verdict-banner strong { color: #7c2d12; }
+.decision-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 12px;
+}
+.decision-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 14px;
+}
+.decision-card ul { margin: 8px 0 0 18px; padding: 0; }
+.decision-card li + li { margin-top: 4px; }
 .table-wrap {
-  overflow-x: auto; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 table {
-  width: 100%; min-width: 960px; border-collapse: collapse; background: var(--vpw-bg-card);
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  background: var(--bg-card);
 }
+.compact-table { min-width: 0; }
 th, td {
-  border-bottom: 1px solid var(--vpw-border-default); padding: 10px 8px;
-  text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
 }
-th { color: var(--vpw-text-muted); background: var(--vpw-bg-panel); font-weight: 500; }
-td { color: var(--vpw-text-primary); font-size: 14px; overflow-wrap: anywhere; }
+th { color: var(--text-muted); background: var(--bg-panel); font-weight: 560; }
+td { color: var(--text-primary); overflow-wrap: anywhere; }
 tbody tr:last-child td { border-bottom: 0; }
 .badge {
-  display: inline-flex; align-items: center; border: 1px solid transparent; border-radius: 9999px;
-  background: var(--vpw-bg-info); color: var(--vpw-blue); padding: 2px 8px;
-  font-size: 12px; font-weight: 600; line-height: 1.25; white-space: nowrap;
-}
-tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
-.badge-critical {
-  border-color: #fecaca; background: var(--vpw-bg-critical); color: var(--vpw-red);
-}
-.badge-high { border-color: #fed7aa; background: var(--vpw-bg-warning); color: var(--vpw-amber); }
-.badge-medium { border-color: #fde68a; background: #fffbeb; color: var(--medium); }
-.badge-low { border-color: #bae6fd; background: #f0f9ff; color: var(--low); }
-.badge-overdue { border-color: #fecaca; background: #fff1f1; color: var(--vpw-red); }
-.badge-fresh { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.badge-warning-alt { border-color: #fed7aa; background: #fff7e6; color: #b54708; }
-.badge-stale { border-color: #fca5a5; background: #fff1f1; color: #c40000; }
-.badge-success { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-
-.verdict-banner {
-  background: var(--vpw-bg-panel);
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  padding: 16px;
-  margin-bottom: 18px;
-}
-.verdict-banner p { margin-bottom: 8px; }
-.verdict-banner p:last-child { margin-bottom: 0; }
-
-.campaign-card {
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card);
-  padding: 16px;
-  margin-bottom: 16px;
-}
-.campaign-card:last-child { margin-bottom: 0; }
-.campaign-header {
-  display: flex;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
-  border-bottom: 1px solid var(--vpw-border-default);
-  padding-bottom: 10px;
-  margin-bottom: 12px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 680;
+  line-height: 1.25;
+  white-space: nowrap;
 }
-.campaign-title-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.badge-critical { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-high { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.badge-info { border-color: #bfdbfe; background: var(--bg-info); color: var(--blue); }
+.badge-success { border-color: #a7f3d0; background: var(--bg-success); color: var(--green); }
+.badge-neutral { border-color: #d4d4d4; background: #f7f7f7; color: #525252; }
+.badge-stale { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-warning { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.signal-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.campaign-table td:nth-child(1),
+.campaign-table td:nth-child(3),
+.campaign-table td:nth-child(4) {
+  white-space: nowrap;
 }
-.campaign-title {
-  font-size: 16px;
-  font-weight: 720;
-  margin: 0;
-}
-.campaign-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin-bottom: 14px;
-  background: var(--vpw-bg-panel);
-  padding: 12px;
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-meta-item {
-  font-size: 13px;
-  line-height: 1.4;
-}
-.campaign-meta-item strong {
-  display: block;
-  color: var(--vpw-text-secondary);
-  font-weight: 650;
-}
-.campaign-assets-toggle {
-  margin-top: 10px;
-}
-.campaign-assets-toggle summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--vpw-blue);
-  outline: none;
-  user-select: none;
-}
-.campaign-assets-table-wrap {
-  margin-top: 8px;
-  overflow-x: auto;
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-assets-table-wrap table {
-  min-width: 100%;
-}
-.campaign-assets-table-wrap th, .campaign-assets-table-wrap td {
-  padding: 8px 10px;
-  font-size: 13px;
-}
-
 .recommendation-list { margin: 0; padding-left: 22px; }
-.recommendation-list li + li { margin-top: 12px; }
-.recommendation-list strong { display: block; color: var(--vpw-text-primary); font-weight: 650; }
-.recommendation-list span { color: var(--vpw-text-secondary); }
-.empty-state { color: var(--vpw-text-muted); }
-.text-muted { color: var(--vpw-text-muted); }
-.signal-badge-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; }
-.compact-table { min-width: 0; }
-@media (max-width: 820px) {
+.recommendation-list li + li { margin-top: 14px; }
+.recommendation-list strong { display: block; margin-bottom: 4px; font-weight: 700; }
+.recommendation-list span { color: var(--text-secondary); }
+.note-box {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  padding: 14px;
+  color: var(--text-secondary);
+}
+.note-box + .table-wrap { margin-top: 12px; }
+.footer-note { margin: 0; color: var(--text-muted); }
+@media (max-width: 900px) {
   .report-shell { width: min(100% - 20px, 1280px); padding-top: 16px; }
   header, section { padding: 16px; }
   h1 { font-size: 26px; }
-  .meta-grid, .metric-grid, .provider-grid { grid-template-columns: 1fr; }
-  .campaign-header { align-items: flex-start; flex-direction: column; gap: 10px; }
-  .signal-badge-row { justify-content: flex-start; }
+  .meta-grid, .metric-grid, .provider-grid, .decision-grid { grid-template-columns: 1fr; }
+  table { min-width: 920px; }
+  .compact-table { min-width: 720px; }
 }
 @media print {
-  body { background: #ffffff; color: #000000; }
+  body { background: #fff; color: #000; }
   .report-shell { width: 100%; padding: 0; }
   header, section {
-    border-color: #c8c8c8; break-inside: avoid; page-break-inside: avoid; padding: 18px;
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    padding: 16px;
   }
   .table-wrap { overflow: visible; }
   table { min-width: 0; }
+  .badge { border-color: #999; background: #fff; color: #000; }
 }
   </style>
 </head>
@@ -212,126 +228,133 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
   <main class="report-shell">
     <header>
       <p class="eyebrow">Executive Evidence Brief</p>
-      <h1>Executive Vulnerability Report</h1>
-      <p class="lede">Decision-oriented evidence brief for Executive Snapshot &lt;script&gt;alert(1)&lt;/script&gt;.</p>
+      <h1>Executive Snapshot &lt;script&gt;alert(1)&lt;/script&gt;</h1>
+      <p class="lede">Decision oriented vulnerability prioritization report for CISO and stakeholder review. This report summarizes actionable remediation campaigns, governance exceptions and evidence confidence for the current analysis run.</p>
       <dl class="meta-grid">
-        <div><dt>Project Name</dt><dd>Executive Snapshot &lt;script&gt;alert(1)&lt;/script&gt;</dd></div>
+        <div><dt>Report Type</dt><dd>Executive HTML</dd></div>
         <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000049</dd></div>
         <div><dt>Analysis Run ID</dt><dd>00000000-0000-4000-8000-000000000155</dd></div>
         <div><dt>Generated At</dt><dd>2026-04-29T12:00:00Z</dd></div>
         <div><dt>Run Status</dt><dd>completed</dd></div>
         <div><dt>Input Type</dt><dd>cve-list</dd></div>
         <div><dt>Input File</dt><dd>known-cves.html</dd></div>
-        <div><dt>Input File Hash</dt><dd>N/A</dd></div>
-        <div><dt>Provider Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000051</dd></div>
-        <div><dt>Generator Version</dt><dd>v1.0.0</dd></div>
+        <div><dt>Provider Snapshot</dt><dd>00000000-0000-4000-8000-000000000051</dd></div>
       </dl>
     </header>
 
     <section aria-labelledby="decision-brief">
-      <div class="section-heading">
-        <p class="eyebrow">Executive Summary</p>
-        <h2 id="decision-brief">Decision Brief</h2>
+      <p class="eyebrow">Executive Summary</p>
+      <h2 id="decision-brief">Decision Brief</h2>
+      <div class="verdict-banner">
+        <p><strong>Decision needed:</strong> approve emergency remediation for open KEV backed production findings, assign owners for top campaigns and require clean validation evidence after re import.</p>
+        <p>This run analyzed 2 findings from known-cves.html. 2 findings are open and actionable, 1 finding is KEV-backed, 0 findings are accepted risk, 0 findings are VEX suppressed and 0 fixed findings are retained as evidence. Immediate focus should be CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell before governance exceptions are signed off.</p>
       </div>
-      <div class="verdict-banner"><p>This run analyzed 2 finding(s) from known-cves.html; 2 are open and actionable, and 1 are KEV-backed. First focus: CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell remediation cluster(s). Management decision needed: approve the remediation window, assign owners, and require clean validation evidence after re-import. Governance review: no active accepted-risk, VEX, fixed, or overdue waiver items. Provider freshness status is Fresh; validate freshness before formal risk sign-off.</p></div>
+      <div class="decision-grid">
+        <div class="decision-card">
+          <span class="status-label">What management should approve</span>
+          <ul>
+            <li>Remediation window for open production campaigns.</li>
+            <li>Named owners for each remediation cluster.</li>
+            <li>Validation evidence after clean re import.</li>
+          </ul>
+        </div>
+        <div class="decision-card">
+          <span class="status-label">What requires caution</span>
+          <ul>
+            <li>Provider snapshot freshness is fresh for formal sign off.</li>
+            <li>Accepted and VEX suppressed findings remain visible as evidence.</li>
+          </ul>
+        </div>
+      </div>
     </section>
 
     <section aria-labelledby="risk-posture">
-      <div class="section-heading">
-        <p class="eyebrow">Risk Posture</p>
-        <h2 id="risk-posture">Risk Posture Cards</h2>
-      </div>
+      <p class="eyebrow">Risk Posture</p>
+      <h2 id="risk-posture">Executive Risk Posture</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Total Findings</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Open Actionable</span><strong>2</strong></div>
-        <div class="metric" data-tone="critical"><span>Critical Open</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>KEV Backed</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>Internet-facing Prod</span><strong>0</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Risk</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Total Findings</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>Open Actionable</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>KEV Backed</span><strong>1</strong></div>
+        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>2</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Risk</span><strong>0</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>0</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Evidence</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due / Expiring</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Unique CVEs</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Occurrences</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="critical"><span>Internet Facing Prod</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Unique CVEs</span><strong>2</strong></div>
+        <div class="metric" data-tone="success"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="success"><span>Evidence Bundle</span><strong>Ready</strong></div>
       </div>
     </section>
 
     <section aria-labelledby="action-plan">
-      <div class="section-heading">
-        <p class="eyebrow">Action Plan</p>
-        <h2 id="action-plan">First 24h and 7d Action Plan</h2>
-      </div>
+      <p class="eyebrow">Action Plan</p>
+      <h2 id="action-plan">First 24h and 7d Action Plan</h2>
       <div class="table-wrap">
   <table class='compact-table action-plan-table'>
     <thead>
       <tr><th>Time Window</th><th>Action</th><th>Scope</th><th>Owner</th><th>Evidence Basis</th></tr>
     </thead>
     <tbody>
-      <tr><td><strong>24h</strong></td><td>Approve emergency remediation and validation window.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell</td><td>Unassigned</td><td>EPSS 0.846, CVSS 10; KEV, EPSS 0.944, CVSS 10</td></tr>
-<tr><td><strong>72h</strong></td><td>Track validation for completed or governed findings.</td><td>No additional open campaign</td><td>Unassigned</td><td>Actionability and governance status</td></tr>
-<tr><td><strong>7d</strong></td><td>Confirm clean re-import and preserve evidence bundle.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell</td><td>Unassigned</td><td>Technical Markdown, analysis JSON, and provider snapshot</td></tr>
-<tr><td><strong>Governance review</strong></td><td>No governance action required.</td><td>No active exceptions</td><td>Risk owner / security owner</td><td>Waiver, VEX, and fixed-state evidence</td></tr>
+      <tr><td><strong>24h</strong></td><td>Approve emergency remediation for open KEV backed production findings and start validation tracking.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell campaigns.</td><td>Unassigned</td><td>EPSS 0.846, CVSS 10; KEV, EPSS 0.944, CVSS 10</td></tr>
+<tr><td><strong>72h</strong></td><td>Confirm owners, patch status and interim compensating controls for campaigns not yet closed.</td><td>All open actionable findings and any VEX under investigation.</td><td>Security owner plus service owners</td><td>Technical Markdown, findings CSV, owner rollups and validation notes.</td></tr>
+<tr><td><strong>7d</strong></td><td>Perform clean re import, close fixed evidence and preserve the evidence package for audit review.</td><td>All remediation campaigns and fixed evidence.</td><td>Security operations and platform owners</td><td>Evidence ZIP, manifest, provider snapshot and analysis JSON.</td></tr>
+<tr><td><strong>Governance review</strong></td><td>Review due waiver, expiring waiver, accepted risks and VEX suppressed findings before formal risk sign off.</td><td>No waiver debt recorded; no VEX suppressed findings.</td><td>Risk owner and security owner</td><td>Waiver records, VEX overlays and governance artifacts.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
 
-    <section aria-labelledby="remediation-campaigns">
-      <div class="section-heading">
-        <p class="eyebrow">Remediation</p>
-        <h2 id="remediation-campaigns">Top Remediation Campaigns</h2>
-      </div>
+    <section aria-labelledby="campaigns">
+      <p class="eyebrow">Remediation</p>
+      <h2 id="campaigns">Top Remediation Campaigns</h2>
       <div class="table-wrap">
   <table class='campaign-table'>
     <thead>
       <tr><th>Priority</th><th>Risk Cluster</th><th>Actionability</th><th>Scope</th><th>Business Services</th><th>Owners</th><th>Evidence Signals</th><th>Decision Statement</th></tr>
     </thead>
     <tbody>
-        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-high'>1 open</span></td><td>1 asset; 1 occurrence</td><td>Unknown service</td><td>Unassigned</td><td>EPSS 0.846, CVSS 10</td><td>Approve remediation window and validate clean re-import after patching.</td></tr>
-        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; 1 occurrence</td><td>Unknown service</td><td>Unassigned</td><td>KEV, EPSS 0.944, CVSS 10</td><td>Approve emergency patch and validation window within 24h.</td></tr>
+        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset</td><td>Unknown service</td><td>Unassigned</td><td><div class="signal-row"><span class='badge badge-critical'>EPSS 0.846</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-neutral'>No KEV</span></div></td><td>Approve prioritized remediation and validation window.</td></tr>
+        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset</td><td>Unknown service</td><td>Unassigned</td><td><div class="signal-row"><span class='badge badge-critical'>KEV</span><span class='badge badge-critical'>EPSS 0.944</span><span class='badge badge-critical'>CVSS 10</span></div></td><td>Approve emergency patch and validation window within 24h.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
 
-    <section aria-labelledby="business-services-risk">
-      <div class="section-heading">
-        <p class="eyebrow">Business Impact</p>
-        <h2 id="business-services-risk">Business Services at Risk</h2>
-      </div>
+    <section aria-labelledby="business-services">
+      <p class="eyebrow">Business Impact</p>
+      <h2 id="business-services">Business Services at Risk</h2>
+      <p class='lede business-impact-lede'>Vulnerability exposure is concentrated in Infrastructure / Shared Services with active actionable findings. No active owners are assigned to the currently open findings. Management decision: Schedule standard remediation cycles and assign owners for all unassigned findings.</p>
       <div class="table-wrap">
-  <table>
-    <thead>
-      <tr><th>Service</th><th>Open Actionable</th><th>Accepted Risk</th><th>Suppressed / Fixed</th><th>Owners</th><th>Environment / Exposure</th><th>Decision Needed</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>Infrastructure / Shared Services</strong></td><td>2</td><td>0</td><td>0</td><td>Unassigned</td><td>Unknown / Unknown</td><td><span class='badge badge-critical'>Emergency remediation</span></td></tr>
-    </tbody>
-  </table>
-</div>
+        <table>
+          <thead>
+            <tr><th>Service</th><th>Open Actionable</th><th>Governed Risk</th><th>Environment / Exposure</th><th>Owner</th><th>Decision Needed</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><strong>Infrastructure / Shared Services</strong></td><td>2</td><td>0 accepted, 0 VEX suppressed</td><td>Unknown / Unknown</td><td>Unassigned</td><td><span class='badge badge-critical'>Emergency remediation</span></td></tr>
+          </tbody>
+        </table>
+      </div>
     </section>
 
-    <section aria-labelledby="governance-rollups">
-      <div class="section-heading">
-        <p class="eyebrow">Governance</p>
-        <h2 id="governance-rollups">Governance Exceptions</h2>
-      </div>
+    <section aria-labelledby="governance">
+      <p class="eyebrow">Governance</p>
+      <h2 id="governance">Governance Exceptions</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Waivers</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Expired</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Waivers</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Expired</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Expiring Soon</span><strong>0</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Findings</span><strong>0</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>0</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Under Investigation</span><strong>0</strong></div>
       </div>
       <h3>Accepted Risk and Waiver Review</h3>
       <div class="table-wrap">
         <table>
           <thead>
-            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expiry</th><th>Review Date</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
+            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th><th>Review</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
           </thead>
           <tbody>
 <tr><td colspan="7" class="empty-state">No accepted-risk waiver debt is currently recorded for this run.</td></tr>
@@ -341,26 +364,27 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
     </section>
 
 
-    <section aria-labelledby="provider-freshness">
-      <div class="section-heading">
-        <p class="eyebrow">Evidence</p>
-        <h2 id="provider-freshness">Evidence Confidence and Provider Freshness</h2>
+    <section aria-labelledby="evidence">
+      <p class="eyebrow">Evidence</p>
+      <h2 id="evidence">Evidence Confidence and Provider Freshness</h2>
+      <div class='verdict-banner'><p><strong>Evidence confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
+      <div class='table-wrap'>
+        <table>
+          <thead>
+            <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
+          </thead>
+          <tbody>
+                  <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo. Note: locked provider data guarantees reproducibility but does not automatically mean the data is fresh.</td></tr>
+            <tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>Content hash</strong></td><td><code>sha256:vpw049-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
+            <tr><td><strong>Selected sources</strong></td><td>nvd, epss, kev</td><td><span class='badge badge-success'>Recorded</span></td><td>Vulnerability intelligence sources selected for data enrichment.</td></tr>
+            <tr><td><strong>Evidence bundle manifest</strong></td><td>manifest.json</td><td><span class='badge badge-success'>Fresh</span></td><td>Evidence package manifest is available for validation.</td></tr>
+            <tr><td><strong>Static HTML safety</strong></td><td>No scripts, no external assets, escaped recommendation text</td><td><span class='badge badge-success'>Controlled</span></td><td>Report is suitable for local review and evidence package distribution.</td></tr>
+          </tbody>
+        </table>
       </div>
-<div class='verdict-banner'><p><strong>Evidence Confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
-<div class='table-wrap'>
-  <table>
-    <thead>
-      <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo.</td></tr>
-<tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>Content hash</strong></td><td><code>sha256:vpw049-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
-    </tbody>
-  </table>
-</div>
       <h3>Raw Provider Metadata</h3>
       <dl class="provider-grid">
         <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000051</dd></div>
@@ -373,84 +397,59 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
       </dl>
             <h3>Evidence Package Contents</h3>
       <div class='table-wrap'>
-        <table>
+        <table class='compact-table'>
           <thead>
-            <tr><th>Artifact File</th><th>Purpose / Description</th><th>Status</th></tr>
+            <tr><th>Artifact File</th><th>Purpose</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>manifest.json</code></td><td>Manifest and artifact hash verification</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>executive.html</code></td><td>Executive HTML decision brief</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>technical.md</code></td><td>Technical Markdown finding explanation</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>analysis.json</code></td><td>Machine-readable run result</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>findings.csv</code></td><td>Findings CSV (spreadsheet review)</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>results.sarif</code></td><td>SARIF toolchain integration</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay / reproducibility</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>attack-navigator-layer.json</code></td><td>ATT&amp;CK Navigator defensive TTP context</td><td><span class='badge badge-low'>Optional</span></td></tr>
-<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX, rollup, and asset-context evidence</td><td><span class='badge badge-low'>Optional</span></td></tr>
+            <tr><td><code>manifest.json</code></td><td>Bundle manifest and artifact hash verification.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>executive.html</code></td><td>Decision oriented executive brief.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>technical.md</code></td><td>Detailed analyst handoff with finding rows and rationale.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>analysis.json</code></td><td>Machine readable analysis export.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>findings.csv</code></td><td>Spreadsheet review of findings and owner scope.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>results.sarif</code></td><td>SARIF 2.1.0 integration output.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay for reproducibility.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>attack-navigator-layer.json</code></td><td>Defensive ATT&amp;CK Navigator layer for mapped findings.</td><td><span class='badge badge-info'>optional</span></td></tr>
+<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX and asset context evidence.</td><td><span class='badge badge-info'>optional</span></td></tr>
           </tbody>
         </table>
       </div>
     </section>
 
     <section aria-labelledby="recommendations">
-      <div class="section-heading">
-        <p class="eyebrow">Recommendations</p>
-        <h2 id="recommendations">Recommendations</h2>
-      </div>
+      <p class="eyebrow">Recommendations</p>
+      <h2 id="recommendations">Decision Ready Recommendations</h2>
       <ol class="recommendation-list">
-<li>
-  <strong>CVE-2024-3094 / XZ Utils Backdoor remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: Unknown service<br>
-    Status: 1 open<br>
-    Recommended action: Patch [open](javascript:alert(1)) now.<br>
-    SLA: Emergency / 24h<br>
-    Owner: Unassigned<br>
-    Evidence basis: EPSS 0.846, CVSS 10
-  </span>
-</li>
-
-<li>
-  <strong>CVE-2021-44228 / Log4Shell remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: Unknown service<br>
-    Status: 1 open<br>
-    Recommended action: Patch via vendor upgrade.<br>
-    SLA: Emergency / 24h<br>
-    Owner: Unassigned<br>
-    Evidence basis: KEV, EPSS 0.944, CVSS 10
-  </span>
-</li>
-
+<li><strong>CVE-2024-3094 / XZ Utils campaign</strong><span>Scope: 1 asset; services: Unknown service. Status: 1 open. Recommended action: Patch [open](javascript:alert(1)) now.. SLA: Emergency / 24h. Owners: Unassigned. Evidence basis: EPSS 0.846, CVSS 10.</span></li>
+<li><strong>CVE-2021-44228 / Log4Shell remediation campaign</strong><span>Scope: 1 asset; services: Unknown service. Status: 1 open. Recommended action: Patch via vendor upgrade.. SLA: Emergency / 24h. Owners: Unassigned. Evidence basis: KEV, EPSS 0.944, CVSS 10.</span></li>
       </ol>
     </section>
 
-    <section aria-labelledby="attack-context">
-      <div class="section-heading">
-        <p class="eyebrow">SOC Context</p>
-        <h2 id="attack-context">ATT&CK/TTP Context</h2>
+    <section aria-labelledby="attack">
+      <p class="eyebrow">SOC Context</p>
+      <h2 id="attack">ATT&amp;CK/TTP Context</h2>
+            <div class='note-box'>
+        <p>ATT&amp;CK context is shown as reviewed defensive context only. It supports SOC validation and telemetry review, but it does not prove compromise and does not override the transparent base priority from CVSS, EPSS, KEV and asset context.</p>
       </div>
-            <div class='table-wrap'>
+      <div class='table-wrap'>
         <table class='compact-table'>
           <thead>
-            <tr><th>ATT&CK/TTP Context</th><th>Status</th></tr>
+            <tr><th>Context</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>Mapped findings</strong></td><td>0</td></tr>
-<tr><td><strong>Unmapped findings</strong></td><td>2</td></tr>
-<tr><td><strong>Mapping source</strong></td><td>CTID JSON / curated local mapping</td></tr>
+            <tr><td><strong>Mapped findings</strong></td><td>0 reviewed mapping records available.</td></tr>
+<tr><td><strong>Common techniques</strong></td><td>No reviewed techniques recorded.</td></tr>
 <tr><td><strong>Navigator layer</strong></td><td>Optional / not generated</td></tr>
+<tr><td><strong>Unmapped CVEs</strong></td><td>2 remain unmapped. No LLM inferred mappings are used.</td></tr>
           </tbody>
         </table>
       </div>
     </section>
 
-    <section aria-labelledby="technical-appendix">
-      <div class="section-heading">
-        <p class="eyebrow">Appendix</p>
-        <h2 id="technical-appendix">Technical Markdown Separation</h2>
-      </div>
-      <p class="empty-state">Detailed finding rows, component versions, long rationale, and per-finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF, and Evidence ZIP.</p>
+    <section aria-labelledby="appendix">
+      <p class="eyebrow">Appendix</p>
+      <h2 id="appendix">Technical Markdown Separation</h2>
+      <p class="footer-note">Detailed finding rows, component versions, long remediation text, input provenance, full rationale and per finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF and Evidence ZIP. This Executive HTML report intentionally summarizes the decision path for stakeholder review.</p>
     </section>
   </main>
 </body>

--- a/backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
+++ b/backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
@@ -7,201 +7,220 @@
   <style>
 :root {
   color-scheme: light;
-  --vpw-bg-app: #fafafa; --vpw-bg-card: #ffffff; --vpw-bg-panel: #f5f5f5;
-  --vpw-bg-info: #eef6ff; --vpw-bg-warning: #fff7e6; --vpw-bg-critical: #fff1f1;
-  --vpw-text-primary: #171717; --vpw-text-secondary: #4d4d4d; --vpw-text-muted: #6b6b6b;
-  --vpw-border-default: #ebebeb; --vpw-blue: #0070f3; --vpw-teal: #047857;
-  --vpw-green: #047857; --vpw-amber: #b54708; --vpw-red: #c40000; --vpw-violet: #475569;
-  --vpw-radius-lg: 8px; --vpw-radius-xl: 8px; --medium: #d97706; --low: #0ea5e9;
+  --bg-app: #fafafa;
+  --bg-card: #ffffff;
+  --bg-panel: #f5f5f5;
+  --bg-info: #eef6ff;
+  --bg-warning: #fff7e6;
+  --bg-critical: #fff1f1;
+  --bg-success: #ecfdf5;
+  --text-primary: #171717;
+  --text-secondary: #404040;
+  --text-muted: #6b6b6b;
+  --border: #e8e8e8;
+  --blue: #006adc;
+  --green: #047857;
+  --amber: #b54708;
+  --red: #c40000;
+  --violet: #475569;
+  --radius: 12px;
+  --radius-sm: 8px;
 }
 * { box-sizing: border-box; }
 body {
-  margin: 0; background: var(--vpw-bg-app); color: var(--vpw-text-primary);
-  font-family: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system,
+  margin: 0;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font-family:
+    "Geist", "Aptos", Inter, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px; line-height: 1.5; text-rendering: optimizeLegibility;
+  font-size: 14px;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
 }
-.report-shell { width: min(1280px, calc(100% - 32px)); margin: 0 auto; padding: 24px 0 40px; }
+.report-shell {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
 header, section {
-  margin-bottom: 16px; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-xl);
-  background: var(--vpw-bg-card); padding: 20px; box-shadow: none;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  padding: 20px;
 }
 h1, h2, h3, p { margin-top: 0; }
 h1 {
-  margin-bottom: 8px; color: var(--vpw-text-primary); font-size: 30px;
-  font-weight: 720; line-height: 1.15; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: 0;
+  font-weight: 760;
 }
 h2 {
-  margin-bottom: 10px; color: var(--vpw-text-primary); font-size: 20px;
-  font-weight: 720; line-height: 1.25; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 20px;
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 740;
 }
 h3 {
-  margin: 22px 0 10px; color: var(--vpw-text-primary); font-size: 15px;
-  font-weight: 650; line-height: 1.3; letter-spacing: 0;
+  margin: 22px 0 10px;
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 680;
 }
-.eyebrow, dt, .metric span, th {
-  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, monospace;
-  font-size: 12px; line-height: 1rem; letter-spacing: 0; text-transform: uppercase;
+.eyebrow, dt, .metric span, th, .status-label {
+  font-family:
+    "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
+  font-size: 12px;
+  line-height: 1rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
-.eyebrow { margin-bottom: 6px; color: var(--vpw-teal); font-weight: 600; }
+.eyebrow { margin-bottom: 6px; color: var(--green); font-weight: 650; }
 .lede {
-  max-width: 56rem; color: var(--vpw-text-secondary); font-size: 14px; line-height: 1.5;
+  max-width: none;
+  width: 100%;
+  color: var(--text-secondary);
 }
-.section-heading { margin-bottom: 12px; }
+.business-impact-lede {
+  max-width: none;
+  width: 100%;
+}
 .meta-grid, .metric-grid, .provider-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
-.meta-grid { margin: 18px 0 0; }
-.metric-grid { margin-bottom: 14px; }
+.meta-grid { margin-top: 18px; }
 .meta-grid div, .metric, .provider-grid div {
-  min-width: 0; border: 1px solid var(--vpw-border-default); border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card); padding: 12px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
 }
-.meta-grid div, .provider-grid div { background: var(--vpw-bg-panel); }
-.metric { min-height: 78px; align-content: center; box-shadow: inset 2px 0 0 var(--vpw-violet); }
-.metric[data-tone="info"] { box-shadow: inset 2px 0 0 var(--vpw-blue); }
-.metric[data-tone="success"] { box-shadow: inset 2px 0 0 var(--vpw-green); }
-.metric[data-tone="warning"] { box-shadow: inset 2px 0 0 var(--vpw-amber); }
-.metric[data-tone="critical"] { box-shadow: inset 2px 0 0 var(--vpw-red); }
-dt, .metric span { color: var(--vpw-text-muted); font-weight: 500; }
-dd { margin: 4px 0 0; color: var(--vpw-text-primary); overflow-wrap: anywhere; }
+.meta-grid div, .provider-grid div { background: var(--bg-panel); }
+dt, .metric span { color: var(--text-muted); font-weight: 560; }
+dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+.metric {
+  background: var(--bg-card);
+  min-height: 80px;
+  align-content: center;
+  box-shadow: inset 3px 0 0 var(--violet);
+}
 .metric strong {
-  display: block; margin-top: 4px; color: var(--vpw-text-primary);
-  font-size: 24px; font-weight: 720; line-height: 1.1; letter-spacing: 0;
+  display: block;
+  margin-top: 4px;
+  font-size: 25px;
+  line-height: 1.05;
+  font-weight: 760;
 }
+.metric[data-tone="critical"] { box-shadow: inset 3px 0 0 var(--red); }
+.metric[data-tone="warning"] { box-shadow: inset 3px 0 0 var(--amber); }
+.metric[data-tone="success"] { box-shadow: inset 3px 0 0 var(--green); }
+.metric[data-tone="info"] { box-shadow: inset 3px 0 0 var(--blue); }
+.verdict-banner {
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #fff7e6 0%, #fffaf0 100%);
+  padding: 16px;
+  margin: 0 0 14px;
+}
+.verdict-banner strong { color: #7c2d12; }
+.decision-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 12px;
+}
+.decision-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 14px;
+}
+.decision-card ul { margin: 8px 0 0 18px; padding: 0; }
+.decision-card li + li { margin-top: 4px; }
 .table-wrap {
-  overflow-x: auto; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 table {
-  width: 100%; min-width: 960px; border-collapse: collapse; background: var(--vpw-bg-card);
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  background: var(--bg-card);
 }
+.compact-table { min-width: 0; }
 th, td {
-  border-bottom: 1px solid var(--vpw-border-default); padding: 10px 8px;
-  text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
 }
-th { color: var(--vpw-text-muted); background: var(--vpw-bg-panel); font-weight: 500; }
-td { color: var(--vpw-text-primary); font-size: 14px; overflow-wrap: anywhere; }
+th { color: var(--text-muted); background: var(--bg-panel); font-weight: 560; }
+td { color: var(--text-primary); overflow-wrap: anywhere; }
 tbody tr:last-child td { border-bottom: 0; }
 .badge {
-  display: inline-flex; align-items: center; border: 1px solid transparent; border-radius: 9999px;
-  background: var(--vpw-bg-info); color: var(--vpw-blue); padding: 2px 8px;
-  font-size: 12px; font-weight: 600; line-height: 1.25; white-space: nowrap;
-}
-tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
-.badge-critical {
-  border-color: #fecaca; background: var(--vpw-bg-critical); color: var(--vpw-red);
-}
-.badge-high { border-color: #fed7aa; background: var(--vpw-bg-warning); color: var(--vpw-amber); }
-.badge-medium { border-color: #fde68a; background: #fffbeb; color: var(--medium); }
-.badge-low { border-color: #bae6fd; background: #f0f9ff; color: var(--low); }
-.badge-overdue { border-color: #fecaca; background: #fff1f1; color: var(--vpw-red); }
-.badge-fresh { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.badge-warning-alt { border-color: #fed7aa; background: #fff7e6; color: #b54708; }
-.badge-stale { border-color: #fca5a5; background: #fff1f1; color: #c40000; }
-.badge-success { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.verdict-banner {
-  background: var(--vpw-bg-panel);
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  padding: 16px;
-  margin-bottom: 18px;
-}
-.verdict-banner p { margin-bottom: 8px; }
-.verdict-banner p:last-child { margin-bottom: 0; }
-.campaign-card {
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card);
-  padding: 16px;
-  margin-bottom: 16px;
-}
-.campaign-card:last-child { margin-bottom: 0; }
-.campaign-header {
-  display: flex;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
-  border-bottom: 1px solid var(--vpw-border-default);
-  padding-bottom: 10px;
-  margin-bottom: 12px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 680;
+  line-height: 1.25;
+  white-space: nowrap;
 }
-.campaign-title-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.campaign-title {
-  font-size: 16px;
-  font-weight: 720;
-  margin: 0;
-}
-.campaign-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin-bottom: 14px;
-  background: var(--vpw-bg-panel);
-  padding: 12px;
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-meta-item {
-  font-size: 13px;
-  line-height: 1.4;
-}
-.campaign-meta-item strong {
-  display: block;
-  color: var(--vpw-text-secondary);
-  font-weight: 650;
-}
-.campaign-assets-toggle {
-  margin-top: 10px;
-}
-.campaign-assets-toggle summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--vpw-blue);
-  outline: none;
-  user-select: none;
-}
-.campaign-assets-table-wrap {
-  margin-top: 8px;
-  overflow-x: auto;
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-assets-table-wrap table {
-  min-width: 100%;
-}
-.campaign-assets-table-wrap th, .campaign-assets-table-wrap td {
-  padding: 8px 10px;
-  font-size: 13px;
+.badge-critical { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-high { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.badge-info { border-color: #bfdbfe; background: var(--bg-info); color: var(--blue); }
+.badge-success { border-color: #a7f3d0; background: var(--bg-success); color: var(--green); }
+.badge-neutral { border-color: #d4d4d4; background: #f7f7f7; color: #525252; }
+.badge-stale { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-warning { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.signal-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.campaign-table td:nth-child(1),
+.campaign-table td:nth-child(3),
+.campaign-table td:nth-child(4) {
+  white-space: nowrap;
 }
 .recommendation-list { margin: 0; padding-left: 22px; }
-.recommendation-list li + li { margin-top: 12px; }
-.recommendation-list strong { display: block; color: var(--vpw-text-primary); font-weight: 650; }
-.recommendation-list span { color: var(--vpw-text-secondary); }
-.empty-state { color: var(--vpw-text-muted); }
-.text-muted { color: var(--vpw-text-muted); }
-.signal-badge-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; }
-.compact-table { min-width: 0; }
-@media (max-width: 820px) {
+.recommendation-list li + li { margin-top: 14px; }
+.recommendation-list strong { display: block; margin-bottom: 4px; font-weight: 700; }
+.recommendation-list span { color: var(--text-secondary); }
+.note-box {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  padding: 14px;
+  color: var(--text-secondary);
+}
+.note-box + .table-wrap { margin-top: 12px; }
+.footer-note { margin: 0; color: var(--text-muted); }
+@media (max-width: 900px) {
   .report-shell { width: min(100% - 20px, 1280px); padding-top: 16px; }
   header, section { padding: 16px; }
   h1 { font-size: 26px; }
-  .meta-grid, .metric-grid, .provider-grid { grid-template-columns: 1fr; }
-  .campaign-header { align-items: flex-start; flex-direction: column; gap: 10px; }
-  .signal-badge-row { justify-content: flex-start; }
+  .meta-grid, .metric-grid, .provider-grid, .decision-grid { grid-template-columns: 1fr; }
+  table { min-width: 920px; }
+  .compact-table { min-width: 720px; }
 }
 @media print {
-  body { background: #ffffff; color: #000000; }
+  body { background: #fff; color: #000; }
   .report-shell { width: 100%; padding: 0; }
   header, section {
-    border-color: #c8c8c8; break-inside: avoid; page-break-inside: avoid; padding: 18px;
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    padding: 16px;
   }
   .table-wrap { overflow: visible; }
   table { min-width: 0; }
+  .badge { border-color: #999; background: #fff; color: #000; }
 }
   </style>
 </head>
@@ -209,121 +228,128 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
   <main class="report-shell">
     <header>
       <p class="eyebrow">Executive Evidence Brief</p>
-      <h1>Executive Vulnerability Report</h1>
-      <p class="lede">Decision-oriented evidence brief for VPW-054 Demo Reports.</p>
+      <h1>VPW-054 Demo Reports</h1>
+      <p class="lede">Decision oriented vulnerability prioritization report for CISO and stakeholder review. This report summarizes actionable remediation campaigns, governance exceptions and evidence confidence for the current analysis run.</p>
       <dl class="meta-grid">
-        <div><dt>Project Name</dt><dd>VPW-054 Demo Reports</dd></div>
+        <div><dt>Report Type</dt><dd>Executive HTML</dd></div>
         <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000054</dd></div>
         <div><dt>Analysis Run ID</dt><dd>00000000-0000-4000-8000-000000000540</dd></div>
         <div><dt>Generated At</dt><dd>2026-04-29T12:00:00Z</dd></div>
         <div><dt>Run Status</dt><dd>completed</dd></div>
         <div><dt>Input Type</dt><dd>cve-list</dd></div>
         <div><dt>Input File</dt><dd>vpw-054-known-cves.txt</dd></div>
-        <div><dt>Input File Hash</dt><dd>N/A</dd></div>
-        <div><dt>Provider Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
-        <div><dt>Generator Version</dt><dd>v1.0.0</dd></div>
+        <div><dt>Provider Snapshot</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
       </dl>
     </header>
     <section aria-labelledby="decision-brief">
-      <div class="section-heading">
-        <p class="eyebrow">Executive Summary</p>
-        <h2 id="decision-brief">Decision Brief</h2>
+      <p class="eyebrow">Executive Summary</p>
+      <h2 id="decision-brief">Decision Brief</h2>
+      <div class="verdict-banner">
+        <p><strong>Decision needed:</strong> approve emergency remediation for open KEV backed production findings, assign owners for top campaigns and require clean validation evidence after re import.</p>
+        <p>This run analyzed 2 findings from vpw-054-known-cves.txt. 2 findings are open and actionable, 1 finding is KEV-backed, 0 findings are accepted risk, 0 findings are VEX suppressed and 0 fixed findings are retained as evidence. Immediate focus should be CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell before governance exceptions are signed off.</p>
       </div>
-      <div class="verdict-banner"><p>This run analyzed 2 finding(s) from vpw-054-known-cves.txt; 2 are open and actionable, and 1 are KEV-backed. First focus: CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell remediation cluster(s). Management decision needed: approve the remediation window, assign owners, and require clean validation evidence after re-import. Governance review: no active accepted-risk, VEX, fixed, or overdue waiver items. Provider freshness status is Fresh; validate freshness before formal risk sign-off.</p></div>
+      <div class="decision-grid">
+        <div class="decision-card">
+          <span class="status-label">What management should approve</span>
+          <ul>
+            <li>Remediation window for open production campaigns.</li>
+            <li>Named owners for each remediation cluster.</li>
+            <li>Validation evidence after clean re import.</li>
+          </ul>
+        </div>
+        <div class="decision-card">
+          <span class="status-label">What requires caution</span>
+          <ul>
+            <li>Provider snapshot freshness is fresh for formal sign off.</li>
+            <li>Accepted and VEX suppressed findings remain visible as evidence.</li>
+          </ul>
+        </div>
+      </div>
     </section>
     <section aria-labelledby="risk-posture">
-      <div class="section-heading">
-        <p class="eyebrow">Risk Posture</p>
-        <h2 id="risk-posture">Risk Posture Cards</h2>
-      </div>
+      <p class="eyebrow">Risk Posture</p>
+      <h2 id="risk-posture">Executive Risk Posture</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Total Findings</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Open Actionable</span><strong>2</strong></div>
-        <div class="metric" data-tone="critical"><span>Critical Open</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>KEV Backed</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>Internet-facing Prod</span><strong>1</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Risk</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Total Findings</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>Open Actionable</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>KEV Backed</span><strong>1</strong></div>
+        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>2</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Risk</span><strong>0</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>0</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Evidence</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due / Expiring</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Unique CVEs</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Occurrences</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="critical"><span>Internet Facing Prod</span><strong>1</strong></div>
+        <div class="metric" data-tone="info"><span>Unique CVEs</span><strong>2</strong></div>
+        <div class="metric" data-tone="success"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="success"><span>Evidence Bundle</span><strong>Ready</strong></div>
       </div>
     </section>
     <section aria-labelledby="action-plan">
-      <div class="section-heading">
-        <p class="eyebrow">Action Plan</p>
-        <h2 id="action-plan">First 24h and 7d Action Plan</h2>
-      </div>
+      <p class="eyebrow">Action Plan</p>
+      <h2 id="action-plan">First 24h and 7d Action Plan</h2>
       <div class="table-wrap">
   <table class='compact-table action-plan-table'>
     <thead>
       <tr><th>Time Window</th><th>Action</th><th>Scope</th><th>Owner</th><th>Evidence Basis</th></tr>
     </thead>
     <tbody>
-      <tr><td><strong>24h</strong></td><td>Approve emergency remediation and validation window.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell</td><td>platform-team, secops</td><td>EPSS 0.846, CVSS 10; KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td></tr>
-<tr><td><strong>72h</strong></td><td>Track validation for completed or governed findings.</td><td>No additional open campaign</td><td>platform-team, secops</td><td>Actionability and governance status</td></tr>
-<tr><td><strong>7d</strong></td><td>Confirm clean re-import and preserve evidence bundle.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell</td><td>platform-team, secops</td><td>Technical Markdown, analysis JSON, and provider snapshot</td></tr>
-<tr><td><strong>Governance review</strong></td><td>No governance action required.</td><td>No active exceptions</td><td>Risk owner / security owner</td><td>Waiver, VEX, and fixed-state evidence</td></tr>
+      <tr><td><strong>24h</strong></td><td>Approve emergency remediation for open KEV backed production findings and start validation tracking.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell campaigns.</td><td>platform-team, secops</td><td>EPSS 0.846, CVSS 10; KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td></tr>
+<tr><td><strong>72h</strong></td><td>Confirm owners, patch status and interim compensating controls for campaigns not yet closed.</td><td>All open actionable findings and any VEX under investigation.</td><td>Security owner plus service owners</td><td>Technical Markdown, findings CSV, owner rollups and validation notes.</td></tr>
+<tr><td><strong>7d</strong></td><td>Perform clean re import, close fixed evidence and preserve the evidence package for audit review.</td><td>All remediation campaigns and fixed evidence.</td><td>Security operations and platform owners</td><td>Evidence ZIP, manifest, provider snapshot and analysis JSON.</td></tr>
+<tr><td><strong>Governance review</strong></td><td>Review due waiver, expiring waiver, accepted risks and VEX suppressed findings before formal risk sign off.</td><td>No waiver debt recorded; no VEX suppressed findings.</td><td>Risk owner and security owner</td><td>Waiver records, VEX overlays and governance artifacts.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
-    <section aria-labelledby="remediation-campaigns">
-      <div class="section-heading">
-        <p class="eyebrow">Remediation</p>
-        <h2 id="remediation-campaigns">Top Remediation Campaigns</h2>
-      </div>
+    <section aria-labelledby="campaigns">
+      <p class="eyebrow">Remediation</p>
+      <h2 id="campaigns">Top Remediation Campaigns</h2>
       <div class="table-wrap">
   <table class='campaign-table'>
     <thead>
       <tr><th>Priority</th><th>Risk Cluster</th><th>Actionability</th><th>Scope</th><th>Business Services</th><th>Owners</th><th>Evidence Signals</th><th>Decision Statement</th></tr>
     </thead>
     <tbody>
-        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-high'>1 open</span></td><td>1 asset; 1 occurrence</td><td>checkout</td><td>platform-team</td><td>EPSS 0.846, CVSS 10</td><td>Approve remediation window and validate clean re-import after patching.</td></tr>
-        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; 1 occurrence</td><td>operations</td><td>secops</td><td>KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td><td>Approve emergency patch and validation window within 24h.</td></tr>
+        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; production; internet facing exposure</td><td>checkout</td><td>platform-team</td><td><div class="signal-row"><span class='badge badge-critical'>EPSS 0.846</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-neutral'>No KEV</span></div></td><td>Approve prioritized remediation and validation window.</td></tr>
+        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; production; internal exposure</td><td>operations</td><td>secops</td><td><div class="signal-row"><span class='badge badge-critical'>KEV</span><span class='badge badge-critical'>EPSS 0.944</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-info'>ATT&CK T1190</span></div></td><td>Approve emergency patch and validation window within 24h.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
-    <section aria-labelledby="business-services-risk">
-      <div class="section-heading">
-        <p class="eyebrow">Business Impact</p>
-        <h2 id="business-services-risk">Business Services at Risk</h2>
-      </div>
+    <section aria-labelledby="business-services">
+      <p class="eyebrow">Business Impact</p>
+      <h2 id="business-services">Business Services at Risk</h2>
+      <p class='lede business-impact-lede'>Vulnerability exposure is concentrated in checkout, operations with active actionable findings. Critical internet-facing production exposure is present in: checkout. Assigned service owners who must prioritize remediation include: platform-team, secops. Management decision: Approve emergency patch windows for internet-facing production assets, review governance exceptions for internal hosts, and require clean re-import validation.</p>
       <div class="table-wrap">
-  <table>
-    <thead>
-      <tr><th>Service</th><th>Open Actionable</th><th>Accepted Risk</th><th>Suppressed / Fixed</th><th>Owners</th><th>Environment / Exposure</th><th>Decision Needed</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>operations</strong></td><td>1</td><td>0</td><td>0</td><td>secops</td><td>prod / internal</td><td><span class='badge badge-critical'>Emergency remediation</span></td></tr>
-<tr><td><strong>checkout</strong></td><td>1</td><td>0</td><td>0</td><td>platform-team</td><td>prod / internet-facing</td><td><span class='badge badge-high'>Remediation scheduling</span></td></tr>
-    </tbody>
-  </table>
-</div>
-    </section>
-    <section aria-labelledby="governance-rollups">
-      <div class="section-heading">
-        <p class="eyebrow">Governance</p>
-        <h2 id="governance-rollups">Governance Exceptions</h2>
+        <table>
+          <thead>
+            <tr><th>Service</th><th>Open Actionable</th><th>Governed Risk</th><th>Environment / Exposure</th><th>Owner</th><th>Decision Needed</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><strong>operations</strong></td><td>1</td><td>0 accepted, 0 VEX suppressed</td><td>production / internal</td><td>secops</td><td><span class='badge badge-critical'>Emergency remediation</span></td></tr>
+            <tr><td><strong>checkout</strong></td><td>1</td><td>0 accepted, 0 VEX suppressed</td><td>production / internet facing</td><td>platform-team</td><td><span class='badge badge-high'>Remediation scheduling</span></td></tr>
+          </tbody>
+        </table>
       </div>
+    </section>
+    <section aria-labelledby="governance">
+      <p class="eyebrow">Governance</p>
+      <h2 id="governance">Governance Exceptions</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Waivers</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Expired</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Waivers</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Expired</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Expiring Soon</span><strong>0</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Findings</span><strong>0</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>0</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Under Investigation</span><strong>0</strong></div>
       </div>
       <h3>Accepted Risk and Waiver Review</h3>
       <div class="table-wrap">
         <table>
           <thead>
-            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expiry</th><th>Review Date</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
+            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th><th>Review</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
           </thead>
           <tbody>
 <tr><td colspan="7" class="empty-state">No accepted-risk waiver debt is currently recorded for this run.</td></tr>
@@ -331,26 +357,27 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
         </table>
       </div>
     </section>
-    <section aria-labelledby="provider-freshness">
-      <div class="section-heading">
-        <p class="eyebrow">Evidence</p>
-        <h2 id="provider-freshness">Evidence Confidence and Provider Freshness</h2>
+    <section aria-labelledby="evidence">
+      <p class="eyebrow">Evidence</p>
+      <h2 id="evidence">Evidence Confidence and Provider Freshness</h2>
+      <div class='verdict-banner'><p><strong>Evidence confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
+      <div class='table-wrap'>
+        <table>
+          <thead>
+            <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
+          </thead>
+          <tbody>
+                  <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo. Note: locked provider data guarantees reproducibility but does not automatically mean the data is fresh.</td></tr>
+            <tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>Content hash</strong></td><td><code>sha256:vpw050-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
+            <tr><td><strong>Selected sources</strong></td><td>nvd, epss, kev</td><td><span class='badge badge-success'>Recorded</span></td><td>Vulnerability intelligence sources selected for data enrichment.</td></tr>
+            <tr><td><strong>Evidence bundle manifest</strong></td><td>manifest.json</td><td><span class='badge badge-success'>Fresh</span></td><td>Evidence package manifest is available for validation.</td></tr>
+            <tr><td><strong>Static HTML safety</strong></td><td>No scripts, no external assets, escaped recommendation text</td><td><span class='badge badge-success'>Controlled</span></td><td>Report is suitable for local review and evidence package distribution.</td></tr>
+          </tbody>
+        </table>
       </div>
-<div class='verdict-banner'><p><strong>Evidence Confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
-<div class='table-wrap'>
-  <table>
-    <thead>
-      <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo.</td></tr>
-<tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>Content hash</strong></td><td><code>sha256:vpw050-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
-    </tbody>
-  </table>
-</div>
       <h3>Raw Provider Metadata</h3>
       <dl class="provider-grid">
         <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
@@ -361,79 +388,56 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
       </dl>
             <h3>Evidence Package Contents</h3>
       <div class='table-wrap'>
-        <table>
+        <table class='compact-table'>
           <thead>
-            <tr><th>Artifact File</th><th>Purpose / Description</th><th>Status</th></tr>
+            <tr><th>Artifact File</th><th>Purpose</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>manifest.json</code></td><td>Manifest and artifact hash verification</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>executive.html</code></td><td>Executive HTML decision brief</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>technical.md</code></td><td>Technical Markdown finding explanation</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>analysis.json</code></td><td>Machine-readable run result</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>findings.csv</code></td><td>Findings CSV (spreadsheet review)</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>results.sarif</code></td><td>SARIF toolchain integration</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay / reproducibility</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>attack-navigator-layer.json</code></td><td>ATT&amp;CK Navigator defensive TTP context</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX, rollup, and asset-context evidence</td><td><span class='badge badge-low'>Optional</span></td></tr>
+            <tr><td><code>manifest.json</code></td><td>Bundle manifest and artifact hash verification.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>executive.html</code></td><td>Decision oriented executive brief.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>technical.md</code></td><td>Detailed analyst handoff with finding rows and rationale.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>analysis.json</code></td><td>Machine readable analysis export.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>findings.csv</code></td><td>Spreadsheet review of findings and owner scope.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>results.sarif</code></td><td>SARIF 2.1.0 integration output.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay for reproducibility.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>attack-navigator-layer.json</code></td><td>Defensive ATT&amp;CK Navigator layer for mapped findings.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX and asset context evidence.</td><td><span class='badge badge-info'>optional</span></td></tr>
           </tbody>
         </table>
       </div>
     </section>
     <section aria-labelledby="recommendations">
-      <div class="section-heading">
-        <p class="eyebrow">Recommendations</p>
-        <h2 id="recommendations">Recommendations</h2>
-      </div>
+      <p class="eyebrow">Recommendations</p>
+      <h2 id="recommendations">Decision Ready Recommendations</h2>
       <ol class="recommendation-list">
-<li>
-  <strong>CVE-2024-3094 / XZ Utils Backdoor remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: checkout<br>
-    Status: 1 open<br>
-    Recommended action: Patch [open](javascript:alert(1)) now.<br>
-    SLA: Emergency / 24h<br>
-    Owner: platform-team<br>
-    Evidence basis: EPSS 0.846, CVSS 10
-  </span>
-</li>
-<li>
-  <strong>CVE-2021-44228 / Log4Shell remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: operations<br>
-    Status: 1 open<br>
-    Recommended action: Patch via vendor upgrade.<br>
-    SLA: Emergency / 24h<br>
-    Owner: secops<br>
-    Evidence basis: KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190
-  </span>
-</li>
+<li><strong>CVE-2024-3094 / XZ Utils campaign</strong><span>Scope: 1 asset; production; internet facing exposure; services: checkout. Status: 1 open. Recommended action: Patch [open](javascript:alert(1)) now.. SLA: Emergency / 24h. Owners: platform-team. Evidence basis: EPSS 0.846, CVSS 10.</span></li>
+<li><strong>CVE-2021-44228 / Log4Shell remediation campaign</strong><span>Scope: 1 asset; production; internal exposure; services: operations. Status: 1 open. Recommended action: Patch via vendor upgrade.. SLA: Emergency / 24h. Owners: secops. Evidence basis: KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190.</span></li>
       </ol>
     </section>
-    <section aria-labelledby="attack-context">
-      <div class="section-heading">
-        <p class="eyebrow">SOC Context</p>
-        <h2 id="attack-context">ATT&CK/TTP Context</h2>
+    <section aria-labelledby="attack">
+      <p class="eyebrow">SOC Context</p>
+      <h2 id="attack">ATT&amp;CK/TTP Context</h2>
+            <div class='note-box'>
+        <p>ATT&amp;CK context is shown as reviewed defensive context only. It supports SOC validation and telemetry review, but it does not prove compromise and does not override the transparent base priority from CVSS, EPSS, KEV and asset context.</p>
       </div>
-            <div class='table-wrap'>
+      <div class='table-wrap'>
         <table class='compact-table'>
           <thead>
-            <tr><th>ATT&CK/TTP Context</th><th>Status</th></tr>
+            <tr><th>Context</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>Mapped findings</strong></td><td>1</td></tr>
-<tr><td><strong>Unmapped findings</strong></td><td>1</td></tr>
-<tr><td><strong>Mapping source</strong></td><td>CTID JSON / curated local mapping</td></tr>
+            <tr><td><strong>Mapped findings</strong></td><td>1 reviewed mapping records available.</td></tr>
+<tr><td><strong>Common techniques</strong></td><td>T1190</td></tr>
 <tr><td><strong>Navigator layer</strong></td><td>Included in Evidence ZIP</td></tr>
+<tr><td><strong>Unmapped CVEs</strong></td><td>1 remain unmapped. No LLM inferred mappings are used.</td></tr>
           </tbody>
         </table>
       </div>
     </section>
-    <section aria-labelledby="technical-appendix">
-      <div class="section-heading">
-        <p class="eyebrow">Appendix</p>
-        <h2 id="technical-appendix">Technical Markdown Separation</h2>
-      </div>
-      <p class="empty-state">Detailed finding rows, component versions, long rationale, and per-finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF, and Evidence ZIP.</p>
+    <section aria-labelledby="appendix">
+      <p class="eyebrow">Appendix</p>
+      <h2 id="appendix">Technical Markdown Separation</h2>
+      <p class="footer-note">Detailed finding rows, component versions, long remediation text, input provenance, full rationale and per finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF and Evidence ZIP. This Executive HTML report intentionally summarizes the decision path for stakeholder review.</p>
     </section>
   </main>
 </body>

--- a/backend/tests/api/snapshots/vpw_068_governance_report.normalized.html
+++ b/backend/tests/api/snapshots/vpw_068_governance_report.normalized.html
@@ -7,201 +7,220 @@
   <style>
 :root {
   color-scheme: light;
-  --vpw-bg-app: #fafafa; --vpw-bg-card: #ffffff; --vpw-bg-panel: #f5f5f5;
-  --vpw-bg-info: #eef6ff; --vpw-bg-warning: #fff7e6; --vpw-bg-critical: #fff1f1;
-  --vpw-text-primary: #171717; --vpw-text-secondary: #4d4d4d; --vpw-text-muted: #6b6b6b;
-  --vpw-border-default: #ebebeb; --vpw-blue: #0070f3; --vpw-teal: #047857;
-  --vpw-green: #047857; --vpw-amber: #b54708; --vpw-red: #c40000; --vpw-violet: #475569;
-  --vpw-radius-lg: 8px; --vpw-radius-xl: 8px; --medium: #d97706; --low: #0ea5e9;
+  --bg-app: #fafafa;
+  --bg-card: #ffffff;
+  --bg-panel: #f5f5f5;
+  --bg-info: #eef6ff;
+  --bg-warning: #fff7e6;
+  --bg-critical: #fff1f1;
+  --bg-success: #ecfdf5;
+  --text-primary: #171717;
+  --text-secondary: #404040;
+  --text-muted: #6b6b6b;
+  --border: #e8e8e8;
+  --blue: #006adc;
+  --green: #047857;
+  --amber: #b54708;
+  --red: #c40000;
+  --violet: #475569;
+  --radius: 12px;
+  --radius-sm: 8px;
 }
 * { box-sizing: border-box; }
 body {
-  margin: 0; background: var(--vpw-bg-app); color: var(--vpw-text-primary);
-  font-family: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system,
+  margin: 0;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font-family:
+    "Geist", "Aptos", Inter, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px; line-height: 1.5; text-rendering: optimizeLegibility;
+  font-size: 14px;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
 }
-.report-shell { width: min(1280px, calc(100% - 32px)); margin: 0 auto; padding: 24px 0 40px; }
+.report-shell {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
 header, section {
-  margin-bottom: 16px; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-xl);
-  background: var(--vpw-bg-card); padding: 20px; box-shadow: none;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  padding: 20px;
 }
 h1, h2, h3, p { margin-top: 0; }
 h1 {
-  margin-bottom: 8px; color: var(--vpw-text-primary); font-size: 30px;
-  font-weight: 720; line-height: 1.15; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: 0;
+  font-weight: 760;
 }
 h2 {
-  margin-bottom: 10px; color: var(--vpw-text-primary); font-size: 20px;
-  font-weight: 720; line-height: 1.25; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 20px;
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 740;
 }
 h3 {
-  margin: 22px 0 10px; color: var(--vpw-text-primary); font-size: 15px;
-  font-weight: 650; line-height: 1.3; letter-spacing: 0;
+  margin: 22px 0 10px;
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 680;
 }
-.eyebrow, dt, .metric span, th {
-  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, monospace;
-  font-size: 12px; line-height: 1rem; letter-spacing: 0; text-transform: uppercase;
+.eyebrow, dt, .metric span, th, .status-label {
+  font-family:
+    "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
+  font-size: 12px;
+  line-height: 1rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
-.eyebrow { margin-bottom: 6px; color: var(--vpw-teal); font-weight: 600; }
+.eyebrow { margin-bottom: 6px; color: var(--green); font-weight: 650; }
 .lede {
-  max-width: 56rem; color: var(--vpw-text-secondary); font-size: 14px; line-height: 1.5;
+  max-width: none;
+  width: 100%;
+  color: var(--text-secondary);
 }
-.section-heading { margin-bottom: 12px; }
+.business-impact-lede {
+  max-width: none;
+  width: 100%;
+}
 .meta-grid, .metric-grid, .provider-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
-.meta-grid { margin: 18px 0 0; }
-.metric-grid { margin-bottom: 14px; }
+.meta-grid { margin-top: 18px; }
 .meta-grid div, .metric, .provider-grid div {
-  min-width: 0; border: 1px solid var(--vpw-border-default); border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card); padding: 12px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
 }
-.meta-grid div, .provider-grid div { background: var(--vpw-bg-panel); }
-.metric { min-height: 78px; align-content: center; box-shadow: inset 2px 0 0 var(--vpw-violet); }
-.metric[data-tone="info"] { box-shadow: inset 2px 0 0 var(--vpw-blue); }
-.metric[data-tone="success"] { box-shadow: inset 2px 0 0 var(--vpw-green); }
-.metric[data-tone="warning"] { box-shadow: inset 2px 0 0 var(--vpw-amber); }
-.metric[data-tone="critical"] { box-shadow: inset 2px 0 0 var(--vpw-red); }
-dt, .metric span { color: var(--vpw-text-muted); font-weight: 500; }
-dd { margin: 4px 0 0; color: var(--vpw-text-primary); overflow-wrap: anywhere; }
+.meta-grid div, .provider-grid div { background: var(--bg-panel); }
+dt, .metric span { color: var(--text-muted); font-weight: 560; }
+dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+.metric {
+  background: var(--bg-card);
+  min-height: 80px;
+  align-content: center;
+  box-shadow: inset 3px 0 0 var(--violet);
+}
 .metric strong {
-  display: block; margin-top: 4px; color: var(--vpw-text-primary);
-  font-size: 24px; font-weight: 720; line-height: 1.1; letter-spacing: 0;
+  display: block;
+  margin-top: 4px;
+  font-size: 25px;
+  line-height: 1.05;
+  font-weight: 760;
 }
+.metric[data-tone="critical"] { box-shadow: inset 3px 0 0 var(--red); }
+.metric[data-tone="warning"] { box-shadow: inset 3px 0 0 var(--amber); }
+.metric[data-tone="success"] { box-shadow: inset 3px 0 0 var(--green); }
+.metric[data-tone="info"] { box-shadow: inset 3px 0 0 var(--blue); }
+.verdict-banner {
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #fff7e6 0%, #fffaf0 100%);
+  padding: 16px;
+  margin: 0 0 14px;
+}
+.verdict-banner strong { color: #7c2d12; }
+.decision-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 12px;
+}
+.decision-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 14px;
+}
+.decision-card ul { margin: 8px 0 0 18px; padding: 0; }
+.decision-card li + li { margin-top: 4px; }
 .table-wrap {
-  overflow-x: auto; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 table {
-  width: 100%; min-width: 960px; border-collapse: collapse; background: var(--vpw-bg-card);
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  background: var(--bg-card);
 }
+.compact-table { min-width: 0; }
 th, td {
-  border-bottom: 1px solid var(--vpw-border-default); padding: 10px 8px;
-  text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
 }
-th { color: var(--vpw-text-muted); background: var(--vpw-bg-panel); font-weight: 500; }
-td { color: var(--vpw-text-primary); font-size: 14px; overflow-wrap: anywhere; }
+th { color: var(--text-muted); background: var(--bg-panel); font-weight: 560; }
+td { color: var(--text-primary); overflow-wrap: anywhere; }
 tbody tr:last-child td { border-bottom: 0; }
 .badge {
-  display: inline-flex; align-items: center; border: 1px solid transparent; border-radius: 9999px;
-  background: var(--vpw-bg-info); color: var(--vpw-blue); padding: 2px 8px;
-  font-size: 12px; font-weight: 600; line-height: 1.25; white-space: nowrap;
-}
-tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
-.badge-critical {
-  border-color: #fecaca; background: var(--vpw-bg-critical); color: var(--vpw-red);
-}
-.badge-high { border-color: #fed7aa; background: var(--vpw-bg-warning); color: var(--vpw-amber); }
-.badge-medium { border-color: #fde68a; background: #fffbeb; color: var(--medium); }
-.badge-low { border-color: #bae6fd; background: #f0f9ff; color: var(--low); }
-.badge-overdue { border-color: #fecaca; background: #fff1f1; color: var(--vpw-red); }
-.badge-fresh { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.badge-warning-alt { border-color: #fed7aa; background: #fff7e6; color: #b54708; }
-.badge-stale { border-color: #fca5a5; background: #fff1f1; color: #c40000; }
-.badge-success { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.verdict-banner {
-  background: var(--vpw-bg-panel);
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  padding: 16px;
-  margin-bottom: 18px;
-}
-.verdict-banner p { margin-bottom: 8px; }
-.verdict-banner p:last-child { margin-bottom: 0; }
-.campaign-card {
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card);
-  padding: 16px;
-  margin-bottom: 16px;
-}
-.campaign-card:last-child { margin-bottom: 0; }
-.campaign-header {
-  display: flex;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
-  border-bottom: 1px solid var(--vpw-border-default);
-  padding-bottom: 10px;
-  margin-bottom: 12px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 680;
+  line-height: 1.25;
+  white-space: nowrap;
 }
-.campaign-title-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.campaign-title {
-  font-size: 16px;
-  font-weight: 720;
-  margin: 0;
-}
-.campaign-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin-bottom: 14px;
-  background: var(--vpw-bg-panel);
-  padding: 12px;
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-meta-item {
-  font-size: 13px;
-  line-height: 1.4;
-}
-.campaign-meta-item strong {
-  display: block;
-  color: var(--vpw-text-secondary);
-  font-weight: 650;
-}
-.campaign-assets-toggle {
-  margin-top: 10px;
-}
-.campaign-assets-toggle summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--vpw-blue);
-  outline: none;
-  user-select: none;
-}
-.campaign-assets-table-wrap {
-  margin-top: 8px;
-  overflow-x: auto;
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-assets-table-wrap table {
-  min-width: 100%;
-}
-.campaign-assets-table-wrap th, .campaign-assets-table-wrap td {
-  padding: 8px 10px;
-  font-size: 13px;
+.badge-critical { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-high { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.badge-info { border-color: #bfdbfe; background: var(--bg-info); color: var(--blue); }
+.badge-success { border-color: #a7f3d0; background: var(--bg-success); color: var(--green); }
+.badge-neutral { border-color: #d4d4d4; background: #f7f7f7; color: #525252; }
+.badge-stale { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-warning { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.signal-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.campaign-table td:nth-child(1),
+.campaign-table td:nth-child(3),
+.campaign-table td:nth-child(4) {
+  white-space: nowrap;
 }
 .recommendation-list { margin: 0; padding-left: 22px; }
-.recommendation-list li + li { margin-top: 12px; }
-.recommendation-list strong { display: block; color: var(--vpw-text-primary); font-weight: 650; }
-.recommendation-list span { color: var(--vpw-text-secondary); }
-.empty-state { color: var(--vpw-text-muted); }
-.text-muted { color: var(--vpw-text-muted); }
-.signal-badge-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; }
-.compact-table { min-width: 0; }
-@media (max-width: 820px) {
+.recommendation-list li + li { margin-top: 14px; }
+.recommendation-list strong { display: block; margin-bottom: 4px; font-weight: 700; }
+.recommendation-list span { color: var(--text-secondary); }
+.note-box {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  padding: 14px;
+  color: var(--text-secondary);
+}
+.note-box + .table-wrap { margin-top: 12px; }
+.footer-note { margin: 0; color: var(--text-muted); }
+@media (max-width: 900px) {
   .report-shell { width: min(100% - 20px, 1280px); padding-top: 16px; }
   header, section { padding: 16px; }
   h1 { font-size: 26px; }
-  .meta-grid, .metric-grid, .provider-grid { grid-template-columns: 1fr; }
-  .campaign-header { align-items: flex-start; flex-direction: column; gap: 10px; }
-  .signal-badge-row { justify-content: flex-start; }
+  .meta-grid, .metric-grid, .provider-grid, .decision-grid { grid-template-columns: 1fr; }
+  table { min-width: 920px; }
+  .compact-table { min-width: 720px; }
 }
 @media print {
-  body { background: #ffffff; color: #000000; }
+  body { background: #fff; color: #000; }
   .report-shell { width: 100%; padding: 0; }
   header, section {
-    border-color: #c8c8c8; break-inside: avoid; page-break-inside: avoid; padding: 18px;
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    padding: 16px;
   }
   .table-wrap { overflow: visible; }
   table { min-width: 0; }
+  .badge { border-color: #999; background: #fff; color: #000; }
 }
   </style>
 </head>
@@ -209,148 +228,156 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
   <main class="report-shell">
     <header>
       <p class="eyebrow">Executive Evidence Brief</p>
-      <h1>Executive Vulnerability Report</h1>
-      <p class="lede">Decision-oriented evidence brief for VPW-050 Snapshot.</p>
+      <h1>VPW-050 Snapshot</h1>
+      <p class="lede">Decision oriented vulnerability prioritization report for CISO and stakeholder review. This report summarizes actionable remediation campaigns, governance exceptions and evidence confidence for the current analysis run.</p>
       <dl class="meta-grid">
-        <div><dt>Project Name</dt><dd>VPW-050 Snapshot</dd></div>
+        <div><dt>Report Type</dt><dd>Executive HTML</dd></div>
         <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000156</dd></div>
         <div><dt>Analysis Run ID</dt><dd>00000000-0000-4000-8000-000000000050</dd></div>
         <div><dt>Generated At</dt><dd>2026-04-29T12:00:00Z</dd></div>
         <div><dt>Run Status</dt><dd>completed</dd></div>
         <div><dt>Input Type</dt><dd>cve-list</dd></div>
         <div><dt>Input File</dt><dd>known-cves.txt</dd></div>
-        <div><dt>Input File Hash</dt><dd>N/A</dd></div>
-        <div><dt>Provider Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
-        <div><dt>Generator Version</dt><dd>v1.0.0</dd></div>
+        <div><dt>Provider Snapshot</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
       </dl>
     </header>
     <section aria-labelledby="decision-brief">
-      <div class="section-heading">
-        <p class="eyebrow">Executive Summary</p>
-        <h2 id="decision-brief">Decision Brief</h2>
+      <p class="eyebrow">Executive Summary</p>
+      <h2 id="decision-brief">Decision Brief</h2>
+      <div class="verdict-banner">
+        <p><strong>Decision needed:</strong> approve owners and remediation windows for open actionable findings, assign owners for top campaigns and require clean validation evidence after re import.</p>
+        <p>This run analyzed 2 findings from known-cves.txt. 0 findings are open and actionable, 1 finding is KEV-backed, 1 finding is accepted risk, 1 finding is VEX suppressed and 0 fixed findings are retained as evidence. Immediate focus should be CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell before governance exceptions are signed off.</p>
       </div>
-      <div class="verdict-banner"><p>This run analyzed 2 finding(s) from known-cves.txt; 0 are open and actionable, and 1 are KEV-backed. There are no open actionable findings requiring immediate remediation; review accepted-risk, VEX, and fixed-state evidence before closure. Governance review: 1 finding(s) accepted risk, 1 VEX suppressed. Provider freshness status is Fresh; validate freshness before formal risk sign-off.</p></div>
+      <div class="decision-grid">
+        <div class="decision-card">
+          <span class="status-label">What management should approve</span>
+          <ul>
+            <li>Remediation window for open production campaigns.</li>
+            <li>Named owners for each remediation cluster.</li>
+            <li>Validation evidence after clean re import.</li>
+          </ul>
+        </div>
+        <div class="decision-card">
+          <span class="status-label">What requires caution</span>
+          <ul>
+            <li>Provider snapshot freshness is fresh for formal sign off.</li>
+            <li>Accepted and VEX suppressed findings remain visible as evidence.</li>
+          </ul>
+        </div>
+      </div>
     </section>
     <section aria-labelledby="risk-posture">
-      <div class="section-heading">
-        <p class="eyebrow">Risk Posture</p>
-        <h2 id="risk-posture">Risk Posture Cards</h2>
-      </div>
+      <p class="eyebrow">Risk Posture</p>
+      <h2 id="risk-posture">Executive Risk Posture</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Total Findings</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Open Actionable</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Critical Open</span><strong>0</strong></div>
-        <div class="metric" data-tone="neutral"><span>KEV Backed</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>Internet-facing Prod</span><strong>0</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Risk</span><strong>1</strong></div>
+        <div class="metric" data-tone="info"><span>Total Findings</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>Open Actionable</span><strong>0</strong></div>
+        <div class="metric" data-tone="critical"><span>KEV Backed</span><strong>1</strong></div>
+        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>0</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Risk</span><strong>1</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>1</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Evidence</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due / Expiring</span><strong>2</strong></div>
-        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>0</strong></div>
-        <div class="metric" data-tone="neutral"><span>Unique CVEs</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Occurrences</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="critical"><span>Internet Facing Prod</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Unique CVEs</span><strong>2</strong></div>
+        <div class="metric" data-tone="success"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="success"><span>Evidence Bundle</span><strong>Ready</strong></div>
       </div>
     </section>
     <section aria-labelledby="action-plan">
-      <div class="section-heading">
-        <p class="eyebrow">Action Plan</p>
-        <h2 id="action-plan">First 24h and 7d Action Plan</h2>
-      </div>
+      <p class="eyebrow">Action Plan</p>
+      <h2 id="action-plan">First 24h and 7d Action Plan</h2>
       <div class="table-wrap">
   <table class='compact-table action-plan-table'>
     <thead>
       <tr><th>Time Window</th><th>Action</th><th>Scope</th><th>Owner</th><th>Evidence Basis</th></tr>
     </thead>
     <tbody>
-      <tr><td><strong>24h</strong></td><td>Confirm no 24h emergency campaign is required.</td><td>No emergency campaign</td><td>Security owner</td><td>Grouped campaign analysis</td></tr>
-<tr><td><strong>72h</strong></td><td>Track validation for completed or governed findings.</td><td>No additional open campaign</td><td>platform-team, secops</td><td>Actionability and governance status</td></tr>
-<tr><td><strong>7d</strong></td><td>Verify accepted, suppressed, and fixed evidence before closure.</td><td>Evidence closure</td><td>platform-team, secops</td><td>Technical Markdown, analysis JSON, and provider snapshot</td></tr>
-<tr><td><strong>Governance review</strong></td><td>Review exceptions and record management decision.</td><td>1 due review, 1 accepted risk, 1 VEX suppressed</td><td>Risk owner / security owner</td><td>Waiver, VEX, and fixed-state evidence</td></tr>
+      <tr><td><strong>24h</strong></td><td>Confirm no 24h emergency remediation is required for KEV-backed or critical internet-facing campaigns.</td><td>No emergency campaigns active</td><td>Security owner</td><td>Grouped campaign analysis</td></tr>
+<tr><td><strong>72h</strong></td><td>Confirm owners, patch status and interim compensating controls for campaigns not yet closed.</td><td>All open actionable findings and any VEX under investigation.</td><td>Security owner plus service owners</td><td>Technical Markdown, findings CSV, owner rollups and validation notes.</td></tr>
+<tr><td><strong>7d</strong></td><td>Perform clean re import, close fixed evidence and preserve the evidence package for audit review.</td><td>All remediation campaigns and fixed evidence.</td><td>Security operations and platform owners</td><td>Evidence ZIP, manifest, provider snapshot and analysis JSON.</td></tr>
+<tr><td><strong>Governance review</strong></td><td>Review due waiver, expiring waiver, accepted risks and VEX suppressed findings before formal risk sign off.</td><td>1 waiver, 1 review due, 1 expiring soon, 1 accepted risk finding; 1 VEX suppressed finding.</td><td>Risk owner and security owner</td><td>Waiver records, VEX overlays and governance artifacts.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
-    <section aria-labelledby="remediation-campaigns">
-      <div class="section-heading">
-        <p class="eyebrow">Remediation</p>
-        <h2 id="remediation-campaigns">Top Remediation Campaigns</h2>
-      </div>
+    <section aria-labelledby="campaigns">
+      <p class="eyebrow">Remediation</p>
+      <h2 id="campaigns">Top Remediation Campaigns</h2>
       <div class="table-wrap">
   <table class='campaign-table'>
     <thead>
       <tr><th>Priority</th><th>Risk Cluster</th><th>Actionability</th><th>Scope</th><th>Business Services</th><th>Owners</th><th>Evidence Signals</th><th>Decision Statement</th></tr>
     </thead>
     <tbody>
-        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-low'>1 accepted</span></td><td>1 asset; 1 occurrence</td><td>checkout</td><td>platform-team</td><td>EPSS 0.846, CVSS 10</td><td>Review accepted-risk exception and keep evidence visible for audit.</td></tr>
-        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-low'>1 suppressed</span></td><td>1 asset; 1 occurrence</td><td>operations</td><td>secops</td><td>KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td><td>Retain VEX evidence and validate suppressed scope remains accurate.</td></tr>
+        <tr><td><span class='badge badge-high'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-neutral'>1 accepted</span></td><td>1 asset; production; internet facing exposure</td><td>checkout</td><td>platform-team</td><td><div class="signal-row"><span class='badge badge-critical'>EPSS 0.846</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-neutral'>No KEV</span></div></td><td>Review accepted-risk exception before sign-off.</td></tr>
+        <tr><td><span class='badge badge-high'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-neutral'>1 suppressed</span></td><td>1 asset; production; internal exposure</td><td>operations</td><td>secops</td><td><div class="signal-row"><span class='badge badge-critical'>KEV</span><span class='badge badge-critical'>EPSS 0.944</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-info'>ATT&CK T1190</span></div></td><td>Retain VEX evidence for suppressed scope.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
-    <section aria-labelledby="business-services-risk">
-      <div class="section-heading">
-        <p class="eyebrow">Business Impact</p>
-        <h2 id="business-services-risk">Business Services at Risk</h2>
-      </div>
+    <section aria-labelledby="business-services">
+      <p class="eyebrow">Business Impact</p>
+      <h2 id="business-services">Business Services at Risk</h2>
+      <p class='lede business-impact-lede'>There are no active open actionable findings across the business services. Active accepted risk exceptions or waiver debt are currently recorded for: checkout. No active owners are assigned to the currently open findings. Management decision: Monitor remaining exceptions and ensure evidence records are preserved.</p>
       <div class="table-wrap">
-  <table>
-    <thead>
-      <tr><th>Service</th><th>Open Actionable</th><th>Accepted Risk</th><th>Suppressed / Fixed</th><th>Owners</th><th>Environment / Exposure</th><th>Decision Needed</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>operations</strong></td><td>0</td><td>0</td><td>1</td><td>secops</td><td>prod / internal</td><td><span class='badge badge-low'>Evidence validation</span></td></tr>
-<tr><td><strong>checkout</strong></td><td>0</td><td>1</td><td>0</td><td>platform-team</td><td>prod / internet-facing</td><td><span class='badge badge-warning-alt'>Governance review</span></td></tr>
-    </tbody>
-  </table>
-</div>
-    </section>
-    <section aria-labelledby="governance-rollups">
-      <div class="section-heading">
-        <p class="eyebrow">Governance</p>
-        <h2 id="governance-rollups">Governance Exceptions</h2>
+        <table>
+          <thead>
+            <tr><th>Service</th><th>Open Actionable</th><th>Governed Risk</th><th>Environment / Exposure</th><th>Owner</th><th>Decision Needed</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><strong>operations</strong></td><td>0</td><td>1 VEX suppressed</td><td>production / internal</td><td>secops</td><td><span class='badge badge-success'>Evidence validation</span></td></tr>
+            <tr><td><strong>checkout</strong></td><td>0</td><td>1 accepted risk</td><td>production / internet facing</td><td>platform-team</td><td><span class='badge badge-warning'>Governance review</span></td></tr>
+          </tbody>
+        </table>
       </div>
+    </section>
+    <section aria-labelledby="governance">
+      <p class="eyebrow">Governance</p>
+      <h2 id="governance">Governance Exceptions</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Waivers</span><strong>1</strong></div>
-        <div class="metric" data-tone="critical"><span>Expired</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Waivers</span><strong>1</strong></div>
+        <div class="metric" data-tone="info"><span>Expired</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due</span><strong>1</strong></div>
         <div class="metric" data-tone="warning"><span>Expiring Soon</span><strong>1</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Findings</span><strong>1</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Findings</span><strong>1</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>1</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Under Investigation</span><strong>0</strong></div>
       </div>
       <h3>Accepted Risk and Waiver Review</h3>
       <div class="table-wrap">
         <table>
           <thead>
-            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expiry</th><th>Review Date</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
+            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th><th>Review</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
           </thead>
           <tbody>
-            <tr><td>service:checkout</td><td>risk-team</td><td>Review Due</td><td>2026-05-07</td><td>2026-04-30</td><td>2</td><td>Review now</td></tr>
+            <tr><td>service:checkout</td><td>risk-team</td><td><span class="badge badge-warning">review due</span></td><td>2026-05-07</td><td>2026-04-30</td><td>2</td><td>Review now</td></tr>
           </tbody>
         </table>
       </div>
     </section>
-    <section aria-labelledby="provider-freshness">
-      <div class="section-heading">
-        <p class="eyebrow">Evidence</p>
-        <h2 id="provider-freshness">Evidence Confidence and Provider Freshness</h2>
+    <section aria-labelledby="evidence">
+      <p class="eyebrow">Evidence</p>
+      <h2 id="evidence">Evidence Confidence and Provider Freshness</h2>
+      <div class='verdict-banner'><p><strong>Evidence confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
+      <div class='table-wrap'>
+        <table>
+          <thead>
+            <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
+          </thead>
+          <tbody>
+                  <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo. Note: locked provider data guarantees reproducibility but does not automatically mean the data is fresh.</td></tr>
+            <tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>Content hash</strong></td><td><code>sha256:vpw050-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
+            <tr><td><strong>Selected sources</strong></td><td>nvd, epss, kev</td><td><span class='badge badge-success'>Recorded</span></td><td>Vulnerability intelligence sources selected for data enrichment.</td></tr>
+            <tr><td><strong>Evidence bundle manifest</strong></td><td>manifest.json</td><td><span class='badge badge-success'>Fresh</span></td><td>Evidence package manifest is available for validation.</td></tr>
+            <tr><td><strong>Static HTML safety</strong></td><td>No scripts, no external assets, escaped recommendation text</td><td><span class='badge badge-success'>Controlled</span></td><td>Report is suitable for local review and evidence package distribution.</td></tr>
+          </tbody>
+        </table>
       </div>
-<div class='verdict-banner'><p><strong>Evidence Confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
-<div class='table-wrap'>
-  <table>
-    <thead>
-      <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo.</td></tr>
-<tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>Content hash</strong></td><td><code>sha256:vpw050-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
-    </tbody>
-  </table>
-</div>
       <h3>Raw Provider Metadata</h3>
       <dl class="provider-grid">
         <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
@@ -361,81 +388,56 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
       </dl>
             <h3>Evidence Package Contents</h3>
       <div class='table-wrap'>
-        <table>
+        <table class='compact-table'>
           <thead>
-            <tr><th>Artifact File</th><th>Purpose / Description</th><th>Status</th></tr>
+            <tr><th>Artifact File</th><th>Purpose</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>manifest.json</code></td><td>Manifest and artifact hash verification</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>executive.html</code></td><td>Executive HTML decision brief</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>technical.md</code></td><td>Technical Markdown finding explanation</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>analysis.json</code></td><td>Machine-readable run result</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>findings.csv</code></td><td>Findings CSV (spreadsheet review)</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>results.sarif</code></td><td>SARIF toolchain integration</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay / reproducibility</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>attack-navigator-layer.json</code></td><td>ATT&amp;CK Navigator defensive TTP context</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX, rollup, and asset-context evidence</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
+            <tr><td><code>manifest.json</code></td><td>Bundle manifest and artifact hash verification.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>executive.html</code></td><td>Decision oriented executive brief.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>technical.md</code></td><td>Detailed analyst handoff with finding rows and rationale.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>analysis.json</code></td><td>Machine readable analysis export.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>findings.csv</code></td><td>Spreadsheet review of findings and owner scope.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>results.sarif</code></td><td>SARIF 2.1.0 integration output.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay for reproducibility.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>attack-navigator-layer.json</code></td><td>Defensive ATT&amp;CK Navigator layer for mapped findings.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX and asset context evidence.</td><td><span class='badge badge-success'>included</span></td></tr>
           </tbody>
         </table>
       </div>
     </section>
     <section aria-labelledby="recommendations">
-      <div class="section-heading">
-        <p class="eyebrow">Recommendations</p>
-        <h2 id="recommendations">Recommendations</h2>
-      </div>
+      <p class="eyebrow">Recommendations</p>
+      <h2 id="recommendations">Decision Ready Recommendations</h2>
       <ol class="recommendation-list">
-<li>
-  <strong>CVE-2024-3094 / XZ Utils Backdoor remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: checkout<br>
-    Status: 1 accepted<br>
-    Recommended action: Patch [open](javascript:alert(1)) now.<br>
-    SLA: Emergency / 24h<br>
-    Owner: platform-team<br>
-    Evidence basis: EPSS 0.846, CVSS 10
-    <br><small class='text-muted'>Governance note: 1 finding(s) accepted risk</small>
-  </span>
-</li>
-<li>
-  <strong>CVE-2021-44228 / Log4Shell remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: operations<br>
-    Status: 1 suppressed<br>
-    Recommended action: Patch via vendor upgrade.<br>
-    SLA: Emergency / 24h<br>
-    Owner: secops<br>
-    Evidence basis: KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190
-    <br><small class='text-muted'>Governance note: 1 finding(s) VEX-suppressed</small>
-  </span>
-</li>
+<li><strong>CVE-2024-3094 / XZ Utils campaign</strong><span>Scope: 1 asset; production; internet facing exposure; services: checkout. Status: 1 accepted. Recommended action: Patch [open](javascript:alert(1)) now.. SLA: Emergency / 24h. Owners: platform-team. Evidence basis: EPSS 0.846, CVSS 10.</span></li>
+<li><strong>CVE-2021-44228 / Log4Shell remediation campaign</strong><span>Scope: 1 asset; production; internal exposure; services: operations. Status: 1 suppressed. Recommended action: Patch via vendor upgrade.. SLA: Emergency / 24h. Owners: secops. Evidence basis: KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190.</span></li>
       </ol>
     </section>
-    <section aria-labelledby="attack-context">
-      <div class="section-heading">
-        <p class="eyebrow">SOC Context</p>
-        <h2 id="attack-context">ATT&CK/TTP Context</h2>
+    <section aria-labelledby="attack">
+      <p class="eyebrow">SOC Context</p>
+      <h2 id="attack">ATT&amp;CK/TTP Context</h2>
+            <div class='note-box'>
+        <p>ATT&amp;CK context is shown as reviewed defensive context only. It supports SOC validation and telemetry review, but it does not prove compromise and does not override the transparent base priority from CVSS, EPSS, KEV and asset context.</p>
       </div>
-            <div class='table-wrap'>
+      <div class='table-wrap'>
         <table class='compact-table'>
           <thead>
-            <tr><th>ATT&CK/TTP Context</th><th>Status</th></tr>
+            <tr><th>Context</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>Mapped findings</strong></td><td>1</td></tr>
-<tr><td><strong>Unmapped findings</strong></td><td>1</td></tr>
-<tr><td><strong>Mapping source</strong></td><td>CTID JSON / curated local mapping</td></tr>
+            <tr><td><strong>Mapped findings</strong></td><td>1 reviewed mapping records available.</td></tr>
+<tr><td><strong>Common techniques</strong></td><td>T1190</td></tr>
 <tr><td><strong>Navigator layer</strong></td><td>Included in Evidence ZIP</td></tr>
+<tr><td><strong>Unmapped CVEs</strong></td><td>1 remain unmapped. No LLM inferred mappings are used.</td></tr>
           </tbody>
         </table>
       </div>
     </section>
-    <section aria-labelledby="technical-appendix">
-      <div class="section-heading">
-        <p class="eyebrow">Appendix</p>
-        <h2 id="technical-appendix">Technical Markdown Separation</h2>
-      </div>
-      <p class="empty-state">Detailed finding rows, component versions, long rationale, and per-finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF, and Evidence ZIP.</p>
+    <section aria-labelledby="appendix">
+      <p class="eyebrow">Appendix</p>
+      <h2 id="appendix">Technical Markdown Separation</h2>
+      <p class="footer-note">Detailed finding rows, component versions, long remediation text, input provenance, full rationale and per finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF and Evidence ZIP. This Executive HTML report intentionally summarizes the decision path for stakeholder review.</p>
     </section>
   </main>
 </body>

--- a/backend/tests/api/test_workbench_demo_workspace.py
+++ b/backend/tests/api/test_workbench_demo_workspace.py
@@ -517,6 +517,11 @@ def _assert_demo_report_downloads(
         elif filename == "executive-report.html":
             assert "<!doctype html>" in download.text
             assert "Executive Summary" in download.text
+            assert "Decision Brief" in download.text
+            assert "Top Remediation Campaigns" in download.text
+            assert "CVE-2021-44228 / Log4Shell" in download.text
+            assert "CVE-2022-22965 / Spring4Shell" in download.text
+            assert "Decision Ready Recommendations" in download.text
         elif filename == "analysis-result.v1.json":
             payload = download.json()
             assert payload["schema"] == "analysis-result.v1"

--- a/backend/tests/api/test_workbench_report_renderers_unit.py
+++ b/backend/tests/api/test_workbench_report_renderers_unit.py
@@ -74,6 +74,7 @@ def test_markdown_and_html_reports_render_empty_states_without_snapshot() -> Non
     assert "Confirm import coverage before treating this as a no-risk result." in html
     assert "No business service risk can be derived because no findings were recorded." in html
     assert "No provider snapshot was linked to this analysis run." in html
+    assert "no VEX suppressed findings" in html
 
 
 def test_governance_and_detection_exports_render_empty_and_minimal_branches() -> None:
@@ -197,6 +198,14 @@ def test_report_renderer_boolish_and_vex_fallback_helpers() -> None:
     assert renderers._vex_status_counts_from_explanation(
         {"provenance": {"vex_status": "under_investigation"}}
     ) == renderers.Counter({"under_investigation": 1})
+
+
+def test_metric_tone_tracks_provider_freshness_value() -> None:
+    from app.services.report_html_components import _html_metric
+
+    assert 'data-tone="success"' in _html_metric("Provider Freshness", "Fresh")
+    assert 'data-tone="warning"' in _html_metric("Provider Freshness", "Warning")
+    assert 'data-tone="critical"' in _html_metric("Provider Freshness", "Stale")
 
 
 def test_executive_html_groups_campaigns_and_interprets_freshness() -> None:
@@ -325,7 +334,7 @@ def test_executive_html_groups_campaigns_and_interprets_freshness() -> None:
 
     headings = [heading.get_text(" ", strip=True) for heading in soup.select("h2")]
     assert "Decision Brief" in headings
-    assert "Risk Posture Cards" in headings
+    assert "Executive Risk Posture" in headings
     assert "First 24h and 7d Action Plan" in headings
     assert "Top Remediation Campaigns" in headings
     assert "Business Services at Risk" in headings
@@ -342,7 +351,7 @@ def test_executive_html_groups_campaigns_and_interprets_freshness() -> None:
 
     campaign_clusters = [
         row.select("td")[1].get_text(" ", strip=True)
-        for row in soup.select('section[aria-labelledby="remediation-campaigns"] tbody tr')
+        for row in soup.select('section[aria-labelledby="campaigns"] tbody tr')
     ]
     assert campaign_clusters.count("CVE-2021-44228 / Log4Shell") == 1
     assert campaign_clusters.count("CVE-2022-22965 / Spring4Shell") == 1
@@ -359,5 +368,180 @@ def test_executive_html_groups_campaigns_and_interprets_freshness() -> None:
     assert provider_statuses["NVD last sync"] == "Fresh"
     assert provider_statuses["EPSS date"] == "Warning"
     assert provider_statuses["KEV catalog version"] == "Stale"
+    assert provider_statuses["Snapshot locked"] == "Reproducible"
+    assert provider_statuses["Selected sources"] == "Recorded"
+    assert provider_statuses["Evidence bundle manifest"] == "Fresh"
     assert renderers._provider_freshness_status(snapshot, payload.generated_at) == "Stale"
     assert "+3 more" not in soup.get_text(" ", strip=True)
+
+
+def test_render_safe_text_with_links() -> None:
+    from app.services.report_html_helpers import render_safe_text_with_links
+
+    # Safe links
+    assert (
+        render_safe_text_with_links("Patch [here](https://example.com) now.")
+        == 'Patch <a href="https://example.com" target="_blank" '
+        'rel="noopener noreferrer">here</a> now.'
+    )
+    assert (
+        render_safe_text_with_links("Check [CISA](http://cisa.gov) details.")
+        == 'Check <a href="http://cisa.gov" target="_blank" '
+        'rel="noopener noreferrer">CISA</a> details.'
+    )
+
+    # Unsafe links (not http/https)
+    assert (
+        render_safe_text_with_links("Run [unsafe](javascript:alert(1)) code.")
+        == "Run [unsafe](javascript:alert(1)) code."
+    )
+    assert (
+        render_safe_text_with_links(
+            "Load [data](data:text/html,<script>alert(1)</script>) content."
+        )
+        == "Load [data](data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;) content."
+    )
+
+    # XSS injection attempts
+    assert (
+        render_safe_text_with_links("<script>alert(1)</script>")
+        == "&lt;script&gt;alert(1)&lt;/script&gt;"
+    )
+    assert (
+        render_safe_text_with_links('<img src=x onerror="alert(1)">')
+        == "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;"
+    )
+
+
+def test_pluralization_grammar_decision_brief() -> None:
+    from app.services.report_html_helpers import _executive_verdict_summary_helper
+
+    # 1 finding, 1 KEV
+    finding1 = _finding(cve_id="CVE-2026-0001", priority="Critical", in_kev=True, status="open")
+    payload1 = _payload(findings=[finding1])
+    verdict1 = _executive_verdict_summary_helper(payload1)
+    assert "analyzed 1 finding from" in verdict1
+    assert "1 finding is open and actionable" in verdict1
+    assert "1 finding is KEV-backed" in verdict1
+
+    # 2 findings, 2 KEV
+    finding2 = _finding(cve_id="CVE-2026-0002", priority="Critical", in_kev=True, status="open")
+    payload2 = _payload(findings=[finding1, finding2])
+    verdict2 = _executive_verdict_summary_helper(payload2)
+    assert "analyzed 2 findings from" in verdict2
+    assert "2 findings are open and actionable" in verdict2
+    assert "2 findings are KEV-backed" in verdict2
+
+
+def test_executive_html_helper_edge_branches_are_decision_oriented() -> None:
+    from app.services.report_html_governance import (
+        _html_asset_rollup_row,
+        _html_service_rollup_row,
+        _html_waiver_debt_row,
+    )
+    from app.services.report_html_helpers import (
+        _actionability_summary_helper,
+        _calculate_age_and_verdict_helper,
+        _campaign_ranking_rationale,
+        _get_remediation_campaigns_helper,
+        _html_business_impact_table_helper,
+        _is_overdue_helper,
+        _provider_status_class,
+        _short_list,
+        _technique_ids_for_findings,
+        render_safe_text_with_links,
+    )
+
+    ref_date = datetime(2026, 5, 1, tzinfo=UTC)
+    assert render_safe_text_with_links(None) == "N/A"
+    assert _short_list([], noun="owner") == "N/A"
+    assert _actionability_summary_helper([]) == "No findings"
+    assert _is_overdue_helper("", ref_date) is False
+    assert _is_overdue_helper("not-a-date", ref_date) is False
+    assert _calculate_age_and_verdict_helper(None, ref_date) == (
+        "N/A",
+        "Unknown",
+        "badge-neutral",
+    )
+    assert _calculate_age_and_verdict_helper("not-a-date", ref_date) == (
+        "N/A",
+        "Unknown",
+        "badge-neutral",
+    )
+    assert _calculate_age_and_verdict_helper("2026-05-03", ref_date)[1] == "Fresh"
+    assert _provider_status_class("Controlled") == "badge-success"
+    assert _provider_status_class("unexpected") == "badge-neutral"
+
+    accepted = _finding(
+        cve_id="CVE-2026-0002",
+        status="accepted",
+        waived=True,
+        business_service="risk",
+        owner="risk-owner",
+    )
+    suppressed = _finding(
+        cve_id="CVE-2026-0003",
+        status="suppressed",
+        suppressed_by_vex=True,
+        business_service="risk",
+        owner="risk-owner",
+    )
+    fixed = _finding(
+        cve_id="CVE-2026-0004",
+        status="fixed",
+        business_service="closed",
+        owner="ops-owner",
+    )
+    business_html = _html_business_impact_table_helper([accepted, suppressed, fixed])
+    assert "Governance review" in business_html
+    assert "Evidence validation" in business_html
+    assert "VEX suppressed" in business_html
+
+    nested_attack = _finding(
+        attack_mapped=True,
+        explanation={
+            "attack_techniques": [{"technique_id": "T1190"}],
+            "attack_context": {"techniques": [{"attack_object_id": "T1210"}]},
+            "attack": {"techniques": ["T1499"]},
+        },
+    )
+    assert _technique_ids_for_findings([nested_attack]) == ["T1190", "T1210", "T1499"]
+
+    campaign = _get_remediation_campaigns_helper(
+        [
+            _finding(
+                cve_id="CVE-2026-0005",
+                status="open",
+                in_kev=True,
+                epss=0.2,
+                cvss_base_score=9.1,
+                environment="production",
+                exposure="internal",
+                criticality="critical",
+            )
+        ]
+    )[0]
+    assert _campaign_ranking_rationale(campaign).startswith("Internal production exposure")
+
+    assert "Review now" in _html_waiver_debt_row(
+        {"status": "expired", "matched_findings": 0},
+        ref_date,
+    )
+    assert "Review before expiry" in _html_waiver_debt_row(
+        {"status": "expiring_soon", "matched_findings": 0},
+        ref_date,
+    )
+    assert "No immediate action" in _html_waiver_debt_row(
+        {"status": "active", "matched_findings": 0, "review_at": "not-a-date"},
+        ref_date,
+    )
+    assert "Accepted risk active" in _html_waiver_debt_row(
+        {"status": "active", "matched_findings": 1},
+        ref_date,
+    )
+    assert "Checkout" in _html_service_rollup_row(
+        {"label": "Checkout", "risk_score_total": 12.5, "review_due_waiver_count": 1}
+    )
+    assert "checkout-api" in _html_asset_rollup_row(
+        {"label": "checkout-api", "risk_score_total": 9, "suppressed_by_vex_count": 1}
+    )

--- a/docs/evidence/vpw-051-manifest.json
+++ b/docs/evidence/vpw-051-manifest.json
@@ -1,7 +1,7 @@
 {
   "artifact_hashes": {
     "analysis.json": "af86abd0cb04d8cb087e289b7e7b42569d647749a8aaf473386bd3e70557c138",
-    "executive.html": "6a7879c3276574025d1d24427059ccd78f8a9caa025a1bee1b3cc824d5755e22",
+    "executive.html": "4ec9a1707c6834f90adb9c0f369e9d3a8d900a3bb2e2bd805203e88d22385e8d",
     "findings.csv": "3901094bf4ec701b7ffdb53394590980732adf806ffbb65618d11114e8c26d60",
     "provider-snapshot.json": "f5dab115122d78f3ac437386b83f2b5341e2694f0db909ca8cac111cdb57fea0",
     "results.sarif": "a3683aabe8ef8cb8d58d8aaf82445417d6f541d41ad93e5c274025c8ea7b5388",
@@ -25,8 +25,8 @@
     {
       "kind": "executive-html",
       "path": "executive.html",
-      "sha256": "6a7879c3276574025d1d24427059ccd78f8a9caa025a1bee1b3cc824d5755e22",
-      "size_bytes": 22269
+      "sha256": "4ec9a1707c6834f90adb9c0f369e9d3a8d900a3bb2e2bd805203e88d22385e8d",
+      "size_bytes": 23656
     },
     {
       "kind": "provider-snapshot",

--- a/docs/evidence/vpw-054-report-snapshots.md
+++ b/docs/evidence/vpw-054-report-snapshots.md
@@ -26,9 +26,9 @@ payload in `backend/tests/api/test_workbench_reports_api.py`.
 
 ```text
 bc8dc6af67958a6d5ef5c48dc487af7a9aaffa356db2a883f4294ff9b560033e  docs/examples/vpw-054-workbench-technical-report.md
-c1d20ba8ee36ec9b36065fb980337b2bac6e366e5eeef2a40db5ff1e4a9c28e9  docs/examples/vpw-054-workbench-executive-report.html
+b79805f9d8721a6bff5261eafd81af2763906b7464a913aa8042cac45651d713  docs/examples/vpw-054-workbench-executive-report.html
 e4dc50f25ffcd529e8104ca387d909144ede5ccc4ae56d28393a20fa6244708b  docs/examples/vpw-054-workbench-analysis-result.v1.json
-af14205bf1388e0e89790d3acd2f0c71e8355ea3631e60e6c2c09b82fc40e5db  backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
+b01b70a9f81ee81532f0d42cfc90fe241bec5aaf2b15eb435698cf73a3f00ea7  backend/tests/api/snapshots/vpw_054_executive_report.normalized.html
 ```
 
 ## Update Process

--- a/docs/examples/vpw-054-workbench-executive-report.html
+++ b/docs/examples/vpw-054-workbench-executive-report.html
@@ -7,204 +7,220 @@
   <style>
 :root {
   color-scheme: light;
-  --vpw-bg-app: #fafafa; --vpw-bg-card: #ffffff; --vpw-bg-panel: #f5f5f5;
-  --vpw-bg-info: #eef6ff; --vpw-bg-warning: #fff7e6; --vpw-bg-critical: #fff1f1;
-  --vpw-text-primary: #171717; --vpw-text-secondary: #4d4d4d; --vpw-text-muted: #6b6b6b;
-  --vpw-border-default: #ebebeb; --vpw-blue: #0070f3; --vpw-teal: #047857;
-  --vpw-green: #047857; --vpw-amber: #b54708; --vpw-red: #c40000; --vpw-violet: #475569;
-  --vpw-radius-lg: 8px; --vpw-radius-xl: 8px; --medium: #d97706; --low: #0ea5e9;
+  --bg-app: #fafafa;
+  --bg-card: #ffffff;
+  --bg-panel: #f5f5f5;
+  --bg-info: #eef6ff;
+  --bg-warning: #fff7e6;
+  --bg-critical: #fff1f1;
+  --bg-success: #ecfdf5;
+  --text-primary: #171717;
+  --text-secondary: #404040;
+  --text-muted: #6b6b6b;
+  --border: #e8e8e8;
+  --blue: #006adc;
+  --green: #047857;
+  --amber: #b54708;
+  --red: #c40000;
+  --violet: #475569;
+  --radius: 12px;
+  --radius-sm: 8px;
 }
 * { box-sizing: border-box; }
 body {
-  margin: 0; background: var(--vpw-bg-app); color: var(--vpw-text-primary);
-  font-family: "Geist", "Aptos", ui-sans-serif, system-ui, -apple-system,
+  margin: 0;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font-family:
+    "Geist", "Aptos", Inter, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px; line-height: 1.5; text-rendering: optimizeLegibility;
+  font-size: 14px;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
 }
-.report-shell { width: min(1280px, calc(100% - 32px)); margin: 0 auto; padding: 24px 0 40px; }
+.report-shell {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
 header, section {
-  margin-bottom: 16px; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-xl);
-  background: var(--vpw-bg-card); padding: 20px; box-shadow: none;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  padding: 20px;
 }
 h1, h2, h3, p { margin-top: 0; }
 h1 {
-  margin-bottom: 8px; color: var(--vpw-text-primary); font-size: 30px;
-  font-weight: 720; line-height: 1.15; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: 0;
+  font-weight: 760;
 }
 h2 {
-  margin-bottom: 10px; color: var(--vpw-text-primary); font-size: 20px;
-  font-weight: 720; line-height: 1.25; letter-spacing: 0;
+  margin-bottom: 8px;
+  font-size: 20px;
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-weight: 740;
 }
 h3 {
-  margin: 22px 0 10px; color: var(--vpw-text-primary); font-size: 15px;
-  font-weight: 650; line-height: 1.3; letter-spacing: 0;
+  margin: 22px 0 10px;
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 680;
 }
-.eyebrow, dt, .metric span, th {
-  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, monospace;
-  font-size: 12px; line-height: 1rem; letter-spacing: 0; text-transform: uppercase;
+.eyebrow, dt, .metric span, th, .status-label {
+  font-family:
+    "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
+  font-size: 12px;
+  line-height: 1rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
-.eyebrow { margin-bottom: 6px; color: var(--vpw-teal); font-weight: 600; }
+.eyebrow { margin-bottom: 6px; color: var(--green); font-weight: 650; }
 .lede {
-  max-width: 56rem; color: var(--vpw-text-secondary); font-size: 14px; line-height: 1.5;
+  max-width: none;
+  width: 100%;
+  color: var(--text-secondary);
 }
-.section-heading { margin-bottom: 12px; }
+.business-impact-lede {
+  max-width: none;
+  width: 100%;
+}
 .meta-grid, .metric-grid, .provider-grid {
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
-.meta-grid { margin: 18px 0 0; }
-.metric-grid { margin-bottom: 14px; }
+.meta-grid { margin-top: 18px; }
 .meta-grid div, .metric, .provider-grid div {
-  min-width: 0; border: 1px solid var(--vpw-border-default); border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card); padding: 12px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
 }
-.meta-grid div, .provider-grid div { background: var(--vpw-bg-panel); }
-.metric { min-height: 78px; align-content: center; box-shadow: inset 2px 0 0 var(--vpw-violet); }
-.metric[data-tone="info"] { box-shadow: inset 2px 0 0 var(--vpw-blue); }
-.metric[data-tone="success"] { box-shadow: inset 2px 0 0 var(--vpw-green); }
-.metric[data-tone="warning"] { box-shadow: inset 2px 0 0 var(--vpw-amber); }
-.metric[data-tone="critical"] { box-shadow: inset 2px 0 0 var(--vpw-red); }
-dt, .metric span { color: var(--vpw-text-muted); font-weight: 500; }
-dd { margin: 4px 0 0; color: var(--vpw-text-primary); overflow-wrap: anywhere; }
+.meta-grid div, .provider-grid div { background: var(--bg-panel); }
+dt, .metric span { color: var(--text-muted); font-weight: 560; }
+dd { margin: 4px 0 0; overflow-wrap: anywhere; }
+.metric {
+  background: var(--bg-card);
+  min-height: 80px;
+  align-content: center;
+  box-shadow: inset 3px 0 0 var(--violet);
+}
 .metric strong {
-  display: block; margin-top: 4px; color: var(--vpw-text-primary);
-  font-size: 24px; font-weight: 720; line-height: 1.1; letter-spacing: 0;
+  display: block;
+  margin-top: 4px;
+  font-size: 25px;
+  line-height: 1.05;
+  font-weight: 760;
 }
+.metric[data-tone="critical"] { box-shadow: inset 3px 0 0 var(--red); }
+.metric[data-tone="warning"] { box-shadow: inset 3px 0 0 var(--amber); }
+.metric[data-tone="success"] { box-shadow: inset 3px 0 0 var(--green); }
+.metric[data-tone="info"] { box-shadow: inset 3px 0 0 var(--blue); }
+.verdict-banner {
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #fff7e6 0%, #fffaf0 100%);
+  padding: 16px;
+  margin: 0 0 14px;
+}
+.verdict-banner strong { color: #7c2d12; }
+.decision-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 12px;
+}
+.decision-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 14px;
+}
+.decision-card ul { margin: 8px 0 0 18px; padding: 0; }
+.decision-card li + li { margin-top: 4px; }
 .table-wrap {
-  overflow-x: auto; border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 table {
-  width: 100%; min-width: 960px; border-collapse: collapse; background: var(--vpw-bg-card);
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  background: var(--bg-card);
 }
+.compact-table { min-width: 0; }
 th, td {
-  border-bottom: 1px solid var(--vpw-border-default); padding: 10px 8px;
-  text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
 }
-th { color: var(--vpw-text-muted); background: var(--vpw-bg-panel); font-weight: 500; }
-td { color: var(--vpw-text-primary); font-size: 14px; overflow-wrap: anywhere; }
+th { color: var(--text-muted); background: var(--bg-panel); font-weight: 560; }
+td { color: var(--text-primary); overflow-wrap: anywhere; }
 tbody tr:last-child td { border-bottom: 0; }
 .badge {
-  display: inline-flex; align-items: center; border: 1px solid transparent; border-radius: 9999px;
-  background: var(--vpw-bg-info); color: var(--vpw-blue); padding: 2px 8px;
-  font-size: 12px; font-weight: 600; line-height: 1.25; white-space: nowrap;
-}
-tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
-.badge-critical {
-  border-color: #fecaca; background: var(--vpw-bg-critical); color: var(--vpw-red);
-}
-.badge-high { border-color: #fed7aa; background: var(--vpw-bg-warning); color: var(--vpw-amber); }
-.badge-medium { border-color: #fde68a; background: #fffbeb; color: var(--medium); }
-.badge-low { border-color: #bae6fd; background: #f0f9ff; color: var(--low); }
-.badge-overdue { border-color: #fecaca; background: #fff1f1; color: var(--vpw-red); }
-.badge-fresh { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-.badge-warning-alt { border-color: #fed7aa; background: #fff7e6; color: #b54708; }
-.badge-stale { border-color: #fca5a5; background: #fff1f1; color: #c40000; }
-.badge-success { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
-
-.verdict-banner {
-  background: var(--vpw-bg-panel);
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  padding: 16px;
-  margin-bottom: 18px;
-}
-.verdict-banner p { margin-bottom: 8px; }
-.verdict-banner p:last-child { margin-bottom: 0; }
-
-.campaign-card {
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-  background: var(--vpw-bg-card);
-  padding: 16px;
-  margin-bottom: 16px;
-}
-.campaign-card:last-child { margin-bottom: 0; }
-.campaign-header {
-  display: flex;
-  justify-content: space-between;
+  display: inline-flex;
   align-items: center;
-  border-bottom: 1px solid var(--vpw-border-default);
-  padding-bottom: 10px;
-  margin-bottom: 12px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 680;
+  line-height: 1.25;
+  white-space: nowrap;
 }
-.campaign-title-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.badge-critical { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-high { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.badge-info { border-color: #bfdbfe; background: var(--bg-info); color: var(--blue); }
+.badge-success { border-color: #a7f3d0; background: var(--bg-success); color: var(--green); }
+.badge-neutral { border-color: #d4d4d4; background: #f7f7f7; color: #525252; }
+.badge-stale { border-color: #fecaca; background: var(--bg-critical); color: var(--red); }
+.badge-warning { border-color: #fed7aa; background: var(--bg-warning); color: var(--amber); }
+.signal-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.campaign-table td:nth-child(1),
+.campaign-table td:nth-child(3),
+.campaign-table td:nth-child(4) {
+  white-space: nowrap;
 }
-.campaign-title {
-  font-size: 16px;
-  font-weight: 720;
-  margin: 0;
-}
-.campaign-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin-bottom: 14px;
-  background: var(--vpw-bg-panel);
-  padding: 12px;
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-meta-item {
-  font-size: 13px;
-  line-height: 1.4;
-}
-.campaign-meta-item strong {
-  display: block;
-  color: var(--vpw-text-secondary);
-  font-weight: 650;
-}
-.campaign-assets-toggle {
-  margin-top: 10px;
-}
-.campaign-assets-toggle summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--vpw-blue);
-  outline: none;
-  user-select: none;
-}
-.campaign-assets-table-wrap {
-  margin-top: 8px;
-  overflow-x: auto;
-  border: 1px solid var(--vpw-border-default);
-  border-radius: var(--vpw-radius-lg);
-}
-.campaign-assets-table-wrap table {
-  min-width: 100%;
-}
-.campaign-assets-table-wrap th, .campaign-assets-table-wrap td {
-  padding: 8px 10px;
-  font-size: 13px;
-}
-
 .recommendation-list { margin: 0; padding-left: 22px; }
-.recommendation-list li + li { margin-top: 12px; }
-.recommendation-list strong { display: block; color: var(--vpw-text-primary); font-weight: 650; }
-.recommendation-list span { color: var(--vpw-text-secondary); }
-.empty-state { color: var(--vpw-text-muted); }
-.text-muted { color: var(--vpw-text-muted); }
-.signal-badge-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; }
-.compact-table { min-width: 0; }
-@media (max-width: 820px) {
+.recommendation-list li + li { margin-top: 14px; }
+.recommendation-list strong { display: block; margin-bottom: 4px; font-weight: 700; }
+.recommendation-list span { color: var(--text-secondary); }
+.note-box {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  padding: 14px;
+  color: var(--text-secondary);
+}
+.note-box + .table-wrap { margin-top: 12px; }
+.footer-note { margin: 0; color: var(--text-muted); }
+@media (max-width: 900px) {
   .report-shell { width: min(100% - 20px, 1280px); padding-top: 16px; }
   header, section { padding: 16px; }
   h1 { font-size: 26px; }
-  .meta-grid, .metric-grid, .provider-grid { grid-template-columns: 1fr; }
-  .campaign-header { align-items: flex-start; flex-direction: column; gap: 10px; }
-  .signal-badge-row { justify-content: flex-start; }
+  .meta-grid, .metric-grid, .provider-grid, .decision-grid { grid-template-columns: 1fr; }
+  table { min-width: 920px; }
+  .compact-table { min-width: 720px; }
 }
 @media print {
-  body { background: #ffffff; color: #000000; }
+  body { background: #fff; color: #000; }
   .report-shell { width: 100%; padding: 0; }
   header, section {
-    border-color: #c8c8c8; break-inside: avoid; page-break-inside: avoid; padding: 18px;
+    border-color: #c8c8c8;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    padding: 16px;
   }
   .table-wrap { overflow: visible; }
   table { min-width: 0; }
+  .badge { border-color: #999; background: #fff; color: #000; }
 }
   </style>
 </head>
@@ -212,127 +228,134 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
   <main class="report-shell">
     <header>
       <p class="eyebrow">Executive Evidence Brief</p>
-      <h1>Executive Vulnerability Report</h1>
-      <p class="lede">Decision-oriented evidence brief for VPW-054 Demo Reports.</p>
+      <h1>VPW-054 Demo Reports</h1>
+      <p class="lede">Decision oriented vulnerability prioritization report for CISO and stakeholder review. This report summarizes actionable remediation campaigns, governance exceptions and evidence confidence for the current analysis run.</p>
       <dl class="meta-grid">
-        <div><dt>Project Name</dt><dd>VPW-054 Demo Reports</dd></div>
+        <div><dt>Report Type</dt><dd>Executive HTML</dd></div>
         <div><dt>Project ID</dt><dd>00000000-0000-4000-8000-000000000054</dd></div>
         <div><dt>Analysis Run ID</dt><dd>00000000-0000-4000-8000-000000000540</dd></div>
         <div><dt>Generated At</dt><dd>2026-04-29T12:00:00Z</dd></div>
         <div><dt>Run Status</dt><dd>completed</dd></div>
         <div><dt>Input Type</dt><dd>cve-list</dd></div>
         <div><dt>Input File</dt><dd>vpw-054-known-cves.txt</dd></div>
-        <div><dt>Input File Hash</dt><dd>N/A</dd></div>
-        <div><dt>Provider Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
-        <div><dt>Generator Version</dt><dd>v1.0.0</dd></div>
+        <div><dt>Provider Snapshot</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
       </dl>
     </header>
 
     <section aria-labelledby="decision-brief">
-      <div class="section-heading">
-        <p class="eyebrow">Executive Summary</p>
-        <h2 id="decision-brief">Decision Brief</h2>
+      <p class="eyebrow">Executive Summary</p>
+      <h2 id="decision-brief">Decision Brief</h2>
+      <div class="verdict-banner">
+        <p><strong>Decision needed:</strong> approve emergency remediation for open KEV backed production findings, assign owners for top campaigns and require clean validation evidence after re import.</p>
+        <p>This run analyzed 2 findings from vpw-054-known-cves.txt. 2 findings are open and actionable, 1 finding is KEV-backed, 0 findings are accepted risk, 0 findings are VEX suppressed and 0 fixed findings are retained as evidence. Immediate focus should be CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell before governance exceptions are signed off.</p>
       </div>
-      <div class="verdict-banner"><p>This run analyzed 2 finding(s) from vpw-054-known-cves.txt; 2 are open and actionable, and 1 are KEV-backed. First focus: CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell remediation cluster(s). Management decision needed: approve the remediation window, assign owners, and require clean validation evidence after re-import. Governance review: no active accepted-risk, VEX, fixed, or overdue waiver items. Provider freshness status is Fresh; validate freshness before formal risk sign-off.</p></div>
+      <div class="decision-grid">
+        <div class="decision-card">
+          <span class="status-label">What management should approve</span>
+          <ul>
+            <li>Remediation window for open production campaigns.</li>
+            <li>Named owners for each remediation cluster.</li>
+            <li>Validation evidence after clean re import.</li>
+          </ul>
+        </div>
+        <div class="decision-card">
+          <span class="status-label">What requires caution</span>
+          <ul>
+            <li>Provider snapshot freshness is fresh for formal sign off.</li>
+            <li>Accepted and VEX suppressed findings remain visible as evidence.</li>
+          </ul>
+        </div>
+      </div>
     </section>
 
     <section aria-labelledby="risk-posture">
-      <div class="section-heading">
-        <p class="eyebrow">Risk Posture</p>
-        <h2 id="risk-posture">Risk Posture Cards</h2>
-      </div>
+      <p class="eyebrow">Risk Posture</p>
+      <h2 id="risk-posture">Executive Risk Posture</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Total Findings</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Open Actionable</span><strong>2</strong></div>
-        <div class="metric" data-tone="critical"><span>Critical Open</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>KEV Backed</span><strong>1</strong></div>
-        <div class="metric" data-tone="neutral"><span>Internet-facing Prod</span><strong>1</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Risk</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Total Findings</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>Open Actionable</span><strong>2</strong></div>
+        <div class="metric" data-tone="critical"><span>KEV Backed</span><strong>1</strong></div>
+        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>2</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Risk</span><strong>0</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>0</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Evidence</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due / Expiring</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Emergency SLA</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Unique CVEs</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Occurrences</span><strong>2</strong></div>
-        <div class="metric" data-tone="neutral"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="critical"><span>Internet Facing Prod</span><strong>1</strong></div>
+        <div class="metric" data-tone="info"><span>Unique CVEs</span><strong>2</strong></div>
+        <div class="metric" data-tone="success"><span>Provider Freshness</span><strong>Fresh</strong></div>
+        <div class="metric" data-tone="success"><span>Evidence Bundle</span><strong>Ready</strong></div>
       </div>
     </section>
 
     <section aria-labelledby="action-plan">
-      <div class="section-heading">
-        <p class="eyebrow">Action Plan</p>
-        <h2 id="action-plan">First 24h and 7d Action Plan</h2>
-      </div>
+      <p class="eyebrow">Action Plan</p>
+      <h2 id="action-plan">First 24h and 7d Action Plan</h2>
       <div class="table-wrap">
   <table class='compact-table action-plan-table'>
     <thead>
       <tr><th>Time Window</th><th>Action</th><th>Scope</th><th>Owner</th><th>Evidence Basis</th></tr>
     </thead>
     <tbody>
-      <tr><td><strong>24h</strong></td><td>Approve emergency remediation and validation window.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell</td><td>platform-team, secops</td><td>EPSS 0.846, CVSS 10; KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td></tr>
-<tr><td><strong>72h</strong></td><td>Track validation for completed or governed findings.</td><td>No additional open campaign</td><td>platform-team, secops</td><td>Actionability and governance status</td></tr>
-<tr><td><strong>7d</strong></td><td>Confirm clean re-import and preserve evidence bundle.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell</td><td>platform-team, secops</td><td>Technical Markdown, analysis JSON, and provider snapshot</td></tr>
-<tr><td><strong>Governance review</strong></td><td>No governance action required.</td><td>No active exceptions</td><td>Risk owner / security owner</td><td>Waiver, VEX, and fixed-state evidence</td></tr>
+      <tr><td><strong>24h</strong></td><td>Approve emergency remediation for open KEV backed production findings and start validation tracking.</td><td>CVE-2024-3094 / XZ Utils Backdoor, CVE-2021-44228 / Log4Shell campaigns.</td><td>platform-team, secops</td><td>EPSS 0.846, CVSS 10; KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td></tr>
+<tr><td><strong>72h</strong></td><td>Confirm owners, patch status and interim compensating controls for campaigns not yet closed.</td><td>All open actionable findings and any VEX under investigation.</td><td>Security owner plus service owners</td><td>Technical Markdown, findings CSV, owner rollups and validation notes.</td></tr>
+<tr><td><strong>7d</strong></td><td>Perform clean re import, close fixed evidence and preserve the evidence package for audit review.</td><td>All remediation campaigns and fixed evidence.</td><td>Security operations and platform owners</td><td>Evidence ZIP, manifest, provider snapshot and analysis JSON.</td></tr>
+<tr><td><strong>Governance review</strong></td><td>Review due waiver, expiring waiver, accepted risks and VEX suppressed findings before formal risk sign off.</td><td>No waiver debt recorded; no VEX suppressed findings.</td><td>Risk owner and security owner</td><td>Waiver records, VEX overlays and governance artifacts.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
 
-    <section aria-labelledby="remediation-campaigns">
-      <div class="section-heading">
-        <p class="eyebrow">Remediation</p>
-        <h2 id="remediation-campaigns">Top Remediation Campaigns</h2>
-      </div>
+    <section aria-labelledby="campaigns">
+      <p class="eyebrow">Remediation</p>
+      <h2 id="campaigns">Top Remediation Campaigns</h2>
       <div class="table-wrap">
   <table class='campaign-table'>
     <thead>
       <tr><th>Priority</th><th>Risk Cluster</th><th>Actionability</th><th>Scope</th><th>Business Services</th><th>Owners</th><th>Evidence Signals</th><th>Decision Statement</th></tr>
     </thead>
     <tbody>
-        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-high'>1 open</span></td><td>1 asset; 1 occurrence</td><td>checkout</td><td>platform-team</td><td>EPSS 0.846, CVSS 10</td><td>Approve remediation window and validate clean re-import after patching.</td></tr>
-        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; 1 occurrence</td><td>operations</td><td>secops</td><td>KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190</td><td>Approve emergency patch and validation window within 24h.</td></tr>
+        <tr><td><span class='badge badge-critical'>P1</span></td><td><strong>CVE-2024-3094 / XZ Utils Backdoor</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; production; internet facing exposure</td><td>checkout</td><td>platform-team</td><td><div class="signal-row"><span class='badge badge-critical'>EPSS 0.846</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-neutral'>No KEV</span></div></td><td>Approve prioritized remediation and validation window.</td></tr>
+        <tr><td><span class='badge badge-critical'>P2</span></td><td><strong>CVE-2021-44228 / Log4Shell</strong></td><td><span class='badge badge-critical'>1 open</span></td><td>1 asset; production; internal exposure</td><td>operations</td><td>secops</td><td><div class="signal-row"><span class='badge badge-critical'>KEV</span><span class='badge badge-critical'>EPSS 0.944</span><span class='badge badge-critical'>CVSS 10</span><span class='badge badge-info'>ATT&CK T1190</span></div></td><td>Approve emergency patch and validation window within 24h.</td></tr>
     </tbody>
   </table>
 </div>
     </section>
 
-    <section aria-labelledby="business-services-risk">
-      <div class="section-heading">
-        <p class="eyebrow">Business Impact</p>
-        <h2 id="business-services-risk">Business Services at Risk</h2>
-      </div>
+    <section aria-labelledby="business-services">
+      <p class="eyebrow">Business Impact</p>
+      <h2 id="business-services">Business Services at Risk</h2>
+      <p class='lede business-impact-lede'>Vulnerability exposure is concentrated in checkout, operations with active actionable findings. Critical internet-facing production exposure is present in: checkout. Assigned service owners who must prioritize remediation include: platform-team, secops. Management decision: Approve emergency patch windows for internet-facing production assets, review governance exceptions for internal hosts, and require clean re-import validation.</p>
       <div class="table-wrap">
-  <table>
-    <thead>
-      <tr><th>Service</th><th>Open Actionable</th><th>Accepted Risk</th><th>Suppressed / Fixed</th><th>Owners</th><th>Environment / Exposure</th><th>Decision Needed</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>operations</strong></td><td>1</td><td>0</td><td>0</td><td>secops</td><td>prod / internal</td><td><span class='badge badge-critical'>Emergency remediation</span></td></tr>
-<tr><td><strong>checkout</strong></td><td>1</td><td>0</td><td>0</td><td>platform-team</td><td>prod / internet-facing</td><td><span class='badge badge-high'>Remediation scheduling</span></td></tr>
-    </tbody>
-  </table>
-</div>
+        <table>
+          <thead>
+            <tr><th>Service</th><th>Open Actionable</th><th>Governed Risk</th><th>Environment / Exposure</th><th>Owner</th><th>Decision Needed</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><strong>operations</strong></td><td>1</td><td>0 accepted, 0 VEX suppressed</td><td>production / internal</td><td>secops</td><td><span class='badge badge-critical'>Emergency remediation</span></td></tr>
+            <tr><td><strong>checkout</strong></td><td>1</td><td>0 accepted, 0 VEX suppressed</td><td>production / internet facing</td><td>platform-team</td><td><span class='badge badge-high'>Remediation scheduling</span></td></tr>
+          </tbody>
+        </table>
+      </div>
     </section>
 
-    <section aria-labelledby="governance-rollups">
-      <div class="section-heading">
-        <p class="eyebrow">Governance</p>
-        <h2 id="governance-rollups">Governance Exceptions</h2>
-      </div>
+    <section aria-labelledby="governance">
+      <p class="eyebrow">Governance</p>
+      <h2 id="governance">Governance Exceptions</h2>
       <div class="metric-grid">
-        <div class="metric" data-tone="neutral"><span>Waivers</span><strong>0</strong></div>
-        <div class="metric" data-tone="critical"><span>Expired</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Waivers</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Expired</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Review Due</span><strong>0</strong></div>
         <div class="metric" data-tone="warning"><span>Expiring Soon</span><strong>0</strong></div>
-        <div class="metric" data-tone="info"><span>Accepted Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="warning"><span>Accepted Findings</span><strong>0</strong></div>
         <div class="metric" data-tone="info"><span>VEX Suppressed</span><strong>0</strong></div>
         <div class="metric" data-tone="success"><span>Fixed Findings</span><strong>0</strong></div>
+        <div class="metric" data-tone="info"><span>Under Investigation</span><strong>0</strong></div>
       </div>
       <h3>Accepted Risk and Waiver Review</h3>
       <div class="table-wrap">
         <table>
           <thead>
-            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expiry</th><th>Review Date</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
+            <tr><th>Scope</th><th>Owner</th><th>Status</th><th>Expires</th><th>Review</th><th>Matched Findings</th><th>Required Governance Action</th></tr>
           </thead>
           <tbody>
 <tr><td colspan="7" class="empty-state">No accepted-risk waiver debt is currently recorded for this run.</td></tr>
@@ -342,26 +365,27 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
     </section>
 
 
-    <section aria-labelledby="provider-freshness">
-      <div class="section-heading">
-        <p class="eyebrow">Evidence</p>
-        <h2 id="provider-freshness">Evidence Confidence and Provider Freshness</h2>
+    <section aria-labelledby="evidence">
+      <p class="eyebrow">Evidence</p>
+      <h2 id="evidence">Evidence Confidence and Provider Freshness</h2>
+      <div class='verdict-banner'><p><strong>Evidence confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
+      <div class='table-wrap'>
+        <table>
+          <thead>
+            <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
+          </thead>
+          <tbody>
+                  <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo. Note: locked provider data guarantees reproducibility but does not automatically mean the data is fresh.</td></tr>
+            <tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-success'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
+            <tr><td><strong>Content hash</strong></td><td><code>sha256:vpw050-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
+            <tr><td><strong>Selected sources</strong></td><td>nvd, epss, kev</td><td><span class='badge badge-success'>Recorded</span></td><td>Vulnerability intelligence sources selected for data enrichment.</td></tr>
+            <tr><td><strong>Evidence bundle manifest</strong></td><td>manifest.json</td><td><span class='badge badge-success'>Fresh</span></td><td>Evidence package manifest is available for validation.</td></tr>
+            <tr><td><strong>Static HTML safety</strong></td><td>No scripts, no external assets, escaped recommendation text</td><td><span class='badge badge-success'>Controlled</span></td><td>Report is suitable for local review and evidence package distribution.</td></tr>
+          </tbody>
+        </table>
       </div>
-<div class='verdict-banner'><p><strong>Evidence Confidence:</strong> Provider data is fresh enough for current operational decision support.</p></div>
-<div class='table-wrap'>
-  <table>
-    <thead>
-      <tr><th>Signal</th><th>Value</th><th>Status</th><th>Meaning</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><strong>Snapshot locked</strong></td><td>Yes</td><td><span class='badge badge-success'>Reproducible</span></td><td>Provider data replay is deterministic for audit and demo.</td></tr>
-<tr><td><strong>NVD last sync</strong></td><td>2026-04-28T10:15:00Z</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>EPSS date</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>KEV catalog version</strong></td><td>2026-04-28</td><td><span class='badge badge-fresh'>Fresh</span></td><td>Source data is 1 day old at report generation time. Suitable for current operational decision support.</td></tr>
-<tr><td><strong>Content hash</strong></td><td><code>sha256:vpw050-snapshot</code></td><td><span class='badge badge-success'>Recorded</span></td><td>Evidence can be verified against the bundle manifest.</td></tr>
-    </tbody>
-  </table>
-</div>
       <h3>Raw Provider Metadata</h3>
       <dl class="provider-grid">
         <div><dt>Snapshot ID</dt><dd>00000000-0000-4000-8000-000000000650</dd></div>
@@ -372,84 +396,59 @@ tbody td:nth-child(-n + 7), thead th:nth-child(-n + 7) { white-space: nowrap; }
       </dl>
             <h3>Evidence Package Contents</h3>
       <div class='table-wrap'>
-        <table>
+        <table class='compact-table'>
           <thead>
-            <tr><th>Artifact File</th><th>Purpose / Description</th><th>Status</th></tr>
+            <tr><th>Artifact File</th><th>Purpose</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>manifest.json</code></td><td>Manifest and artifact hash verification</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>executive.html</code></td><td>Executive HTML decision brief</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>technical.md</code></td><td>Technical Markdown finding explanation</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>analysis.json</code></td><td>Machine-readable run result</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>findings.csv</code></td><td>Findings CSV (spreadsheet review)</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>results.sarif</code></td><td>SARIF toolchain integration</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay / reproducibility</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>attack-navigator-layer.json</code></td><td>ATT&amp;CK Navigator defensive TTP context</td><td><span class='badge badge-fresh'>Yes</span></td></tr>
-<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX, rollup, and asset-context evidence</td><td><span class='badge badge-low'>Optional</span></td></tr>
+            <tr><td><code>manifest.json</code></td><td>Bundle manifest and artifact hash verification.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>executive.html</code></td><td>Decision oriented executive brief.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>technical.md</code></td><td>Detailed analyst handoff with finding rows and rationale.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>analysis.json</code></td><td>Machine readable analysis export.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>findings.csv</code></td><td>Spreadsheet review of findings and owner scope.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>results.sarif</code></td><td>SARIF 2.1.0 integration output.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>provider-snapshot.json</code></td><td>Provider snapshot replay for reproducibility.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>attack-navigator-layer.json</code></td><td>Defensive ATT&amp;CK Navigator layer for mapped findings.</td><td><span class='badge badge-success'>included</span></td></tr>
+<tr><td><code>governance/*.json</code></td><td>Accepted risk, VEX and asset context evidence.</td><td><span class='badge badge-info'>optional</span></td></tr>
           </tbody>
         </table>
       </div>
     </section>
 
     <section aria-labelledby="recommendations">
-      <div class="section-heading">
-        <p class="eyebrow">Recommendations</p>
-        <h2 id="recommendations">Recommendations</h2>
-      </div>
+      <p class="eyebrow">Recommendations</p>
+      <h2 id="recommendations">Decision Ready Recommendations</h2>
       <ol class="recommendation-list">
-<li>
-  <strong>CVE-2024-3094 / XZ Utils Backdoor remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: checkout<br>
-    Status: 1 open<br>
-    Recommended action: Patch [open](javascript:alert(1)) now.<br>
-    SLA: Emergency / 24h<br>
-    Owner: platform-team<br>
-    Evidence basis: EPSS 0.846, CVSS 10
-  </span>
-</li>
-
-<li>
-  <strong>CVE-2021-44228 / Log4Shell remediation campaign</strong>
-  <span>
-    Scope: 1 asset; 1 occurrence; services: operations<br>
-    Status: 1 open<br>
-    Recommended action: Patch via vendor upgrade.<br>
-    SLA: Emergency / 24h<br>
-    Owner: secops<br>
-    Evidence basis: KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190
-  </span>
-</li>
-
+<li><strong>CVE-2024-3094 / XZ Utils campaign</strong><span>Scope: 1 asset; production; internet facing exposure; services: checkout. Status: 1 open. Recommended action: Patch [open](javascript:alert(1)) now.. SLA: Emergency / 24h. Owners: platform-team. Evidence basis: EPSS 0.846, CVSS 10.</span></li>
+<li><strong>CVE-2021-44228 / Log4Shell remediation campaign</strong><span>Scope: 1 asset; production; internal exposure; services: operations. Status: 1 open. Recommended action: Patch via vendor upgrade.. SLA: Emergency / 24h. Owners: secops. Evidence basis: KEV, EPSS 0.944, CVSS 10, ATT&amp;CK T1190.</span></li>
       </ol>
     </section>
 
-    <section aria-labelledby="attack-context">
-      <div class="section-heading">
-        <p class="eyebrow">SOC Context</p>
-        <h2 id="attack-context">ATT&CK/TTP Context</h2>
+    <section aria-labelledby="attack">
+      <p class="eyebrow">SOC Context</p>
+      <h2 id="attack">ATT&amp;CK/TTP Context</h2>
+            <div class='note-box'>
+        <p>ATT&amp;CK context is shown as reviewed defensive context only. It supports SOC validation and telemetry review, but it does not prove compromise and does not override the transparent base priority from CVSS, EPSS, KEV and asset context.</p>
       </div>
-            <div class='table-wrap'>
+      <div class='table-wrap'>
         <table class='compact-table'>
           <thead>
-            <tr><th>ATT&CK/TTP Context</th><th>Status</th></tr>
+            <tr><th>Context</th><th>Status</th></tr>
           </thead>
           <tbody>
-            <tr><td><strong>Mapped findings</strong></td><td>1</td></tr>
-<tr><td><strong>Unmapped findings</strong></td><td>1</td></tr>
-<tr><td><strong>Mapping source</strong></td><td>CTID JSON / curated local mapping</td></tr>
+            <tr><td><strong>Mapped findings</strong></td><td>1 reviewed mapping records available.</td></tr>
+<tr><td><strong>Common techniques</strong></td><td>T1190</td></tr>
 <tr><td><strong>Navigator layer</strong></td><td>Included in Evidence ZIP</td></tr>
+<tr><td><strong>Unmapped CVEs</strong></td><td>1 remain unmapped. No LLM inferred mappings are used.</td></tr>
           </tbody>
         </table>
       </div>
     </section>
 
-    <section aria-labelledby="technical-appendix">
-      <div class="section-heading">
-        <p class="eyebrow">Appendix</p>
-        <h2 id="technical-appendix">Technical Markdown Separation</h2>
-      </div>
-      <p class="empty-state">Detailed finding rows, component versions, long rationale, and per-finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF, and Evidence ZIP.</p>
+    <section aria-labelledby="appendix">
+      <p class="eyebrow">Appendix</p>
+      <h2 id="appendix">Technical Markdown Separation</h2>
+      <p class="footer-note">Detailed finding rows, component versions, long remediation text, input provenance, full rationale and per finding actions remain in the Technical Markdown report, Analysis JSON, Findings CSV, SARIF and Evidence ZIP. This Executive HTML report intentionally summarizes the decision path for stakeholder review.</p>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary\n- widen executive report text blocks so the Decision Brief, executive lede and business-impact narrative use the full content width\n- refine KPI tone handling for Provider Freshness and clean up governance/action-plan wording\n- regenerate the affected HTML snapshots, evidence manifest and docs example artefacts\n\n## Validation\n- python3 -m pytest backend/tests/api/test_workbench_report_renderers_unit.py backend/tests/api/test_workbench_reports_api.py backend/tests/api/test_workbench_demo_workspace.py -q --no-cov\n- browser E2E check against the executive report demo (local HTML render, no overflow, full-width text blocks)