### PR TITLE
[codex] Repair local SQLite schema bootstrap

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -51,15 +51,18 @@ def run_migrations_online() -> None:
         poolclass=pool.NullPool,
     )
 
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            compare_type=True,
-        )
+    try:
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+                compare_type=True,
+            )
 
-        with context.begin_transaction():
-            context.run_migrations()
+            with context.begin_transaction():
+                context.run_migrations()
+    finally:
+        connectable.dispose()
 
 
 if context.is_offline_mode():

--- a/backend/app/core/local_schema_bootstrap.py
+++ b/backend/app/core/local_schema_bootstrap.py
@@ -1,0 +1,90 @@
+"""Local-only schema bootstrap and repair helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from alembic import command
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+from sqlmodel import SQLModel
+
+from app.core.config import Settings
+from app.core.migration_bootstrap import ALEMBIC_HEAD, _alembic_config
+from app.core.schema_smoke import assert_migrated_schema, required_model_tables
+from app.models import import_table_models
+
+
+@dataclass(frozen=True, slots=True)
+class LocalSchemaBootstrapResult:
+    """Outcome of the local SQLite schema bootstrap."""
+
+    status: str
+    repaired: bool = False
+
+
+def bootstrap_local_sqlite_schema(
+    active_engine: Engine,
+    active_settings: Settings,
+) -> LocalSchemaBootstrapResult:
+    """
+    Bring a local SQLite Workbench database to a usable schema.
+
+    This is intentionally scoped to local SQLite. Compose/Postgres and every
+    non-local environment keep the stricter explicit migration/fail-fast model.
+    """
+    if active_settings.ENVIRONMENT != "local" or active_engine.dialect.name != "sqlite":
+        return LocalSchemaBootstrapResult(status="skipped")
+
+    if _schema_ready(active_engine):
+        return LocalSchemaBootstrapResult(status="ready")
+
+    try:
+        _run_alembic_upgrade(active_settings.SQLALCHEMY_DATABASE_URI)
+    except Exception:
+        if not _can_repair_missing_sqlite_schema(active_engine):
+            raise
+
+    if _schema_ready(active_engine):
+        return LocalSchemaBootstrapResult(status="migrated", repaired=True)
+
+    if not _can_repair_missing_sqlite_schema(active_engine):
+        assert_migrated_schema(active_engine)
+
+    _repair_missing_sqlite_schema(active_engine)
+    assert_migrated_schema(active_engine)
+    return LocalSchemaBootstrapResult(status="repaired", repaired=True)
+
+
+def _schema_ready(active_engine: Engine) -> bool:
+    try:
+        assert_migrated_schema(active_engine)
+    except RuntimeError:
+        return False
+    return True
+
+
+def _run_alembic_upgrade(database_uri: str) -> None:
+    config = _alembic_config()
+    config.set_main_option("sqlalchemy.url", database_uri)
+    command.upgrade(config, "head")
+
+
+def _can_repair_missing_sqlite_schema(active_engine: Engine) -> bool:
+    inspector = inspect(active_engine)
+    table_names = set(inspector.get_table_names())
+    return bool(required_model_tables() - table_names) or "alembic_version" not in table_names
+
+
+def _repair_missing_sqlite_schema(active_engine: Engine) -> None:
+    import_table_models()
+    SQLModel.metadata.create_all(active_engine)
+    with active_engine.begin() as connection:
+        table_names = set(inspect(connection).get_table_names())
+        if "alembic_version" not in table_names:
+            connection.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        connection.execute(text("DELETE FROM alembic_version"))
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:version_num)"),
+            {"version_num": ALEMBIC_HEAD},
+        )

--- a/backend/app/core/local_schema_bootstrap.py
+++ b/backend/app/core/local_schema_bootstrap.py
@@ -36,24 +36,41 @@ def bootstrap_local_sqlite_schema(
     if active_settings.ENVIRONMENT != "local" or active_engine.dialect.name != "sqlite":
         return LocalSchemaBootstrapResult(status="skipped")
 
-    if _schema_ready(active_engine):
-        return LocalSchemaBootstrapResult(status="ready")
+    repaired = False
 
-    try:
-        _run_alembic_upgrade(active_settings.SQLALCHEMY_DATABASE_URI)
-    except Exception:
-        if not _can_repair_missing_sqlite_schema(active_engine):
-            raise
+    if not _schema_ready(active_engine):
+        try:
+            _run_alembic_upgrade(active_settings.SQLALCHEMY_DATABASE_URI)
+        except Exception:
+            if not _can_repair_missing_sqlite_schema(active_engine):
+                raise
 
-    if _schema_ready(active_engine):
-        return LocalSchemaBootstrapResult(status="migrated", repaired=True)
+        if _schema_ready(active_engine):
+            repaired = True
+        else:
+            if not _can_repair_missing_sqlite_schema(active_engine):
+                assert_migrated_schema(active_engine)
 
-    if not _can_repair_missing_sqlite_schema(active_engine):
-        assert_migrated_schema(active_engine)
+            _repair_missing_sqlite_schema(active_engine)
+            repaired = True
 
-    _repair_missing_sqlite_schema(active_engine)
+    legacy_tables = _legacy_blocking_column_tables(active_engine)
+    for table_name in legacy_tables:
+        _rebuild_sqlite_table(active_engine, table_name)
+        repaired = True
+
+    remaining_legacy_tables = _legacy_blocking_column_tables(active_engine)
+    if remaining_legacy_tables:
+        raise RuntimeError(
+            "Local SQLite schema still has blocking legacy columns in: "
+            + ", ".join(remaining_legacy_tables)
+        )
+
     assert_migrated_schema(active_engine)
-    return LocalSchemaBootstrapResult(status="repaired", repaired=True)
+    return LocalSchemaBootstrapResult(
+        status="repaired" if repaired else "ready",
+        repaired=repaired,
+    )
 
 
 def _schema_ready(active_engine: Engine) -> bool:
@@ -71,9 +88,30 @@ def _run_alembic_upgrade(database_uri: str) -> None:
 
 
 def _can_repair_missing_sqlite_schema(active_engine: Engine) -> bool:
-    inspector = inspect(active_engine)
-    table_names = set(inspector.get_table_names())
+    with active_engine.connect() as connection:
+        table_names = set(inspect(connection).get_table_names())
     return bool(required_model_tables() - table_names) or "alembic_version" not in table_names
+
+
+def _legacy_blocking_column_tables(active_engine: Engine) -> tuple[str, ...]:
+    import_table_models()
+    with active_engine.connect() as connection:
+        inspector = inspect(connection)
+        actual_table_names = set(inspector.get_table_names())
+        drifted_tables: list[str] = []
+        for table_name, table in SQLModel.metadata.tables.items():
+            if table_name == "alembic_version" or table_name not in actual_table_names:
+                continue
+            expected_columns = {column.name for column in table.columns}
+            for column in inspector.get_columns(table_name):
+                if (
+                    column["name"] not in expected_columns
+                    and not column.get("nullable", True)
+                    and column.get("default") is None
+                ):
+                    drifted_tables.append(table_name)
+                    break
+    return tuple(drifted_tables)
 
 
 def _repair_missing_sqlite_schema(active_engine: Engine) -> None:
@@ -88,3 +126,49 @@ def _repair_missing_sqlite_schema(active_engine: Engine) -> None:
             text("INSERT INTO alembic_version (version_num) VALUES (:version_num)"),
             {"version_num": ALEMBIC_HEAD},
         )
+
+
+def _rebuild_sqlite_table(active_engine: Engine, table_name: str) -> None:
+    import_table_models()
+    table = SQLModel.metadata.tables[table_name]
+    backup_table_name = f"_{table_name}_legacy_repair"
+    with active_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        connection.execute(text("PRAGMA foreign_keys=OFF"))
+        try:
+            connection.execute(text(f"DROP TABLE IF EXISTS {_quote_identifier(backup_table_name)}"))
+            index_names: list[str] = []
+            for index in inspect(connection).get_indexes(table_name):
+                index_name = index.get("name")
+                if isinstance(index_name, str):
+                    index_names.append(index_name)
+            connection.execute(
+                text(
+                    f"ALTER TABLE {_quote_identifier(table_name)} "
+                    f"RENAME TO {_quote_identifier(backup_table_name)}"
+                )
+            )
+            for index_name in index_names:
+                connection.execute(text(f"DROP INDEX IF EXISTS {_quote_identifier(index_name)}"))
+            table.create(bind=connection)
+            old_columns = {
+                row[1]
+                for row in connection.execute(
+                    text(f"PRAGMA table_info({_quote_identifier(backup_table_name)})")
+                ).all()
+            }
+            copy_columns = [column.name for column in table.columns if column.name in old_columns]
+            if copy_columns:
+                column_list = ", ".join(_quote_identifier(column) for column in copy_columns)
+                connection.execute(
+                    text(
+                        f"INSERT INTO {_quote_identifier(table_name)} ({column_list}) "
+                        f"SELECT {column_list} FROM {_quote_identifier(backup_table_name)}"
+                    )
+                )
+            connection.execute(text(f"DROP TABLE {_quote_identifier(backup_table_name)}"))
+        finally:
+            connection.execute(text("PRAGMA foreign_keys=ON"))
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'

--- a/backend/app/core/schema_smoke.py
+++ b/backend/app/core/schema_smoke.py
@@ -43,17 +43,16 @@ def assert_postgres_engine(active_engine: Engine) -> str:
 
 def assert_migrated_schema(active_engine: Engine) -> SchemaSmokeResult:
     """Validate Alembic head and model tables on the active database."""
-    inspector = inspect(active_engine)
-    table_names = set(inspector.get_table_names())
-    missing_tables = sorted(required_model_tables() - table_names)
-    if missing_tables:
-        raise RuntimeError(
-            "Database schema is missing model tables: " + ", ".join(missing_tables[:20])
-        )
-    if "alembic_version" not in table_names:
-        raise RuntimeError("Database schema is missing alembic_version.")
-
     with active_engine.connect() as connection:
+        table_names = set(inspect(connection).get_table_names())
+        missing_tables = sorted(required_model_tables() - table_names)
+        if missing_tables:
+            raise RuntimeError(
+                "Database schema is missing model tables: " + ", ".join(missing_tables[:20])
+            )
+        if "alembic_version" not in table_names:
+            raise RuntimeError("Database schema is missing alembic_version.")
+
         versions = tuple(
             sorted(
                 str(row[0])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.api.main import api_router, assert_api_local_actor_policy
 from app.core.app_state import configure_workbench_state, workbench_settings
 from app.core.config import Settings, settings
 from app.core.db import create_db_engine
+from app.core.local_schema_bootstrap import bootstrap_local_sqlite_schema
 from app.core.rate_limit import RateLimiter, create_rate_limiter, rate_limit_key
 from app.core.schema_smoke import assert_migrated_schema
 from app.services.provider_updates import reconcile_stale_provider_update_runs
@@ -73,7 +74,11 @@ def create_app(active_settings: Settings | None = None) -> FastAPI:
         active_engine=active_engine,
     )
     app.state.rate_limiter = create_rate_limiter(selected_settings, active_engine)
-    if selected_settings.ENVIRONMENT != "local":
+    if selected_settings.ENVIRONMENT == "local":
+        app.router.on_startup.append(
+            lambda: bootstrap_local_sqlite_schema(active_engine, selected_settings)
+        )
+    else:
         app.router.on_startup.append(lambda: assert_migrated_schema(active_engine))
     app.router.on_startup.append(
         lambda: _reconcile_stale_import_runs_on_startup(active_engine, selected_settings)

--- a/backend/app/services/demo_workspace.py
+++ b/backend/app/services/demo_workspace.py
@@ -14,13 +14,16 @@ from sqlmodel import Session, col, func, select
 from app.core.config import Settings
 from app.core.local_actor import LocalWorkbenchActor
 from app.models import (
+    AnalysisEvidence,
     AnalysisRun,
     Asset,
     Finding,
+    FindingDecisionEvidence,
     Project,
     Report,
     Waiver,
     WaiverCreate,
+    WorkflowRun,
 )
 from app.models.base import get_datetime_utc
 from app.repositories import RunRepository, WaiverRepository
@@ -89,6 +92,9 @@ class DemoWorkspaceSnapshot:
     asset_count: int
     waiver_count: int
     report_count: int
+    analysis_evidence_count: int
+    finding_decision_evidence_count: int
+    workflow_count: int
     waiver_status_counts: dict[str, int]
 
     @property
@@ -108,6 +114,9 @@ class DemoWorkspaceSnapshot:
             and self.asset_count == EXPECTED_ASSET_COUNT
             and self.waiver_count == EXPECTED_WAIVER_COUNT
             and self.report_count == len(EXPECTED_REPORT_FORMATS)
+            and self.analysis_evidence_count > 0
+            and self.finding_decision_evidence_count >= self.finding_count
+            and self.workflow_count > 0
             and {report.filename for report in self.reports} == EXPECTED_REPORT_FILENAMES
             and {
                 status: self.waiver_status_counts.get(status, 0)
@@ -134,6 +143,9 @@ def read_demo_workspace_snapshot(session: Session) -> DemoWorkspaceSnapshot:
             asset_count=0,
             waiver_count=0,
             report_count=0,
+            analysis_evidence_count=0,
+            finding_decision_evidence_count=0,
+            workflow_count=0,
             waiver_status_counts={},
         )
 
@@ -147,6 +159,13 @@ def read_demo_workspace_snapshot(session: Session) -> DemoWorkspaceSnapshot:
         asset_count=_count_for_project(session, "asset", project.id),
         waiver_count=_count_for_project(session, "waiver", project.id),
         report_count=_count_for_project(session, "report", project.id),
+        analysis_evidence_count=_count_for_project(session, "analysis_evidence", project.id),
+        finding_decision_evidence_count=_count_for_project(
+            session,
+            "finding_decision_evidence",
+            project.id,
+        ),
+        workflow_count=_count_for_project(session, "workflow_run", project.id),
         waiver_status_counts=_waiver_status_counts(session, project.id),
     )
 
@@ -391,10 +410,13 @@ def _upload_content(path: Path, *, content_type: str) -> ImportUploadContent:
 def _count_for_project(session: Session, table: str, project_id: uuid.UUID) -> int:
     """Count for project function."""
     model_by_table: dict[str, Any] = {
+        "analysis_evidence": AnalysisEvidence,
         "asset": Asset,
         "finding": Finding,
+        "finding_decision_evidence": FindingDecisionEvidence,
         "report": Report,
         "waiver": Waiver,
+        "workflow_run": WorkflowRun,
     }
     model = model_by_table[table]
     statement = select(func.count()).select_from(model).where(model.project_id == project_id)

--- a/backend/tests/api/test_workbench_backend_adapter.py
+++ b/backend/tests/api/test_workbench_backend_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -24,7 +25,8 @@ from app.core.config import (
 )
 from app.core.migration_bootstrap import ALEMBIC_HEAD
 from app.main import app, create_app, custom_generate_unique_id
-from app.repositories import RuntimeHeartbeatRepository
+from app.models import AnalysisRunStatus, ProjectCreate
+from app.repositories import ProjectRepository, RunRepository, RuntimeHeartbeatRepository
 
 
 def test_workbench_backend_status_uses_versioned_api_namespace(tmp_path) -> None:
@@ -715,7 +717,8 @@ def test_workbench_backend_local_startup_repairs_head_stamped_missing_tables(
 
     with TestClient(selected_app) as client:
         status = client.get("/api/v1/workbench/status")
-        table_names = set(inspect(selected_app.state.workbench_engine).get_table_names())
+        with selected_app.state.workbench_engine.connect() as connection:
+            table_names = set(inspect(connection).get_table_names())
 
     assert status.status_code == 200
     assert status.json()["schema_status"] == "ready"
@@ -725,6 +728,92 @@ def test_workbench_backend_local_startup_repairs_head_stamped_missing_tables(
         "workflow_event",
         "workflow_run",
     }.issubset(table_names)
+    selected_app.state.workbench_engine.dispose()
+
+
+def test_workbench_backend_local_startup_repairs_legacy_analysis_run_columns(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "legacy-analysis-run-columns.db"
+    legacy_project_id = uuid.uuid4()
+    legacy_run_id = uuid.uuid4()
+    engine = create_engine(f"sqlite:///{database_path}")
+    try:
+        SQLModel.metadata.create_all(engine)
+        _stamp_alembic_head(engine)
+        with engine.begin() as connection:
+            connection.execute(text("ALTER TABLE analysis_run ADD COLUMN error_json JSON NOT NULL"))
+            connection.execute(
+                text("ALTER TABLE analysis_run ADD COLUMN summary_json JSON NOT NULL")
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO project (name, description, id, created_at, updated_at) "
+                    "VALUES (:name, :description, :id, :created_at, :updated_at)"
+                ),
+                {
+                    "name": "Legacy project",
+                    "description": None,
+                    "id": legacy_project_id.hex,
+                    "created_at": "2026-06-10 00:00:00",
+                    "updated_at": "2026-06-10 00:00:00",
+                },
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO analysis_run ("
+                    "input_type, filename, status, started_at, finished_at, error_message, "
+                    "error_json, summary_json, id, project_id, provider_snapshot_id"
+                    ") VALUES ("
+                    ":input_type, :filename, :status, :started_at, :finished_at, "
+                    ":error_message, :error_json, :summary_json, :id, :project_id, "
+                    ":provider_snapshot_id"
+                    ")"
+                ),
+                {
+                    "input_type": "legacy-cve-list",
+                    "filename": "legacy.txt",
+                    "status": AnalysisRunStatus.SUCCEEDED.value,
+                    "started_at": "2026-06-10 00:00:00",
+                    "finished_at": "2026-06-10 00:01:00",
+                    "error_message": None,
+                    "error_json": "{}",
+                    "summary_json": "{}",
+                    "id": legacy_run_id.hex,
+                    "project_id": legacy_project_id.hex,
+                    "provider_snapshot_id": None,
+                },
+            )
+    finally:
+        engine.dispose()
+
+    selected_app = create_app(Settings(SQLALCHEMY_DATABASE_URI=f"sqlite:///{database_path}"))
+
+    with TestClient(selected_app) as client:
+        status = client.get("/api/v1/workbench/status")
+
+    assert status.status_code == 200
+    assert status.json()["schema_status"] == "ready"
+    assert "error_json" not in _column_names(selected_app.state.workbench_engine, "analysis_run")
+    assert "summary_json" not in _column_names(selected_app.state.workbench_engine, "analysis_run")
+
+    with Session(selected_app.state.workbench_engine) as session:
+        assert RunRepository(session).get_analysis_run(legacy_run_id) is not None
+        project = ProjectRepository(session).create_project(
+            ProjectCreate(name="Import smoke", description=None)
+        )
+        session.commit()
+        run = RunRepository(session).create_analysis_run(
+            project_id=project.id,
+            input_type="cve-list",
+            filename="smoke.txt",
+            status=AnalysisRunStatus.PENDING,
+        )
+        run_id = run.id
+        session.commit()
+
+    assert run_id is not None
+    selected_app.state.workbench_engine.dispose()
 
 
 def test_workbench_backend_disposes_engine_on_shutdown(
@@ -782,6 +871,11 @@ def _stamp_alembic_head(engine: Engine) -> None:
             text("INSERT INTO alembic_version (version_num) VALUES (:version_num)"),
             {"version_num": ALEMBIC_HEAD},
         )
+
+
+def _column_names(engine: Engine, table_name: str) -> set[str]:
+    with engine.connect() as connection:
+        return {column["name"] for column in inspect(connection).get_columns(table_name)}
 
 
 def _route_dependency_names(route: APIRoute) -> set[str]:

--- a/backend/tests/api/test_workbench_backend_adapter.py
+++ b/backend/tests/api/test_workbench_backend_adapter.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
-from sqlalchemy import text
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
@@ -689,6 +689,42 @@ def test_workbench_backend_local_startup_tolerates_first_run_missing_schema(
 
     with TestClient(selected_app) as client:
         assert client.get("/api/v1/utils/health-check/").status_code == 200
+        status = client.get("/api/v1/workbench/status")
+
+    assert status.status_code == 200
+    assert status.json()["schema_status"] == "ready"
+
+
+def test_workbench_backend_local_startup_repairs_head_stamped_missing_tables(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "head-stamped-missing-tables.db"
+    engine = create_engine(f"sqlite:///{database_path}")
+    try:
+        SQLModel.metadata.create_all(engine)
+        _stamp_alembic_head(engine)
+        with engine.begin() as connection:
+            connection.execute(text("DROP TABLE finding_decision_evidence"))
+            connection.execute(text("DROP TABLE analysis_evidence"))
+            connection.execute(text("DROP TABLE workflow_event"))
+            connection.execute(text("DROP TABLE workflow_run"))
+    finally:
+        engine.dispose()
+
+    selected_app = create_app(Settings(SQLALCHEMY_DATABASE_URI=f"sqlite:///{database_path}"))
+
+    with TestClient(selected_app) as client:
+        status = client.get("/api/v1/workbench/status")
+        table_names = set(inspect(selected_app.state.workbench_engine).get_table_names())
+
+    assert status.status_code == 200
+    assert status.json()["schema_status"] == "ready"
+    assert {
+        "finding_decision_evidence",
+        "analysis_evidence",
+        "workflow_event",
+        "workflow_run",
+    }.issubset(table_names)
 
 
 def test_workbench_backend_disposes_engine_on_shutdown(

--- a/backend/tests/api/test_workbench_demo_workspace.py
+++ b/backend/tests/api/test_workbench_demo_workspace.py
@@ -10,7 +10,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 from utils.workbench_env import WorkbenchApiEnv, local_api_headers
 
 from app.domain.engine.providers.curated_attack_mappings import CuratedAttackMappingProvider
@@ -343,6 +343,40 @@ def test_demo_workspace_load_repairs_missing_report_artifact(
     )
 
 
+def test_demo_workspace_load_repairs_missing_decision_evidence(
+    workbench_api_env: WorkbenchApiEnv,
+    tmp_path: Path,
+) -> None:
+    _enable_demo_workspace(workbench_api_env, tmp_path)
+    headers = local_api_headers(workbench_api_env.client)
+
+    first_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": True},
+    )
+    assert first_response.status_code == 200
+    first_payload = first_response.json()
+    project_id = first_payload["project"]["id"]
+    first_run_id = first_payload["latest_run"]["id"]
+
+    _delete_demo_decision_evidence(workbench_api_env, project_id)
+
+    repaired_response = workbench_api_env.client.post(
+        "/api/v1/workbench/demo",
+        headers=headers,
+        json={"reset": False},
+    )
+
+    assert repaired_response.status_code == 200
+    repaired_payload = repaired_response.json()
+    assert repaired_payload["project"]["id"] == project_id
+    assert repaired_payload["latest_run"]["id"] != first_run_id
+    assert repaired_payload["latest_run"]["evidence"]["schema_version"] == "analysis-evidence.v2"
+    assert repaired_payload["latest_run"]["workflow"]["status"] == "succeeded"
+    assert repaired_payload["finding_count"] == 24
+
+
 def test_demo_workspace_seed_stays_disabled_outside_local(
     workbench_api_env: WorkbenchApiEnv,
     tmp_path: Path,
@@ -430,6 +464,38 @@ def _delete_one_demo_report_artifact(
     assert artifact_path.is_file()
     artifact_path.unlink()
     return artifact_path
+
+
+def _delete_demo_decision_evidence(
+    workbench_api_env: WorkbenchApiEnv,
+    project_id: str,
+) -> None:
+    project_uuid = uuid.UUID(project_id)
+    models = workbench_api_env.app_models
+    with Session(workbench_api_env.engine) as session:
+        workflow_ids = [
+            workflow.id
+            for workflow in session.exec(
+                select(models.WorkflowRun).where(models.WorkflowRun.project_id == project_uuid)
+            ).all()
+        ]
+        if workflow_ids:
+            events = session.exec(
+                select(models.WorkflowEvent).where(
+                    col(models.WorkflowEvent.workflow_run_id).in_(workflow_ids)
+                )
+            ).all()
+            for event in events:
+                session.delete(event)
+        for model in (
+            models.FindingDecisionEvidence,
+            models.AnalysisEvidence,
+            models.WorkflowRun,
+        ):
+            rows = session.exec(select(model).where(model.project_id == project_uuid)).all()
+            for row in rows:
+                session.delete(row)
+        session.commit()
 
 
 def _all_demo_report_artifacts_exist(


### PR DESCRIPTION
## Summary
- publishes the two previously local repair commits as one PR against `main`
- bootstraps and repairs local SQLite Workbench schemas on startup for local environments
- handles legacy blocking columns and demo evidence drift while keeping non-local environments fail-fast
- closes pooled SQLite connections in the local schema inspection paths and Alembic runner so shutdown tests stay clean

## Validation
- `uv run pytest backend/tests/api/test_workbench_backend_adapter.py backend/tests/api/test_workbench_demo_workspace.py -q`

## Branch split
- dashboard/risk-visualization work is not in this PR
- dashboard/risk-visualization backup branch is `codex/risk-visualization-dashboard` and currently contains only one commit over `origin/main`