### PR TITLE
[codex] Finalize v1.2.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ exact git tag output when release wording needs to be verified.
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-06-17
+## [1.2.0] - 2026-06-19
 
 ### Added
 


### PR DESCRIPTION
## Summary

Refs #594.

Aligns the `CHANGELOG.md` `v1.2.0` entry date with the actual release finalization date before tagging and publishing the GitHub Release.

## Validation

- `make docs-check`