### PR TITLE
[codex] Align release readiness browser gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,13 @@ jobs:
           retention-days: 3
           path: |
             ${{ runner.temp }}/workflow-artifacts/**
+            build/frontend-playwright-workbench-*.db
+            build/frontend-playwright-workbench-*-reports
             docs/example*.json
             docs/examples/*.json
+            frontend/blob-report
+            frontend/playwright-report
+            frontend/test-results/**
 
       - name: Publish GitHub release from checked-in notes
         if: startsWith(github.ref, 'refs/tags/v') && steps.release_notes.outputs.body_path != ''

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ NPM ?= scripts/frontend-npm.sh
 FRONTEND_NPM_ENGINE_STRICT ?= true
 FRONTEND_NPM := $(NPM) --prefix frontend --workspaces=false --engine-strict=$(FRONTEND_NPM_ENGINE_STRICT)
 
-.PHONY: install launch workbench-status workbench-stop workbench-reset workbench-update workbench-diagnostics test lint format fix typecheck check critical-coverage-check backend-compatibility-check property-check mutation-check quality-10-check local-workbench-check performance-smoke playwright-install playwright-check frontend-install frontend-build frontend-lint frontend-test-types frontend-test-unit frontend-test-unit-coverage frontend-generate-client api-client-drift-check frontend-design-audit frontend-design-audit-update frontend-design-audit-linux-docker frontend-design-audit-linux-docker-update demo-screenshot frontend-audit frontend-check python-lock-check docker-base-image-check pre-commit-pin-check archive-evidence-check public-production-evidence-check release-evidence-hygiene-check docs-check docs-serve actionlint-check workflow-check ci-cost-report docker-demo-smoke docker-production-smoke dependency-audit clean-local clean-deps provider-snapshot-validate package release-bundle package-contents-check package-check package-check-temp release-check release-readiness-check precommit-install
+.PHONY: install launch workbench-status workbench-stop workbench-reset workbench-update workbench-diagnostics test lint format fix typecheck check critical-coverage-check backend-compatibility-check property-check mutation-check quality-10-check local-workbench-check performance-smoke playwright-install playwright-check playwright-check-without-design-audit frontend-install frontend-build frontend-lint frontend-test-types frontend-test-unit frontend-test-unit-coverage frontend-generate-client api-client-drift-check frontend-design-audit frontend-design-audit-update frontend-design-audit-linux-docker frontend-design-audit-linux-docker-update demo-screenshot frontend-audit frontend-check python-lock-check docker-base-image-check pre-commit-pin-check archive-evidence-check public-production-evidence-check release-evidence-hygiene-check docs-check docs-serve actionlint-check workflow-check ci-cost-report docker-demo-smoke docker-production-smoke dependency-audit clean-local clean-deps provider-snapshot-validate package release-bundle package-contents-check package-check package-check-temp release-check release-readiness-check precommit-install
 
 install:
 	$(PYTHON) -m pip install -e "$(BACKEND_DIR)[dev]"
@@ -108,6 +108,9 @@ playwright-install: frontend-install
 
 playwright-check: playwright-install
 	$(FRONTEND_NPM) run test
+
+playwright-check-without-design-audit: playwright-install
+	$(FRONTEND_NPM) run test -- --grep-invert "design audit matches VPW visual regression baselines"
 
 frontend-install:
 	$(FRONTEND_NPM) ci
@@ -355,7 +358,7 @@ release-check:
 	$(MAKE) dependency-audit
 	$(MAKE) docker-demo-smoke
 
-release-readiness-check: release-check api-client-drift-check archive-evidence-check playwright-check docker-production-smoke
+release-readiness-check: release-check api-client-drift-check archive-evidence-check frontend-design-audit-linux-docker playwright-check-without-design-audit docker-production-smoke
 
 quality-10-check:
 	$(MAKE) release-readiness-check

--- a/backend/tests/test_backend_runtime_boundary.py
+++ b/backend/tests/test_backend_runtime_boundary.py
@@ -654,11 +654,19 @@ def test_makefile_has_no_legacy_runtime_smoke_or_compose_path() -> None:
     assert "$(BACKEND_TESTS)/playwright" not in makefile
     assert "playwright install --with-deps chromium" in playwright_install
     assert "playwright-check: playwright-install" in makefile
+    assert "playwright-check-without-design-audit: playwright-install" in makefile
     assert "$(FRONTEND_NPM) run test" in playwright_check
+    assert (
+        '--grep-invert "design audit matches VPW visual regression baselines"' in playwright_check
+    )
     assert "tests/ui-smoke.spec.ts tests/responsive-shell.spec.ts" not in playwright_check
     assert "frontend-test-unit-coverage" in makefile
     assert "public-production-evidence-check" not in release_readiness
     assert "release-check api-client-drift-check archive-evidence-check" in release_readiness
+    assert (
+        "frontend-design-audit-linux-docker playwright-check-without-design-audit"
+        in release_readiness
+    )
     assert "--profile legacy-postgres" not in docker_demo_smoke
     assert "workbench-postgres" not in docker_demo_smoke
     assert "$(COMPOSE) up -d --build backend frontend worker" in docker_demo_smoke

--- a/docs/release_operations.md
+++ b/docs/release_operations.md
@@ -62,11 +62,13 @@ make release-readiness-check
 ```
 
 This adds generated-client drift, archive binary evidence validation,
-Playwright smoke evidence, and package smoke validation to the normal release
-gate. It also runs the production-like Docker smoke. It does not by itself
-certify a public deployment: live public TLS/header evidence and the explicit
-public deployment evidence contract still have to be captured for the exact
-deployed candidate.
+CI-aligned Playwright evidence, and package smoke validation to the normal
+release gate. The visual regression audit runs in the pinned Playwright Docker
+image, while the remaining Playwright suite runs without the visual audit. It
+also runs the production-like Docker smoke. It does not by itself certify a
+public deployment: live public TLS/header evidence and the explicit public
+deployment evidence contract still have to be captured for the exact deployed
+candidate.
 For tagged releases, `.github/workflows/release.yml` runs this gate before any
 draft GitHub Release is created or any PyPI publish job can proceed.
 


### PR DESCRIPTION
## Summary
- align `make release-readiness-check` with the CI browser split: Docker-backed visual design audit plus non-visual Playwright suite
- keep `make playwright-check` as the full local browser suite for developers
- upload Playwright reports and test-results in release debug artifacts when release readiness fails
- document the CI-aligned release-readiness behavior

## Root cause
The tag release workflow ran `make playwright-check`, which executed the visual design audit directly on the GitHub-hosted runner. CI already treats that visual audit as Docker-pinned evidence and runs the remaining Playwright suite separately. The release gate was stricter in an unstable way and failed before building release assets.

## Validation
- `python3 -m pytest -q backend/tests/test_backend_runtime_boundary.py::test_makefile_has_no_legacy_runtime_smoke_or_compose_path --no-cov`
- `make workflow-check`
- `make docs-check`
- `make actionlint-check`
- `python3 scripts/check_github_action_pins.py`
- `scripts/frontend-npm.sh --prefix frontend --workspaces=false --engine-strict=true run test -- --list --grep-invert "design audit matches VPW visual regression baselines"`

Refs #594